### PR TITLE
Fix bullet bug

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
@@ -1,9 +1,36 @@
 import execFormatWithUndo from './execFormatWithUndo';
-import { Editor } from 'roosterjs-editor-core';
+import getNodeAtCursor from '../cursor/getNodeAtCursor';
+import { Editor, browserData } from 'roosterjs-editor-core';
+import { NodeType } from 'roosterjs-editor-types';
+
+// Edge may incorrectly put cursor after toggle bullet, workaround it by adding a space.
+// The space will be removed by Edge after toggle bullet
+export function workaroundForEdge(editor: Editor): boolean {
+    if (browserData.isEdge) {
+        let node = getNodeAtCursor(editor);
+        if (node.nodeType == NodeType.Element && (<Element>node).textContent == '') {
+            (<Element>node).textContent = ' ';
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export function removeWorkaroundForEdge(editor: Editor) {
+    let node = getNodeAtCursor(editor);
+    if (node.nodeType == NodeType.Element && (<Element>node).textContent == ' ') {
+        (<Element>node).textContent = '';
+    }
+}
 
 export default function toggleBullet(editor: Editor): void {
     editor.focus();
     execFormatWithUndo(editor, () => {
+        let hasWoraround = workaroundForEdge(editor);
         editor.getDocument().execCommand('insertUnorderedList', false, null);
+        if (hasWoraround) {
+            removeWorkaroundForEdge(editor);
+        }
     });
 }

--- a/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
@@ -5,32 +5,31 @@ import { NodeType } from 'roosterjs-editor-types';
 
 // Edge may incorrectly put cursor after toggle bullet, workaround it by adding a space.
 // The space will be removed by Edge after toggle bullet
-export function workaroundForEdge(editor: Editor): boolean {
+export function workaroundForEdge(editor: Editor): HTMLElement {
     if (browserData.isEdge) {
-        let node = getNodeAtCursor(editor);
-        if (node.nodeType == NodeType.Element && (<Element>node).textContent == '') {
-            (<Element>node).textContent = ' ';
-            return true;
+        let node = getNodeAtCursor(editor) as Element;
+        if (node.nodeType == NodeType.Element && node.textContent == '') {
+            let span = editor.getDocument().createElement('span');
+            node.insertBefore(span, node.firstChild);
+            span.innerHTML = 'a';
+            return span;
         }
     }
 
-    return false;
+    return null;
 }
 
-export function removeWorkaroundForEdge(editor: Editor) {
-    let node = getNodeAtCursor(editor);
-    if (node.nodeType == NodeType.Element && (<Element>node).textContent == ' ') {
-        (<Element>node).textContent = '';
+export function removeWorkaroundForEdge(workaroundSpan: HTMLElement) {
+    if (workaroundSpan && workaroundSpan.parentNode) {
+        workaroundSpan.parentNode.removeChild(workaroundSpan);
     }
 }
 
 export default function toggleBullet(editor: Editor): void {
     editor.focus();
     execFormatWithUndo(editor, () => {
-        let hasWoraround = workaroundForEdge(editor);
+        let workaroundSpan = workaroundForEdge(editor);
         editor.getDocument().execCommand('insertUnorderedList', false, null);
-        if (hasWoraround) {
-            removeWorkaroundForEdge(editor);
-        }
+        removeWorkaroundForEdge(workaroundSpan);
     });
 }

--- a/packages/roosterjs-editor-api/lib/format/toggleNumbering.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleNumbering.ts
@@ -1,9 +1,14 @@
 import execFormatWithUndo from './execFormatWithUndo';
 import { Editor } from 'roosterjs-editor-core';
+import { workaroundForEdge, removeWorkaroundForEdge } from './toggleBullet';
 
 export default function toggleNumbering(editor: Editor): void {
     editor.focus();
     execFormatWithUndo(editor, () => {
+        let hasWorkaround = workaroundForEdge(editor);
         editor.getDocument().execCommand('insertOrderedList', false, null);
+        if (hasWorkaround) {
+            removeWorkaroundForEdge(editor);
+        }
     });
 }

--- a/packages/roosterjs-editor-api/lib/format/toggleNumbering.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleNumbering.ts
@@ -5,10 +5,8 @@ import { workaroundForEdge, removeWorkaroundForEdge } from './toggleBullet';
 export default function toggleNumbering(editor: Editor): void {
     editor.focus();
     execFormatWithUndo(editor, () => {
-        let hasWorkaround = workaroundForEdge(editor);
+        let workaroundSpan = workaroundForEdge(editor);
         editor.getDocument().execCommand('insertOrderedList', false, null);
-        if (hasWorkaround) {
-            removeWorkaroundForEdge(editor);
-        }
+        removeWorkaroundForEdge(workaroundSpan);
     });
 }

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -57,6 +57,7 @@ export default class Editor {
     private isBeforeDeactivateEventSupported: boolean;
     private undoService: UndoService;
     private isInIMESequence: boolean;
+    private suspendAddingUndoSnapshot: boolean;
 
     constructor(private contentDiv: HTMLDivElement, options: EditorOptions) {
         if (!contentDiv) {
@@ -195,8 +196,17 @@ export default class Editor {
         }
     }
 
+    public runWithoutAddingUndoSnapshot(callback: () => void) {
+        try {
+            this.suspendAddingUndoSnapshot = true;
+            callback();
+        } finally {
+            this.suspendAddingUndoSnapshot = false;
+        }
+    }
+
     public addUndoSnapshot(): void {
-        if (this.undoService && this.undoService.addUndoSnapshot) {
+        if (this.undoService && this.undoService.addUndoSnapshot && !this.suspendAddingUndoSnapshot) {
             this.undoService.addUndoSnapshot();
         }
     }

--- a/sample/sample.htm
+++ b/sample/sample.htm
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
     <head>
+        <title>RoosterJs Sample Page</title>
         <style>
             html, body {
                 height: 100%;
@@ -20,6 +21,20 @@
                 background-color: #4444ff;
                 padding: 10px 20px;
                 margin-bottom: 20px;
+            }
+
+            .topButtons {
+                float: right;
+            }
+
+            .topButtons a {
+                font-size: 16px;
+                color: white;
+                text-decoration: none;
+            }
+
+            .topButtons a:hover {
+                text-decoration: underline;
             }
 
             .tabs {
@@ -92,7 +107,13 @@
     <body>
         <script src="scripts/sample.js"></script>
         <div class="root">
-            <div class="banner">RoosterJs Sample Site</div>
+            <div class="banner">
+                RoosterJs Sample Site
+                <div class="topButtons">
+                    <a href="https://github.com/microsoft/roosterjs" target="_blank">RoosterJs on GitHub</a>
+                    <a href="https://github.com/Microsoft/roosterjs/wiki" target="_blank">Documentations</a>
+                </div>
+            </div>
             <div class="tabs">
                 <div id="quickstartTab">Quick Start</div>
                 <div id="optionsTab">Editor Options</div>

--- a/sample/scripts/sample.ts
+++ b/sample/scripts/sample.ts
@@ -40,5 +40,4 @@ function initEditor() {
         new ShowCursorPosition(document.getElementById('cursorPosition')),
         new ShowFromState(document.getElementById('formatState')),
     ]));
-    getCurrentEditor().setContent('Hello, RoosterJs!');
 }


### PR DESCRIPTION
1. Toggle bullet/numbering for empty line may put cursor in incorrect position in Edge, fix it by adding a space before toggle, and remove it after toggle.

2. Add a function in Editor class to allow suspending undo snapshot.

3. Add git and wiki link to sample site.