### PR TITLE
Fix 4 issues

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreAPI/select.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/select.ts
@@ -1,6 +1,6 @@
 import EditorCore, { Select } from '../interfaces/EditorCore';
 import hasFocus from './hasFocus';
-import { Browser, contains, createRange, Position } from 'roosterjs-editor-dom';
+import { contains, createRange, Position } from 'roosterjs-editor-dom';
 import { NodePosition, PositionType } from 'roosterjs-editor-types';
 
 const select: Select = (core: EditorCore, arg1: any, arg2?: any, arg3?: any, arg4?: any) => {
@@ -40,10 +40,7 @@ const select: Select = (core: EditorCore, arg1: any, arg2?: any, arg3?: any, arg
                 try {
                     // Do not remove/add range if current selection is the same with target range
                     // Without this check, execCommand() may fail in Edge since we changed the selection
-                    let currentRange =
-                        Browser.isEdge && selection.rangeCount == 1
-                            ? selection.getRangeAt(0)
-                            : null;
+                    let currentRange = selection.rangeCount == 1 ? selection.getRangeAt(0) : null;
                     if (
                         currentRange &&
                         currentRange.startContainer == range.startContainer &&

--- a/packages/roosterjs-editor-types/package.json
+++ b/packages/roosterjs-editor-types/package.json
@@ -1,6 +1,8 @@
 {
-  "name": "roosterjs-editor-types",
-  "description": "Type definition for roosterjs",
-  "dependencies": {},
-  "main": "./lib/index.ts"
+    "name": "roosterjs-editor-types",
+    "description": "Type definition for roosterjs",
+    "dependencies": {
+        "@types/dom-inputevent": "^1.0.3"
+    },
+    "main": "./lib/index.ts"
 }

--- a/tools/build.js
+++ b/tools/build.js
@@ -254,7 +254,6 @@ async function pack(isProduction, isAmd) {
                     countWord(targetFile);
                     exploreSourceMap(targetFile);
                 }
-                insertLicense(targetFile);
                 resolve();
             }
         });
@@ -286,14 +285,6 @@ function exploreSourceMap(inputFile) {
     var commandPath = path.join(nodeModulesPath, 'source-map-explorer/index.js');
     var targetFile = path.join(roosterJsDistPath, 'sourceMap.html');
     runNode(`${commandPath} -m --html ${inputFile} > ${targetFile}`, rootPath);
-}
-
-function insertLicense(filename) {
-    var fileContent = fs.readFileSync(filename).toString();
-    fs.writeFileSync(
-        filename,
-        `/*\r\n    VERSION: ${version}\r\n\r\n${license}\r\n*/\r\n${fileContent}`
-    );
 }
 
 var dtsQueue = [];


### PR DESCRIPTION
1. Add "@types/dom-inputevent" to dependency of roosterjs-types package to avoid build error from other projects that take roosterjs as dependency  (package.json)

2. Remove "insertLicense" step from build script. I added this step in order to mark version number of a packed file, however this causes source map doesn't work. So let's remove it. (build.js)

3. In select.ts, we have a browser check and skip setting selection if browser is already selecting the same range. Currently we only do this for Edge, but we need to do this for all browser so that we won't deselect and reselect when focus to editor. This is the first step of fixing the state of B/I/U issue. (select.ts)

 I also removed related workaround code in RibbonButton.tsx since we don't need them after this fix.  (RibbonButton.tsx)

4. The demo site can't change font size in IE because we have code to reselect after a drop down is dismissed. Actually this is only required by Safari, so add a browser check there. (RibbonButton.tsx)

