### PR TITLE
Refactor ReplaceWithNode to use the editor core API

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/replaceWithNode.ts
+++ b/packages/roosterjs-editor-api/lib/format/replaceWithNode.ts
@@ -1,6 +1,6 @@
 import { Editor } from 'roosterjs-editor-core';
 import { PositionContentSearcher } from 'roosterjs-editor-dom';
-import { PositionType } from 'roosterjs-editor-types';
+import { ContentPosition } from 'roosterjs-editor-types';
 
 /**
  * Replace text before current selection with a node, current selection will be kept if possible
@@ -56,16 +56,13 @@ export default function replaceWithNode(
     }
 
     if (range) {
-        let backupRange = editor.getSelectionRange();
-
-        range.deleteContents();
-        range.insertNode(node);
-
-        if (exactMatch) {
-            editor.select(node, PositionType.After);
-        } else {
-            editor.select(backupRange);
-        }
+        editor.insertNode(node, {
+            position: ContentPosition.Range,
+            updateCursor: exactMatch,
+            replaceSelection: true,
+            insertOnNewLine: false,
+            range: range,
+        });
 
         return true;
     }

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -18,27 +18,30 @@ import {
 } from 'roosterjs-editor-dom';
 
 const insertNode: InsertNode = (core: EditorCore, node: Node, option: InsertOption) => {
-    let position = option ? option.position : ContentPosition.SelectionStart;
-    let updateCursor = option ? option.updateCursor : true;
-    let replaceSelection = option ? option.replaceSelection : true;
-    let insertOnNewLine = option ? option.insertOnNewLine : false;
-    let optionRange = option && option.position == ContentPosition.Range ? option.range : null;
+    if (!option) {
+        option = <InsertOption>{
+            position: ContentPosition.SelectionStart,
+            insertOnNewLine: false,
+            updateCursor: true,
+            replaceSelection: true,
+        }
+    }
     let contentDiv = core.contentDiv;
 
-    if (updateCursor) {
+    if (option.updateCursor) {
         core.api.focus(core);
     }
 
-    switch (position) {
+    switch (option.position) {
         case ContentPosition.Begin:
         case ContentPosition.End:
-            let isBegin = position == ContentPosition.Begin;
+            let isBegin = option.position == ContentPosition.Begin;
             let block = getFirstLastBlockElement(contentDiv, isBegin);
             let insertedNode: Node;
             if (block) {
                 let refNode = isBegin ? block.getStartNode() : block.getEndNode();
                 if (
-                    insertOnNewLine ||
+                    option.insertOnNewLine ||
                     refNode.nodeType == NodeType.Text ||
                     isVoidHtmlElement(refNode)
                 ) {
@@ -61,29 +64,33 @@ const insertNode: InsertNode = (core: EditorCore, node: Node, option: InsertOpti
 
             // Final check to see if the inserted node is a block. If not block and the ask is to insert on new line,
             // add a DIV wrapping
-            if (insertedNode && insertOnNewLine && !isBlockElement(insertedNode)) {
+            if (insertedNode && option.insertOnNewLine && !isBlockElement(insertedNode)) {
                 wrap(insertedNode);
             }
 
             break;
         case ContentPosition.Range:
         case ContentPosition.SelectionStart:
+            // Selection start replaces based on the current selection.
+            // Range inserts based on a provided range.
+            // Both have the potential to use the current selection to restore cursor position
+            // So in both cases we need to store the selection state.
             let range = core.api.getSelectionRange(core, true /*tryGetFromCache*/);
-            let clonedRange = null;
-            if (!optionRange) {
+            let rangeToRestore = null;
+            if (option.position == ContentPosition.Range) {
+                rangeToRestore = range;
+                range = option.range;
+            } else {
                 if (!range) {
                     return;
                 } else {
                     // Create a clone (backup) for the selection first as we may need to restore to it later
-                    clonedRange = range.cloneRange();
+                    rangeToRestore = range.cloneRange();
                 }
-            } else {
-                clonedRange = range;
-                range = optionRange;
             }
 
             // if to replace the selection and the selection is not collapsed, remove the the content at selection first
-            if (replaceSelection && !range.collapsed) {
+            if (option.replaceSelection && !range.collapsed) {
                 range.deleteContents();
             }
 
@@ -91,7 +98,7 @@ const insertNode: InsertNode = (core: EditorCore, node: Node, option: InsertOpti
             let blockElement: BlockElement;
 
             if (
-                insertOnNewLine &&
+                option.insertOnNewLine &&
                 (blockElement = getBlockElementAtNode(contentDiv, pos.normalize().node))
             ) {
                 pos = new Position(blockElement.getEndNode(), PositionType.After);
@@ -102,10 +109,10 @@ const insertNode: InsertNode = (core: EditorCore, node: Node, option: InsertOpti
             let nodeForCursor = node.nodeType == NodeType.DocumentFragment ? node.lastChild : node;
             range = createRange(pos);
             range.insertNode(node);
-            if (updateCursor && nodeForCursor) {
+            if (option.updateCursor && nodeForCursor) {
                 core.api.select(core, new Position(nodeForCursor, PositionType.After).normalize());
             } else {
-                core.api.select(core, clonedRange);
+                core.api.select(core, rangeToRestore);
             }
 
             break;

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -22,6 +22,7 @@ const insertNode: InsertNode = (core: EditorCore, node: Node, option: InsertOpti
     let updateCursor = option ? option.updateCursor : true;
     let replaceSelection = option ? option.replaceSelection : true;
     let insertOnNewLine = option ? option.insertOnNewLine : false;
+    let optionRange = option && option.position == ContentPosition.Range ? option.range : null;
     let contentDiv = core.contentDiv;
 
     if (updateCursor) {
@@ -65,10 +66,20 @@ const insertNode: InsertNode = (core: EditorCore, node: Node, option: InsertOpti
             }
 
             break;
+        case ContentPosition.Range:
         case ContentPosition.SelectionStart:
             let range = core.api.getSelectionRange(core, true /*tryGetFromCache*/);
-            if (!range) {
-                return;
+            let clonedRange = null;
+            if (!optionRange) {
+                if (!range) {
+                    return;
+                } else {
+                    // Create a clone (backup) for the selection first as we may need to restore to it later
+                    clonedRange = range.cloneRange();
+                }
+            } else {
+                clonedRange = range;
+                range = optionRange;
             }
 
             // if to replace the selection and the selection is not collapsed, remove the the content at selection first
@@ -76,8 +87,6 @@ const insertNode: InsertNode = (core: EditorCore, node: Node, option: InsertOpti
                 range.deleteContents();
             }
 
-            // Create a clone (backup) for the selection first as we may need to restore to it later
-            let clonedRange = range.cloneRange();
             let pos = Position.getStart(range);
             let blockElement: BlockElement;
 

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -1,8 +1,8 @@
 import createEditorCore from './createEditorCore';
 import EditorCore from '../interfaces/EditorCore';
 import EditorOptions from '../interfaces/EditorOptions';
+import { Browser, getRangeFromSelectionPath, getSelectionPath } from 'roosterjs-editor-dom';
 import { GenericContentEditFeature } from '../interfaces/ContentEditFeature';
-import { getRangeFromSelectionPath, getSelectionPath, Browser } from 'roosterjs-editor-dom';
 import {
     BlockElement,
     ChangeSource,

--- a/packages/roosterjs-editor-types/lib/enum/ContentPosition.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ContentPosition.ts
@@ -23,4 +23,9 @@ export const enum ContentPosition {
      * Outside of editor
      */
     Outside,
+
+    /**
+     * Manually defined range
+     */
+    Range,
 }

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -45,7 +45,7 @@ export { default as ClipboardItems } from './interface/ClipboardItems';
 export { default as DefaultFormat } from './interface/DefaultFormat';
 export { default as FormatState } from './interface/FormatState';
 export { default as InlineElement } from './interface/InlineElement';
-export { default as InsertOption } from './interface/InsertOption';
+export { default as InsertOption, InsertOptionBase, InsertOptionBasic, InsertOptionRange } from './interface/InsertOption';
 export { default as LinkData } from './interface/LinkData';
 export { default as NodePosition } from './interface/NodePosition';
 export { default as Rect } from './interface/Rect';

--- a/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
+++ b/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
@@ -22,12 +22,22 @@ export interface InsertOptionBase {
     replaceSelection?: boolean;
 }
 
+/**
+ * The "basic" insertNode related ContentPositions that require no additional parameters to use.
+ */
 export interface InsertOptionBasic extends InsertOptionBase {
     position: ContentPosition.Begin | ContentPosition.End | ContentPosition.Outside | ContentPosition.SelectionStart;
 }
 
+/**
+ * The Range varient where insertNode will opperate on a range disjointed from the current selection state.
+ */
 export interface InsertOptionRange extends InsertOptionBase {
     position: ContentPosition.Range;
+
+    /**
+     * The range to be targeted when insertion happens.
+     */
     range: Range;
 }
 

--- a/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
+++ b/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
@@ -1,28 +1,44 @@
 import { ContentPosition } from '../enum/ContentPosition';
 
 /**
- * Options for insertContent API
+ * Shared options for insertNode related APIs
  */
-export default interface InsertOption {
-    /**
-     * Target position
-     */
-    position: ContentPosition;
-
+export interface InsertOptionBase {
     /**
      * Whether need to update cursor
      */
-    updateCursor: boolean;
+    updateCursor?: boolean;
 
     /**
      * Whether need to replace current selection
      */
-    replaceSelection: boolean;
+    replaceSelection?: boolean;
 
     /**
      * Whether need to insert the content into a new line
      */
-    insertOnNewLine: boolean;
-
-    range?: Range;
+    insertOnNewLine?: boolean;
 }
+
+/**
+ * The "basic" insertNode related ContentPositions that require no additional parameters to use.
+ */
+export interface InsertOptionBasic extends InsertOptionBase {
+    position: ContentPosition.Begin | ContentPosition.End | ContentPosition.Outside | ContentPosition.SelectionStart;
+}
+
+/**
+ * The Range varient where insertNode will opperate on a range disjointed from the current selection state.
+ */
+export interface InsertOptionRange extends InsertOptionBase {
+    position: ContentPosition.Range;
+
+    /**
+     * The range to be targeted when insertion happens.
+     */
+    range: Range;
+}
+
+type InsertOption = InsertOptionBasic | InsertOptionRange;
+
+export default InsertOption;

--- a/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
+++ b/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
@@ -5,40 +5,38 @@ import { ContentPosition } from '../enum/ContentPosition';
  */
 export interface InsertOptionBase {
     /**
-     * Whether need to update cursor
+     * Whether need to update cursor.
      */
     updateCursor?: boolean;
 
     /**
-     * Whether need to replace current selection
-     */
-    replaceSelection?: boolean;
-
-    /**
-     * Whether need to insert the content into a new line
+     * Boolean flag for inserting the content onto a new line.
+     * No-op for ContentPosition.Outside
      */
     insertOnNewLine?: boolean;
+
+    /**
+     * Boolean flag for inserting the content onto a new line.
+     * No-op for ContentPosition.Begin, End, and Outside
+     */
+    replaceSelection?: boolean;
 }
 
-/**
- * The "basic" insertNode related ContentPositions that require no additional parameters to use.
- */
 export interface InsertOptionBasic extends InsertOptionBase {
     position: ContentPosition.Begin | ContentPosition.End | ContentPosition.Outside | ContentPosition.SelectionStart;
 }
 
-/**
- * The Range varient where insertNode will opperate on a range disjointed from the current selection state.
- */
 export interface InsertOptionRange extends InsertOptionBase {
     position: ContentPosition.Range;
-
-    /**
-     * The range to be targeted when insertion happens.
-     */
     range: Range;
 }
 
-type InsertOption = InsertOptionBasic | InsertOptionRange;
+/**
+ * Type definition for the InsertOption, used in the insertNode API.
+ * The position parameter defines how the node will be inserted.
+ * In a future revision, this will become strongly typed
+ * Only parameters applicable to the given position will be accepted.
+ */
+type InsertOption = InsertOptionRange | InsertOptionBasic;
 
 export default InsertOption;

--- a/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
+++ b/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
@@ -23,4 +23,6 @@ export default interface InsertOption {
      * Whether need to insert the content into a new line
      */
     insertOnNewLine: boolean;
+
+    range?: Range;
 }

--- a/publish/samplesite/scripts/controls/sidePane/apiPlayground/insertContent/InsertContentPane.tsx
+++ b/publish/samplesite/scripts/controls/sidePane/apiPlayground/insertContent/InsertContentPane.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import ApiPaneProps from '../ApiPaneProps';
-import { ContentPosition, InsertOption } from 'roosterjs-editor-types';
+import { ContentPosition, InsertOptionBasic } from 'roosterjs-editor-types';
 
 const styles = require('./InsertContentPane.scss');
 
-export interface InsertContentPaneState extends InsertOption {
+export interface InsertContentPaneState {
     content: string;
+    position: ContentPosition,
+    updateCursor: boolean,
+    replaceSelection: boolean,
+    insertOnNewLine: boolean,
 }
 
 export default class InsertContentPane extends React.Component<
@@ -92,7 +96,7 @@ export default class InsertContentPane extends React.Component<
                             id="insertUpdateCursor"
                             checked={this.state.updateCursor}
                             onClick={() =>
-                                this.setState({ updateCursor: !this.state.updateCursor })
+                                this.setState({updateCursor: !this.state.updateCursor })
                             }
                         />
                         <label htmlFor="insertUpdateCursor">Update cursor</label>
@@ -143,6 +147,14 @@ export default class InsertContentPane extends React.Component<
 
     private onClick = () => {
         let editor = this.props.getEditor();
-        editor.addUndoSnapshot(() => editor.insertContent(this.state.content, this.state));
+        if (this.state.position != ContentPosition.Range) {
+            const inputOption: InsertOptionBasic = {
+                position: this.state.position,
+                updateCursor: this.state.updateCursor,
+                replaceSelection: this.state.replaceSelection,
+                insertOnNewLine: this.state.insertOnNewLine,
+            }
+            editor.addUndoSnapshot(() => editor.insertContent(this.state.content, inputOption));
+        }
     };
 }


### PR DESCRIPTION
ReplaceWithNode currently manipulates the dom directly, when there exists an editor API for inserting nodes to begin with. If we extend the definition of the core API to allow for replacing an existing node (instead of relying on calculating what node to replace every time), we can use the editor API. This also will help us with dark mode, as replacing with node is a common operation, and centralizing dom manipulation calls helps us maintain good editor state.