### PR TITLE
 Encapsulate undo snapshots

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreAPI/editWithUndo.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/editWithUndo.ts
@@ -1,7 +1,11 @@
 import EditorCore, { EditWithUndo } from '../editor/EditorCore';
-import { ChangeSource, ContentChangedEvent, PluginEventType } from 'roosterjs-editor-types';
+import {
+    ChangeSource,
+    ContentChangedEvent,
+    PluginEventType,
+    UndoSnapshot,
+} from 'roosterjs-editor-types';
 import { Position } from 'roosterjs-editor-dom';
-import { UndoSnapshot } from '../undo/UndoSnapshotTranslator';
 
 const editWithUndo: EditWithUndo = (
     core: EditorCore,

--- a/packages/roosterjs-editor-core/lib/coreAPI/editWithUndo.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/editWithUndo.ts
@@ -1,10 +1,11 @@
 import EditorCore, { EditWithUndo } from '../editor/EditorCore';
 import { ChangeSource, ContentChangedEvent, PluginEventType } from 'roosterjs-editor-types';
 import { Position } from 'roosterjs-editor-dom';
+import { UndoSnapshot } from '../undo/UndoSnapshotTranslator';
 
 const editWithUndo: EditWithUndo = (
     core: EditorCore,
-    callback: (start: Position, end: Position, snapshotBeforeCallback: string) => any,
+    callback: (start: Position, end: Position, snapshotBeforeCallback: UndoSnapshot) => any,
     changeSource: ChangeSource | string
 ) => {
     let isNested = core.currentUndoSnapshot !== null;

--- a/packages/roosterjs-editor-core/lib/editor/CorePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/editor/CorePlugin.ts
@@ -7,6 +7,7 @@ import {
     PluginEventType,
     PluginMouseUpEvent,
     PositionType,
+    UndoSnapshot,
 } from 'roosterjs-editor-types';
 import {
     Browser,
@@ -18,7 +19,6 @@ import {
     getBlockElementAtNode,
     StartEndBlockElement,
 } from 'roosterjs-editor-dom';
-import { UndoSnapshot } from '../undo/UndoSnapshotTranslator';
 
 const KEY_BACKSPACE = 8;
 

--- a/packages/roosterjs-editor-core/lib/editor/CorePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/editor/CorePlugin.ts
@@ -18,6 +18,7 @@ import {
     getBlockElementAtNode,
     StartEndBlockElement,
 } from 'roosterjs-editor-dom';
+import { UndoSnapshot } from '../undo/UndoSnapshotTranslator';
 
 const KEY_BACKSPACE = 8;
 
@@ -35,6 +36,7 @@ interface AutoCompleteInfo {
 export default class CorePlugin implements EditorPlugin {
     public name = 'CorePlugin';
     private editor: Editor;
+    private snapshotBeforeAutoComplete: UndoSnapshot;
     private autoCompleteInfo: AutoCompleteInfo;
     private inIME: boolean;
     private disposers: (() => void)[] = null;
@@ -196,10 +198,7 @@ export default class CorePlugin implements EditorPlugin {
         if (this.autoCompleteInfo) {
             if (event && event.which == KEY_BACKSPACE) {
                 event.preventDefault();
-                this.editor.setContent(
-                    this.autoCompleteInfo.snapshot,
-                    false /*triggerContentChangedEvent*/
-                );
+                this.editor.undoSnapshotTranslator.restoreUndoSnapshot(this.snapshotBeforeAutoComplete);
             }
             this.autoCompleteInfo = null;
         }

--- a/packages/roosterjs-editor-core/lib/editor/CorePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/editor/CorePlugin.ts
@@ -23,7 +23,7 @@ import {
 const KEY_BACKSPACE = 8;
 
 interface AutoCompleteInfo {
-    snapshot: string;
+    snapshot: UndoSnapshot;
     changeSource: string;
 }
 
@@ -36,7 +36,6 @@ interface AutoCompleteInfo {
 export default class CorePlugin implements EditorPlugin {
     public name = 'CorePlugin';
     private editor: Editor;
-    private snapshotBeforeAutoComplete: UndoSnapshot;
     private autoCompleteInfo: AutoCompleteInfo;
     private inIME: boolean;
     private disposers: (() => void)[] = null;
@@ -106,7 +105,7 @@ export default class CorePlugin implements EditorPlugin {
      * @param changeSource Chagne source of ContentChangedEvent. If not passed, no ContentChangedEvent will be  triggered
      */
     public performAutoComplete(callback: () => any, changeSource?: ChangeSource) {
-        this.editor.addUndoSnapshot((start, end, snapshot) => {
+        this.editor.addUndoSnapshot((start, end, snapshot: UndoSnapshot) => {
             let data = callback();
             this.autoCompleteInfo = {
                 snapshot,
@@ -198,7 +197,7 @@ export default class CorePlugin implements EditorPlugin {
         if (this.autoCompleteInfo) {
             if (event && event.which == KEY_BACKSPACE) {
                 event.preventDefault();
-                this.editor.undoSnapshotTranslator.restoreUndoSnapshot(this.snapshotBeforeAutoComplete);
+                this.editor.undoSnapshotTranslator.restoreUndoSnapshot(this.autoCompleteInfo.snapshot);
             }
             this.autoCompleteInfo = null;
         }

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -36,9 +36,6 @@ import {
     collapseNodes,
     wrap,
 } from 'roosterjs-editor-dom';
-import {
-    UndoSnapshotTranslator
-} from '../undo/UndoSnapshotTranslator';
 import UndoSnapshotTranslatorService from './UndoSnapshotTranslatorService';
 
 /**

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -17,6 +17,7 @@ import {
     QueryScope,
     Rect,
     NodeType,
+    UndoSnapshot,
 } from 'roosterjs-editor-types';
 import {
     Browser,
@@ -36,7 +37,6 @@ import {
     wrap,
 } from 'roosterjs-editor-dom';
 import {
-    UndoSnapshot,
     UndoSnapshotTranslator
 } from '../undo/UndoSnapshotTranslator';
 import UndoSnapshotTranslatorService from './UndoSnapshotTranslatorService';

--- a/packages/roosterjs-editor-core/lib/editor/EditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/EditorCore.ts
@@ -1,6 +1,7 @@
 import CorePlugin from './CorePlugin';
 import EditorPlugin from './EditorPlugin';
 import UndoService from './UndoService';
+import UndoSnapshotTranslatorService from './UndoSnapshotTranslatorService';
 import {
     ChangeSource,
     DefaultFormat,
@@ -9,6 +10,7 @@ import {
     PluginEventType,
 } from 'roosterjs-editor-types';
 import { Position } from 'roosterjs-editor-dom';
+import { UndoSnapshot } from '../undo/UndoSnapshotTranslator';
 
 /**
  * Represents the core data structure of an editor
@@ -45,6 +47,11 @@ interface EditorCore {
     readonly undo: UndoService;
 
     /**
+     * Undo snapshot translation service of this editor.
+     */
+    readonly undoSnapshotTranslator: UndoSnapshotTranslatorService;
+
+    /**
      * Custom data of this editor
      */
     readonly customData: {
@@ -67,7 +74,7 @@ interface EditorCore {
     /**
      * The undo snapshot taken by addUndoSnapshot() before callback function is invoked.
      */
-    currentUndoSnapshot: string;
+    currentUndoSnapshot: UndoSnapshot;
 
     /**
      * Cached selection range of this editor
@@ -85,7 +92,7 @@ export type AttachDomEvent = (
 ) => () => void;
 export type EditWithUndo = (
     core: EditorCore,
-    callback: (start: Position, end: Position, snapshotBeforeCallback: string) => any,
+    callback: (start: Position, end: Position, snapshotBeforeCallback: UndoSnapshot) => any,
     changeSource: ChangeSource | string
 ) => void;
 export type Focus = (core: EditorCore) => void;

--- a/packages/roosterjs-editor-core/lib/editor/EditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/EditorCore.ts
@@ -8,9 +8,9 @@ import {
     InsertOption,
     PluginEvent,
     PluginEventType,
+    UndoSnapshot,
 } from 'roosterjs-editor-types';
 import { Position } from 'roosterjs-editor-dom';
-import { UndoSnapshot } from '../undo/UndoSnapshotTranslator';
 
 /**
  * Represents the core data structure of an editor

--- a/packages/roosterjs-editor-core/lib/editor/UndoService.ts
+++ b/packages/roosterjs-editor-core/lib/editor/UndoService.ts
@@ -1,4 +1,5 @@
 import EditorPlugin from './EditorPlugin';
+import { UndoSnapshot } from '../undo/UndoSnapshotTranslator';
 
 /**
  * Defines replaceable undo service for editor
@@ -19,7 +20,7 @@ interface UndoService extends EditorPlugin {
      * This method will not trigger ExtractContent event, so any temporary content will be
      * added into undo snapshot
      */
-    addUndoSnapshot: () => string;
+    addUndoSnapshot: () => UndoSnapshot;
 
     /**
      * Whether there is snapshot for undo

--- a/packages/roosterjs-editor-core/lib/editor/UndoService.ts
+++ b/packages/roosterjs-editor-core/lib/editor/UndoService.ts
@@ -1,5 +1,5 @@
 import EditorPlugin from './EditorPlugin';
-import { UndoSnapshot } from '../undo/UndoSnapshotTranslator';
+import { UndoSnapshot } from 'roosterjs-editor-types';
 
 /**
  * Defines replaceable undo service for editor

--- a/packages/roosterjs-editor-core/lib/editor/UndoSnapshotTranslatorService.ts
+++ b/packages/roosterjs-editor-core/lib/editor/UndoSnapshotTranslatorService.ts
@@ -1,5 +1,5 @@
 import Editor from './Editor';
-import { UndoSnapshot } from '../undo/UndoSnapshotTranslator';
+import { UndoSnapshot } from 'roosterjs-editor-types';
 
 export default interface UndoSnapshotTranslatorService {
     initialize(editor: Editor): void;

--- a/packages/roosterjs-editor-core/lib/editor/UndoSnapshotTranslatorService.ts
+++ b/packages/roosterjs-editor-core/lib/editor/UndoSnapshotTranslatorService.ts
@@ -1,0 +1,8 @@
+import Editor from './Editor';
+import { UndoSnapshot } from '../undo/UndoSnapshotTranslator';
+
+export default interface UndoSnapshotTranslatorService {
+    initialize(editor: Editor): void;
+    restoreUndoSnapshot(snapshot: UndoSnapshot): void;
+    getUndoSnapshot(): UndoSnapshot;
+}

--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -27,7 +27,7 @@ export default function createEditorCore(
         defaultFormat: calcDefaultFormat(contentDiv, options.defaultFormat),
         corePlugin,
         undo,
-        undoSnapshotTranslator: new UndoSnapshotTranslator(contentDiv),
+        undoSnapshotTranslator: new UndoSnapshotTranslator(),
         currentUndoSnapshot: null,
         customData: {},
         cachedSelectionRange: null,

--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -13,6 +13,7 @@ import select from '../coreAPI/select';
 import triggerEvent from '../coreAPI/triggerEvent';
 import { DefaultFormat } from 'roosterjs-editor-types';
 import { getComputedStyles } from 'roosterjs-editor-dom';
+import { UndoSnapshotTranslator } from '../undo/UndoSnapshotTranslator';
 
 export default function createEditorCore(
     contentDiv: HTMLDivElement,
@@ -26,6 +27,7 @@ export default function createEditorCore(
         defaultFormat: calcDefaultFormat(contentDiv, options.defaultFormat),
         corePlugin,
         undo,
+        undoSnapshotTranslator: new UndoSnapshotTranslator(contentDiv),
         currentUndoSnapshot: null,
         customData: {},
         cachedSelectionRange: null,

--- a/packages/roosterjs-editor-core/lib/undo/Undo.ts
+++ b/packages/roosterjs-editor-core/lib/undo/Undo.ts
@@ -1,6 +1,5 @@
-import { ChangeSource, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
+import { ChangeSource, PluginEvent, PluginEventType, UndoSnapshot } from 'roosterjs-editor-types';
 import { Editor, UndoService, UndoSnapshotsService } from 'roosterjs-editor-core';
-import { UndoSnapshot } from './UndoSnapshotTranslator';
 
 const KEY_BACKSPACE = 8;
 const KEY_DELETE = 46;

--- a/packages/roosterjs-editor-core/lib/undo/UndoSnapshotTranslator.ts
+++ b/packages/roosterjs-editor-core/lib/undo/UndoSnapshotTranslator.ts
@@ -1,21 +1,8 @@
 import { Editor } from 'roosterjs-editor-core';
-
-/**
- * Opaque type alias for Undo snapshots.
- *
- * It can only reasonably be created in this class, so we can enforce that
- * this service can swap out the type of the UndoSnapshot under the hood
- * safely
- *
- * See https://github.com/Microsoft/TypeScript/issues/15807
- */
-export type UndoSnapshot = string & { _tag: "undo-snapshot-type-alias" };
+import { UndoSnapshot } from 'roosterjs-editor-types';
 
 export class UndoSnapshotTranslator {
     private editor: Editor;
-    constructor(
-        private editorRoot: HTMLDivElement,
-    ) {}
 
     public initialize(editor: Editor): void {
         this.editor = editor;

--- a/packages/roosterjs-editor-core/lib/undo/UndoSnapshotTranslator.ts
+++ b/packages/roosterjs-editor-core/lib/undo/UndoSnapshotTranslator.ts
@@ -1,0 +1,38 @@
+import { Editor } from 'roosterjs-editor-core';
+
+/**
+ * Opaque type alias for Undo snapshots.
+ *
+ * It can only reasonably be created in this class, so we can enforce that
+ * this service can swap out the type of the UndoSnapshot under the hood
+ * safely
+ *
+ * See https://github.com/Microsoft/TypeScript/issues/15807
+ */
+export type UndoSnapshot = string & { _tag: "undo-snapshot-type-alias" };
+
+export class UndoSnapshotTranslator {
+    private editor: Editor;
+    constructor(
+        private editorRoot: HTMLDivElement,
+    ) {}
+
+    public initialize(editor: Editor): void {
+        this.editor = editor;
+    }
+
+    public getUndoSnapshot(): UndoSnapshot {
+        let snapshotContent = this.editor.getContent(
+            false /*triggerExtractContentEvent*/,
+            true /*markSelection*/
+        );
+        return snapshotContent as UndoSnapshot;
+    }
+
+    public restoreUndoSnapshot(snapshot: UndoSnapshot): void {
+        this.editor.setContent(
+            (<string>snapshot), // content
+            true, // triggerContentChangedEvent
+        );
+    }
+}

--- a/packages/roosterjs-editor-plugins/lib/Paste/Paste.ts
+++ b/packages/roosterjs-editor-plugins/lib/Paste/Paste.ts
@@ -146,12 +146,11 @@ export default class Paste implements EditorPlugin {
         this.editor.focus();
         this.editor.addUndoSnapshot(() => {
             if (clipboardData.snapshotBeforePaste == null) {
-                clipboardData.snapshotBeforePaste = this.editor.getContent(
-                    false /*triggerExtractContentEvent*/,
-                    true /*markSelection*/
-                );
+                clipboardData.snapshotBeforePaste = this.editor.undoSnapshotTranslator.getUndoSnapshot();
             } else {
-                this.editor.setContent(clipboardData.snapshotBeforePaste);
+                this.editor.undoSnapshotTranslator.restoreUndoSnapshot(
+                    clipboardData.snapshotBeforePaste
+                );
             }
 
             switch (pasteOption) {

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -45,6 +45,7 @@ export { default as InsertOption } from './interface/InsertOption';
 export { default as LinkData } from './interface/LinkData';
 export { default as Rect } from './interface/Rect';
 export { default as TableFormat } from './interface/TableFormat';
+export { default as UndoSnapshot } from './interface/UndoSnapshot';
 
 // Legacy
 export { default as BlockElement } from './legacy/BlockElement';

--- a/packages/roosterjs-editor-types/lib/interface/ClipboardData.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ClipboardData.ts
@@ -1,4 +1,5 @@
 import DefaultFormat from './DefaultFormat';
+import { UndoSnapshot } from './UndoSnapshot';
 
 /**
  * An object contains all related data for pasting
@@ -7,7 +8,7 @@ interface ClipboardData {
     /**
      * An editor content snapshot before pasting happens. This is used for changing paste format
      */
-    snapshotBeforePaste: string;
+    snapshotBeforePaste: UndoSnapshot;
 
     /**
      * The format state at cursor before pasting. This is used for changing paste format

--- a/packages/roosterjs-editor-types/lib/interface/UndoSnapshot.ts
+++ b/packages/roosterjs-editor-types/lib/interface/UndoSnapshot.ts
@@ -1,0 +1,13 @@
+/**
+ * Opaque type alias for Undo snapshots.
+ *
+ * It can only be created via casting, so consumers outside of
+ * UndoSnapshotTranslator cannot reasonably look in to the class and
+ * expect non-breaking changes.
+ *
+ * See https://github.com/Microsoft/TypeScript/issues/15807
+ */
+
+export type UndoSnapshot = string & {tag: "undo-snapshot-opaque-type"};
+
+export default UndoSnapshot;


### PR DESCRIPTION
encapsulates taking / writing an undo snapshot into a new part of
EditorCore (UndoSnapshotTranslator). This is so we can continue to
test our new approach to serializing the undo state without merging
straight into rooster.

We ensure that undo snapshots can only be created / written to the dom
by using the closest thing typescript has to an opaque type alias (see
Microsoft/TypeScript#15807). Since other
classes can't reach into the UndoSnapshot type, it will be safe to
switch out the UndoSnapshotTranslator implementation
