### PR TITLE
Rewrite Hyperlink plugin, fix #131

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -792,6 +792,19 @@ export default class Editor {
         });
     }
 
+    /**
+     * Set DOM attribute of editor content DIV
+     * @param name Name of the attribute
+     * @param value Value of the attribute
+     */
+    public setEditorDomAttribute(name: string, value: string) {
+        if (value === null) {
+            this.core.contentDiv.removeAttribute(name);
+        } else {
+            this.core.contentDiv.setAttribute(name, value);
+        }
+    }
+
     //#endregion
 
     //#region Deprecated methods

--- a/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
@@ -37,7 +37,7 @@ export default class HyperLink implements EditorPlugin {
             : [];
     }
 
-    private onMouse = (e: MouseEvent) => {
+    protected onMouse = (e: MouseEvent) => {
         const a = this.editor.getElementAtCursor('a[href]', e.srcElement) as HTMLAnchorElement;
         const href = this.tryGetHref(a);
 

--- a/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
@@ -1,19 +1,14 @@
 import { Browser } from 'roosterjs-editor-dom';
-import { ChangeSource, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import { Editor, EditorPlugin } from 'roosterjs-editor-core';
-
-const TEMP_TITLE = 'istemptitle';
-const TEMP_TITLE_REGEX = new RegExp(
-    `<a\\s+([^>]*\\s+)?(title|${TEMP_TITLE})="[^"]*"\\s*([^>]*)\\s+(title|${TEMP_TITLE})="[^"]*"(\\s+[^>]*)?>`,
-    'gm'
-);
+import { PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 
 /**
  * An editor plugin that show a tooltip for existing link
  */
 export default class HyperLink implements EditorPlugin {
-    private editor: Editor;
     public name: 'HyperLink';
+    private editor: Editor;
+    private disposers: (() => void)[];
 
     /**
      * Create a new instance of HyperLink class
@@ -33,13 +28,30 @@ export default class HyperLink implements EditorPlugin {
      */
     public initialize(editor: Editor): void {
         this.editor = editor;
+        this.disposers = this.getTooltipCallback
+            ? [
+                  editor.addDomEventHandler('mouseover', this.onMouse),
+                  editor.addDomEventHandler('mouseout', this.onMouse),
+              ]
+            : [];
     }
+
+    private onMouse = (e: MouseEvent) => {
+        let href = this.tryGetHref(e.srcElement);
+        if (href) {
+            this.editor.setEditorDomAttribute(
+                'titile',
+                e.type == 'mouseover' ? this.getTooltipCallback(href) : null
+            );
+        }
+    };
 
     /**
      * Dispose this plugin
      */
     public dispose(): void {
-        this.editor.queryElements('a[href]', this.resetAnchor);
+        this.disposers.forEach(disposer => disposer());
+        this.disposers = null;
         this.editor = null;
     }
 
@@ -48,118 +60,19 @@ export default class HyperLink implements EditorPlugin {
      * @param event The event object
      */
     public onPluginEvent(event: PluginEvent): void {
-        switch (event.eventType) {
-            case PluginEventType.EditorReady:
-                this.editor.queryElements('a[href]', this.processLink);
-                break;
-
-            case PluginEventType.ContentChanged:
-                if (event.source == ChangeSource.CreateLink) {
-                    this.resetAnchor(event.data as HTMLAnchorElement);
-                }
-
-                let anchors = this.editor.queryElements('a[href]');
-                if (anchors.length > 0) {
-                    // 1. Cache existing snapshot
-                    let snapshotBeforeProcessLink = this.getSnapshot();
-
-                    // 2. Process links
-                    anchors.forEach(this.processLink);
-
-                    // 3. See if cached snapshot is the same with lastSnapshot
-                    // Same snapshot means content isn't changed by other plugins,
-                    // Then we can overwrite the sanpshot here to avoid Undo plugin
-                    // adding undo snapshot for the link title attribute change
-                    if (snapshotBeforeProcessLink == event.lastSnapshot) {
-                        // Overwrite last snapshot to suppress undo for the temp properties
-                        event.lastSnapshot = this.editor.getContent(false, true);
-                    }
-                }
-
-                break;
-
-            case PluginEventType.ExtractContent:
-                event.content = this.removeTempTooltip(event.content);
-                break;
-        }
-    }
-
-    private getSnapshot() {
-        return this.editor.getContent(
-            false /*triggerContentChangedEvent*/,
-            true /*addSelectionMarker*/
-        );
-    }
-
-    private resetAnchor = (a: HTMLAnchorElement) => {
-        try {
-            if (a.getAttribute(TEMP_TITLE)) {
-                a.removeAttribute(TEMP_TITLE);
-                a.removeAttribute('title');
-            }
-            a.removeEventListener('mouseup', this.onClickLink);
-        } catch (e) {}
-    };
-
-    private processLink = (a: HTMLAnchorElement) => {
-        if (!a.title && this.getTooltipCallback) {
-            a.setAttribute(TEMP_TITLE, 'true');
-            a.title = this.getTooltipCallback(this.tryGetHref(a));
-        }
-        a.addEventListener('mouseup', this.onClickLink);
-    };
-
-    private removeTempTooltip(content: string): string {
-        return content.replace(
-            TEMP_TITLE_REGEX,
-            (...groups: string[]): string => {
-                const firstValue = groups[1] == null ? '' : groups[1].trim();
-                const secondValue = groups[3] == null ? '' : groups[3].trim();
-                const thirdValue = groups[5] == null ? '' : groups[5].trim();
-
-                // possible values (* is space, x, y, z are the first, second, and third value respectively):
-                // *** (no values) << empty case
-                // x** (first value only)
-                // *x* (second value only)
-                // **x (third value only)
-                // x*y* (first and second)
-                // x**z (first and third) << double spaces
-                // *y*z (second and third)
-                // x*y*z (all)
-                if (
-                    firstValue.length === 0 &&
-                    secondValue.length === 0 &&
-                    thirdValue.length === 0
-                ) {
-                    return '<a>';
-                }
-
-                let result;
-                if (secondValue.length === 0) {
-                    result = `${firstValue} ${thirdValue}`;
-                } else {
-                    result = `${firstValue} ${secondValue} ${thirdValue}`;
-                }
-
-                return `<a ${result.trim()}>`;
-            }
-        );
-    }
-
-    private onClickLink = (keyboardEvent: KeyboardEvent) => {
         let href: string;
         if (
             !Browser.isFirefox &&
-            (href = this.tryGetHref(keyboardEvent.srcElement)) &&
-            (Browser.isMac ? keyboardEvent.metaKey : keyboardEvent.ctrlKey)
+            event.eventType == PluginEventType.MouseUp &&
+            (Browser.isMac ? event.rawEvent.metaKey : event.rawEvent.ctrlKey) &&
+            (href = this.tryGetHref(event.rawEvent.srcElement))
         ) {
-            let target = this.target || '_blank';
             let window = this.editor.getDocument().defaultView;
             try {
-                window.open(href, target);
+                window.open(href, this.target || '_blank');
             } catch {}
         }
-    };
+    }
 
     /**
      * Try get href from an anchor element
@@ -169,13 +82,11 @@ export default class HyperLink implements EditorPlugin {
     private tryGetHref(element: Element): string {
         let href: string = null;
         try {
-            do {
-                if (element.tagName == 'A') {
-                    href = (<HTMLAnchorElement>element).href;
-                    break;
-                }
-                element = element.parentElement;
-            } while (this.editor.contains(element));
+            let a = this.editor.getElementAtCursor('a[href]', element);
+
+            if (a) {
+                href = (<HTMLAnchorElement>a).href;
+            }
         } catch (error) {
             // Not do anything for the moment
         }

--- a/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
@@ -40,7 +40,7 @@ export default class HyperLink implements EditorPlugin {
         let href = this.tryGetHref(e.srcElement);
         if (href) {
             this.editor.setEditorDomAttribute(
-                'titile',
+                'title',
                 e.type == 'mouseover' ? this.getTooltipCallback(href) : null
             );
         }

--- a/packages/roosterjs-plugin-image-resize/lib/ImageResize.ts
+++ b/packages/roosterjs-plugin-image-resize/lib/ImageResize.ts
@@ -282,7 +282,7 @@ export default class ImageResize implements EditorPlugin {
     private stopEvent = (e: UIEvent) => {
         e.stopPropagation();
         e.preventDefault();
-    }
+    };
 
     private removeResizeDiv(resizeDiv: HTMLElement) {
         if (this.editor && this.editor.contains(resizeDiv)) {


### PR DESCRIPTION
I rewrote HyperLink plugin to change the way of implementing hyperlink title. The new approach doesn't need to add temporary attribute into A tag, so copy/paste won't have other side effect.