### PR TITLE
Insert node on empty wordToReplace in PickerPlugin

### DIFF
--- a/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
@@ -66,25 +66,24 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
                     wordToReplace = this.getWord(null);
                 }
 
-                if (wordToReplace) {
-                    let insertNode = () => {
+                let insertNode = () => {
+                    if (wordToReplace) {
                         replaceWithNode(
                             this.editor,
                             wordToReplace,
                             htmlNode,
                             true /* exactMatch */
                         );
-                        this.setIsSuggesting(false);
-                    };
-
-                    if (this.pickerOptions.handleAutoComplete) {
-                        this.editor.performAutoComplete(
-                            insertNode,
-                            this.pickerOptions.changeSource
-                        );
                     } else {
-                        this.editor.addUndoSnapshot(insertNode, this.pickerOptions.changeSource);
+                        this.editor.insertNode(htmlNode);
                     }
+                    this.setIsSuggesting(false);
+                };
+
+                if (this.pickerOptions.handleAutoComplete) {
+                    this.editor.performAutoComplete(insertNode, this.pickerOptions.changeSource);
+                } else {
+                    this.editor.addUndoSnapshot(insertNode, this.pickerOptions.changeSource);
                 }
             },
             (isSuggesting: boolean) => {


### PR DESCRIPTION
Currently, PickerPlugin's insertNode callback does nothing when the wordToReplace is empty 

In order for the ExpressionPane in client-web to use this callback, it needs to be able to insert nodes even when there is no text to replace 