### PR TITLE
Tighten url regex

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/processList.ts
+++ b/packages/roosterjs-editor-api/lib/format/processList.ts
@@ -1,7 +1,13 @@
 import getNodeAtCursor from './getNodeAtCursor';
 import { DocumentCommand } from 'roosterjs-editor-types';
 import { Editor } from 'roosterjs-editor-core';
-import { fromHtml, isVoidHtmlElement, isBlockElement, Browser, isNodeEmpty } from 'roosterjs-editor-dom';
+import {
+    fromHtml,
+    isVoidHtmlElement,
+    isBlockElement,
+    Browser,
+    isNodeEmpty,
+} from 'roosterjs-editor-dom';
 
 const TEMP_NODE_CLASS = 'ROOSTERJS_TEMP_NODE_FOR_LIST';
 const TEMP_NODE_HTML = `<img class="${TEMP_NODE_CLASS}">`;

--- a/packages/roosterjs-editor-dom/lib/selection/Position.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/Position.ts
@@ -140,7 +140,9 @@ export default class Position {
         range.setStart(this.node, this.offset);
 
         // 1) try to get rect using range.getBoundingClientRect()
-        let rect = range.getBoundingClientRect ? normalizeRect(range.getBoundingClientRect()) : null;
+        let rect = range.getBoundingClientRect
+            ? normalizeRect(range.getBoundingClientRect())
+            : null;
         if (rect) {
             return rect;
         }

--- a/packages/roosterjs-editor-dom/lib/test/utils/matchLinkTests.ts
+++ b/packages/roosterjs-editor-dom/lib/test/utils/matchLinkTests.ts
@@ -82,26 +82,6 @@ describe('defaultLinkMatchRules regular https links with extact match', () => {
 });
 
 describe('defaultLinkMatchRules special http links that has % and @, but is valid', () => {
-    it('www.test%20it.com/', () => {
-        // URL: www.test%20it.com/ => %20 is a valid percent encoding
-        let link = 'www.test%20it.com/';
-        runMatchTestWithValidLink(link, {
-            scheme: 'http',
-            originalUrl: link,
-            normalizedUrl: 'http://' + link,
-        });
-    });
-
-    it('www.test%20it%20.com/', () => {
-        // URL: www.test%20it%20.com/ => test two %20 in a row
-        let link = 'www.test%20it%20.com/';
-        runMatchTestWithValidLink(link, {
-            scheme: 'http',
-            originalUrl: link,
-            normalizedUrl: 'http://' + link,
-        });
-    });
-
     it('www.test.com/?test=test%00it', () => {
         // URL: www.test.com/?test=test%00it %00 => %00 is invalid percent encoding but URL is valid since it is after ?
         let link = 'www.test.com/?test=test%00it';
@@ -181,6 +161,16 @@ describe('defaultLinkMatchRules exact match with extra space and text', () => {
     it('www.bing.com more', () => {
         // exact match should not match since there is some space and extra text after the url
         runMatchTestWithBadLink('www.bing.com more');
+    });
+});
+
+describe('defaultLinkmatchRules does not match invalid urls', () => {
+    it('www.bing,com', () => {
+        runMatchTestWithBadLink('www.bing,com');
+    });
+
+    it('www.b,,au', () => {
+        runMatchTestWithBadLink('www.b,,au');
     });
 });
 

--- a/packages/roosterjs-editor-dom/lib/utils/matchLink.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/matchLink.ts
@@ -24,31 +24,47 @@ interface LinkMatchRule {
 // ^[^?]+%$ => to exclude URL like www.bing.com%
 // ^https?:\/\/[^?\/]+@ => to exclude URL like http://www.bing.com@name
 // ^www\.[^?\/]+@ => to exclude URL like www.bing.com@name
+// , => to exclude url like www.bing,,com
 const httpExcludeRegEx = /^[^?]+%[^0-9a-f]+|^[^?]+%[0-9a-f][^0-9a-f]+|^[^?]+%00|^[^?]+%$|^https?:\/\/[^?\/]+@|^www\.[^?\/]+@/i;
+
+// via https://tools.ietf.org/html/rfc1035 Page 7
+const labelRegEx = '[a-z](?:[a-z0-9-]*[a-z0-9])?'; // We're using case insensitive regexes below so don't bother including A-Z
+const domainNameRegEx = `(?:${labelRegEx}\\.)*${labelRegEx}`;
+const domainPortRegEx = `${domainNameRegEx}(?:\\:[0-9]+)?`;
+const domainPortWithUrlRegEx = `${domainPortRegEx}(?:[\\/\\?]\\S*)?`;
 
 const linkMatchRules: { [schema: string]: LinkMatchRule } = {
     http: {
-        match: /^(microsoft-edge:)?http:\/\/\S+|www\.\S+/i,
+        match: new RegExp(
+            `^(?:microsoft-edge:)?http:\\/\\/${domainPortWithUrlRegEx}|www\\.${domainPortWithUrlRegEx}`,
+            'i'
+        ),
         except: httpExcludeRegEx,
-        normalizeUrl: url => (/^(microsoft-edge:)?http:\/\//i.test(url) ? url : 'http://' + url),
+        normalizeUrl: url =>
+            new RegExp('^(?:microsoft-edge:)?http:\\/\\/', 'i').test(url) ? url : 'http://' + url,
     },
     https: {
-        match: /^(microsoft-edge:)?https:\/\/\S+/i,
+        match: new RegExp(`^(?:microsoft-edge:)?https:\\/\\/${domainPortWithUrlRegEx}`, 'i'),
         except: httpExcludeRegEx,
     },
-    mailto: { match: /^mailto:\S+@\S+\.\S+/i },
-    notes: { match: /^notes:\/\/\S+/i },
-    file: { match: /^file:\/\/\/?\S+/i },
-    unc: { match: /^\\\\\S+/i },
+    mailto: { match: new RegExp('^mailto:\\S+@\\S+\\.\\S+', 'i') },
+    notes: { match: new RegExp('^notes:\\/\\/\\S+', 'i') },
+    file: { match: new RegExp('^file:\\/\\/\\/?\\S+', 'i') },
+    unc: { match: new RegExp('^\\\\\\\\\\S+', 'i') },
     ftp: {
-        match: /^ftp:\/\/\S+|ftp\.\S+/i,
-        normalizeUrl: url => (/^ftp:\/\//i.test(url) ? url : 'ftp://' + url),
+        match: new RegExp(
+            `^ftp:\\/\\/${domainPortWithUrlRegEx}|ftp\\.${domainPortWithUrlRegEx}`,
+            'i'
+        ),
+        normalizeUrl: url => (new RegExp('^ftp:\\/\\/', 'i').test(url) ? url : 'ftp://' + url),
     },
-    news: { match: /^news:(\/\/)?\S+/i },
-    telnet: { match: /^telnet:\S+/i },
-    gopher: { match: /^gopher:\/\/\S+/i },
-    wais: { match: /^wais:\S+/i },
+    news: { match: new RegExp(`^news:(\\/\\/)?${domainPortWithUrlRegEx}`, 'i') },
+    telnet: { match: new RegExp(`^telnet:(\\/\\/)?${domainPortWithUrlRegEx}`, 'i') },
+    gopher: { match: new RegExp(`^gopher:\\/\\/${domainPortWithUrlRegEx}`, 'i') },
+    wais: { match: new RegExp(`^wais:(\\/\\/)?${domainPortWithUrlRegEx}`, 'i') },
 };
+
+console.log(`^wais:${domainPortWithUrlRegEx}`);
 
 /**
  * Try to match a given string with link match rules, return matched link

--- a/packages/roosterjs-editor-dom/lib/utils/matchLink.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/matchLink.ts
@@ -64,8 +64,6 @@ const linkMatchRules: { [schema: string]: LinkMatchRule } = {
     wais: { match: new RegExp(`^wais:(\\/\\/)?${domainPortWithUrlRegEx}`, 'i') },
 };
 
-console.log(`^wais:${domainPortWithUrlRegEx}`);
-
 /**
  * Try to match a given string with link match rules, return matched link
  * @param url Input url to match


### PR DESCRIPTION
The existing url regex is super permissable as to what is considered a
domain slug (e.g. any non-whitespace characters were considered
domains).

This work updates the regex to be compliant with the ietf domain name
spec, and removes erroneous test cases that were testing for invalid
regexes.

Note that this will also mean that _Invalid urls with valid punycode
encodings will no longer work_. Is this an acceptable tradeoff?