### PR TITLE
Rooster 6.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "description": "Framework-independent javascript editor",
   "repository": {
     "type": "git",

--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -1,9 +1,9 @@
 import execFormatWithUndo from './execFormatWithUndo';
-import { Editor, browserData } from 'roosterjs-editor-core';
+import setBackgroundColor from './setBackgroundColor';
 import setFontName from './setFontName';
 import setFontSize from './setFontSize';
 import setTextColor from './setTextColor';
-import setBackgroundColor from './setBackgroundColor';
+import { Editor, browserData } from 'roosterjs-editor-core';
 
 export default function clearFormat(editor: Editor): void {
     editor.focus();

--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -1,11 +1,25 @@
 import execFormatWithUndo from './execFormatWithUndo';
-import { Editor } from 'roosterjs-editor-core';
+import { Editor, browserData } from 'roosterjs-editor-core';
+import setFontName from './setFontName';
+import setFontSize from './setFontSize';
+import setTextColor from './setTextColor';
+import setBackgroundColor from './setBackgroundColor';
 
 export default function clearFormat(editor: Editor): void {
     editor.focus();
     // We have no way if this clear format will really result in any DOM change
     // Let's just do it with undo
     execFormatWithUndo(editor, () => {
-        editor.getDocument().execCommand('removeFormat', false, null);
+        editor.runWithoutAddingUndoSnapshot(() => {
+            editor.getDocument().execCommand('removeFormat', false, null);
+
+            if (browserData.isEdge || browserData.isIE) {
+                let defaultFormat = editor.getDefaultFormat();
+                setFontName(editor, defaultFormat.fontFamily);
+                setFontSize(editor, defaultFormat.fontSize);
+                setTextColor(editor, defaultFormat.textColor);
+                setBackgroundColor(editor, defaultFormat.backgroundColor);
+            }
+        });
     });
 }

--- a/packages/roosterjs-editor-api/lib/format/setIndentation.ts
+++ b/packages/roosterjs-editor-api/lib/format/setIndentation.ts
@@ -1,11 +1,21 @@
 import execFormatWithUndo from './execFormatWithUndo';
 import { Editor } from 'roosterjs-editor-core';
 import { Indentation } from 'roosterjs-editor-types';
+import getFormatState from '../format/getFormatState';
+import queryNodesWithSelection from '../cursor/queryNodesWithSelection';
 
 export default function setIndentation(editor: Editor, indentation: Indentation): void {
     editor.focus();
     let command = indentation == Indentation.Increase ? 'indent' : 'outdent';
     execFormatWithUndo(editor, () => {
+        let format = getFormatState(editor);
         editor.getDocument().execCommand(command, false, null);
+        if (!format.isBullet && !format.isNumbering) {
+            let nodes = queryNodesWithSelection(editor, 'blockquote');
+            nodes.forEach(node => {
+                (<HTMLElement>node).style.marginTop = '0px';
+                (<HTMLElement>node).style.marginBottom = '0px';
+            });
+        }
     });
 }

--- a/packages/roosterjs-editor-api/lib/format/setIndentation.ts
+++ b/packages/roosterjs-editor-api/lib/format/setIndentation.ts
@@ -1,8 +1,8 @@
 import execFormatWithUndo from './execFormatWithUndo';
-import { Editor } from 'roosterjs-editor-core';
-import { Indentation } from 'roosterjs-editor-types';
 import getFormatState from '../format/getFormatState';
 import queryNodesWithSelection from '../cursor/queryNodesWithSelection';
+import { Editor } from 'roosterjs-editor-core';
+import { Indentation } from 'roosterjs-editor-types';
 
 export default function setIndentation(editor: Editor, indentation: Indentation): void {
     editor.focus();

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -39,6 +39,7 @@ import {
     applyFormat,
     contains,
     fromHtml,
+    getComputedStyle,
     getInlineElementAtNode,
     getFirstLeafNode,
     getFirstBlockElement,
@@ -74,7 +75,7 @@ export default class Editor {
         }
 
         // 2. Store options values to local variables
-        this.defaultFormat = options.defaultFormat;
+        this.setDefaultFormat(options.defaultFormat);
         this.plugins = options.plugins || [];
 
         // 3. Initialize plugins
@@ -449,6 +450,11 @@ export default class Editor {
         return getCursorRect(this.contentDiv);
     }
 
+    // Get default format of this editor
+    public getDefaultFormat(): DefaultFormat {
+        return this.defaultFormat;
+    }
+
     private bindEvents(): void {
         this.isBeforeDeactivateEventSupported = browserData.isIE || browserData.isEdge;
         this.contentDiv.addEventListener('keypress', this.onKeyPress);
@@ -735,5 +741,13 @@ export default class Editor {
         }
 
         return selectionRestored;
+    }
+
+    private setDefaultFormat(format: DefaultFormat) {
+        this.defaultFormat = format || {};
+        this.defaultFormat.fontFamily = this.defaultFormat.fontFamily || getComputedStyle(this.contentDiv, 'font-family');
+        this.defaultFormat.fontSize = this.defaultFormat.fontSize || getComputedStyle(this.contentDiv, 'font-size');
+        this.defaultFormat.textColor = this.defaultFormat.textColor || getComputedStyle(this.contentDiv, 'color');
+        this.defaultFormat.backgroundColor = this.defaultFormat.backgroundColor || getComputedStyle(this.contentDiv, 'background-color');
     }
 }

--- a/packages/roosterjs-editor-dom/lib/utils/applyFormat.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/applyFormat.ts
@@ -13,6 +13,9 @@ export default function applyFormat(element: HTMLElement, format: DefaultFormat)
         if (format.textColor) {
             elementStyle.color = format.textColor;
         }
+        if (format.backgroundColor) {
+            elementStyle.backgroundColor = format.backgroundColor;
+        }
         if (format.bold) {
             elementStyle.fontWeight = 'bold';
         }

--- a/packages/roosterjs-editor-types/lib/editor/DefaultFormat.ts
+++ b/packages/roosterjs-editor-types/lib/editor/DefaultFormat.ts
@@ -9,6 +9,9 @@ interface DefaultFormat {
     // Text color
     textColor?: string;
 
+    // Background Color
+    backgroundColor?: string;
+
     // Whether is bold
     bold?: boolean;
 


### PR DESCRIPTION
1. Fix clear format behavior for IE and Edge
2. Fix Indent command to remove top and bottom margin.