### PR TITLE
Fixed HyperLink plugin's TEMP_TITLE_REGEX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs",
-  "version": "6.10.8",
+  "version": "6.10.9",
   "description": "Framework-independent javascript editor",
   "repository": {
     "type": "git",

--- a/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
@@ -17,7 +17,7 @@ import { Editor, EditorPlugin, browserData } from 'roosterjs-editor-core';
 // When user type, they may end a link with a puncatuation, i.e. www.bing.com;
 // we need to trim off the trailing puncatuation before turning it to link match
 const TRAILING_PUNCTUATION_REGEX = /[.()+={}\[\]\s:;"',>]+$/i;
-const TEMP_TITLE_REGEX = /<a\s+([^>]*\s+)?(title|istemptitle)="[^"]*"\s*([^>]*)\s+(title|istemptitle)="[^"]*"(\s+[^>]*)?>/gm;
+const TEMP_TITLE_REGEX = /<a\s+(([^>]*)\s+)?(title|istemptitle)="[^"]*"(\s*[^>]*)\s+(title|istemptitle)="[^"]*"(\s+[^>]*)?>/gm;
 const TEMP_TITLE = 'istemptitle';
 const MINIMUM_LENGTH = 5;
 const KEY_BACKSPACE = 8;
@@ -176,7 +176,7 @@ export default class HyperLink implements EditorPlugin {
     }
 
     private removeTempTooltip(content: string): string {
-        return content.replace(TEMP_TITLE_REGEX, '<a $1$3$5>');
+        return content.replace(TEMP_TITLE_REGEX, '<a $2$4$6>');
     }
 
     private onClickLink = (keyboardEvent: KeyboardEvent) => {

--- a/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
@@ -17,8 +17,8 @@ import { Editor, EditorPlugin, browserData } from 'roosterjs-editor-core';
 // When user type, they may end a link with a puncatuation, i.e. www.bing.com;
 // we need to trim off the trailing puncatuation before turning it to link match
 const TRAILING_PUNCTUATION_REGEX = /[.()+={}\[\]\s:;"',>]+$/i;
-const TEMP_TITLE_REGEX = /<a\s+(([^>]*)\s+)?(title|istemptitle)="[^"]*"(\s*[^>]*)\s+(title|istemptitle)="[^"]*"(\s+[^>]*)?>/gm;
 const TEMP_TITLE = 'istemptitle';
+const TEMP_TITLE_REGEX = new RegExp(`<a\\s+([^>]*\\s+)?(title|${TEMP_TITLE})="[^"]*"\\s*([^>]*)\\s+(title|${TEMP_TITLE})="[^"]*"(\\s+[^>]*)?>`, 'gm');
 const MINIMUM_LENGTH = 5;
 const KEY_BACKSPACE = 8;
 const KEY_SPACE = 32;
@@ -176,7 +176,33 @@ export default class HyperLink implements EditorPlugin {
     }
 
     private removeTempTooltip(content: string): string {
-        return content.replace(TEMP_TITLE_REGEX, '<a $2$4$6>');
+        return content.replace(TEMP_TITLE_REGEX, (...groups: string[]): string => {
+            const firstValue = groups[1] == null ? "" : groups[1].trim();
+            const secondValue = groups[3] == null ? "" : groups[3].trim();
+            const thirdValue = groups[5] == null ? "" : groups[5].trim();
+
+            // possible values (* is space, x, y, z are the first, second, and third value respectively):
+            // *** (no values) << empty case
+            // x** (first value only)
+            // *x* (second value only)
+            // **x (third value only)
+            // x*y* (first and second)
+            // x**z (first and third) << double spaces
+            // *y*z (second and third)
+            // x*y*z (all)
+            if (firstValue.length === 0 && secondValue.length === 0 && thirdValue.length === 0) {
+                return "<a>";
+            }
+
+            let result;
+            if (secondValue.length === 0) {
+                result = `${firstValue} ${thirdValue}`;
+            } else {
+                result = `${firstValue} ${secondValue} ${thirdValue}`;
+            }
+
+            return `<a ${result.trim()}>`;
+        });
     }
 
     private onClickLink = (keyboardEvent: KeyboardEvent) => {


### PR DESCRIPTION
Fixed HyperLink plugin's TEMP_TITLE_REGEX where after replace anchor tag has an extra space (i.e. &lt;a href="..." &gt;foo&lt;/a&gt;). This creates dirty content when getContent is called.