### PR TITLE
Fix issue 118

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs",
-  "version": "6.16.1",
+  "version": "6.16.2",
   "description": "Framework-independent javascript editor",
   "repository": {
     "type": "git",

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/shortcutFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/shortcutFeatures.ts
@@ -64,7 +64,9 @@ function cacheGetCommand(event: PluginKeyboardEvent) {
     return cacheGetEventData(event, 'DEFAULT_SHORT_COMMAND', () => {
         let e = event.rawEvent;
         let key =
-            event.eventType == PluginEventType.KeyDown
+            // Need to check ALT key to be false since in some language (e.g. Polski) uses AltGr to input some special charactors
+            // In that case, ctrlKey and altKey are both true in Edge, but we should not trigger any shortcut function here
+            event.eventType == PluginEventType.KeyDown && !e.altKey
                 ? e.which |
                   (e.metaKey && Keys.Meta) |
                   (e.shiftKey && Keys.Shift) |


### PR DESCRIPTION
In Edge, AltGr (right ALT in some languages, like Polski) key sets both e.altKey and e.ctrlKey to true. We need to check e.altKey not to be true before treat them as CTRL+* shortcut.