### PR TITLE
stopPropagation for key inputs

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreAPI/attachDomEvent.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/attachDomEvent.ts
@@ -8,6 +8,14 @@ const attachDomEvent: AttachDomEvent = (
     beforeDispatch?: (event: UIEvent) => void
 ) => {
     let onEvent = (event: UIEvent) => {
+        // Stop propagation of a printable keyboard event (a keyboard event which is caused by printable char input).
+        // This detection is not 100% accurate. event.key is not fully supported by all brwosers, and in some browser (e.g. IE)
+        // event.key is longer than 1 for num pad input. But here we just want to improve performance as mush as possible.
+        // So if we missed some case here it is still acceptable.
+        if (isKeyboardEvent(event) && event.key && event.key.length == 1) {
+            event.stopPropagation();
+        }
+
         if (beforeDispatch) {
             beforeDispatch(event);
         }
@@ -29,3 +37,7 @@ const attachDomEvent: AttachDomEvent = (
 };
 
 export default attachDomEvent;
+
+function isKeyboardEvent(e: UIEvent): e is KeyboardEvent {
+    return e.type == 'keydown' || e.type == 'keypress' || e.type == 'keyup';
+}


### PR DESCRIPTION
For printable key inputs (a-z, 0-9, ...), call stopPropagation() to avoid the event being handled by parent container in order to improve perf.