### PR TITLE
RoosterJs 6.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Framework-independent javascript editor",
   "repository": {
     "type": "git",

--- a/packages/roosterjs-editor-api/lib/format/removeLink.ts
+++ b/packages/roosterjs-editor-api/lib/format/removeLink.ts
@@ -1,6 +1,6 @@
 import execFormatWithUndo from './execFormatWithUndo';
 import queryNodesWithSelection from '../cursor/queryNodesWithSelection';
-import { unwrap } from 'roosterjs-editor-dom';
+import { normalizeEditorPoint, unwrap } from 'roosterjs-editor-dom';
 import { Editor } from 'roosterjs-editor-core';
 
 export default function removeLink(editor: Editor): void {
@@ -8,8 +8,23 @@ export default function removeLink(editor: Editor): void {
     let nodes = queryNodesWithSelection(editor, 'a[href]');
     if (nodes.length) {
         execFormatWithUndo(editor, () => {
+            let range = editor.getSelectionRange();
+            let startPoint = range
+                ? normalizeEditorPoint(range.startContainer, range.startOffset)
+                : null;
+            let endPoint = range ? normalizeEditorPoint(range.endContainer, range.endOffset) : null;
             for (let node of nodes) {
                 unwrap(node);
+            }
+            if (
+                range &&
+                editor.contains(startPoint.containerNode) &&
+                editor.contains(endPoint.containerNode)
+            ) {
+                let newRange = editor.getDocument().createRange();
+                newRange.setStart(startPoint.containerNode, startPoint.offset);
+                newRange.setEnd(endPoint.containerNode, endPoint.offset);
+                editor.updateSelection(newRange);
             }
         });
     }

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -69,11 +69,7 @@ export default class Editor {
      */
     constructor(private contentDiv: HTMLDivElement, options: EditorOptions = {}) {
         // 1. Make sure all parameters are valid
-        if (
-            !contentDiv ||
-            !(contentDiv instanceof HTMLDivElement) ||
-            contentDiv.tagName.toUpperCase() != 'DIV'
-        ) {
+        if (getTagOfNode(contentDiv) != 'DIV') {
             throw new Error('contentDiv must be an HTML DIV element');
         }
 
@@ -287,6 +283,9 @@ export default class Editor {
                     node,
                     option
                 );
+                break;
+            case ContentPosition.Outside:
+                this.contentDiv.parentNode.insertBefore(node, this.contentDiv.nextSibling);
                 break;
         }
 

--- a/packages/roosterjs-editor-dom/lib/test/utils/convertInlineCssTests.ts
+++ b/packages/roosterjs-editor-dom/lib/test/utils/convertInlineCssTests.ts
@@ -11,15 +11,15 @@ describe('convertInlineCss', () => {
 
     it('input = <style>div{font-size:12px}</style><div style="margin-top:0;">Test</div>', () => {
         runTest(
-            '<style>div{font-size:12px}</style><div style="margin-top:0;">Test</div>',
-            '<div style="font-size: 12px; margin-top: 0px;">Test</div>'
+            '<style>div{font-size: 12px}</style><div style="margin-top: 0;">Test</div>',
+            '<div style="font-size: 12px;margin-top: 0;">Test</div>'
         );
     });
 
     it('input = <style>div{font-size:12px}</style><style>div{background-color:#98a3a6}<div style="margin-top:0;">Test</div>', () => {
         runTest(
-            '<style>div{font-size:12px}</style><style>div{background-color:#98a3a6}</style><div style="margin-top:0;">Test</div>',
-            '<div style="font-size: 12px; background-color: rgb(152, 163, 166); margin-top: 0px;">Test</div>'
+            '<style>div{font-size: 12px}</style><style>div{background-color:#98a3a6}</style><div style="margin-top: 0;">Test</div>',
+            '<div style="font-size: 12px;background-color: rgb(152, 163, 166);margin-top: 0;">Test</div>'
         );
     });
 

--- a/packages/roosterjs-editor-dom/lib/utils/convertInlineCss.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/convertInlineCss.ts
@@ -114,7 +114,10 @@ export default function convertInlineCss(sourceHtml: string): string {
                             // Always put existing styles after so that they have higher priority
                             // Which means if both global style and inline style apply to the same element,
                             // inline style will have higher priority
-                            element.style.cssText = styleRule.style.cssText + element.style.cssText;
+                            element.setAttribute(
+                                'style',
+                                styleRule.style.cssText + element.getAttribute('style')
+                            );
                         }
                     }
                 }

--- a/packages/roosterjs-editor-types/lib/editor/ContentPosition.ts
+++ b/packages/roosterjs-editor-types/lib/editor/ContentPosition.ts
@@ -1,15 +1,28 @@
-// The position. Mostly used for content insertion and traversing
-// On insertion, we will need to specify where we want the content to be placed (begin, end or selection)
-// On content traversing, we will need to specify the start position of traversing
+/**
+ * The position. Mostly used for content insertion and traversing
+ * On insertion, we will need to specify where we want the content to be placed (begin, end, selection or outside)
+ * On content traversing, we will need to specify the start position of traversing
+ */
 const enum ContentPosition {
-    // Begin of the container
+    /**
+     * Begin of the container
+     */
     Begin,
 
-    // End of the container
+    /**
+     * End of the container
+     */
     End,
 
-    // Selection start
+    /**
+     * Selection start
+     */
     SelectionStart,
+
+    /**
+     * Outside of editor
+     */
+    Outside,
 }
 
 export default ContentPosition;


### PR DESCRIPTION
Fix several bugs
1. Fix the tag check in Editor class to allow creating editor in a different window
2. When paste text, insert the whole pasted node first then unwrap, to improve perf a little.
3. Persist cursor position when remove link
4. Paste, insert the hidden div right after editor to keep cursor not run out to far, allow each editor instance has its own hidden div
5. convertInlineCss, use get/setAttribute instead of cssText to persist non-standard css texts.