### PR TITLE
Fix keyboard event issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.2.2",
+    "version": "7.2.3",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-core/lib/coreAPI/attachDomEvent.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/attachDomEvent.ts
@@ -12,7 +12,14 @@ const attachDomEvent: AttachDomEvent = (
         // This detection is not 100% accurate. event.key is not fully supported by all brwosers, and in some browser (e.g. IE)
         // event.key is longer than 1 for num pad input. But here we just want to improve performance as mush as possible.
         // So if we missed some case here it is still acceptable.
-        if (isKeyboardEvent(event) && event.key && event.key.length == 1) {
+        if (
+            isKeyboardEvent(event) &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.metaKey &&
+            event.key &&
+            event.key.length == 1
+        ) {
             event.stopPropagation();
         }
 


### PR DESCRIPTION
In my previous check in I added stopPropagation() for keyboard event. But this should only be added for text input key event. Event such as ALT+, CTRL+, META+ should still be propagated.