### PR TITLE
Fix #290

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/setBackgroundColor.ts
+++ b/packages/roosterjs-editor-api/lib/format/setBackgroundColor.ts
@@ -10,5 +10,7 @@ import { Editor } from 'roosterjs-editor-core';
  */
 export default function setBackgroundColor(editor: Editor, color: string) {
     color = color.trim();
-    applyInlineStyle(editor, element => (element.style.backgroundColor = color));
+    applyInlineStyle(editor, (element, isInnerNode) => {
+        element.style.backgroundColor = isInnerNode ? '' : color;
+    });
 }

--- a/packages/roosterjs-editor-api/lib/format/setFontName.ts
+++ b/packages/roosterjs-editor-api/lib/format/setFontName.ts
@@ -12,5 +12,7 @@ export default function setFontName(editor: Editor, fontName: string) {
     // The browser provided execCommand creates a HTML <font> tag with face attribute. <font> is not HTML5 standard
     // (http://www.w3schools.com/tags/tag_font.asp). Use applyInlineStyle which gives flexibility on applying inline style
     // for here, we use CSS font-family style
-    applyInlineStyle(editor, element => (element.style.fontFamily = fontName));
+    applyInlineStyle(editor, (element, isInnerNode) => {
+        element.style.fontFamily = isInnerNode ? '' : fontName;
+    });
 }

--- a/packages/roosterjs-editor-api/lib/format/setFontSize.ts
+++ b/packages/roosterjs-editor-api/lib/format/setFontSize.ts
@@ -13,8 +13,8 @@ export default function setFontSize(editor: Editor, fontSize: string) {
     // The browser provided execCommand only accepts 1-7 point value. In addition, it uses HTML <font> tag with size attribute.
     // <font> is not HTML5 standard (http://www.w3schools.com/tags/tag_font.asp). Use applyInlineStyle which gives flexibility on applying inline style
     // for here, we use CSS font-size style
-    applyInlineStyle(editor, element => {
-        element.style.fontSize = fontSize;
+    applyInlineStyle(editor, (element, isInnerNode) => {
+        element.style.fontSize = isInnerNode ? '' : fontSize;
         let lineHeight = getComputedStyle(element, 'line-height');
         if (lineHeight != 'normal') {
             element.style.lineHeight = 'normal';

--- a/packages/roosterjs-editor-api/lib/format/setTextColor.ts
+++ b/packages/roosterjs-editor-api/lib/format/setTextColor.ts
@@ -10,5 +10,7 @@ import { Editor } from 'roosterjs-editor-core';
  */
 export default function setTextColor(editor: Editor, color: string) {
     color = color.trim();
-    applyInlineStyle(editor, element => (element.style.color = color));
+    applyInlineStyle(editor, (element, isInnerNode) => {
+        element.style.color = isInnerNode ? '' : color;
+    });
 }

--- a/packages/roosterjs-editor-api/lib/utils/applyInlineStyle.ts
+++ b/packages/roosterjs-editor-api/lib/utils/applyInlineStyle.ts
@@ -9,7 +9,10 @@ const ZERO_WIDTH_SPACE = '\u200B';
  * @param editor The editor instance
  * @param callback The callback function to apply style
  */
-export default function applyInlineStyle(editor: Editor, callback: (element: HTMLElement) => any) {
+export default function applyInlineStyle(
+    editor: Editor,
+    callback: (element: HTMLElement, isInnerNode?: boolean) => any
+) {
     editor.focus();
     let range = editor.getSelectionRange();
 
@@ -51,8 +54,8 @@ export default function applyInlineStyle(editor: Editor, callback: (element: HTM
             let inlineElement = contentTraverser && contentTraverser.currentInlineElement;
             while (inlineElement) {
                 let nextInlineElement = contentTraverser.getNextInlineElement();
-                inlineElement.applyStyle(element => {
-                    callback(element);
+                inlineElement.applyStyle((element, isInnerNode) => {
+                    callback(element, isInnerNode);
                     firstNode = firstNode || element;
                     lastNode = element;
                 });

--- a/packages/roosterjs-editor-dom/lib/inlineElements/NodeInlineElement.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/NodeInlineElement.ts
@@ -84,7 +84,7 @@ class NodeInlineElement implements InlineElement {
     /**
      * Apply inline style to an inline element
      */
-    public applyStyle(styler: (element: HTMLElement) => any): void {
+    public applyStyle(styler: (element: HTMLElement, isInnerNode?: boolean) => any): void {
         applyTextStyle(this.containerNode, styler);
     }
 }

--- a/packages/roosterjs-editor-dom/lib/inlineElements/PartialInlineElement.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/PartialInlineElement.ts
@@ -102,7 +102,7 @@ class PartialInlineElement implements InlineElement {
     /**
      * apply style
      */
-    public applyStyle(styler: (element: HTMLElement) => any) {
+    public applyStyle(styler: (element: HTMLElement, isInnerNode?: boolean) => any) {
         let from = this.getStartPosition().normalize();
         let to = this.getEndPosition().normalize();
         let container = this.getContainerNode();

--- a/packages/roosterjs-editor-dom/lib/test/utils/applyTextStyleTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/utils/applyTextStyleTest.ts
@@ -175,7 +175,12 @@ describe('applyTextStyle()', () => {
         div.innerHTML = 'test1<b>test2<i>test3</i></b><i>test4</i>test5<span>test6</span>';
         let start = new Position(div, PositionType.Begin).normalize().move(2);
         let end = new Position(div, PositionType.End).normalize().move(-2);
-        applyTextStyle(div, node => (node.style.color = 'red'), start, end);
+        applyTextStyle(
+            div,
+            (node, isInnerNode) => (node.style.color = isInnerNode ? '' : 'red'),
+            start,
+            end
+        );
         expect(div.innerHTML).toBe(
             'te<span style="color: red;">st1</span><span style="color: red;"><b>test2</b></span><span style="color: red;"><b><i>test3</i></b></span><span style="color: red;"><i>test4</i></span><span style="color: red;">test5</span><span style="color: red;">tes</span><span>t6</span>'
         );
@@ -189,6 +194,22 @@ describe('applyTextStyle()', () => {
         applyTextStyle(div, node => (node.style.color = 'red'), start, end);
         expect(div.innerHTML).toBe(
             '<span><span>t</span><span style="color: red;">ex</span><span>t</span></span>'
+        );
+    });
+
+    it('applyTextStyle() inner node has conflict style', () => {
+        let div = document.createElement('DIV');
+        div.innerHTML = 'aabb<b style="color:yellow">cc</b>ddee';
+        let start = new Position(div, PositionType.Begin).normalize().move(2);
+        let end = new Position(div, PositionType.End).normalize().move(-2);
+        applyTextStyle(
+            div,
+            (node, isInnerNode) => (node.style.color = isInnerNode ? '' : 'red'),
+            start,
+            end
+        );
+        expect(div.innerHTML).toBe(
+            'aa<span style="color: red;">bb</span><span style="color: red;"><b style="">cc</b></span><span style="color: red;">dd</span>ee'
         );
     });
 });

--- a/packages/roosterjs-editor-dom/lib/utils/applyTextStyle.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/applyTextStyle.ts
@@ -9,7 +9,7 @@ const STYLETAGS = 'SPAN,B,I,U,EM,STRONG,STRIKE,S,SMALL'.split(',');
 
 export default function applyTextStyle(
     container: Node,
-    styler: (node: HTMLElement) => any,
+    styler: (node: HTMLElement, isInnerNode?: boolean) => any,
     from: NodePosition = new Position(container, PositionType.Begin).normalize(),
     to: NodePosition = new Position(container, PositionType.End).normalize()
 ) {
@@ -54,10 +54,25 @@ export default function applyTextStyle(
                 getTagOfNode(node) != 'SPAN' &&
                 STYLETAGS.indexOf(getTagOfNode(node.parentNode)) >= 0
             ) {
+                callStylerWithInnerNode(node, styler);
                 node = splitBalancedNodeRange(node);
             }
-            styler(getTagOfNode(node) == 'SPAN' ? <HTMLElement>node : wrap(node, 'span'));
+
+            if (getTagOfNode(node) != 'SPAN') {
+                callStylerWithInnerNode(node, styler);
+                node = wrap(node, 'SPAN');
+            }
+            styler(<HTMLElement>node);
         });
+    }
+}
+
+function callStylerWithInnerNode(
+    node: Node,
+    styler: (node: HTMLElement, isInnerNode?: boolean) => any
+) {
+    if (node && node.nodeType == NodeType.Element) {
+        styler(node as HTMLElement, true /*isInnerNode*/);
     }
 }
 

--- a/packages/roosterjs-editor-types/lib/interface/InlineElement.ts
+++ b/packages/roosterjs-editor-types/lib/interface/InlineElement.ts
@@ -56,5 +56,5 @@ export default interface InlineElement {
     /**
      * Apply inline style to a region of an inline element
      */
-    applyStyle(styler: (element: HTMLElement) => any): void;
+    applyStyle(styler: (element: HTMLElement, isInnerNode?: boolean) => any): void;
 }


### PR DESCRIPTION
#290 applyInlineStyle() needs to clean any conflict styles from b/i/u/... tags

When apply style to HTML which contains some inner node with style, e.g.
```html
<span>aa<b style="color:red">bb</b>cc</span>
```
The existing code will always apply style to the outer SPAN tag (or create a SPAN tag if SPAN can't be found). So the style on inner node will override the style will apply.

The fix there is to call the callback styler function with an additional parameter (isInnerNode) for the inner nodes, and caller code can check this parameter and do proper handling.