### PR TITLE
Skip the root element when setContent is called w/ dark mode transform.

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -418,6 +418,7 @@ export default class Editor {
      * Set HTML content to this editor. All existing content will be replaced. A ContentChanged event will be triggered
      * @param content HTML content to set in
      * @param triggerContentChangedEvent True to trigger a ContentChanged event. Default value is true
+     * @param convertToDarkMode True to conver the editor's new content to dark mode formatting. Default value is false.
      */
     public setContent(content: string, triggerContentChangedEvent: boolean = true, convertToDarkMode?: boolean) {
         let contentDiv = this.core.contentDiv;
@@ -436,7 +437,7 @@ export default class Editor {
             }
 
             if (convertToDarkMode) {
-                this.convertContentToDarkMode(contentDiv)();
+                this.convertContentToDarkMode(contentDiv, true /* skipRootElement */)();
             }
 
             if (triggerContentChangedEvent) {
@@ -926,8 +927,9 @@ export default class Editor {
     /**
      * Converter for dark mode that runs all child elements of a node through the content transform function.
      * @param node The node containing HTML elements to convert.
+     * @param skipRootElement Optional parameter to skip the root element of the Node passed in, if applicable.
      */
-    private convertContentToDarkMode(node: Node): () => void {
+    private convertContentToDarkMode(node: Node, skipRootElement?: boolean): () => void {
         let childElements: HTMLElement[] = [];
 
         // Get a list of all the decendents of a node.
@@ -935,7 +937,9 @@ export default class Editor {
         // So we use getElementsByTagName instead for HTMLElement types.
         if (node instanceof HTMLElement) {
             childElements = Array.prototype.slice.call(node.getElementsByTagName('*'));
-            childElements.unshift(node);
+            if (!skipRootElement) {
+                childElements.unshift(node);
+            }
         } else if (node instanceof DocumentFragment) {
             childElements = Array.prototype.slice.call(node.querySelectorAll('*'));
         }


### PR DESCRIPTION
When we call setContent, we get a reference to the core CED and set the content that way. However, when we do this, all we have left that's an HTML node is that root CED. We actually don't want to modify the CED, but we do want to modify the content coming into it. So, we add a parameter to the dark mode transform function to skip that root element, meaning the only thing that gets transformed is the actual editor content itself.