### PR TITLE
[PickerPlugin] Modify check to register Backspace key onKeyUp

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreAPI/attachDomEvent.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/attachDomEvent.ts
@@ -1,5 +1,5 @@
 import EditorCore, { AttachDomEvent } from '../interfaces/EditorCore';
-import isCharacterValue from '../eventApi/isCharacterValue';
+import isModifierKey from '../eventApi/isModifierKey';
 import { PluginDomEvent, PluginEventType } from 'roosterjs-editor-types';
 
 const attachDomEvent: AttachDomEvent = (
@@ -10,8 +10,14 @@ const attachDomEvent: AttachDomEvent = (
 ) => {
     let onEvent = (event: UIEvent) => {
         // Stop propagation of a printable keyboard event (a keyboard event which is caused by printable char input).
+        // This detection is not 100% accurate. event.key is not fully supported by all browsers, and in some browsers (e.g. IE),
+        // event.key is longer than 1 for num pad input. But here we just want to improve performance as much as possible.
+        // So if we missed some case here it is still acceptable.
         if (
-            (isKeyboardEvent(event) && isCharacterValue(event)) ||
+            (isKeyboardEvent(event) &&
+                !isModifierKey(event) &&
+                event.key &&
+                event.key.length == 1) ||
             pluginEventType == PluginEventType.Input
         ) {
             event.stopPropagation();

--- a/packages/roosterjs-editor-core/lib/eventApi/isCharacterValue.ts
+++ b/packages/roosterjs-editor-core/lib/eventApi/isCharacterValue.ts
@@ -1,7 +1,0 @@
-// Returns true when the event was fired from a key that produces a character value, otherwise false
-// This detection is not 100% accurate. event.key is not fully supported by all browsers, and in some browsers (e.g. IE),
-// event.key is longer than 1 for num pad input. But here we just want to improve performance as much as possible.
-// So if we missed some case here it is still acceptable.
-export default function isCharacterValue(event: KeyboardEvent): boolean {
-    return !event.ctrlKey && !event.altKey && !event.metaKey && event.key && event.key.length == 1;
-}

--- a/packages/roosterjs-editor-core/lib/eventApi/isModifierKey.ts
+++ b/packages/roosterjs-editor-core/lib/eventApi/isModifierKey.ts
@@ -1,0 +1,4 @@
+// Returns true when the event was fired from a modifier key, otherwise false
+export default function isModifierKey(event: KeyboardEvent): boolean {
+    return event.ctrlKey || event.altKey || event.metaKey;
+}

--- a/packages/roosterjs-editor-core/lib/eventApi/isModifierKey.ts
+++ b/packages/roosterjs-editor-core/lib/eventApi/isModifierKey.ts
@@ -1,4 +1,12 @@
+const CTRL_CHARCODE = 'Control';
+const ALT_CHARCODE = 'Alt';
+const META_CHARCODE = 'Meta';
+
 // Returns true when the event was fired from a modifier key, otherwise false
 export default function isModifierKey(event: KeyboardEvent): boolean {
-    return event.ctrlKey || event.altKey || event.metaKey;
+    const isCtrlKey = event.ctrlKey || event.key === CTRL_CHARCODE;
+    const isAltKey = event.altKey || event.key === ALT_CHARCODE;
+    const isMetaKey = event.metaKey || event.key === META_CHARCODE;
+
+    return isCtrlKey || isAltKey || isMetaKey;
 }

--- a/packages/roosterjs-editor-core/lib/index.ts
+++ b/packages/roosterjs-editor-core/lib/index.ts
@@ -43,4 +43,4 @@ export {
     clearContentSearcherCache,
 } from './eventApi/cacheGetContentSearcher';
 export { default as cacheGetElementAtCursor } from './eventApi/cacheGetElementAtCursor';
-export { default as isCharacterValue } from './eventApi/isCharacterValue';
+export { default as isModifierKey } from './eventApi/isModifierKey';

--- a/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
@@ -1,6 +1,6 @@
 import { Browser, createRange, PartialInlineElement } from 'roosterjs-editor-dom';
 import { cacheGetContentSearcher, Editor, EditorPlugin } from 'roosterjs-editor-core';
-import { isCharacterValue } from 'roosterjs-editor-core';
+import { isModifierKey } from 'roosterjs-editor-core';
 import { PickerDataProvider, PickerPluginOptions } from './PickerDataProvider';
 import { replaceWithNode } from 'roosterjs-editor-api';
 import {
@@ -148,7 +148,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
         if (
             event.eventType == PluginEventType.KeyUp &&
             !this.eventHandledOnKeyDown &&
-            isCharacterValue(event.rawEvent)
+            !isModifierKey(event.rawEvent)
         ) {
             this.onKeyUpDomEvent(event);
         } else if (event.eventType == PluginEventType.MouseUp) {


### PR DESCRIPTION
### Context
We got feedback that the picker was not dismissing after hitting Backspace on the trigger character. 

This is because of the change I made removing the KeyPress event. Instead of checking the event onKeyPress, we were checking that the key isCharacterValue for the event onKeyUp. This included `event.key && event.key.length == 1`

Backspace was not passing this check, so it was not being registered and thus `queryStringUpdated` was never called. This check was originally in attachDomEvent, so I call it directly there and changed the function to be just the common code.

### Deploy Link: coming 