### PR TITLE
Recalculate default format when dark mode toggles

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -1,4 +1,4 @@
-import createEditorCore from './createEditorCore';
+import createEditorCore, { calcDefaultFormat } from './createEditorCore';
 import EditorCore from '../interfaces/EditorCore';
 import EditorOptions from '../interfaces/EditorOptions';
 import { GenericContentEditFeature } from '../interfaces/ContentEditFeature';
@@ -937,7 +937,10 @@ export default class Editor {
             undefined /* triggerContentChangedEvent */,
             true /* getSelectionMarker */
         );
+
         this.core.inDarkMode = nextDarkMode;
+        this.core.defaultFormat = calcDefaultFormat(this.core.contentDiv, this.core.defaultFormat, this.core.inDarkMode);
+
         if (nextDarkMode) {
             this.setContent(
                 currentContent,

--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -46,7 +46,7 @@ export default function createEditorCore(
     return {
         contentDiv,
         document: contentDiv.ownerDocument,
-        defaultFormat: calcDefaultFormat(contentDiv, options),
+        defaultFormat: calcDefaultFormat(contentDiv, options.defaultFormat, options.inDarkMode),
         corePlugins,
         currentUndoSnapshot: null,
         customData: {},
@@ -60,10 +60,8 @@ export default function createEditorCore(
     };
 }
 
-function calcDefaultFormat(node: Node, options: EditorOptions): DefaultFormat {
-    let baseFormat = options.defaultFormat;
-
-    if (options.inDarkMode) {
+export function calcDefaultFormat(node: Node, baseFormat: DefaultFormat, inDarkMode: boolean): DefaultFormat {
+    if (inDarkMode) {
         if (!baseFormat.backgroundColors) {
             baseFormat.backgroundColors = DARK_MODE_DEFAULT_FORMAT.backgroundColors;
         }
@@ -83,7 +81,7 @@ function calcDefaultFormat(node: Node, options: EditorOptions): DefaultFormat {
         fontSize: baseFormat.fontSize || styles[1],
         get textColor() {
             return baseFormat.textColors
-                ? options.inDarkMode
+                ? inDarkMode
                     ? baseFormat.textColors.darkModeColor
                     : baseFormat.textColors.lightModeColor
                 : baseFormat.textColor || styles[2];
@@ -91,7 +89,7 @@ function calcDefaultFormat(node: Node, options: EditorOptions): DefaultFormat {
         textColors: baseFormat.textColors,
         get backgroundColor() {
             return baseFormat.backgroundColors
-                ? options.inDarkMode
+                ? inDarkMode
                     ? baseFormat.backgroundColors.darkModeColor
                     : baseFormat.backgroundColors.lightModeColor
                 : baseFormat.backgroundColor || '';

--- a/packages/roosterjs-editor-core/lib/interfaces/EditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/interfaces/EditorCore.ts
@@ -51,7 +51,7 @@ export default interface EditorCore {
     /**
      * Default format of this editor
      */
-    readonly defaultFormat: DefaultFormat;
+    defaultFormat: DefaultFormat;
 
     /**
      * Core plugin of this editor


### PR DESCRIPTION
When we toggle dark mode, the default formatting can sometimes get re-applied by ensureTypeInElement. This requires us to re-set the default format based on the dark mode state. We can achieve this by exporting the calcDefaultFormat function from createEditorCore to do this calculation. Open to placing this somewhere else.