### PR TITLE
[PickerPlugin] Use performAutoComplete when flagged in PickerPluginOptions

### DIFF
--- a/packages/roosterjs-plugin-picker/lib/PickerDataProvider.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerDataProvider.ts
@@ -26,7 +26,7 @@ export interface PickerDataProvider {
     // The first is called in order to "commit" a new element to the editor body that isn't handled automatically by the editor plugin.
     // The second sets the isSuggesting value for situations wherethe UX needs to manipulate the suggesting state that's otherwise plugin managed.
     onInitalize: (
-        insertNodeCallback: (nodeToAvoiddd: HTMLElement) => void,
+        insertNodeCallback: (nodeToAvoid: HTMLElement) => void,
         setIsSuggestingCallback: (isSuggesting: boolean) => void,
         editor?: Editor
     ) => void;

--- a/packages/roosterjs-plugin-picker/lib/PickerDataProvider.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerDataProvider.ts
@@ -16,6 +16,9 @@ export interface PickerPluginOptions {
     // Vertical (the default, when this is false), will call shiftHighlight with up (false) and down (true).
     // Horizontal (when this is true), will call shiftHighlight with left (false) and right (true).
     isHorizontal?: boolean;
+
+    // Option for letting the editor handle autocomplete on node insertion
+    handleAutoComplete?: boolean;
 }
 
 export interface PickerDataProvider {
@@ -23,7 +26,7 @@ export interface PickerDataProvider {
     // The first is called in order to "commit" a new element to the editor body that isn't handled automatically by the editor plugin.
     // The second sets the isSuggesting value for situations wherethe UX needs to manipulate the suggesting state that's otherwise plugin managed.
     onInitalize: (
-        commitMentionCallback: (nodeToAvoiddd: HTMLElement) => void,
+        insertNodeCallback: (nodeToAvoiddd: HTMLElement) => void,
         setIsSuggestingCallback: (isSuggesting: boolean) => void,
         editor?: Editor
     ) => void;

--- a/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
@@ -36,7 +36,7 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
     constructor(
         public readonly dataProvider: PickerDataProvider,
         private pickerOptions: PickerPluginOptions
-    ) {}
+    ) { }
 
     /**
      * Get a friendly name
@@ -53,20 +53,21 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
         this.editor = editor;
         this.dataProvider.onInitalize(
             (htmlNode: Node) => {
-                let nodeInserted = false;
                 this.editor.focus();
                 this.editor.addUndoSnapshot();
 
                 let wordToReplace = this.getWord(null);
                 if (wordToReplace) {
-                    replaceWithNode(this.editor, wordToReplace, htmlNode, true);
-                    nodeInserted = true;
-                    this.setIsSuggesting(false);
-                }
+                    let insertNode = () => {
+                        replaceWithNode(this.editor, wordToReplace, htmlNode, true /* exactMatch */);
+                        this.setIsSuggesting(false);
+                    }
 
-                if (nodeInserted) {
-                    this.editor.triggerContentChangedEvent(this.pickerOptions.changeSource);
-                    this.editor.addUndoSnapshot();
+                    if (this.pickerOptions.handleAutoComplete) {
+                        this.editor.performAutoComplete(insertNode, this.pickerOptions.changeSource);
+                    } else {
+                        this.editor.addUndoSnapshot(insertNode, this.pickerOptions.changeSource)
+                    }
                 }
             },
             (isSuggesting: boolean) => {
@@ -271,9 +272,9 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
                 this.dataProvider.shiftHighlight &&
                 (this.pickerOptions.isHorizontal
                     ? keyboardEvent.key == LEFT_ARROW_CHARCODE ||
-                      keyboardEvent.key == RIGHT_ARROW_CHARCODE
+                    keyboardEvent.key == RIGHT_ARROW_CHARCODE
                     : keyboardEvent.key == UP_ARROW_CHARCODE ||
-                      keyboardEvent.key == DOWN_ARROW_CHARCODE)
+                    keyboardEvent.key == DOWN_ARROW_CHARCODE)
             ) {
                 this.dataProvider.shiftHighlight(
                     this.pickerOptions.isHorizontal

--- a/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
@@ -112,6 +112,8 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
         if (event.eventType == PluginEventType.KeyUp && !this.eventHandledOnKeyDown) {
             this.onKeyUpDomEvent(event);
         } else if (event.eventType == PluginEventType.KeyPress) {
+            // The KeyPress event is fired when a key that produces a character value is pressed down
+            // Keys that don't produce character values include modifier keys like Ctrl and Backspace
             this.isCharacterValue = true;
         } else if (event.eventType == PluginEventType.MouseUp) {
             if (this.isSuggesting) {
@@ -202,7 +204,7 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
                 this.setIsSuggesting(false);
             }
         } else if (this.isCharacterValue) {
-            // Check for isCharacterValue to filter out events like Ctrl+Z and modifiers
+            // Check for isCharacterValue to filter out modifiers like Ctrl+Z and Backspace
             let wordBeforeCursor = this.getWordBeforeCursor(event);
             if (!this.blockSuggestions) {
                 if (


### PR DESCRIPTION
This makes it so Undo happens when hitting Backspace. The emoji is re-autocompleted after because the KeyUp event triggers queryStringUpdated - so this should be fixed in another PR.

Code Changes
1. Add `handleAutoComplete` flag to PickerPluginOptions
2. When defined, use `performAutoComplete` instead of `addUndoSnapshot `

Deploy Link: https://outlook-sdf.office.com/mail/?branch=DESKTOP-ONVDVE4-u-titrongt-testRoosterJs

