### PR TITLE
7.1.0 Fix #209

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.0.4",
+    "version": "7.1.0",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.0.3",
+    "version": "7.0.4",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-api/lib/utils/processList.ts
+++ b/packages/roosterjs-editor-api/lib/utils/processList.ts
@@ -63,7 +63,6 @@ function applyListFormat(node: Node, formats: string[]) {
         fontFamily: formats[0],
         fontSize: formats[1],
         textColor: formats[2],
-        backgroundColor: formats[3],
     });
 }
 

--- a/packages/roosterjs/package.json
+++ b/packages/roosterjs/package.json
@@ -8,6 +8,7 @@
     "roosterjs-editor-api": "",
     "roosterjs-editor-plugins": "",
     "roosterjs-plugin-image-resize": "",
+    "roosterjs-plugin-picker": "",
     "roosterjs-html-sanitizer": ""
   },
   "main": "./lib/index.ts"


### PR DESCRIPTION
1. Fix #209 Start a number list which has text with background color at beginning of the line, causes the background color fill the whole line
2. Add a new plugin CustomReplace
3. Fix issue when insert node on empty wordToReplace in PickerPlugin
4. Fix a missing package dependency
