### PR TITLE
Allow empty default format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs",
-  "version": "6.10.3",
+  "version": "6.10.4",
   "description": "Framework-independent javascript editor",
   "repository": {
     "type": "git",

--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -1,5 +1,8 @@
 import execFormatWithUndo from './execFormatWithUndo';
 import setBackgroundColor from './setBackgroundColor';
+import toggleBold from './toggleBold';
+import toggleItalic from './toggleItalic';
+import toggleUnderline from './toggleUnderline';
 import setFontName from './setFontName';
 import setFontSize from './setFontSize';
 import setTextColor from './setTextColor';
@@ -23,20 +26,38 @@ export default function clearFormat(editor: Editor) {
             editor.getDocument().execCommand('removeFormat', false, null);
 
             let nodes = queryNodesWithSelection(editor, '[class]');
-            for (let node of nodes) {
+            for (const node of nodes) {
                 (<HTMLElement>node).removeAttribute('class');
             }
 
+            const defaultFormat = editor.getDefaultFormat();
+            const isDefaultFormatEmpty = Object.keys(defaultFormat).length === 0;
             nodes = queryNodesWithSelection(editor, '[style]', true /*nodeContainedByRangeOnly*/);
-            for (let node of nodes) {
+            for (const node of nodes) {
                 STYLES_TO_REMOVE.forEach(style => (<HTMLElement>node).style.removeProperty(style));
+
+                // when default format is empty, keep the HTML minimum by removing style attribute if there's no style
+                // (note: because default format is empty, we're not adding style back in)
+                if (isDefaultFormatEmpty && node.getAttribute('style') === '') {
+                    node.removeAttribute('style');
+                }
             }
 
-            let defaultFormat = editor.getDefaultFormat();
-            setFontName(editor, defaultFormat.fontFamily);
-            setFontSize(editor, defaultFormat.fontSize);
-            setTextColor(editor, defaultFormat.textColor);
-            setBackgroundColor(editor, defaultFormat.backgroundColor);
+            if (!isDefaultFormatEmpty) {
+                setFontName(editor, defaultFormat.fontFamily);
+                setFontSize(editor, defaultFormat.fontSize);
+                setTextColor(editor, defaultFormat.textColor);
+                setBackgroundColor(editor, defaultFormat.backgroundColor);
+                if (defaultFormat.bold) {
+                    toggleBold(editor);
+                }
+                if (defaultFormat.italic) {
+                    toggleItalic(editor);
+                }
+                if (defaultFormat.underline) {
+                    toggleUnderline(editor);
+                }
+            }
         });
     });
 }

--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -33,6 +33,10 @@ export default function createEditorCore(
 }
 
 function calcDefaultFormat(node: Node, baseFormat: DefaultFormat): DefaultFormat {
+    if (baseFormat && Object.keys(baseFormat).length === 0 ) {
+        return {};
+    }
+
     baseFormat = baseFormat || <DefaultFormat>{};
     return {
         fontFamily: baseFormat.fontFamily || getComputedStyle(node, 'font-family'),

--- a/sample/sample.htm
+++ b/sample/sample.htm
@@ -166,6 +166,7 @@
                         <div><input type="checkbox" id="underlineCheckbox"><label for="underlineCheckbox">Underline</label></div>
                         <div>Text color:
                             <select id="textColorDefaultFormat" title="Text Color">
+                                <option value="" selected>(Inherit)</option>
                                 <option value="#757b80">Gray</option>
                                 <option value="#bd1398">Violet</option>
                                 <option value="#7232ad">Purple</option>
@@ -175,13 +176,14 @@
                                 <option value="#d05c12">Orange</option>
                                 <option value="#ff0000">Red</option>
                                 <option value="#ffffff">White</option>
-                                <option value="#000000" selected>Black</option>
+                                <option value="#000000">Black</option>
                             </select>
                         </div>
                         <div>Font name:
                             <select id="fontNameDefaultFormat" title="Font Name">
+                                <option value="" selected>(Inherit)</option>
                                 <option value="Arial">Arial</option>
-                                <option value="Calibri" selected>Calibri</option>
+                                <option value="Calibri">Calibri</option>
                                 <option value="Courier New">Courier New</option>
                                 <option value="Tahoma">Tahoma</option>
                                 <option value="Times New Roman">Times New Roman</option>

--- a/sample/scripts/initOptions.ts
+++ b/sample/scripts/initOptions.ts
@@ -88,12 +88,14 @@ export function initEditorForOptions() {
     if ((document.getElementById('underlineCheckbox') as HTMLInputElement).checked) {
         defaultFormat.underline = true;
     }
-    defaultFormat.textColor = (document.getElementById(
-        'textColorDefaultFormat'
-    ) as HTMLInputElement).value;
-    defaultFormat.fontFamily = (document.getElementById(
-        'fontNameDefaultFormat'
-    ) as HTMLInputElement).value;
+    const textColor = (document.getElementById('textColorDefaultFormat') as HTMLInputElement).value;
+    if (textColor) {
+        defaultFormat.textColor = textColor;
+    }
+    const fontFamily = (document.getElementById('fontNameDefaultFormat') as HTMLInputElement).value;
+    if (fontFamily) {
+        defaultFormat.fontFamily = fontFamily;
+    }
     let editorOptions: EditorOptions = {
         plugins: plugins,
         defaultFormat: defaultFormat,

--- a/sample/scripts/updateSampleCode.ts
+++ b/sample/scripts/updateSampleCode.ts
@@ -118,8 +118,12 @@ function assembleFormatString(defaultFormat: DefaultFormat): string {
     if (defaultFormat.underline) {
         defaultFormatString += '  underline: true,\n';
     }
-    defaultFormatString += `  textColor: \"${defaultFormat.textColor}\",\n`;
-    defaultFormatString += `  fontFamily: \"${defaultFormat.fontFamily}\",\n`;
+    if (defaultFormat.textColor) {
+        defaultFormatString += `  textColor: \"${defaultFormat.textColor}\",\n`;
+    }
+    if (defaultFormat.fontFamily) {
+        defaultFormatString += `  fontFamily: \"${defaultFormat.fontFamily}\",\n`;
+    }
     defaultFormatString += '};\n';
     return defaultFormatString;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+const devServerPort = 3000;
+
 module.exports = {
     entry: './sample/scripts/sample.ts',
     devtool: 'source-map',
@@ -23,6 +25,9 @@ module.exports = {
     stats: "minimal",
     devServer: {
         host: "0.0.0.0", // This makes the server public so that others can test by http://hostname ...
-        port: 3000
+        port: devServerPort,
+        open: true,
+        openPage: "sample/sample.htm",
+        public: "localhost:" + devServerPort
     }
-}
+};


### PR DESCRIPTION
Also set bold, italic, and underline if it's in the default format, when clearing format.