### PR TITLE
7.2.5-darkmode.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.2.5-darkmode.0",
+    "version": "7.2.5-darkmode.1",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",


### PR DESCRIPTION
I did a bad and ran yarn package, which has changed behavior recently and doesn't run our build script. So, 7.2.5-darkmode.0's name is spiked, so I'm bumping the name here. No other changes.