### PR TITLE
Hyperlink plugin use ExtractContentEvent

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/createLink.ts
+++ b/packages/roosterjs-editor-api/lib/format/createLink.ts
@@ -1,9 +1,7 @@
 import CursorData from '../cursor/CursorData';
-import defaultLinkMatchRules from '../linkMatch/defaultLinkMatchRules';
 import execFormatWithUndo from './execFormatWithUndo';
 import isSelectionCollapsed from '../cursor/isSelectionCollapsed';
 import matchLink from '../linkMatch/matchLink';
-import { LinkMatchOption } from 'roosterjs-editor-types';
 import { Editor } from 'roosterjs-editor-core';
 import { LinkInlineElement } from 'roosterjs-editor-dom';
 
@@ -32,7 +30,7 @@ function applyLinkPrefix(url: string): string {
             prefix = 'ftp://';
         } else {
             // fallback to http://
-            prefix = 'http' + '://';
+            prefix = 'http://';
         }
     }
 
@@ -61,7 +59,7 @@ export default function createLink(
     let url = link ? link.trim() : '';
     if (url) {
         let formatter: () => void = null;
-        let linkData = matchLink(url, LinkMatchOption.Exact, defaultLinkMatchRules);
+        let linkData = matchLink(url);
         // matchLink can match most links, but not all, i.e. if you pass link a link as "abc", it won't match
         // we know in that case, users will want to insert a link like http://abc
         // so we have separate logic in applyLinkPrefix to add link prefix depending on the format of the link

--- a/packages/roosterjs-editor-api/lib/linkMatch/defaultLinkMatchRules.ts
+++ b/packages/roosterjs-editor-api/lib/linkMatch/defaultLinkMatchRules.ts
@@ -56,7 +56,7 @@ const waisMatchingRegEx = /^wais:\S+/i;
 
 // Default match rules that will be used in matching a link
 const defaultLinkMatchRules: LinkMatchRule[] = [
-    new RegExLinkMatchRule('http', 'http' + '://', httpMatchingRegEx, httpExcludeRegEx),
+    new RegExLinkMatchRule('http', 'http://', httpMatchingRegEx, httpExcludeRegEx),
     new RegExLinkMatchRule('https', 'https://', httpsMatchingRegEx, httpExcludeRegEx),
     new RegExLinkMatchRule('mailto', 'mailto:', mailtoMatchingRegEx),
     new RegExLinkMatchRule('notes', 'notes://', notesMatchingRegEx),

--- a/packages/roosterjs-editor-api/lib/linkMatch/matchLink.ts
+++ b/packages/roosterjs-editor-api/lib/linkMatch/matchLink.ts
@@ -1,11 +1,18 @@
+import defaultLinkMatchRules from './defaultLinkMatchRules';
 import { LinkData, LinkMatchOption, LinkMatchRule } from 'roosterjs-editor-types';
 
-// Match a url against the rules
-function matchLink(url: string, option: LinkMatchOption, rules: LinkMatchRule[]): LinkData {
-    if (!url || !rules || rules.length == 0) {
+/**
+ * Try to match a given string with link match rules, return matched link
+ * @param url Input url to match
+ * @param option Link match option, exact or partial
+ * @param rules Optional link match rules
+ */
+function matchLink(url: string, option: LinkMatchOption = LinkMatchOption.Exact, rules?: LinkMatchRule[]): LinkData {
+    if (!url) {
         return null;
     }
 
+    rules = rules || defaultLinkMatchRules;
     let matchedLink: LinkData = null;
     for (let rule of rules) {
         let link = rule.include(url);

--- a/packages/roosterjs-editor-api/lib/test/linkMatch/defaultLinkMatchRulesTests.ts
+++ b/packages/roosterjs-editor-api/lib/test/linkMatch/defaultLinkMatchRulesTests.ts
@@ -21,29 +21,29 @@ function runMatchTestWithBadLink(link: string, matchOption: LinkMatchOption): vo
 }
 
 describe('defaultLinkMatchRules regular http links with extact match', () => {
-    it('http' + '://www.bing.com', () => {
-        let link = 'http' + '://www.bing.com';
+    it('http://www.bing.com', () => {
+        let link = 'http://www.bing.com';
         runMatchTestWithValidLink(
             link,
-            { scheme: 'http', prefix: 'http' + '://', originalUrl: link, normalizedUrl: link },
+            { scheme: 'http', prefix: 'http://', originalUrl: link, normalizedUrl: link },
             LinkMatchOption.Exact
         );
     });
 
-    it('http' + '://www.bing.com/', () => {
-        let link = 'http' + '://www.bing.com/';
+    it('http://www.bing.com/', () => {
+        let link = 'http://www.bing.com/';
         runMatchTestWithValidLink(
             link,
-            { scheme: 'http', prefix: 'http' + '://', originalUrl: link, normalizedUrl: link },
+            { scheme: 'http', prefix: 'http://', originalUrl: link, normalizedUrl: link },
             LinkMatchOption.Exact
         );
     });
 
-    it('http' + '://www.lifewire.com/how-torrent-downloading-works-2483513', () => {
-        let link = 'http' + '://www.lifewire.com/how-torrent-downloading-works-2483513';
+    it('http://www.lifewire.com/how-torrent-downloading-works-2483513', () => {
+        let link = 'http://www.lifewire.com/how-torrent-downloading-works-2483513';
         runMatchTestWithValidLink(
             link,
-            { scheme: 'http', prefix: 'http' + '://', originalUrl: link, normalizedUrl: link },
+            { scheme: 'http', prefix: 'http://', originalUrl: link, normalizedUrl: link },
             LinkMatchOption.Exact
         );
     });
@@ -56,9 +56,9 @@ describe('defaultLinkMatchRules regular www links with extact match', () => {
             link,
             {
                 scheme: 'http',
-                prefix: 'http' + '://',
+                prefix: 'http://',
                 originalUrl: link,
-                normalizedUrl: 'http' + '://' + link,
+                normalizedUrl: 'http://' + link,
             },
             LinkMatchOption.Exact
         );
@@ -112,9 +112,9 @@ describe('defaultLinkMatchRules special http links that has % and @, but is vali
             link,
             {
                 scheme: 'http',
-                prefix: 'http' + '://',
+                prefix: 'http://',
                 originalUrl: link,
-                normalizedUrl: 'http' + '://' + link,
+                normalizedUrl: 'http://' + link,
             },
             LinkMatchOption.Exact
         );
@@ -127,9 +127,9 @@ describe('defaultLinkMatchRules special http links that has % and @, but is vali
             link,
             {
                 scheme: 'http',
-                prefix: 'http' + '://',
+                prefix: 'http://',
                 originalUrl: link,
-                normalizedUrl: 'http' + '://' + link,
+                normalizedUrl: 'http://' + link,
             },
             LinkMatchOption.Exact
         );
@@ -142,20 +142,20 @@ describe('defaultLinkMatchRules special http links that has % and @, but is vali
             link,
             {
                 scheme: 'http',
-                prefix: 'http' + '://',
+                prefix: 'http://',
                 originalUrl: link,
-                normalizedUrl: 'http' + '://' + link,
+                normalizedUrl: 'http://' + link,
             },
             LinkMatchOption.Exact
         );
     });
 
-    it('http' + '://www.test.com/?test=test%hhit', () => {
+    it('http://www.test.com/?test=test%hhit', () => {
         // URL: http://www.test.com/?test=test%hhit => %h is invalid encoding, but URL is valid since it is after ?
-        let link = 'http' + '://www.test.com/?test=test%hhit';
+        let link = 'http://www.test.com/?test=test%hhit';
         runMatchTestWithValidLink(
             link,
-            { scheme: 'http', prefix: 'http' + '://', originalUrl: link, normalizedUrl: link },
+            { scheme: 'http', prefix: 'http://', originalUrl: link, normalizedUrl: link },
             LinkMatchOption.Exact
         );
     });
@@ -167,9 +167,9 @@ describe('defaultLinkMatchRules special http links that has % and @, but is vali
             link,
             {
                 scheme: 'http',
-                prefix: 'http' + '://',
+                prefix: 'http://',
                 originalUrl: link,
-                normalizedUrl: 'http' + '://' + link,
+                normalizedUrl: 'http://' + link,
             },
             LinkMatchOption.Exact
         );
@@ -182,34 +182,34 @@ describe('defaultLinkMatchRules special http links that has % and @, but is vali
             link,
             {
                 scheme: 'http',
-                prefix: 'http' + '://',
+                prefix: 'http://',
                 originalUrl: link,
-                normalizedUrl: 'http' + '://' + link,
+                normalizedUrl: 'http://' + link,
             },
             LinkMatchOption.Exact
         );
     });
 
-    it('http' + '://www.test.com/kitty@supercute.com', () => {
+    it('http://www.test.com/kitty@supercute.com', () => {
         // URL: http://www.test.com/kitty@supercute.com @ is valid when it is after / for URL that has http:// prefix
-        let link = 'http' + '://www.test.com/kitty@supercute.com';
+        let link = 'http://www.test.com/kitty@supercute.com';
         runMatchTestWithValidLink(
             link,
-            { scheme: 'http', prefix: 'http' + '://', originalUrl: link, normalizedUrl: link },
+            { scheme: 'http', prefix: 'http://', originalUrl: link, normalizedUrl: link },
             LinkMatchOption.Exact
         );
     });
 });
 
 describe('defaultLinkMatchRules invalid http links with % and @ in URL', () => {
-    it('http' + '://www.test%00it.com/', () => {
+    it('http://www.test%00it.com/', () => {
         // %00 is invalid percent encoding
-        runMatchTestWithBadLink('http' + '://www.test%00it.com/', LinkMatchOption.Exact);
+        runMatchTestWithBadLink('http://www.test%00it.com/', LinkMatchOption.Exact);
     });
 
-    it('http' + '://www.test%hhit.com/', () => {
+    it('http://www.test%hhit.com/', () => {
         // %h is invalid percent encoding
-        runMatchTestWithBadLink('http' + '://www.test%hhit.com/', LinkMatchOption.Exact);
+        runMatchTestWithBadLink('http://www.test%hhit.com/', LinkMatchOption.Exact);
     });
 
     it('www.test%0hit.com/', () => {
@@ -244,15 +244,15 @@ describe('defaultLinkMatchRules exact match with extra space and text', () => {
 });
 
 describe('defaultLinkMatchRules partial match with extra space', () => {
-    it('http' + '://www.bing.com more', () => {
-        let link = 'http' + '://www.bing.com more';
-        let matchedLink = 'http' + '://www.bing.com';
+    it('http://www.bing.com more', () => {
+        let link = 'http://www.bing.com more';
+        let matchedLink = 'http://www.bing.com';
         // It should match since it is a partial match
         runMatchTestWithValidLink(
             link,
             {
                 scheme: 'http',
-                prefix: 'http' + '://',
+                prefix: 'http://',
                 originalUrl: matchedLink,
                 normalizedUrl: matchedLink,
             },

--- a/packages/roosterjs-editor-api/lib/test/linkMatch/matchLinkTests.ts
+++ b/packages/roosterjs-editor-api/lib/test/linkMatch/matchLinkTests.ts
@@ -4,7 +4,7 @@ import { LinkMatchOption } from 'roosterjs-editor-types';
 
 describe('matchLink', () => {
     it('exclude override test', () => {
-        let regexRule = new RegExLinkMatchRule('http', 'http' + '://', /http:\/\/\S+|www\.\S+/i);
+        let regexRule = new RegExLinkMatchRule('http', 'http://', /http:\/\/\S+|www\.\S+/i);
 
         // Spyon on exclude to return true
         spyOn(regexRule, 'exclude').and.returnValue(true);

--- a/tslint.json
+++ b/tslint.json
@@ -17,7 +17,6 @@
     "no-exec-script": true,
     "no-function-constructor-with-string-args": true,
     "no-function-expression": false,
-    "no-http-string": [true, "http://", "http://www.example.com/?.*", "http://www.examples.com/?.*"],
     "no-increment-decrement": false,
     "no-invalid-regexp": true,
     "no-for-in": true,


### PR DESCRIPTION
Use ExtractContentEvent to extract hyperlink content, avoid using mouseover/mouseout event in plugin.
Make LinkMatchOption parameter optional.