### PR TITLE
Track content changed events and report up to PickerPluginDataProvider

### DIFF
--- a/packages/roosterjs-plugin-picker/lib/PickerDataProvider.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerDataProvider.ts
@@ -52,4 +52,8 @@ export interface PickerDataProvider {
 
     // Function that returns the current cursor position as an anchor point for where to show UX.
     setCursorPoint?: (targetPoint: { x: number; y: number }, buffer: number) => void;
+
+    // Function that is called when the plugin detects the editor's content has changed.
+    // Provides a list of current picker placed elements in the document.
+    onContentChanged?: (elementIds: string[]) => void;
 }

--- a/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
@@ -8,6 +8,7 @@ import {
     PluginEvent,
     PluginEventType,
     PositionType,
+    ChangeSource,
 } from 'roosterjs-editor-types';
 
 // Character codes.
@@ -123,6 +124,18 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
      * @param event PluginEvent object
      */
     public onPluginEvent(event: PluginEvent) {
+        if (event.eventType == PluginEventType.ContentChanged &&
+            event.source == ChangeSource.SetContent && this.dataProvider.onContentChanged) {
+                // Undos and other major changes to document content fire this type of event.
+                // Inform the data provider of the current picker placed elements in the body.
+                const elementsInDocument = this.editor.getDocument()
+                                            .querySelectorAll("[id^='" + this.pickerOptions.elementIdPrefix + "']");
+                let elementIds: string[] = [];
+                elementsInDocument.forEach(element => {
+                    element.id && elementIds.push(element.id);
+                });
+                this.dataProvider.onContentChanged(elementIds);
+        }
         if (event.eventType == PluginEventType.KeyDown) {
             this.eventHandledOnKeyDown = false;
             this.onKeyDownEvent(event);

--- a/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
@@ -131,7 +131,11 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
             let elementIds: string[] = [];
             this.editor.queryElements(
                 "[id^='" + this.pickerOptions.elementIdPrefix + "']",
-                (element) => { element.id && elementIds.push(element.id); });
+                (element) => {
+                    if (element.id) {
+                        elementIds.push(element.id);
+                    }
+                });
             this.dataProvider.onContentChanged(elementIds);
         }
         if (event.eventType == PluginEventType.KeyDown) {

--- a/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
@@ -39,7 +39,7 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
     constructor(
         public readonly dataProvider: PickerDataProvider,
         private pickerOptions: PickerPluginOptions
-    ) {}
+    ) { }
 
     /**
      * Get a friendly name
@@ -126,15 +126,13 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
     public onPluginEvent(event: PluginEvent) {
         if (event.eventType == PluginEventType.ContentChanged &&
             event.source == ChangeSource.SetContent && this.dataProvider.onContentChanged) {
-                // Undos and other major changes to document content fire this type of event.
-                // Inform the data provider of the current picker placed elements in the body.
-                const elementsInDocument = this.editor.getDocument()
-                                            .querySelectorAll("[id^='" + this.pickerOptions.elementIdPrefix + "']");
-                let elementIds: string[] = [];
-                elementsInDocument.forEach(element => {
-                    element.id && elementIds.push(element.id);
-                });
-                this.dataProvider.onContentChanged(elementIds);
+            // Undos and other major changes to document content fire this type of event.
+            // Inform the data provider of the current picker placed elements in the body.
+            let elementIds: string[] = [];
+            this.editor.queryElements(
+                "[id^='" + this.pickerOptions.elementIdPrefix + "']",
+                (element) => { element.id && elementIds.push(element.id); });
+            this.dataProvider.onContentChanged(elementIds);
         }
         if (event.eventType == PluginEventType.KeyDown) {
             this.eventHandledOnKeyDown = false;
@@ -318,9 +316,9 @@ export default class PickerPlugin implements EditorPickerPluginInterface {
                 this.dataProvider.shiftHighlight &&
                 (this.pickerOptions.isHorizontal
                     ? keyboardEvent.key == LEFT_ARROW_CHARCODE ||
-                      keyboardEvent.key == RIGHT_ARROW_CHARCODE
+                    keyboardEvent.key == RIGHT_ARROW_CHARCODE
                     : keyboardEvent.key == UP_ARROW_CHARCODE ||
-                      keyboardEvent.key == DOWN_ARROW_CHARCODE)
+                    keyboardEvent.key == DOWN_ARROW_CHARCODE)
             ) {
                 this.dataProvider.shiftHighlight(
                     this.pickerOptions.isHorizontal


### PR DESCRIPTION
When we get a content changed event, and it's set content, we can assume that something drastic has changed about the state of the editor document. This is used for Undo for instance.

When we get one of these events, we can scan through the document and report any picker placed elements that still exist, and report it to the data provider. For instance, if the data provider is maintaining a list of elements for some reason (like if it needs to track how many are inserted for logging), they currently can't tell if elements are removed through that system. This adds a way for a DataProvider to be informed of the current element list's state after the change happens.