### PR TITLE
Update the query string when just the cursor character is present.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs",
-  "version": "6.15.1",
+  "version": "6.16.0",
   "description": "Framework-independent javascript editor",
   "repository": {
     "type": "git",

--- a/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
@@ -156,12 +156,14 @@ export default class EditorPickerPlugin implements EditorPickerPluginInterface {
             const wordBeforeCursor = this.getWord(event);
             const trimmedWordBeforeCursor = wordBeforeCursor.substring(1).trim();
 
-            // Update the query string when:
+            // If we hit a case where wordBeforeCursor is just the trigger character,
+            // that means we've gotten a onKeyUp event right after it's been typed.
+            // Otherwise, update the query string when:
             // 1. There's an actual value
             // 2. That actual value isn't just pure whitespace
             // 3. That actual value isn't more than 4 words long (at which point we assume the person kept typing)
             // Otherwise, we want to dismiss the picker plugin's UX.
-            if (trimmedWordBeforeCursor && trimmedWordBeforeCursor.length > 0 && trimmedWordBeforeCursor.split(' ').length <= 4) {
+            if (wordBeforeCursor == this.pickerOptions.triggerCharacter || (trimmedWordBeforeCursor && trimmedWordBeforeCursor.length > 0 && trimmedWordBeforeCursor.split(' ').length <= 4)) {
                 this.dataProvider.queryStringUpdated(trimmedWordBeforeCursor);
             } else {
                 this.setIsSuggesting(false);


### PR DESCRIPTION
In the change for 6.16, we added functionality to dismiss the picker when the only text in the query string would be whitespace. However, empty query strings are a special case, so, we should do an additional check to ensure that the wordBeforeCursor isn't the trigger character, capturing this case.