### PR TITLE
Add alternative selection marker format

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -65,12 +65,13 @@ export default class Editor {
         // 2. Store options values to local variables
         this.core = createEditorCore(contentDiv, options);
         this.markSelection = options.useExperimentalAttributeBasedSelectionMarker
-             ? markSelectionWithAttributes
-             : markSelectionWithSpan;
+            ? markSelectionWithAttributes
+            : markSelectionWithSpan;
         this.removeMarker = options.useExperimentalAttributeBasedSelectionMarker
-             ? removeAttributeMarker
-             : removeSpanMarker;
-        this.isUsingAttributeBasedSelectionMarker = options.useExperimentalAttributeBasedSelectionMarker;
+            ? removeAttributeMarker
+            : removeSpanMarker;
+        this.isUsingAttributeBasedSelectionMarker =
+            options.useExperimentalAttributeBasedSelectionMarker;
 
         // 3. Initialize plugins
         this.core.plugins.forEach(plugin => plugin.initialize(this));

--- a/packages/roosterjs-editor-core/lib/editor/EditorOptions.ts
+++ b/packages/roosterjs-editor-core/lib/editor/EditorOptions.ts
@@ -54,7 +54,7 @@ interface EditorOptions {
     /**
      * Whether or not to use the new experimental non-reflowing selection marker
      */
-    useExperimentalAttributeBasedSelectionMarker?: boolean,
+    useExperimentalAttributeBasedSelectionMarker?: boolean;
 }
 
 export default EditorOptions;

--- a/packages/roosterjs-editor-core/lib/editor/EditorOptions.ts
+++ b/packages/roosterjs-editor-core/lib/editor/EditorOptions.ts
@@ -51,6 +51,10 @@ interface EditorOptions {
      * Default value is null
      */
     coreApiOverride?: Partial<CoreApiMap>;
+    /**
+     * Whether or not to use the new experimental non-reflowing selection marker
+     */
+    useExperimentalAttributeBasedSelectionMarker?: boolean,
 }
 
 export default EditorOptions;

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -61,8 +61,14 @@ export { default as VTable, VCell } from './table/VTable';
 export { default as Position } from './selection/Position';
 export { default as createRange } from './selection/createRange';
 
-export { markSelection as markSelectionWithSpan, removeMarker as removeSpanMarker } from './selection/selectionMarker';
-export { markSelection as markSelectionWithAttributes, removeMarker as removeAttributeMarker } from './selection/experimentalAttributeBasedSelectionMarker';
+export {
+    markSelection as markSelectionWithSpan,
+    removeMarker as removeSpanMarker,
+} from './selection/selectionMarker';
+export {
+    markSelection as markSelectionWithAttributes,
+    removeMarker as removeAttributeMarker,
+} from './selection/experimentalAttributeBasedSelectionMarker';
 
 // Deprecated
 export { default as isTextualInlineElement } from './deprecated/isTextualInlineElement';

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -60,7 +60,9 @@ export { default as VTable, VCell } from './table/VTable';
 
 export { default as Position } from './selection/Position';
 export { default as createRange } from './selection/createRange';
-export { markSelection, removeMarker } from './selection/selectionMarker';
+
+export { markSelection as markSelectionWithSpan, removeMarker as removeSpanMarker } from './selection/selectionMarker';
+export { markSelection as markSelectionWithAttributes, removeMarker as removeAttributeMarker } from './selection/experimentalAttributeBasedSelectionMarker';
 
 // Deprecated
 export { default as isTextualInlineElement } from './deprecated/isTextualInlineElement';

--- a/packages/roosterjs-editor-dom/lib/selection/experimentalAttributeBasedSelectionMarker.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/experimentalAttributeBasedSelectionMarker.ts
@@ -1,0 +1,149 @@
+import Position from "./Position";
+import createRange from "./createRange";
+import queryElements from "../utils/queryElements";
+
+const SELECTION_START_OFFSET_ATTRIBUTE = "data-offset1";
+const SELECTION_END_OFFSET_ATTRIBUTE = "data-offset2";
+const SELECTION_START_SELECTOR = `[${SELECTION_START_OFFSET_ATTRIBUTE}]`;
+const SELECTION_END_SELECTOR = `[${SELECTION_END_OFFSET_ATTRIBUTE}]`;
+
+type SerializablePosition = {
+  anchorElement: Element;
+  offsetCharacters: number;
+};
+
+/**
+ * Insert selection marker element into content, so that after doing some modification,
+ * we can still restore the selection as long as the selection marker is still there
+ * @param container Container HTML element to query selection markers from
+ * @param rawRange Current selection range
+ * @param useInlineMarker Inline marker will be inserted at the position where current selection is,
+ * so that even some content is changed, we can still still restore the selection. But this can cause
+ * adjacent text nodes to be created. If we are sure the content won't be changed and we don't want to
+ * create adjacent text nodes, set this parameter to false. This usually happens for undo/redo.
+ * @returns True if selection markers are added, otherwise false.
+ */
+export function markSelection(
+  container: HTMLElement,
+  range: Range,
+  useInlineMarker: boolean
+): boolean {
+  if (!range || queryElements(container, SELECTION_START_SELECTOR).length > 0) {
+    return false;
+  }
+  let start = Position.getStart(range).normalize();
+  let end = Position.getEnd(range).normalize();
+  markPosition(
+    positionToSerializablePosition(start),
+    SELECTION_START_OFFSET_ATTRIBUTE
+  );
+  markPosition(
+    positionToSerializablePosition(end),
+    SELECTION_END_OFFSET_ATTRIBUTE
+  );
+  return true;
+}
+
+/**
+ * If there is selection marker in content, convert into back to a selection range and remove the markers,
+ * otherwise no op.
+ * @param container Container HTML element to query selection markers from
+ * @param retrieveSelectionRange Whether retrieve selection range from the markers if any
+ * @returns The selection range converted from makers, or null if no valid marker found.
+ */
+export function removeMarker(
+  container: HTMLElement,
+  retrieveSelectionRange: boolean
+): Range {
+  const selectionStart = container.querySelector(SELECTION_START_SELECTOR);
+  const selectionEnd = container.querySelector(SELECTION_END_SELECTOR);
+  if (selectionStart == null || selectionEnd == null) {
+    return null;
+  }
+
+  const toReturn = retrieveSelectionRange
+    ? createRange(
+        serializablePositionToPosition({
+          anchorElement: selectionStart,
+          offsetCharacters: Number.parseInt(
+            selectionStart.getAttribute(SELECTION_START_OFFSET_ATTRIBUTE)
+          )
+        }),
+
+        serializablePositionToPosition({
+          anchorElement: selectionEnd,
+          offsetCharacters: Number.parseInt(
+            selectionEnd.getAttribute(SELECTION_END_OFFSET_ATTRIBUTE)
+          )
+        })
+      )
+    : null;
+
+  selectionStart.removeAttribute(SELECTION_START_OFFSET_ATTRIBUTE);
+  selectionEnd.removeAttribute(SELECTION_END_OFFSET_ATTRIBUTE);
+
+  return toReturn;
+}
+
+function markPosition(sp: SerializablePosition, offsetAttribute: string) {
+  sp.anchorElement.setAttribute(offsetAttribute, sp.offsetCharacters + "");
+}
+
+function positionToSerializablePosition(p: Position): SerializablePosition {
+  const node = p.node;
+  if (node instanceof Element) {
+    let offsetCharacters = 0;
+    for (let i = 0; i < p.offset; i++) {
+      offsetCharacters += p.element.childNodes[i].textContent.length;
+    }
+    return {
+      anchorElement: node,
+      offsetCharacters
+    };
+  } else if (node instanceof Text || node instanceof Comment) {
+    let parent = node.parentElement;
+    let offsetCharacters = 0;
+    for (let child : Node = parent.childNodes[0]; child != node; child = child.nextSibling) {
+      offsetCharacters += child.textContent.length;
+    }
+    return {
+      anchorElement: parent,
+      offsetCharacters: offsetCharacters + p.offset
+    };
+  } else {
+      throw new Error(`node of unknown type ${typeof node}`);
+  }
+}
+
+function serializablePositionToPosition(sp: SerializablePosition): Position {
+    // preorder walk
+    const walker = sp.anchorElement.ownerDocument.createTreeWalker(
+      sp.anchorElement,
+      NodeFilter.SHOW_TEXT
+    );
+
+    if (sp.offsetCharacters === 0) {
+      return new Position(sp.anchorElement, 0).normalize();
+    }
+
+    let cumulativeTextLength = 0;
+    while (cumulativeTextLength < sp.offsetCharacters) {
+        // step to next node is safe on first iteration, since the anchor element
+        // is not a text node, and the initial element of a tree walker is always
+        // the passed in root (regardless of if it matches the filter)
+        walker.nextNode();
+        const currentTextNode = walker.currentNode as Text;
+        cumulativeTextLength += currentTextNode.textContent.length;
+
+        if (cumulativeTextLength >= sp.offsetCharacters) {
+          break;
+        }
+    }
+    // distance stepped past the intended selection position
+    const overstep = cumulativeTextLength - sp.offsetCharacters
+    const offset = walker.currentNode.textContent.length - overstep
+    return new Position(
+        walker.currentNode,
+        offset,
+    ).normalize();
+}

--- a/packages/roosterjs-editor-dom/lib/selection/experimentalAttributeBasedSelectionMarker.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/experimentalAttributeBasedSelectionMarker.ts
@@ -1,15 +1,15 @@
-import Position from "./Position";
-import createRange from "./createRange";
-import queryElements from "../utils/queryElements";
+import Position from './Position';
+import createRange from './createRange';
+import queryElements from '../utils/queryElements';
 
-const SELECTION_START_OFFSET_ATTRIBUTE = "data-offset1";
-const SELECTION_END_OFFSET_ATTRIBUTE = "data-offset2";
+const SELECTION_START_OFFSET_ATTRIBUTE = 'data-offset1';
+const SELECTION_END_OFFSET_ATTRIBUTE = 'data-offset2';
 const SELECTION_START_SELECTOR = `[${SELECTION_START_OFFSET_ATTRIBUTE}]`;
 const SELECTION_END_SELECTOR = `[${SELECTION_END_OFFSET_ATTRIBUTE}]`;
 
 type SerializablePosition = {
-  anchorElement: Element;
-  offsetCharacters: number;
+    anchorElement: Element;
+    offsetCharacters: number;
 };
 
 /**
@@ -24,24 +24,18 @@ type SerializablePosition = {
  * @returns True if selection markers are added, otherwise false.
  */
 export function markSelection(
-  container: HTMLElement,
-  range: Range,
-  useInlineMarker: boolean
+    container: HTMLElement,
+    range: Range,
+    useInlineMarker: boolean
 ): boolean {
-  if (!range || queryElements(container, SELECTION_START_SELECTOR).length > 0) {
-    return false;
-  }
-  let start = Position.getStart(range).normalize();
-  let end = Position.getEnd(range).normalize();
-  markPosition(
-    positionToSerializablePosition(start),
-    SELECTION_START_OFFSET_ATTRIBUTE
-  );
-  markPosition(
-    positionToSerializablePosition(end),
-    SELECTION_END_OFFSET_ATTRIBUTE
-  );
-  return true;
+    if (!range || queryElements(container, SELECTION_START_SELECTOR).length > 0) {
+        return false;
+    }
+    let start = Position.getStart(range).normalize();
+    let end = Position.getEnd(range).normalize();
+    markPosition(positionToSerializablePosition(start), SELECTION_START_OFFSET_ATTRIBUTE);
+    markPosition(positionToSerializablePosition(end), SELECTION_END_OFFSET_ATTRIBUTE);
+    return true;
 }
 
 /**
@@ -51,79 +45,76 @@ export function markSelection(
  * @param retrieveSelectionRange Whether retrieve selection range from the markers if any
  * @returns The selection range converted from makers, or null if no valid marker found.
  */
-export function removeMarker(
-  container: HTMLElement,
-  retrieveSelectionRange: boolean
-): Range {
-  const selectionStart = container.querySelector(SELECTION_START_SELECTOR);
-  const selectionEnd = container.querySelector(SELECTION_END_SELECTOR);
-  if (selectionStart == null || selectionEnd == null) {
-    return null;
-  }
+export function removeMarker(container: HTMLElement, retrieveSelectionRange: boolean): Range {
+    const selectionStart = container.querySelector(SELECTION_START_SELECTOR);
+    const selectionEnd = container.querySelector(SELECTION_END_SELECTOR);
+    if (selectionStart == null || selectionEnd == null) {
+        return null;
+    }
 
-  const toReturn = retrieveSelectionRange
-    ? createRange(
-        serializablePositionToPosition({
-          anchorElement: selectionStart,
-          offsetCharacters: Number.parseInt(
-            selectionStart.getAttribute(SELECTION_START_OFFSET_ATTRIBUTE)
+    const toReturn = retrieveSelectionRange
+        ? createRange(
+              serializablePositionToPosition({
+                  anchorElement: selectionStart,
+                  offsetCharacters: Number.parseInt(
+                      selectionStart.getAttribute(SELECTION_START_OFFSET_ATTRIBUTE)
+                  ),
+              }),
+
+              serializablePositionToPosition({
+                  anchorElement: selectionEnd,
+                  offsetCharacters: Number.parseInt(
+                      selectionEnd.getAttribute(SELECTION_END_OFFSET_ATTRIBUTE)
+                  ),
+              })
           )
-        }),
+        : null;
 
-        serializablePositionToPosition({
-          anchorElement: selectionEnd,
-          offsetCharacters: Number.parseInt(
-            selectionEnd.getAttribute(SELECTION_END_OFFSET_ATTRIBUTE)
-          )
-        })
-      )
-    : null;
+    selectionStart.removeAttribute(SELECTION_START_OFFSET_ATTRIBUTE);
+    selectionEnd.removeAttribute(SELECTION_END_OFFSET_ATTRIBUTE);
 
-  selectionStart.removeAttribute(SELECTION_START_OFFSET_ATTRIBUTE);
-  selectionEnd.removeAttribute(SELECTION_END_OFFSET_ATTRIBUTE);
-
-  return toReturn;
+    return toReturn;
 }
 
 function markPosition(sp: SerializablePosition, offsetAttribute: string) {
-  sp.anchorElement.setAttribute(offsetAttribute, sp.offsetCharacters + "");
+    sp.anchorElement.setAttribute(offsetAttribute, sp.offsetCharacters + '');
 }
 
 function positionToSerializablePosition(p: Position): SerializablePosition {
-  const node = p.node;
-  if (node instanceof Element) {
-    let offsetCharacters = 0;
-    for (let i = 0; i < p.offset; i++) {
-      offsetCharacters += p.element.childNodes[i].textContent.length;
+    const node = p.node;
+    if (node instanceof Element) {
+        let offsetCharacters = 0;
+        for (let i = 0; i < p.offset; i++) {
+            offsetCharacters += p.element.childNodes[i].textContent.length;
+        }
+        return {
+            anchorElement: node,
+            offsetCharacters,
+        };
+    } else if (node instanceof Text || node instanceof Comment) {
+        let parent = node.parentElement;
+        let offsetCharacters = 0;
+        for (let child: Node = parent.childNodes[0]; child != node; child = child.nextSibling) {
+            offsetCharacters += child.textContent.length;
+        }
+        return {
+            anchorElement: parent,
+            offsetCharacters: offsetCharacters + p.offset,
+        };
+    } else {
+        throw new Error(`node of unknown type ${typeof node}`);
     }
-    return {
-      anchorElement: node,
-      offsetCharacters
-    };
-  } else if (node instanceof Text || node instanceof Comment) {
-    let parent = node.parentElement;
-    let offsetCharacters = 0;
-    for (let child : Node = parent.childNodes[0]; child != node; child = child.nextSibling) {
-      offsetCharacters += child.textContent.length;
-    }
-    return {
-      anchorElement: parent,
-      offsetCharacters: offsetCharacters + p.offset
-    };
-  } else {
-      throw new Error(`node of unknown type ${typeof node}`);
-  }
 }
 
 function serializablePositionToPosition(sp: SerializablePosition): Position {
     // preorder walk
     const walker = sp.anchorElement.ownerDocument.createTreeWalker(
-      sp.anchorElement,
-      NodeFilter.SHOW_TEXT
+        sp.anchorElement,
+        NodeFilter.SHOW_TEXT
     );
 
     if (sp.offsetCharacters === 0) {
-      return new Position(sp.anchorElement, 0).normalize();
+        return new Position(sp.anchorElement, 0).normalize();
     }
 
     let cumulativeTextLength = 0;
@@ -136,14 +127,11 @@ function serializablePositionToPosition(sp: SerializablePosition): Position {
         cumulativeTextLength += currentTextNode.textContent.length;
 
         if (cumulativeTextLength >= sp.offsetCharacters) {
-          break;
+            break;
         }
     }
     // distance stepped past the intended selection position
-    const overstep = cumulativeTextLength - sp.offsetCharacters
-    const offset = walker.currentNode.textContent.length - overstep
-    return new Position(
-        walker.currentNode,
-        offset,
-    ).normalize();
+    const overstep = cumulativeTextLength - sp.offsetCharacters;
+    const offset = walker.currentNode.textContent.length - overstep;
+    return new Position(walker.currentNode, offset).normalize();
 }

--- a/packages/roosterjs-editor-dom/lib/test/selection/SelectionMarkerTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/selection/SelectionMarkerTest.ts
@@ -1,0 +1,99 @@
+import {markSelection as markSelectionSpan, removeMarker as removeMarkerSpan} from '../../selection/selectionMarker';
+import {markSelection as markSelectionContainerAttributes, removeMarker as removeMarkerContainerAttributes} from '../../selection/experimentalAttributeBasedSelectionMarker';
+
+function dom(domString: string): HTMLElement {
+    const parsedResult = new DOMParser().parseFromString(domString, "text/html").body.childNodes[0];
+    return parsedResult as HTMLElement;
+}
+
+/**
+ * Helper to test a case agaisnt both markSelection APIs.
+ */
+function testMarkSelectionIsNonDestructive(message: string, getTestData: () => [HTMLElement, Range]) {
+    describe(message, () => {
+        it('For a Reflowing Selection', () => {
+            const [container, initialRange] = getTestData();
+            test(
+                markSelectionSpan,
+                removeMarkerSpan,
+                container,
+                initialRange
+            );
+        });
+
+        it('For a Non-Reflowing Selection', () => {
+            const [container, initialRange] = getTestData();
+            test(
+                markSelectionContainerAttributes,
+                removeMarkerContainerAttributes,
+                container,
+                initialRange
+            );
+        });
+    });
+}
+
+function test(
+        markSelection: (contianer: HTMLElement, range: Range, useInlineMarker: boolean) => void,
+        removeMarker: (container: HTMLElement, retrieveSelectioNRange: boolean) => Range,
+        element: HTMLElement,
+        initialRange: Range
+    ) {
+
+    const parentElement = element.parentElement;
+    markSelection(parentElement, initialRange, true);
+    const resultingRange = removeMarker(parentElement, true);
+
+    expect(resultingRange.startContainer).toEqual(initialRange.startContainer, "start containers should match");
+    expect(resultingRange.startOffset).toEqual(initialRange.startOffset, "start offsets should match");
+    expect(resultingRange.endContainer).toEqual(initialRange.endContainer, "end containers should match");
+    expect(resultingRange.endOffset).toEqual(initialRange.endOffset, "ending offsets should match");
+}
+
+
+describe('markSelection()', () => {
+
+    describe('When deserializing a selection that was previously serialized, it should be consistent', () => {
+        testMarkSelectionIsNonDestructive('should be consistent when the serialized selection starts at the beginning of an element\'s text', () => {
+            const div = dom('<div>Characters are selected</div>');
+            const initialRange = new Range()
+            initialRange.setStart(div.childNodes[0], 0);
+            initialRange.setEnd(div.childNodes[0], 5);
+            return [div, initialRange];
+        });
+
+        testMarkSelectionIsNonDestructive('should be consistent when  the serialized selection is in a text node that is the only child of its parent', () => {
+            const div = dom('<div>ZZZ i\'m so selected</div>');
+            const initialRange = new Range()
+            initialRange.setStart(div.childNodes[0], 1);
+            initialRange.setEnd(div.childNodes[0], 3);
+            return [div, initialRange];
+        });
+
+        testMarkSelectionIsNonDestructive('should be consistent when the serialized selection is in text node that spans across elements', () => {
+            const div = dom('<div>ZZZ <span> selected </span> selected</div>');
+            const initialRange = new Range()
+            initialRange.setStart(div.childNodes[0], 1);
+            initialRange.setEnd(div.childNodes[1].childNodes[0], 3);
+
+            return [div, initialRange];
+        });
+
+        testMarkSelectionIsNonDestructive('should be consistent when the serialized selection is an element\'s full text', () => {
+            const div = dom('<div><span>333</span> characters are selected</div>');
+            const initialRange = new Range()
+            initialRange.setStart(div.childNodes[0].childNodes[0], 0);
+            initialRange.setEnd(div.childNodes[0].childNodes[0], 3);
+
+            return [div, initialRange];
+        });
+
+        testMarkSelectionIsNonDestructive('should be consistent when the serialized selection spans across multiple elements', () => {
+            const div = dom('<div><span>333</span><span>ggg</span><span>fff</span></div>');
+            const initialRange = new Range()
+            initialRange.setStart(div.childNodes[0].childNodes[0], 2);
+            initialRange.setEnd(div.childNodes[2].childNodes[0], 2);
+            return [div, initialRange];
+        })
+    })
+});

--- a/packages/roosterjs-editor-dom/lib/test/selection/SelectionMarkerTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/selection/SelectionMarkerTest.ts
@@ -1,99 +1,67 @@
-import {markSelection as markSelectionSpan, removeMarker as removeMarkerSpan} from '../../selection/selectionMarker';
-import {markSelection as markSelectionContainerAttributes, removeMarker as removeMarkerContainerAttributes} from '../../selection/experimentalAttributeBasedSelectionMarker';
+import {markSelection, removeMarker} from '../../selection/selectionMarker';
 
 function dom(domString: string): HTMLElement {
     const parsedResult = new DOMParser().parseFromString(domString, "text/html").body.childNodes[0];
     return parsedResult as HTMLElement;
 }
 
-/**
- * Helper to test a case agaisnt both markSelection APIs.
- */
-function testMarkSelectionIsNonDestructive(message: string, getTestData: () => [HTMLElement, Range]) {
-    describe(message, () => {
-        it('For a Reflowing Selection', () => {
-            const [container, initialRange] = getTestData();
-            test(
-                markSelectionSpan,
-                removeMarkerSpan,
-                container,
-                initialRange
-            );
-        });
-
-        it('For a Non-Reflowing Selection', () => {
-            const [container, initialRange] = getTestData();
-            test(
-                markSelectionContainerAttributes,
-                removeMarkerContainerAttributes,
-                container,
-                initialRange
-            );
-        });
-    });
-}
-
-function test(
-        markSelection: (contianer: HTMLElement, range: Range, useInlineMarker: boolean) => void,
-        removeMarker: (container: HTMLElement, retrieveSelectioNRange: boolean) => Range,
-        element: HTMLElement,
-        initialRange: Range
-    ) {
-
-    const parentElement = element.parentElement;
-    markSelection(parentElement, initialRange, true);
-    const resultingRange = removeMarker(parentElement, true);
-
-    expect(resultingRange.startContainer).toEqual(initialRange.startContainer, "start containers should match");
-    expect(resultingRange.startOffset).toEqual(initialRange.startOffset, "start offsets should match");
-    expect(resultingRange.endContainer).toEqual(initialRange.endContainer, "end containers should match");
-    expect(resultingRange.endOffset).toEqual(initialRange.endOffset, "ending offsets should match");
-}
-
-
-describe('markSelection()', () => {
+fdescribe('markSelection()', () => {
 
     describe('When deserializing a selection that was previously serialized, it should be consistent', () => {
-        testMarkSelectionIsNonDestructive('should be consistent when the serialized selection starts at the beginning of an element\'s text', () => {
+
+        function test(element: HTMLElement, initialRange: Range) {
+            const parentElement = element.parentElement;
+            markSelection(parentElement, initialRange, true);
+            const resultingRange = removeMarker(parentElement, true);
+
+            expect(resultingRange.startContainer).toEqual(initialRange.startContainer, "start containers should match");
+            expect(resultingRange.startOffset).toEqual(initialRange.startOffset, "start offsets should match");
+            expect(resultingRange.endContainer).toEqual(initialRange.endContainer, "end containers should match");
+            expect(resultingRange.endOffset).toEqual(initialRange.endOffset, "ending offsets should match");
+        }
+
+        it('should be consistent when the serialized selection starts at the beginning of an element\'s text', () => {
             const div = dom('<div>Characters are selected</div>');
             const initialRange = new Range()
             initialRange.setStart(div.childNodes[0], 0);
             initialRange.setEnd(div.childNodes[0], 5);
-            return [div, initialRange];
+
+            test(div, initialRange);
         });
 
-        testMarkSelectionIsNonDestructive('should be consistent when  the serialized selection is in a text node that is the only child of its parent', () => {
+        it('should be consistent when  the serialized selection is in a text node that is the only child of its parent', () => {
             const div = dom('<div>ZZZ i\'m so selected</div>');
             const initialRange = new Range()
             initialRange.setStart(div.childNodes[0], 1);
             initialRange.setEnd(div.childNodes[0], 3);
-            return [div, initialRange];
+
+            test(div, initialRange);
         });
 
-        testMarkSelectionIsNonDestructive('should be consistent when the serialized selection is in text node that spans across elements', () => {
+        it('should be consistent when the serialized selection is in text node that spans across elements', () => {
             const div = dom('<div>ZZZ <span> selected </span> selected</div>');
             const initialRange = new Range()
             initialRange.setStart(div.childNodes[0], 1);
             initialRange.setEnd(div.childNodes[1].childNodes[0], 3);
 
-            return [div, initialRange];
+            test(div, initialRange);
         });
 
-        testMarkSelectionIsNonDestructive('should be consistent when the serialized selection is an element\'s full text', () => {
+        it('should be consistent when the serialized selection is an element\'s full text', () => {
             const div = dom('<div><span>333</span> characters are selected</div>');
             const initialRange = new Range()
             initialRange.setStart(div.childNodes[0].childNodes[0], 0);
             initialRange.setEnd(div.childNodes[0].childNodes[0], 3);
 
-            return [div, initialRange];
+            test(div, initialRange);
         });
 
-        testMarkSelectionIsNonDestructive('should be consistent when the serialized selection spans across multiple elements', () => {
+        it('should be consistent when the serialized selection spans across multiple elements', () => {
             const div = dom('<div><span>333</span><span>ggg</span><span>fff</span></div>');
             const initialRange = new Range()
             initialRange.setStart(div.childNodes[0].childNodes[0], 2);
             initialRange.setEnd(div.childNodes[2].childNodes[0], 2);
-            return [div, initialRange];
+            test(div, initialRange);
         })
     })
 });

--- a/packages/roosterjs-editor-dom/lib/test/selection/SelectionMarkerTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/selection/SelectionMarkerTest.ts
@@ -1,28 +1,41 @@
-import {markSelection, removeMarker} from '../../selection/experimentalAttributeBasedSelectionMarker';
+import {
+    markSelection,
+    removeMarker,
+} from '../../selection/experimentalAttributeBasedSelectionMarker';
 
 function dom(domString: string): HTMLElement {
-    const parsedResult = new DOMParser().parseFromString(domString, "text/html").body.childNodes[0];
+    const parsedResult = new DOMParser().parseFromString(domString, 'text/html').body.childNodes[0];
     return parsedResult as HTMLElement;
 }
 
 describe('markSelection()', () => {
-
-    describe('When deserializing a selection that was previously serialized, it should be consistent', () => {
-
+    describe('When deserializing a selection that was previously serialized', () => {
         function testSelectionIsNondestructive(element: HTMLElement, initialRange: Range) {
             const parentElement = element.parentElement;
             markSelection(parentElement, initialRange, true);
             const resultingRange = removeMarker(parentElement, true);
 
-            expect(resultingRange.startContainer).toEqual(initialRange.startContainer, "start containers should match");
-            expect(resultingRange.startOffset).toEqual(initialRange.startOffset, "start offsets should match");
-            expect(resultingRange.endContainer).toEqual(initialRange.endContainer, "end containers should match");
-            expect(resultingRange.endOffset).toEqual(initialRange.endOffset, "ending offsets should match");
+            expect(resultingRange.startContainer).toEqual(
+                initialRange.startContainer,
+                'start containers should match'
+            );
+            expect(resultingRange.startOffset).toEqual(
+                initialRange.startOffset,
+                'start offsets should match'
+            );
+            expect(resultingRange.endContainer).toEqual(
+                initialRange.endContainer,
+                'end containers should match'
+            );
+            expect(resultingRange.endOffset).toEqual(
+                initialRange.endOffset,
+                'ending offsets should match'
+            );
         }
 
-        it('should be consistent when the serialized selection starts at the beginning of an element\'s text', () => {
+        it("should be consistent when the serialized selection starts at the beginning of an element's text", () => {
             const div = dom('<div>Characters are selected</div>');
-            const initialRange = new Range()
+            const initialRange = new Range();
             initialRange.setStart(div.childNodes[0], 0);
             initialRange.setEnd(div.childNodes[0], 5);
 
@@ -30,8 +43,8 @@ describe('markSelection()', () => {
         });
 
         it('should be consistent when  the serialized selection is in a text node that is the only child of its parent', () => {
-            const div = dom('<div>ZZZ i\'m so selected</div>');
-            const initialRange = new Range()
+            const div = dom("<div>ZZZ i'm so selected</div>");
+            const initialRange = new Range();
             initialRange.setStart(div.childNodes[0], 1);
             initialRange.setEnd(div.childNodes[0], 3);
 
@@ -40,16 +53,16 @@ describe('markSelection()', () => {
 
         it('should be consistent when the serialized selection is in text node that spans across elements', () => {
             const div = dom('<div>ZZZ <span> selected </span> selected</div>');
-            const initialRange = new Range()
+            const initialRange = new Range();
             initialRange.setStart(div.childNodes[0], 1);
             initialRange.setEnd(div.childNodes[1].childNodes[0], 3);
 
             testSelectionIsNondestructive(div, initialRange);
         });
 
-        it('should be consistent when the serialized selection is an element\'s full text', () => {
+        it("should be consistent when the serialized selection is an element's full text", () => {
             const div = dom('<div><span>333</span> characters are selected</div>');
-            const initialRange = new Range()
+            const initialRange = new Range();
             initialRange.setStart(div.childNodes[0].childNodes[0], 0);
             initialRange.setEnd(div.childNodes[0].childNodes[0], 3);
 
@@ -58,10 +71,10 @@ describe('markSelection()', () => {
 
         it('should be consistent when the serialized selection spans across multiple elements', () => {
             const div = dom('<div><span>333</span><span>ggg</span><span>fff</span></div>');
-            const initialRange = new Range()
+            const initialRange = new Range();
             initialRange.setStart(div.childNodes[0].childNodes[0], 2);
             initialRange.setEnd(div.childNodes[2].childNodes[0], 2);
             testSelectionIsNondestructive(div, initialRange);
-        })
-    })
+        });
+    });
 });

--- a/packages/roosterjs-editor-dom/lib/test/selection/SelectionMarkerTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/selection/SelectionMarkerTest.ts
@@ -5,7 +5,7 @@ function dom(domString: string): HTMLElement {
     return parsedResult as HTMLElement;
 }
 
-fdescribe('markSelection()', () => {
+describe('markSelection()', () => {
 
     describe('When deserializing a selection that was previously serialized, it should be consistent', () => {
 

--- a/packages/roosterjs-editor-dom/lib/test/selection/SelectionMarkerTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/selection/SelectionMarkerTest.ts
@@ -1,4 +1,4 @@
-import {markSelection, removeMarker} from '../../selection/selectionMarker';
+import {markSelection, removeMarker} from '../../selection/experimentalAttributeBasedSelectionMarker';
 
 function dom(domString: string): HTMLElement {
     const parsedResult = new DOMParser().parseFromString(domString, "text/html").body.childNodes[0];
@@ -9,7 +9,7 @@ fdescribe('markSelection()', () => {
 
     describe('When deserializing a selection that was previously serialized, it should be consistent', () => {
 
-        function test(element: HTMLElement, initialRange: Range) {
+        function testSelectionIsNondestructive(element: HTMLElement, initialRange: Range) {
             const parentElement = element.parentElement;
             markSelection(parentElement, initialRange, true);
             const resultingRange = removeMarker(parentElement, true);
@@ -26,7 +26,7 @@ fdescribe('markSelection()', () => {
             initialRange.setStart(div.childNodes[0], 0);
             initialRange.setEnd(div.childNodes[0], 5);
 
-            test(div, initialRange);
+            testSelectionIsNondestructive(div, initialRange);
         });
 
         it('should be consistent when  the serialized selection is in a text node that is the only child of its parent', () => {
@@ -35,7 +35,7 @@ fdescribe('markSelection()', () => {
             initialRange.setStart(div.childNodes[0], 1);
             initialRange.setEnd(div.childNodes[0], 3);
 
-            test(div, initialRange);
+            testSelectionIsNondestructive(div, initialRange);
         });
 
         it('should be consistent when the serialized selection is in text node that spans across elements', () => {
@@ -44,7 +44,7 @@ fdescribe('markSelection()', () => {
             initialRange.setStart(div.childNodes[0], 1);
             initialRange.setEnd(div.childNodes[1].childNodes[0], 3);
 
-            test(div, initialRange);
+            testSelectionIsNondestructive(div, initialRange);
         });
 
         it('should be consistent when the serialized selection is an element\'s full text', () => {
@@ -53,7 +53,7 @@ fdescribe('markSelection()', () => {
             initialRange.setStart(div.childNodes[0].childNodes[0], 0);
             initialRange.setEnd(div.childNodes[0].childNodes[0], 3);
 
-            test(div, initialRange);
+            testSelectionIsNondestructive(div, initialRange);
         });
 
         it('should be consistent when the serialized selection spans across multiple elements', () => {
@@ -61,7 +61,7 @@ fdescribe('markSelection()', () => {
             const initialRange = new Range()
             initialRange.setStart(div.childNodes[0].childNodes[0], 2);
             initialRange.setEnd(div.childNodes[2].childNodes[0], 2);
-            test(div, initialRange);
+            testSelectionIsNondestructive(div, initialRange);
         })
     })
 });


### PR DESCRIPTION
The existing selection marker forces a reflow and invalidates the selection in webkit-based browsers, forcing another reflow to reselect the cursor. In large applications with many nodes in their DOM, this can lead to slowdown when typing, since selection is marked every time the user types a space after a non-space character by UndoPlugin.

This PR introduces an alternative experimental selection marker implementation that consumers can opt into consuming. This new selection marker API uses attributes on the DOM instead of spans to track where the selection was on the document.