### PR TITLE
prevent fromHtml from accessing document directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "description": "Framework-independent javascript editor",
   "repository": {
     "type": "git",

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -238,7 +238,7 @@ export default class Editor {
     // Insert content into editor
     public insertContent(content: string, option?: InsertOption): void {
         if (content) {
-            let allNodes = fromHtml(content);
+            let allNodes = fromHtml(content, this.getDocument());
             // If it is to insert on new line, and there are more than one node in the collection, wrap all nodes with
             // a parent DIV before calling insertNode on each top level sub node. Otherwise, every sub node may get wrapped
             // separately to show up on its own line
@@ -547,7 +547,7 @@ export default class Editor {
                 // Only reason we don't get the selection block is that we have an empty content div
                 // which can happen when users removes everything (i.e. select all and DEL, or backspace from very end to begin)
                 // The fix is to add a DIV wrapping, apply default format and move cursor over
-                let nodes = fromHtml(HTML_EMPTY_DIV_BLOCK);
+                let nodes = fromHtml(HTML_EMPTY_DIV_BLOCK, this.getDocument());
                 let element = this.contentDiv.appendChild(nodes[0]) as HTMLElement;
                 applyFormat(element, this.defaultFormat);
                 // element points to a wrapping node we added "<div><br></div>". We should move the selection left to <br>
@@ -648,7 +648,7 @@ export default class Editor {
 
         if (!firstBlock) {
             // No first block, let's create one
-            let nodes = fromHtml(HTML_EMPTY_DIV_BLOCK);
+            let nodes = fromHtml(HTML_EMPTY_DIV_BLOCK, this.getDocument());
             defaultFormatBlockElement = this.contentDiv.appendChild(nodes[0]) as HTMLElement;
         } else if (firstBlock instanceof NodeBlockElement) {
             // There is a first block and it is a Node (P, DIV etc.) block

--- a/packages/roosterjs-editor-dom/lib/test/utils/fromHtmlTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/utils/fromHtmlTest.ts
@@ -3,19 +3,19 @@ import { NodeType } from 'roosterjs-editor-types';
 
 describe('EditorUitls fromHtml()', () => {
     it('htmlFragment = null', () => {
-        let result = fromHtml(null);
+        let result = fromHtml(null, document);
         expect(result.length).toBe(0);
     });
 
     it('htmlFragment = text', () => {
-        let result = fromHtml('text');
+        let result = fromHtml('text', document);
         expect(result.length).toBe(1);
         expect(result[0].nodeType).toBe(NodeType.Text);
         expect(result[0].nodeValue).toBe('text');
     });
 
     it('htmlFragment = <div>text</div>', () => {
-        let result = fromHtml('<div>text</div>');
+        let result = fromHtml('<div>text</div>', document);
         expect(result.length).toBe(1);
         expect(result[0].nodeType).toBe(NodeType.Element);
         expect((result[0] as HTMLElement).tagName).toBe('DIV');
@@ -23,7 +23,7 @@ describe('EditorUitls fromHtml()', () => {
     });
 
     it('htmlFragment = <div>text</div><br/>', () => {
-        let result = fromHtml('<div>text</div><br/>');
+        let result = fromHtml('<div>text</div><br/>', document);
         expect(result.length).toBe(2);
         expect(result[0].nodeType).toBe(NodeType.Element);
         expect((result[0] as HTMLElement).tagName).toBe('DIV');

--- a/packages/roosterjs-editor-dom/lib/utils/fromHtml.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/fromHtml.ts
@@ -1,6 +1,6 @@
 // Creates a HTMLElement array from html
-export default function fromHtml(htmlFragment: string): Node[] {
-    let element = document.createElement('DIV');
+export default function fromHtml(htmlFragment: string, ownerDocument: HTMLDocument): Node[] {
+    let element = ownerDocument.createElement('DIV');
     element.innerHTML = htmlFragment;
 
     let children: Node[] = [];

--- a/packages/roosterjs-editor-dom/lib/utils/wrap.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/wrap.ts
@@ -9,7 +9,7 @@ export default function wrap(node: Node, htmlFragment: string): Node {
     let wrapper = node;
 
     if (htmlFragment) {
-        wrapper = fromHtml(htmlFragment)[0];
+        wrapper = fromHtml(htmlFragment, node.ownerDocument)[0];
         if (node.parentNode) {
             node.parentNode.insertBefore(wrapper, node);
             node.parentNode.removeChild(node);

--- a/packages/roosterjs-editor-dom/lib/utils/wrapAll.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/wrapAll.ts
@@ -11,7 +11,7 @@ export default function wrapAll(nodes: Node[], htmlFragment: string): Node {
     let wrapper = parentNode;
 
     if (htmlFragment) {
-        wrapper = fromHtml(htmlFragment)[0];
+        wrapper = fromHtml(htmlFragment, parentNode.ownerDocument)[0];
         if (parentNode) {
             parentNode.insertBefore(wrapper, nodes[0]);
         }

--- a/packages/roosterjs-editor-plugins/lib/PasteManager/PasteManager.ts
+++ b/packages/roosterjs-editor-plugins/lib/PasteManager/PasteManager.ts
@@ -117,7 +117,7 @@ export default class PasteManager implements EditorPlugin {
         let originalSelectionRange = editor.getSelectionRange();
 
         if (!this.pasteContainer || !this.pasteContainer.parentNode) {
-            this.pasteContainer = fromHtml(CONTAINER_HTML)[0] as HTMLElement;
+            this.pasteContainer = fromHtml(CONTAINER_HTML, editor.getDocument())[0] as HTMLElement;
             editor.insertNode(this.pasteContainer, {
                 position: ContentPosition.Outside,
                 updateCursor: false,


### PR DESCRIPTION
For popouts, one cannot call document.createElement and expect it to be able to be adopted to the child window's document. For IE & Edge, those have to be created inside the ownerDocument of the child window.