### PR TITLE
Modify Dark Mode transform order, and enable setContent to transform as well.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.0.2",
+    "version": "7.0.2-darkmode.0",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -70,7 +70,7 @@ export default class Editor {
         this.setContent(
             options.initialContent || contentDiv.innerHTML || '',
             true /* triggerContentChangedEvent */,
-            this.core.darkModeOptions.transformOnInitialize
+            this.core.darkModeOptions && this.core.darkModeOptions.transformOnInitialize
         );
 
         // 5. Create event handler to bind DOM events

--- a/packages/roosterjs-editor-plugins/lib/Paste/Paste.ts
+++ b/packages/roosterjs-editor-plugins/lib/Paste/Paste.ts
@@ -133,18 +133,6 @@ export default class Paste implements EditorPlugin {
                 if (mergeCurrentFormat) {
                     this.applyToElements(node, this.applyFormatting(clipboardData.originalFormat, this.editor.isDarkMode()));
                 }
-                if (this.editor.isDarkMode()) {
-                    // either use their paste handler or ours, but check it here.
-                    this.applyToElements(node, (element) => {
-                        const darkModeOptions = this.editor.getDarkModeOptions();
-                        if (darkModeOptions && darkModeOptions.onExternalContentTransform) {
-                            darkModeOptions.onExternalContentTransform(element);
-                        } else {
-                            element.style.color = null;
-                            element.style.backgroundColor = null;
-                        }
-                    });
-                }
                 fragment.appendChild(node);
             }
         }

--- a/packages/roosterjs-editor-types/lib/interface/DarkModeOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/DarkModeOptions.ts
@@ -2,6 +2,12 @@
  * The options to specify dark mode editor behavior
  */
 interface DarkModeOptions {
+    /** Transform on insert controls if, when the editor is initialized, content should be transformed for dark mode.
+     *  Set this to true to run the content being set to the editor through an initial transform into dark mode.
+     *  Set this to false if you are setting dark mode compliant content initialy.
+     */
+    transformOnInitialize?: boolean;
+
     /**
      * RoosterJS provides an experemental "external content handler" that transforms text
      * This is used when content is pasted or inserted via a method we can hook into.


### PR DESCRIPTION
1. Move the dark mode transform logic to be post insertion of the node. This means we can use getComputedStyles if desired in the future to compute dark mode transformations, which is necessary for proper and accessible color normalization.

2. Add a parameter to set content to declare you want the content inserted to be transformed for dark mode.

3. Add a parameter to DarkModeOptions to be used when initializing to transform the content when inserted.