### PR TITLE
[Bullets] Tab should resolve AtMention instead of indenting bullet

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -32,10 +32,10 @@ export default function createEditorCore(
         firefoxTypeAfterLink: Browser.isFirefox && new FirefoxTypeAfterLink(),
     };
     let allPlugins: EditorPlugin[] = [
+        ...(options.plugins || []),
         corePlugins.typeInContainer,
         corePlugins.edit,
         corePlugins.mouseUp,
-        ...(options.plugins || []),
         corePlugins.firefoxTypeAfterLink,
         corePlugins.undo,
         corePlugins.domEvent,

--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -32,8 +32,8 @@ export default function createEditorCore(
         firefoxTypeAfterLink: Browser.isFirefox && new FirefoxTypeAfterLink(),
     };
     let allPlugins: EditorPlugin[] = [
-        ...(options.plugins || []),
         corePlugins.typeInContainer,
+        ...(options.plugins || []),
         corePlugins.edit,
         corePlugins.mouseUp,
         corePlugins.firefoxTypeAfterLink,

--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -33,9 +33,9 @@ export default function createEditorCore(
     };
     let allPlugins: EditorPlugin[] = [
         corePlugins.typeInContainer,
+        corePlugins.mouseUp,
         ...(options.plugins || []),
         corePlugins.edit,
-        corePlugins.mouseUp,
         corePlugins.firefoxTypeAfterLink,
         corePlugins.undo,
         corePlugins.domEvent,


### PR DESCRIPTION
Adjust the order of how the plugins are added so that the PickerPlugin's `willHandleExclusively` takes precedence over EditPlugin. 

Deploy Link: https://outlook-sdf.office.com/mail/?branch=TISHAPC-u-titrongt-testTabShouldResolveAtMention