### PR TITLE
RoosterJs 6.4.0: Add APIs, some other fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs",
-  "version": "6.3.6",
+  "version": "6.4.0",
   "description": "Framework-independent javascript editor",
   "repository": {
     "type": "git",

--- a/packages/roosterjs-editor-api/lib/format/insertImage.ts
+++ b/packages/roosterjs-editor-api/lib/format/insertImage.ts
@@ -1,0 +1,16 @@
+import { Editor } from 'roosterjs-editor-core';
+
+export default function insertImage(editor: Editor, imageFile: File) {
+    editor.addUndoSnapshot();
+    let reader = new FileReader();
+    reader.onload = (event: ProgressEvent) => {
+        if (!editor.isDisposed()) {
+            let image = editor.getDocument().createElement('img');
+            image.src = (event.target as FileReader).result;
+            image.style.maxWidth = '100%';
+            editor.insertNode(image);
+            editor.addUndoSnapshot();
+        }
+    };
+    reader.readAsDataURL(imageFile);
+}

--- a/packages/roosterjs-editor-api/lib/format/insertImage.ts
+++ b/packages/roosterjs-editor-api/lib/format/insertImage.ts
@@ -1,4 +1,5 @@
 import { Editor } from 'roosterjs-editor-core';
+import { PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 
 export default function insertImage(editor: Editor, imageFile: File) {
     editor.addUndoSnapshot();
@@ -9,6 +10,10 @@ export default function insertImage(editor: Editor, imageFile: File) {
             image.src = (event.target as FileReader).result;
             image.style.maxWidth = '100%';
             editor.insertNode(image);
+            editor.triggerEvent({
+                eventType: PluginEventType.ContentChanged,
+                source: 'Format',
+            } as PluginEvent);
             editor.addUndoSnapshot();
         }
     };

--- a/packages/roosterjs-editor-api/lib/format/insertTable.ts
+++ b/packages/roosterjs-editor-api/lib/format/insertTable.ts
@@ -1,0 +1,56 @@
+import { Editor } from 'roosterjs-editor-core';
+import execFormatWithUndo from './execFormatWithUndo';
+
+const ZERO_WIDTH_SPACE = '&#8203;';
+
+export interface TableFormat {
+    cellSpacing?: string;
+    cellPadding?: string;
+    borderWidth?: string;
+    borderStyle?: string;
+    borderColor?: string;
+    borderCollapse?: string;
+}
+
+export default function insertTable(editor: Editor, columns: number, rows: number, format?: TableFormat) {
+    let document = editor.getDocument();
+    let fragment = document.createDocumentFragment();
+    let table = document.createElement('table') as HTMLTableElement;
+    fragment.appendChild(table);
+    table.cellSpacing = (format && format.cellSpacing) || '0';
+    table.cellPadding = (format && format.cellPadding) || '0';
+    buildBorderStyle(table, format);
+    for (let i = 0; i < rows; i++) {
+        let tr = document.createElement('tr') as HTMLTableRowElement;
+        table.appendChild(tr);
+        for (let j = 0; j < columns; j++) {
+            let td = document.createElement('td') as HTMLTableCellElement;
+            tr.appendChild(td);
+            buildBorderStyle(td, format);
+            td.style.width = getTableCellWidth(columns);
+            td.innerHTML = ZERO_WIDTH_SPACE;
+        }
+    }
+
+    execFormatWithUndo(editor, () => {
+        editor.insertNode(fragment);
+    });
+}
+
+function buildBorderStyle(node: HTMLElement, format: TableFormat) {
+    format = format || {};
+    node.style.borderWidth = format.borderWidth || '1px';
+    node.style.borderStyle = format.borderStyle || 'solid';
+    node.style.borderColor = format.borderColor || '#c6c6c6';
+    node.style.borderCollapse = format.borderCollapse || 'collapse';
+}
+
+function getTableCellWidth(columns: number): string {
+    if (columns <= 4) {
+        return '120px';
+    } else if (columns <= 6) {
+        return '100px';
+    } else {
+        return '70px';
+    }
+}

--- a/packages/roosterjs-editor-api/lib/index.ts
+++ b/packages/roosterjs-editor-api/lib/index.ts
@@ -16,6 +16,8 @@ export { default as clearFormat } from './format/clearFormat';
 export { default as createLink } from './format/createLink';
 export { default as execFormatWithUndo } from './format/execFormatWithUndo';
 export { default as getFormatState } from './format/getFormatState';
+export { default as insertImage } from './format/insertImage';
+export { default as insertTable } from './format/insertTable';
 export { default as removeLink } from './format/removeLink';
 export { default as setAlignment } from './format/setAlignment';
 export { default as setBackgroundColor } from './format/setBackgroundColor';

--- a/packages/roosterjs-editor-api/lib/test/format/clearFormatTest.ts
+++ b/packages/roosterjs-editor-api/lib/test/format/clearFormatTest.ts
@@ -37,6 +37,6 @@ describe('clearFormat()', () => {
         clearFormat(editor);
 
         // Assert
-        expect(editor.getContent()).toBe('<div id="text" style="">text</div>');
+        expect(editor.getContent()).toBe('<div id="text" style=""><span style="font-family: &quot;times new roman&quot;; font-size: 16px; color: black; background-color: rgba(0, 0, 0, 0);">text</span></div>');
     });
 });

--- a/packages/roosterjs-editor-core/lib/editor/EditorOptions.ts
+++ b/packages/roosterjs-editor-core/lib/editor/EditorOptions.ts
@@ -8,6 +8,7 @@ interface EditorOptions {
     defaultFormat?: DefaultFormat;
     undo?: UndoService;
     initialContent?: string;
+    doNotRestoreSelectionOnFocus?: boolean;
 }
 
 export default EditorOptions;

--- a/packages/roosterjs-editor-core/lib/undo/Undo.ts
+++ b/packages/roosterjs-editor-core/lib/undo/Undo.ts
@@ -132,7 +132,7 @@ export default class Undo implements UndoService {
     private restoreSnapshot(delta: number) {
         let snapshot = this.getSnapshotsManager().move(delta);
 
-        if (snapshot) {
+        if (snapshot != null) {
             try {
                 this.isRestoring = true;
                 restoreSnapshot(this.editor, snapshot);

--- a/packages/roosterjs-editor-core/lib/utils/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/utils/insertNode.ts
@@ -143,9 +143,10 @@ export function insertNodeAtSelection(
             selectionRange.collapse(false /*toStart*/);
         }
 
+        let nodeForCursor = node.nodeType == NodeType.DocumentFragment ? node.lastChild : node;
         selectionRange.insertNode(node);
-        if (option.updateCursor) {
-            selectionRange.setEndAfter(node);
+        if (option.updateCursor && nodeForCursor) {
+            selectionRange.setEndAfter(nodeForCursor);
             selectionRange.collapse(false /*toStart*/);
             updateSelectionToRange(container.ownerDocument, selectionRange);
         } else {

--- a/packages/roosterjs-editor-dom/lib/utils/convertInlineCss.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/convertInlineCss.ts
@@ -68,14 +68,14 @@ function convertThroughRegEx(sourceHtml: string): string {
 /**
  * Convert CSS from header or external, to inline CSS
  */
-export default function convertInlineCss(sourceHtml: string): string {
+export default function convertInlineCss(sourceHtml: string, additionalStyleNodes?: HTMLStyleElement[]): string {
     // Skip for empty string
     if (!sourceHtml) {
         return '';
     }
 
     // If there's no stylesheet, just return
-    if (!STYLEORLINK_REGEX.test(sourceHtml)) {
+    if (!STYLEORLINK_REGEX.test(sourceHtml) && !additionalStyleNodes) {
         return convertThroughRegEx(sourceHtml);
     }
     // Always add <!doctype html> if source html doesn't have doctype
@@ -89,8 +89,15 @@ export default function convertInlineCss(sourceHtml: string): string {
         contentDocument.write(sourceHtml);
         contentDocument.close();
 
+        let styleSheets: CSSStyleSheet[] = [];
+        for (let i = (additionalStyleNodes ? additionalStyleNodes.length - 1 : -1); i >= 0; i--) {
+            styleSheets.push(additionalStyleNodes[i].sheet as CSSStyleSheet);
+        }
         for (let i = contentDocument.styleSheets.length - 1; i >= 0; i--) {
-            let styleSheet = contentDocument.styleSheets[i] as CSSStyleSheet;
+            styleSheets.push(contentDocument.styleSheets[i] as CSSStyleSheet);
+        }
+
+        for (let styleSheet of styleSheets) {
             for (let j = styleSheet.cssRules.length - 1; j >= 0; j--) {
                 // Skip any none-style rule, i.e. @page
                 let cssRule = styleSheet.cssRules[j];
@@ -116,7 +123,7 @@ export default function convertInlineCss(sourceHtml: string): string {
                             // inline style will have higher priority
                             element.setAttribute(
                                 'style',
-                                styleRule.style.cssText + element.getAttribute('style')
+                                styleRule.style.cssText + (element.getAttribute('style') || '')
                             );
                         }
                     }

--- a/packages/roosterjs-editor-plugins/lib/PasteManager/PasteManager.ts
+++ b/packages/roosterjs-editor-plugins/lib/PasteManager/PasteManager.ts
@@ -8,10 +8,9 @@ import {
 } from 'roosterjs-editor-types';
 import { Editor, EditorPlugin } from 'roosterjs-editor-core';
 import { processImages } from './PasteUtility';
-import { fromHtml, unwrap } from 'roosterjs-editor-dom';
+import { fromHtml } from 'roosterjs-editor-dom';
 import { insertImage } from 'roosterjs-editor-api';
 import convertPastedContentFromWord from './wordConverter/convertPastedContentFromWord';
-import convertInlineCss from 'roosterjs-editor-dom/lib/utils/convertInlineCss';
 
 const INLINE_POSITION_STYLE = /(<\w+[^>]*style=['"][^>]*)position:[^>;'"]*/gi;
 const TEXT_WITH_BR_ONLY = /^[^<]*(<br>[^<]*)+$/i;

--- a/packages/roosterjs-editor-plugins/lib/PasteManager/wordConverter/convertPastedContentFromWord.ts
+++ b/packages/roosterjs-editor-plugins/lib/PasteManager/wordConverter/convertPastedContentFromWord.ts
@@ -3,7 +3,7 @@ import { createWordConverterArguments } from './WordConverterArguments';
 import { processNodesDiscovery, processNodeConvert } from './converterUtils';
 
 /** Converts all the Word generated list items in the specified node into standard HTML UL and OL tags */
-export default function convertPastedContentFromWord(root: HTMLElement) {
+export default function convertPastedContentFromWord(root: NodeSelector) {
     let wordConverter = createWordConverter();
 
     // First find all the nodes that we need to check for list item information

--- a/sample/sample.htm
+++ b/sample/sample.htm
@@ -283,6 +283,10 @@
                 <button id="undoButton">Undo</button>
                 <button id="redoButton">Redo</button>
                 &nbsp;
+                <button id="insertImage">Insert Image</button>
+                <button id="insertTable">Insert Table</button>
+                <input style='display: none' type='file' id='selectFile' accept='image/*'>
+                &nbsp;
                 <button id="clearFormatButton">Clear Format</button>
             </div>
         </div>

--- a/sample/scripts/initFormatBar.ts
+++ b/sample/scripts/initFormatBar.ts
@@ -1,6 +1,8 @@
 import {
     clearFormat,
     createLink,
+    insertImage,
+    insertTable,
     toggleBold,
     toggleItalic,
     toggleUnderline,
@@ -79,6 +81,29 @@ export default function initFormatBar() {
     // ClearFormat
     document.getElementById('clearFormatButton').addEventListener('click', function() {
         clearFormat(getCurrentEditor());
+    });
+
+    // Insert Table
+    document.getElementById('insertTable').addEventListener('click', function() {
+        let columns = Math.min(parseInt(window.prompt('How many columns?')), 10);
+        let rows = Math.min(parseInt(window.prompt('How many rows?')), 10);
+        if (columns > 0 && rows > 0) {
+            insertTable(getCurrentEditor(), columns, rows);
+        }
+    });
+
+    // Insert Image
+    document.getElementById('insertImage').addEventListener('click', function() {
+        (document.getElementById('selectFile') as HTMLInputElement).click();
+    });
+
+    document.getElementById('selectFile').addEventListener('change', function () {
+        let input = document.getElementById('selectFile') as HTMLInputElement;
+        let file = input.files[0];
+        if (file) {
+            insertImage(getCurrentEditor(), file);
+            input.value = '';
+        }
     });
 
     // Indent


### PR DESCRIPTION
1. Add API: insertTable
2. Add API: insertImage, change pasteManager to use this API
3. Add an editor option param "doNotRestoreSelectionOnFocus", when set it to true, editor will not restore selection when focus
4. Fix a code bug in undo: we should allow empty undo snapshot ( #23 )
5. Fix insertNode API to allow insert a HTML fragment
6. Fix pasteManager to use HtmlDocumentFragment to have a better performance
7. Allow passing in extra Css Style node to convertInlineCss API
8. Add buttons for insertTable and insertImage in sample page