### PR TITLE
Replace deprecated TSLint extension with MSFT TSLint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["esbenp.prettier-vscode", "eg2.tslint", "miclo.sort-typescript-imports"]
+    "recommendations": ["esbenp.prettier-vscode", "ms-vscode.vscode-typescript-tslint-plugin", "miclo.sort-typescript-imports"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.1.2",
+    "version": "7.2.0",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",


### PR DESCRIPTION
I noticed the recommended tslint package was deprecated. Microsoft has it's own TSLint extension, so I replaced our current recommendation with the microsoft one.