### PR TITLE
Improved Hyperlink plugin onLinkClick option

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
@@ -14,12 +14,12 @@ export default class HyperLink implements EditorPlugin {
      * @param getTooltipCallback A callback function to get tooltip text for an existing hyperlink.
      * Default value is to return the href itself. If null, there will be no tooltip text.
      * @param target (Optional) Target window name for hyperlink. If null, will use "_blank"
-     * @param onLinkClick (Optional) Open link callback
+     * @param onLinkClick (Optional) Open link callback (return false to use default behavior)
      */
     constructor(
         private getTooltipCallback: (href: string, a: HTMLAnchorElement) => string = href => href,
         private target?: string,
-        private onLinkClick?: (anchor: HTMLAnchorElement, mouseEvent: MouseEvent) => void
+        private onLinkClick?: (anchor: HTMLAnchorElement, mouseEvent: MouseEvent) => boolean | void
     ) {}
 
     /**
@@ -73,8 +73,7 @@ export default class HyperLink implements EditorPlugin {
             ) as HTMLAnchorElement;
 
             if (anchor) {
-                if (this.onLinkClick) {
-                    this.onLinkClick(anchor, event.rawEvent);
+                if (this.onLinkClick && this.onLinkClick(anchor, event.rawEvent) !== false) {
                     return;
                 }
 


### PR DESCRIPTION
Allow Hyperlink onLinkClick to fall back to default handling to reduce redundant code.