### PR TITLE
7.1.2 Fix #218

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.1.1",
+    "version": "7.1.2",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-api/lib/format/replaceWithNode.ts
+++ b/packages/roosterjs-editor-api/lib/format/replaceWithNode.ts
@@ -58,6 +58,15 @@ export default function replaceWithNode(
     if (range) {
         let backupRange = editor.getSelectionRange();
 
+        // If the range to replace is rgith before current cursor, it is actually an exact match
+        if (
+            backupRange.collapsed &&
+            range.endContainer == backupRange.startContainer &&
+            range.endOffset == backupRange.startOffset
+        ) {
+            exactMatch = true;
+        }
+
         range.deleteContents();
         range.insertNode(node);
 

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/autoLinkFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/autoLinkFeatures.ts
@@ -45,8 +45,8 @@ function cacheGetLinkData(event: PluginEvent, editor: Editor): LinkData {
         (event.eventType == PluginEventType.ContentChanged && event.source == ChangeSource.Paste)
         ? cacheGetEventData(event, 'LINK_DATA', () => {
               // First try to match link from the whole paste string from the plain text in clipboard.
-              // This helps when we paste a link next to some existing charactor, and the text we got
-              // from clipboard will only contain what we pasted, any existing charactors will not
+              // This helps when we paste a link next to some existing character, and the text we got
+              // from clipboard will only contain what we pasted, any existing characters will not
               // be included.
               let clipboardData =
                   event.eventType == PluginEventType.ContentChanged &&

--- a/packages/roosterjs-editor-plugins/lib/Paste/Paste.ts
+++ b/packages/roosterjs-editor-plugins/lib/Paste/Paste.ts
@@ -80,9 +80,7 @@ export default class Paste implements EditorPlugin {
                 image: items.image,
                 text: items.text,
                 rawHtml: items.html,
-                html: items.html
-                    ? this.sanitizeHtml(items.html)
-                    : textToHtml(items.text, true /*parseLink*/),
+                html: items.html ? this.sanitizeHtml(items.html) : textToHtml(items.text),
             });
         });
     };

--- a/packages/roosterjs-editor-plugins/lib/Paste/textToHtml.ts
+++ b/packages/roosterjs-editor-plugins/lib/Paste/textToHtml.ts
@@ -1,15 +1,13 @@
-import { Browser, matchLink } from 'roosterjs-editor-dom';
+import { Browser } from 'roosterjs-editor-dom';
 
 var ZERO_WIDTH_SPACE = '&#8203;';
 
 /**
  * Convert plain to HTML
  * @param text The plain text to convert
- * @param parseLink True to parse hyperlink from the text and generate HTML A tag, otherwise false
  * @returns HTML string to present the input text
  */
-export default function textToHtml(text: string, parseLink?: boolean): string {
-    let linkData = parseLink && matchLink(text);
+export default function textToHtml(text: string): string {
     text = (text || '')
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
@@ -35,5 +33,5 @@ export default function textToHtml(text: string, parseLink?: boolean): string {
         });
     }
     text = text.replace(/\s\s/g, ' &nbsp;');
-    return linkData ? `<a href="${linkData.normalizedUrl}">${text}</a>` : text;
+    return text;
 }


### PR DESCRIPTION
In an earlier change I fixed an issue when paste a link next to existing charactor, e.g.
Before paste: ()
After paste: (www.test.com)
And the fix allows do auto link to the pasted text. However, this won't trigger ContentChangedEvent with the new anchor element.

So the fix here is to defer this action after text is pasted, and go through the same code path of regular autolink.