### PR TITLE
6.14.9 Fix cursor position issue in PickerPlugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs",
-  "version": "6.14.8",
+  "version": "6.14.9",
   "description": "Framework-independent javascript editor",
   "repository": {
     "type": "git",

--- a/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
@@ -2,7 +2,12 @@ import { PickerDataProvider, PickerPluginOptions } from './PickerDataProvider';
 import { replaceWithNode } from 'roosterjs-editor-api';
 import { Editor, EditorPlugin, cacheGetContentSearcher } from 'roosterjs-editor-core';
 import { PartialInlineElement } from 'roosterjs-editor-dom';
-import { PluginKeyboardEvent, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
+import {
+    PluginKeyboardEvent,
+    PluginEvent,
+    PluginEventType,
+    PositionType,
+} from 'roosterjs-editor-types';
 
 // Character codes
 export const BACKSPACE_CHARCODE = 8;
@@ -259,6 +264,7 @@ export default class EditorPickerPlugin implements EditorPickerPluginInterface {
                 ) {
                     let replacementNode = this.dataProvider.onRemove(nodeBeforeCursor, true);
                     this.replaceNode(nodeBeforeCursor, replacementNode);
+                    this.editor.select(replacementNode, PositionType.After);
                     this.handleKeyDownEvent(event);
                 }
             } else if (keyboardEvent.which == DELETE_CHARCODE) {


### PR DESCRIPTION
Once remove node by Backspace key in PickerPlugin, always put cursor after the replaced node.