### PR TITLE
Set content should base itself off of inDarkMode

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -73,7 +73,7 @@ export default class Editor {
         this.setContent(
             options.initialContent || contentDiv.innerHTML || '',
             true /* triggerContentChangedEvent */,
-            this.core.darkModeOptions && this.core.darkModeOptions.transformOnInitialize
+            this.core.inDarkMode
         );
 
         // 5. Create event handler to bind DOM events


### PR DESCRIPTION
Instead of looking at the editor options object, we should instead base off of if inDarkMode is set to true. This allows an editor to be provided dark mode options, but be in non-dark mode, at least to start.