### PR TITLE
Fix link to License in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,4 +195,4 @@ We are still working on more documentation in [roosterjs wiki](https://github.co
 License
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the [MIT](LICENSE.txt) License.
+Licensed under the [MIT](LICENSE) License.


### PR DESCRIPTION
Previous link was to the LICENSE.txt, but this lead to a 404 page rather than the license