### PR TITLE
Add more comments to improve doc

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreAPI/attachDomEvent.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/attachDomEvent.ts
@@ -2,7 +2,14 @@ import EditorCore, { AttachDomEvent } from '../interfaces/EditorCore';
 import isCharacterValue from '../eventApi/isCharacterValue';
 import { PluginDomEvent, PluginEventType } from 'roosterjs-editor-types';
 
-const attachDomEvent: AttachDomEvent = (
+/**
+ * Attach a DOM event to the editor content DIV
+ * @param core The EditorCore object
+ * @param eventName The DOM event name
+ * @param pluginEventType Optional event type. When specified, editor will trigger a plugin event with this name when the DOM event is triggered
+ * @param beforeDispatch Optional callback function to be invoked when the DOM event is triggered before trigger plugin event
+ */
+export const attachDomEvent: AttachDomEvent = (
     core: EditorCore,
     eventName: string,
     pluginEventType?: PluginEventType,
@@ -36,8 +43,6 @@ const attachDomEvent: AttachDomEvent = (
         core.contentDiv.removeEventListener(eventName, onEvent);
     };
 };
-
-export default attachDomEvent;
 
 function isKeyboardEvent(e: UIEvent): e is KeyboardEvent {
     return e.type == 'keydown' || e.type == 'keypress' || e.type == 'keyup';

--- a/packages/roosterjs-editor-core/lib/coreAPI/editWithUndo.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/editWithUndo.ts
@@ -7,7 +7,14 @@ import {
     PluginEventType,
 } from 'roosterjs-editor-types';
 
-const editWithUndo: EditWithUndo = (
+/**
+ * Call an editing callback with adding undo snapshots around, and trigger a ContentChanged event if change source is specified.
+ * Undo snapshot will not be added if this call is nested inside another editWithUndo() call.
+ * @param core The EditorCore object
+ * @param callback The editing callback, accepting current selection start and end position, returns an optional object used as the data field of ContentChangedEvent.
+ * @param changeSource The ChangeSource string of ContentChangedEvent. @default ChangeSource.Format. Set to null to avoid triggering ContentChangedEvent
+ */
+export const editWithUndo: EditWithUndo = (
     core: EditorCore,
     callback: (start: NodePosition, end: NodePosition, snapshotBeforeCallback: string) => any,
     changeSource: ChangeSource | string
@@ -47,5 +54,3 @@ const editWithUndo: EditWithUndo = (
         core.api.triggerEvent(core, event, true /*broadcast*/);
     }
 };
-
-export default editWithUndo;

--- a/packages/roosterjs-editor-core/lib/coreAPI/focus.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/focus.ts
@@ -2,7 +2,11 @@ import EditorCore, { Focus } from '../interfaces/EditorCore';
 import { createRange, getFirstLeafNode } from 'roosterjs-editor-dom';
 import { PositionType } from 'roosterjs-editor-types';
 
-const focus: Focus = (core: EditorCore) => {
+/**
+ * Focus to editor. If there is a cached selection range, use it as current selection
+ * @param core The EditorCore object
+ */
+export const focus: Focus = (core: EditorCore) => {
     if (!core.api.hasFocus(core) || !core.api.getSelectionRange(core, false /*tryGetFromCache*/)) {
         // Focus (document.activeElement indicates) and selection are mostly in sync, but could be out of sync in some extreme cases.
         // i.e. if you programmatically change window selection to point to a non-focusable DOM element (i.e. tabindex=-1 etc.).
@@ -32,5 +36,3 @@ const focus: Focus = (core: EditorCore) => {
         core.contentDiv.focus();
     }
 };
-
-export default focus;

--- a/packages/roosterjs-editor-core/lib/coreAPI/getCustomData.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/getCustomData.ts
@@ -1,6 +1,15 @@
 import EditorCore, { GetCustomData } from '../interfaces/EditorCore';
 
-const getCustomData: GetCustomData = <T>(
+/**
+ * Get custom data related with this editor
+ * @param core The EditorCore object
+ * @param key Key of the custom data
+ * @param getter Getter function. If custom data for the given key doesn't exist,
+ * call this function to get one and store it.
+ * @param disposer An optional disposer function to dispose this custom data when
+ * dispose editor.
+ */
+export const getCustomData: GetCustomData = <T>(
     core: EditorCore,
     key: string,
     getter: () => T,
@@ -11,5 +20,3 @@ const getCustomData: GetCustomData = <T>(
         disposer,
     }).value as T;
 };
-
-export default getCustomData;

--- a/packages/roosterjs-editor-core/lib/coreAPI/getSelectionRange.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/getSelectionRange.ts
@@ -1,7 +1,16 @@
 import EditorCore, { GetSelectionRange } from '../interfaces/EditorCore';
 import { contains } from 'roosterjs-editor-dom';
 
-const getSelectionRange: GetSelectionRange = (core: EditorCore, tryGetFromCache: boolean) => {
+/**
+ * Get current or cached selection range
+ * @param core The EditorCore object
+ * @param tryGetFromCache Set to true to retrieve the selection range from cache if editor doesn't own the focus now
+ * @returns A Range object of the selection range
+ */
+export const getSelectionRange: GetSelectionRange = (
+    core: EditorCore,
+    tryGetFromCache: boolean
+) => {
     let result: Range = null;
 
     if (!tryGetFromCache || core.api.hasFocus(core)) {
@@ -20,5 +29,3 @@ const getSelectionRange: GetSelectionRange = (core: EditorCore, tryGetFromCache:
 
     return result;
 };
-
-export default getSelectionRange;

--- a/packages/roosterjs-editor-core/lib/coreAPI/hasFocus.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/hasFocus.ts
@@ -1,11 +1,14 @@
 import EditorCore, { HasFocus } from '../interfaces/EditorCore';
 import { contains } from 'roosterjs-editor-dom';
 
-const hasFocus: HasFocus = (core: EditorCore) => {
+/**
+ * Check if the editor has focus now
+ * @param core The EditorCore object
+ * @returns True if the editor has focus, otherwise false
+ */
+export const hasFocus: HasFocus = (core: EditorCore) => {
     let activeElement = core.document.activeElement;
     return (
         activeElement && contains(core.contentDiv, activeElement, true /*treatSameNodeAsContain*/)
     );
 };
-
-export default hasFocus;

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -37,7 +37,12 @@ function getInitialRange(
     return { range, rangeToRestore };
 }
 
-const insertNode: InsertNode = (core: EditorCore, node: Node, option: InsertOption) => {
+/**
+ * Insert a DOM node into editor content
+ * @param core The EditorCore object. No op if null.
+ * @param option An insert option object to specify how to insert the node
+ */
+export const insertNode: InsertNode = (core: EditorCore, node: Node, option: InsertOption) => {
     option = option || {
         position: ContentPosition.SelectionStart,
         insertOnNewLine: false,
@@ -130,5 +135,3 @@ const insertNode: InsertNode = (core: EditorCore, node: Node, option: InsertOpti
 
     return true;
 };
-
-export default insertNode;

--- a/packages/roosterjs-editor-core/lib/coreAPI/selectRange.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/selectRange.ts
@@ -1,8 +1,20 @@
 import EditorCore, { Select, SelectRange } from '../interfaces/EditorCore';
-import hasFocus from './hasFocus';
 import { Browser, contains, createRange } from 'roosterjs-editor-dom';
+import { hasFocus } from './hasFocus';
 
-const selectRange: SelectRange = (core: EditorCore, range: Range, skipSameRange?: boolean) => {
+/**
+ * Change the editor selection to the given range
+ * @param core The EditorCore object
+ * @param range The range to select
+ * @param skipSameRange When set to true, do nothing if the given range is the same with current selection
+ * in editor, otherwise it will always remove current selection ranage and set to the given one.
+ * This parameter is always treat as true in Edge to avoid some weird runtime exception.
+ */
+export const selectRange: SelectRange = (
+    core: EditorCore,
+    range: Range,
+    skipSameRange?: boolean
+) => {
     if (contains(core.contentDiv, range)) {
         let selection = core.document.defaultView.getSelection();
         if (selection) {
@@ -44,8 +56,6 @@ const selectRange: SelectRange = (core: EditorCore, range: Range, skipSameRange?
 
     return false;
 };
-
-export default selectRange;
 
 /**
  * @deprecated Only for compatibility with existing code, don't use ths function, use selectRange instead

--- a/packages/roosterjs-editor-core/lib/coreAPI/triggerEvent.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/triggerEvent.ts
@@ -2,7 +2,13 @@ import EditorCore, { TriggerEvent } from '../interfaces/EditorCore';
 import EditorPlugin from '../interfaces/EditorPlugin';
 import { PluginEvent } from 'roosterjs-editor-types';
 
-const triggerEvent: TriggerEvent = (
+/**
+ * Trigger a plugin event
+ * @param core The EditorCore object
+ * @param pluginEvent The event object to trigger
+ * @param broadcast Set to true to skip the shouldHandleEventExclusively check
+ */
+export const triggerEvent: TriggerEvent = (
     core: EditorCore,
     pluginEvent: PluginEvent,
     broadcast: boolean
@@ -31,5 +37,3 @@ function handledExclusively(event: PluginEvent, plugin: EditorPlugin): boolean {
 
     return false;
 }
-
-export default triggerEvent;

--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -1,23 +1,23 @@
-import attachDomEvent from '../coreAPI/attachDomEvent';
 import DOMEventPlugin from '../corePlugins/DOMEventPlugin';
 import EditorCore, { CoreApiMap, CorePlugins } from '../interfaces/EditorCore';
 import EditorOptions from '../interfaces/EditorOptions';
 import EditorPlugin from '../interfaces/EditorPlugin';
 import EditPlugin from '../corePlugins/EditPlugin';
-import editWithUndo from '../coreAPI/editWithUndo';
 import FirefoxTypeAfterLink from '../corePlugins/FirefoxTypeAfterLink';
-import focus from '../coreAPI/focus';
-import getCustomData from '../coreAPI/getCustomData';
-import getSelectionRange from '../coreAPI/getSelectionRange';
-import hasFocus from '../coreAPI/hasFocus';
-import insertNode from '../coreAPI/insertNode';
 import MouseUpPlugin from '../corePlugins/MouseUpPlugin';
-import selectRange, { select } from '../coreAPI/selectRange';
-import triggerEvent from '../coreAPI/triggerEvent';
 import TypeInContainerPlugin from '../corePlugins/TypeInContainerPlugin';
 import Undo from '../undo/Undo';
+import { attachDomEvent } from '../coreAPI/attachDomEvent';
 import { Browser, getComputedStyles } from 'roosterjs-editor-dom';
 import { DefaultFormat } from 'roosterjs-editor-types';
+import { editWithUndo } from '../coreAPI/editWithUndo';
+import { focus } from '../coreAPI/focus';
+import { getCustomData } from '../coreAPI/getCustomData';
+import { getSelectionRange } from '../coreAPI/getSelectionRange';
+import { hasFocus } from '../coreAPI/hasFocus';
+import { insertNode } from '../coreAPI/insertNode';
+import { select, selectRange } from '../coreAPI/selectRange';
+import { triggerEvent } from '../coreAPI/triggerEvent';
 
 export default function createEditorCore(
     contentDiv: HTMLDivElement,

--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -19,6 +19,11 @@ import { insertNode } from '../coreAPI/insertNode';
 import { select, selectRange } from '../coreAPI/selectRange';
 import { triggerEvent } from '../coreAPI/triggerEvent';
 
+/**
+ * Create core object for editor
+ * @param contentDiv The DIV element used for editor
+ * @param options Options to create an editor
+ */
 export default function createEditorCore(
     contentDiv: HTMLDivElement,
     options: EditorOptions
@@ -31,15 +36,7 @@ export default function createEditorCore(
         domEvent: new DOMEventPlugin(options.disableRestoreSelectionOnFocus),
         firefoxTypeAfterLink: Browser.isFirefox && new FirefoxTypeAfterLink(),
     };
-    let allPlugins: EditorPlugin[] = [
-        corePlugins.typeInContainer,
-        corePlugins.mouseUp,
-        ...(options.plugins || []),
-        corePlugins.edit,
-        corePlugins.firefoxTypeAfterLink,
-        corePlugins.undo,
-        corePlugins.domEvent,
-    ].filter(plugin => !!plugin);
+    let allPlugins = buildPluginList(corePlugins, options.plugins);
     let eventHandlerPlugins = allPlugins.filter(
         plugin => plugin.onPluginEvent || plugin.willHandleEventExclusively
     );
@@ -56,6 +53,18 @@ export default function createEditorCore(
         api: createCoreApiMap(options.coreApiOverride),
         defaultApi: createCoreApiMap(),
     };
+}
+
+function buildPluginList(corePlugins: CorePlugins, plugins: EditorPlugin[]): EditorPlugin[] {
+    return [
+        corePlugins.typeInContainer,
+        corePlugins.mouseUp,
+        ...(plugins || []),
+        corePlugins.edit,
+        corePlugins.firefoxTypeAfterLink,
+        corePlugins.undo,
+        corePlugins.domEvent,
+    ].filter(plugin => !!plugin);
 }
 
 function calcDefaultFormat(node: Node, baseFormat: DefaultFormat): DefaultFormat {

--- a/packages/roosterjs-editor-core/lib/interfaces/ContentEditFeature.ts
+++ b/packages/roosterjs-editor-core/lib/interfaces/ContentEditFeature.ts
@@ -1,6 +1,9 @@
 import Editor from '../editor/Editor';
 import { ChangeSource, PluginEvent, PluginKeyboardEvent } from 'roosterjs-editor-types';
 
+/**
+ * Key numbers used for ContentEditFeature
+ */
 export const enum Keys {
     NULL = 0,
     BACKSPACE = 8,
@@ -24,6 +27,9 @@ export const enum Keys {
     MOUSEDOWN = 0x1000,
 }
 
+/**
+ * Generic ContentEditFeature interface
+ */
 export interface GenericContentEditFeature<TEvent extends PluginEvent> {
     keys: number[];
     initialize?: (editor: Editor) => any;
@@ -32,4 +38,7 @@ export interface GenericContentEditFeature<TEvent extends PluginEvent> {
     allowFunctionKeys?: boolean;
 }
 
+/**
+ * ContentEditFeature interface that handles keyboard event
+ */
 export type ContentEditFeature = GenericContentEditFeature<PluginKeyboardEvent>;

--- a/packages/roosterjs-editor-core/lib/interfaces/EditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/interfaces/EditorCore.ts
@@ -14,12 +14,39 @@ import {
     PluginEventType,
 } from 'roosterjs-editor-types';
 
+/**
+ * An interface for editor core plugins.
+ * These plugins are built-in and most of them are not able to be replaced
+ */
 export interface CorePlugins {
+    /**
+     * Edit plugin handles ContentEditFeatures
+     */
     readonly edit: EditPlugin;
+
+    /**
+     * Undo plugin provides the ability to undo/redo
+     */
     readonly undo: UndoService;
+
+    /**
+     * TypeInContainer plugin makes sure user is always type under a container element under editor DIV
+     */
     readonly typeInContainer: TypeInContainerPlugin;
+
+    /**
+     * MouseUp plugin helps generate MouseUp event even mouse is out of editor area
+     */
     readonly mouseUp: MouseUpPlugin;
+
+    /**
+     * DomEvent plugin helps handle additional DOM events such as IME composition, cut, drop.
+     */
     readonly domEvent: DOMEventPlugin;
+
+    /**
+     * FirefoxTypeAfterLink plugin helps workaround a Firefox bug to allow type outside a hyperlink
+     */
     readonly firefoxTypeAfterLink: FirefoxTypeAfterLink;
 }
 

--- a/packages/roosterjs-editor-core/lib/test/coreApi/attachDomEventTest.ts
+++ b/packages/roosterjs-editor-core/lib/test/coreApi/attachDomEventTest.ts
@@ -1,7 +1,7 @@
-import attachDomEvent from '../../coreAPI/attachDomEvent';
 import createEditorCore from '../../editor/createEditorCore';
 import EditorCore from '../../interfaces/EditorCore';
 import EditorPlugin from '../../interfaces/EditorPlugin';
+import { attachDomEvent } from '../../coreAPI/attachDomEvent';
 import { PluginEvent, PluginEventType, PluginKeyboardEvent } from 'roosterjs-editor-types';
 
 class MockPlugin implements EditorPlugin {

--- a/packages/roosterjs-editor-core/lib/test/coreApi/hasFocusTest.ts
+++ b/packages/roosterjs-editor-core/lib/test/coreApi/hasFocusTest.ts
@@ -1,7 +1,7 @@
 import createEditorCore from '../../editor/createEditorCore';
 import EditorCore from '../../interfaces/EditorCore';
-import hasFocus from '../../coreAPI/hasFocus';
 import { createRange } from 'roosterjs-editor-dom';
+import { hasFocus } from '../../coreAPI/hasFocus';
 
 describe('hasFocus', () => {
     let div: HTMLDivElement;

--- a/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
+++ b/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
@@ -29,7 +29,7 @@ describe('Editor getSelectionRange()', () => {
 
     it('getSelectionRange shold return null if not in focus', () => {
         // Arrange
-        spyOn(getSelectionRange, 'default').and.callThrough();
+        spyOn(getSelectionRange, 'getSelectionRange').and.callThrough();
 
         // Act
         let selectionRange = editor.getSelectionRange();

--- a/packages/roosterjs-editor-core/lib/undo/UndoSnapshots.ts
+++ b/packages/roosterjs-editor-core/lib/undo/UndoSnapshots.ts
@@ -4,6 +4,9 @@ import UndoSnapshotsService from '../interfaces/UndoSnapshotsService';
 // to keep size under limit. This is kept at 10MB
 const MAXSIZELIMIT = 1e7;
 
+/**
+ * A class to help manage undo snapshots
+ */
 export default class UndoSnapshots implements UndoSnapshotsService {
     private snapshots: string[];
     private totalSize: number;

--- a/packages/roosterjs-editor-dom/lib/contentTraverser/BodyScoper.ts
+++ b/packages/roosterjs-editor-dom/lib/contentTraverser/BodyScoper.ts
@@ -9,7 +9,7 @@ import { getFirstInlineElement } from '../inlineElements/getFirstLastInlineEleme
 /**
  * provides scoper for traversing the entire editor body starting from the beginning
  */
-class BodyScoper implements TraversingScoper {
+export default class BodyScoper implements TraversingScoper {
     private startNode: Node;
 
     /**
@@ -53,5 +53,3 @@ class BodyScoper implements TraversingScoper {
         return inlineElement;
     }
 }
-
-export default BodyScoper;

--- a/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionBlockScoper.ts
+++ b/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionBlockScoper.ts
@@ -17,7 +17,7 @@ import {
  * they want to know text being typed at cursor
  * This provides a scope for parsing from cursor position up to begin of the selection block
  */
-class SelectionBlockScoper implements TraversingScoper {
+export default class SelectionBlockScoper implements TraversingScoper {
     private block: BlockElement;
     private position: NodePosition;
 
@@ -91,8 +91,6 @@ class SelectionBlockScoper implements TraversingScoper {
             : null;
     }
 }
-
-export default SelectionBlockScoper;
 
 /**
  * Get first/last InlineElement of the given BlockElement

--- a/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionScoper.ts
+++ b/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionScoper.ts
@@ -10,7 +10,7 @@ import { getInlineElementAfter } from '../inlineElements/getInlineElementBeforeA
  * and checks if a block falls in the selection (isBlockInScope)
  * last trimInlineElement to trim any inline element to return a partial that falls in the selection
  */
-class SelectionScoper implements TraversingScoper {
+export default class SelectionScoper implements TraversingScoper {
     private start: NodePosition;
     private end: NodePosition;
     private startBlock: BlockElement;
@@ -118,5 +118,3 @@ class SelectionScoper implements TraversingScoper {
             : inline;
     }
 }
-
-export default SelectionScoper;

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -13,7 +13,7 @@ export { default as NodeInlineElement } from './inlineElements/NodeInlineElement
 export { default as PartialInlineElement } from './inlineElements/PartialInlineElement';
 
 export { default as applyTextStyle } from './utils/applyTextStyle';
-export { default as Browser, getBrowserInfo } from './utils/Browser';
+export { Browser, getBrowserInfo } from './utils/Browser';
 export { default as applyFormat } from './utils/applyFormat';
 export { default as changeElementTag } from './utils/changeElementTag';
 export { default as collapseNodes } from './utils/collapseNodes';

--- a/packages/roosterjs-editor-dom/lib/inlineElements/NodeInlineElement.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/NodeInlineElement.ts
@@ -15,7 +15,7 @@ import {
  * of all operations that can happen on an inline element. Other sub inline elements mostly
  * just identify themself for a certain type
  */
-class NodeInlineElement implements InlineElement {
+export default class NodeInlineElement implements InlineElement {
     constructor(private containerNode: Node, private parentBlock: BlockElement) {}
 
     /**
@@ -88,5 +88,3 @@ class NodeInlineElement implements InlineElement {
         applyTextStyle(this.containerNode, styler);
     }
 }
-
-export default NodeInlineElement;

--- a/packages/roosterjs-editor-dom/lib/inlineElements/PartialInlineElement.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/PartialInlineElement.ts
@@ -11,7 +11,7 @@ import { getNextLeafSibling, getPreviousLeafSibling } from '../utils/getLeafSibl
  * PartialInlineElement is implemented in a way that decorate another full inline element with its own override on methods like isAfter
  * It also offers some special methods that others don't have, i.e. nextInlineElement etc.
  */
-class PartialInlineElement implements InlineElement {
+export default class PartialInlineElement implements InlineElement {
     constructor(
         private inlineElement: InlineElement,
         private start?: NodePosition,
@@ -119,5 +119,3 @@ class PartialInlineElement implements InlineElement {
         applyTextStyle(container, styler, from, to);
     }
 }
-
-export default PartialInlineElement;

--- a/packages/roosterjs-editor-dom/lib/utils/Browser.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/Browser.ts
@@ -55,8 +55,9 @@ export function getBrowserInfo(userAgent: string, appVersion: string): BrowserIn
     };
 }
 
-const Browser = window
+/**
+ * Browser object contains browser and operating system informations of current environment
+ */
+export const Browser = window
     ? getBrowserInfo(window.navigator.userAgent, window.navigator.appVersion)
     : {};
-
-export default Browser;

--- a/packages/roosterjs-editor-dom/lib/utils/applyTextStyle.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/applyTextStyle.ts
@@ -7,6 +7,13 @@ import { splitBalancedNodeRange } from './splitParentNode';
 
 const STYLETAGS = 'SPAN,B,I,U,EM,STRONG,STRIKE,S,SMALL'.split(',');
 
+/**
+ * Apply style using a styler function to the given container node in the given range
+ * @param container The container node to apply style to
+ * @param styler The styler function
+ * @param from From position
+ * @param to To position
+ */
 export default function applyTextStyle(
     container: Node,
     styler: (node: HTMLElement, isInnerNode?: boolean) => any,

--- a/packages/roosterjs-editor-dom/lib/utils/extractClipboardEvent.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/extractClipboardEvent.ts
@@ -1,4 +1,4 @@
-import Browser from './Browser';
+import { Browser } from './Browser';
 import { ClipboardItems } from 'roosterjs-editor-types';
 
 // HTML header to indicate where is the HTML content started from.

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/autoLinkFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/autoLinkFeatures.ts
@@ -17,11 +17,17 @@ import {
     Keys,
 } from 'roosterjs-editor-core';
 
-// When user type, they may end a link with a puncatuation, i.e. www.bing.com;
-// we need to trim off the trailing puncatuation before turning it to link match
+/**
+ * When user type, they may end a link with a puncatuation, i.e. www.bing.com;
+ * we need to trim off the trailing puncatuation before turning it to link match
+ */
 const TRAILING_PUNCTUATION_REGEX = /[.+=\s:;"',>]+$/i;
 const MINIMUM_LENGTH = 5;
 
+/**
+ * AutoLink edit feature, provides the ability to automatically convert text user typed or pasted
+ * in hyperlink format into a real hyperlink
+ */
 export const AutoLink: GenericContentEditFeature<PluginEvent> = {
     keys: [Keys.ENTER, Keys.SPACE, Keys.CONTENTCHANGED],
     initialize: editor =>
@@ -31,6 +37,10 @@ export const AutoLink: GenericContentEditFeature<PluginEvent> = {
     handleEvent: autoLink,
 };
 
+/**
+ * UnlinkWhenBackspaceAfterLink edit feature, provides the ability to convert a hyperlink back into text
+ * if user presses BACKSPACE right after a hyperlink
+ */
 export const UnlinkWhenBackspaceAfterLink: GenericContentEditFeature<PluginKeyboardEvent> = {
     keys: [Keys.BACKSPACE],
     shouldHandleEvent: hasLinkBeforeCursor,

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/insertLineBeforeStructuredNodeFeature.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/insertLineBeforeStructuredNodeFeature.ts
@@ -18,6 +18,11 @@ const CHILD_PARENT_TAG_MAP: { [childTag: string]: string } = {
 };
 const CHILD_SELECTOR = Object.keys(CHILD_PARENT_TAG_MAP).join(',');
 
+/**
+ * InsertLineBeforeStructuredNode edit feature, provides the ability to insert an empty line before
+ * a structured element (bullet/numbering list, blockquote, table) if the element is at beginning of
+ * document
+ */
 export const InsertLineBeforeStructuredNodeFeature: ContentEditFeature = {
     keys: [Keys.ENTER],
     shouldHandleEvent: cacheGetStructuredElement,

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/listFeatures.ts
@@ -21,6 +21,9 @@ import {
     isPositionAtBeginningOf,
 } from 'roosterjs-editor-dom';
 
+/**
+ * IndentWhenTab edit feature, provides the ability to indent current list when user press TAB
+ */
 export const IndentWhenTab: ContentEditFeature = {
     keys: [Keys.TAB],
     shouldHandleEvent: (event, editor) =>
@@ -31,6 +34,9 @@ export const IndentWhenTab: ContentEditFeature = {
     },
 };
 
+/**
+ * OutdentWhenShiftTab edit feature, provides the ability to outdent current list when user press Shift+TAB
+ */
 export const OutdentWhenShiftTab: ContentEditFeature = {
     keys: [Keys.TAB],
     shouldHandleEvent: (event, editor) =>
@@ -41,6 +47,10 @@ export const OutdentWhenShiftTab: ContentEditFeature = {
     },
 };
 
+/**
+ * MergeInNewLine edit feature, provides the ability to merge current line into a new line when user press
+ * BACKSPACE at beginning of a list item
+ */
 export const MergeInNewLine: ContentEditFeature = {
     keys: [Keys.BACKSPACE],
     shouldHandleEvent: (event, editor) => {
@@ -62,6 +72,10 @@ export const MergeInNewLine: ContentEditFeature = {
     },
 };
 
+/**
+ * OutdentWhenBackOn1stEmptyLine edit feature, provides the ability to outdent current item if user press
+ * BACKSPACE at the first and empty line of a list
+ */
 export const OutdentWhenBackOn1stEmptyLine: ContentEditFeature = {
     keys: [Keys.BACKSPACE],
     shouldHandleEvent: (event, editor) => {
@@ -71,6 +85,10 @@ export const OutdentWhenBackOn1stEmptyLine: ContentEditFeature = {
     handleEvent: toggleListAndPreventDefault,
 };
 
+/**
+ * OutdentWhenEnterOnEmptyLine edit feature, provides the ability to outdent current item if user press
+ * ENTER at the beginning of an empty line of a list
+ */
 export const OutdentWhenEnterOnEmptyLine: ContentEditFeature = {
     keys: [Keys.ENTER],
     shouldHandleEvent: (event, editor) => {
@@ -82,6 +100,11 @@ export const OutdentWhenEnterOnEmptyLine: ContentEditFeature = {
     },
 };
 
+/**
+ * AutoBullet edit feature, provides the ablility to automatically convert current line into a list.
+ * When user input "1. ", convert into a numbering list
+ * When user input "- " or "* ", convert into a bullet list
+ */
 export const AutoBullet: ContentEditFeature = {
     keys: [Keys.SPACE],
     shouldHandleEvent: (event, editor) => {
@@ -131,6 +154,12 @@ export const AutoBullet: ContentEditFeature = {
     },
 };
 
+/**
+ * Get an instance of SmartOrderedList edit feature. This feature provides the ability to use different
+ * number style for different level of numbering list.
+ * @param styleList The list of number styles used for this feature.
+ * See https://www.w3schools.com/cssref/pr_list-style-type.asp for more information
+ */
 export function getSmartOrderedList(
     styleList: string[]
 ): GenericContentEditFeature<ContentChangedEvent> {

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/quoteFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/quoteFeatures.ts
@@ -11,6 +11,10 @@ import {
 const QUOTE_TAG = 'BLOCKQUOTE';
 const STRUCTURED_TAGS = [QUOTE_TAG, 'LI', 'TD', 'TH'].join(',');
 
+/**
+ * UnquoteWhenBackOnEmpty1stLine edit feature, provides the ability to Unquote current line when
+ * user press BACKSPACE on first and empty line of a BLOCKQUOTE
+ */
 export const UnquoteWhenBackOnEmpty1stLine: ContentEditFeature = {
     keys: [Keys.BACKSPACE],
     shouldHandleEvent: (event, editor) => {
@@ -20,6 +24,10 @@ export const UnquoteWhenBackOnEmpty1stLine: ContentEditFeature = {
     handleEvent: splitQuote,
 };
 
+/**
+ * UnquoteWhenEnterOnEmptyLine edit feature, provides the ability to Unquote current line when
+ * user press ENTER on an empty line of a BLOCKQUOTE
+ */
 export const UnquoteWhenEnterOnEmptyLine: ContentEditFeature = {
     keys: [Keys.ENTER],
     shouldHandleEvent: (event, editor) => {

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/shortcutFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/shortcutFeatures.ts
@@ -44,6 +44,18 @@ const commands: ShortcutCommand[] = [
     ),
 ];
 
+/**
+ * DefaultShortcut edit feature, provides shortcuts for the following features:
+ * Ctrl/Meta+B: toggle bold style
+ * Ctrl/Meta+I: toggle italic style
+ * Ctrl/Meta+U: toggle underline style
+ * Ctrl/Meta+Z: undo
+ * Ctrl+Y/Meta+Shift+Z: redo
+ * Ctrl/Meta+PERIOD: toggle bullet list
+ * Ctrl/Meta+/: toggle numbering list
+ * Ctrl/Meta+Shift+>: increase font size
+ * Ctrl/Meta+Shift+<: decrease font size
+ */
 export const DefaultShortcut: ContentEditFeature = {
     allowFunctionKeys: true,
     keys: [Keys.B, Keys.I, Keys.U, Keys.Y, Keys.Z, Keys.COMMA, Keys.PERIOD, Keys.FORWARDSLASH],

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/tableFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/tableFeatures.ts
@@ -8,6 +8,9 @@ import {
     } from 'roosterjs-editor-dom';
 import { NodeType, PluginEvent, PositionType } from 'roosterjs-editor-types';
 
+/**
+ * TabInTable edit feature, provides the ability to jump between cells when user press TAB in table
+ */
 export const TabInTable: ContentEditFeature = {
     keys: [Keys.TAB],
     shouldHandleEvent: cacheGetTableCell,
@@ -40,6 +43,10 @@ export const TabInTable: ContentEditFeature = {
     },
 };
 
+/**
+ * UpDownInTable edit feature, provides the ability to jump to cell above/below when user press UP/DOWN
+ * in table
+ */
 export const UpDownInTable: ContentEditFeature = {
     keys: [Keys.UP, Keys.DOWN],
     shouldHandleEvent: cacheGetTableCell,

--- a/packages/roosterjs-editor-plugins/lib/CustomReplace/CustomReplace.ts
+++ b/packages/roosterjs-editor-plugins/lib/CustomReplace/CustomReplace.ts
@@ -1,9 +1,23 @@
-import { Editor, EditorPlugin, cacheGetContentSearcher } from 'roosterjs-editor-core';
-import { PositionType, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
+import { cacheGetContentSearcher, Editor, EditorPlugin } from 'roosterjs-editor-core';
+import { PluginEvent, PluginEventType, PositionType } from 'roosterjs-editor-types';
 
+/**
+ * An interface to define a replacement rule for CustomReplace plugin
+ */
 export type Replacement = {
+    /**
+     * Source string to replace from
+     */
     sourceString: string;
+
+    /**
+     * HTML string to replace to
+     */
     replacementHTML: string;
+
+    /**
+     * Whether the matching should be case sensitive
+     */
     matchSourceCaseSensitive: boolean;
 };
 
@@ -12,6 +26,7 @@ const makeReplacement = (
     replacementHTML: string,
     matchSourceCaseSensitive: boolean
 ): Replacement => ({ sourceString, replacementHTML, matchSourceCaseSensitive });
+
 const defaultReplacements: Replacement[] = [
     makeReplacement(':)', '🙂', true),
     makeReplacement(';)', '😉', true),
@@ -32,7 +47,7 @@ export default class CustomReplacePlugin implements EditorPlugin {
 
     /**
      * Create instance of CustomReplace plugin
-     * @param features An optional feature set to determine which features the plugin should provide
+     * @param replacements Replacement rules. If not passed, a default replacement rule set will be applied
      */
     constructor(replacements: Replacement[] = defaultReplacements) {
         this.updateReplacements(replacements);

--- a/packages/roosterjs-editor-plugins/lib/Paste/excelConverter/convertPastedContentFromExcel.ts
+++ b/packages/roosterjs-editor-plugins/lib/Paste/excelConverter/convertPastedContentFromExcel.ts
@@ -1,5 +1,9 @@
 import { HtmlSanitizer } from 'roosterjs-html-sanitizer';
 
+/**
+ * Convert pasted content from Excel, add borders when source doc doesn't have a border
+ * @param doc HTML Document which contains the content from Excel
+ */
 export default function convertPastedContentFromExcel(doc: HTMLDocument) {
     let sanitizer = new HtmlSanitizer({
         styleCallbacks: {

--- a/packages/roosterjs-editor-plugins/lib/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/TableResize/TableResize.ts
@@ -12,6 +12,9 @@ const TABLE_RESIZE_HANDLE_KEY = 'TABLE_RESIZE_HANDLE';
 const HANDLE_WIDTH = 6;
 const CONTAINER_HTML = `<div style="position: fixed; cursor: col-resize; width: ${HANDLE_WIDTH}px; border: solid 0 #C6C6C6;"></div>`;
 
+/**
+ * TableResize plugin, provides the ability to resize a table by drag-and-drop
+ */
 export default class TableResize implements EditorPlugin {
     private editor: Editor;
     private onMouseOverDisposer: () => void;

--- a/packages/roosterjs-editor-plugins/lib/Watermark/Watermark.ts
+++ b/packages/roosterjs-editor-plugins/lib/Watermark/Watermark.ts
@@ -19,7 +19,7 @@ const WATERMARK_REGEX = new RegExp(
 /**
  * A watermark plugin to manage watermark string for roosterjs
  */
-class Watermark implements EditorPlugin {
+export default class Watermark implements EditorPlugin {
     private editor: Editor;
     private isWatermarkShowing: boolean;
     private disposer: () => void;
@@ -125,5 +125,3 @@ class Watermark implements EditorPlugin {
         event.content = content;
     }
 }
-
-export default Watermark;

--- a/packages/roosterjs-editor-types/lib/enum/TableOperation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/TableOperation.ts
@@ -1,3 +1,6 @@
+/**
+ * Operations used by editTable() API
+ */
 export const enum TableOperation {
     /**
      * Insert a row above current row

--- a/packages/roosterjs-editor-types/lib/event/PluginDomEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/PluginDomEvent.ts
@@ -48,6 +48,9 @@ export interface PluginKeyUpEvent extends BasePluginEvent<PluginEventType.KeyUp>
     rawEvent: KeyboardEvent;
 }
 
+/**
+ * The represents a PluginEvent wrapping native Keyboard event
+ */
 export type PluginKeyboardEvent = PluginKeyDownEvent | PluginKeyPressEvent | PluginKeyUpEvent;
 
 /**

--- a/packages/roosterjs-editor-types/lib/event/PluginEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/PluginEvent.ts
@@ -8,7 +8,6 @@ import { PluginDomEvent } from './PluginDomEvent';
 /**
  * Editor plugin event interface
  */
-
 export type PluginEvent =
     | BeforePasteEvent
     | ContentChangedEvent

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -51,7 +51,7 @@ export {
 } from './interface/FormatState';
 export { default as InlineElement } from './interface/InlineElement';
 export {
-    default as InsertOption,
+    InsertOption,
     InsertOptionBase,
     InsertOptionBasic,
     InsertOptionRange,

--- a/packages/roosterjs-editor-types/lib/interface/BlockElement.ts
+++ b/packages/roosterjs-editor-types/lib/interface/BlockElement.ts
@@ -4,7 +4,7 @@
  * but can also be just a text node, followed by a &lt;br&gt;, i.e.
  * for html fragment &lt;div&gt;abc&lt;br&gt;123&lt;/div&gt;, abc&lt;br&gt; is a block, 123 is another block
  */
-export interface BlockElement {
+export default interface BlockElement {
     /**
      * Collapse this block element to a single DOM element.
      */
@@ -35,5 +35,3 @@ export interface BlockElement {
      */
     contains(node: Node): boolean;
 }
-
-export default BlockElement;

--- a/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
+++ b/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
@@ -26,7 +26,11 @@ export interface InsertOptionBase {
  * The "basic" insertNode related ContentPositions that require no additional parameters to use.
  */
 export interface InsertOptionBasic extends InsertOptionBase {
-    position: ContentPosition.Begin | ContentPosition.End | ContentPosition.Outside | ContentPosition.SelectionStart;
+    position:
+        | ContentPosition.Begin
+        | ContentPosition.End
+        | ContentPosition.Outside
+        | ContentPosition.SelectionStart;
 }
 
 /**
@@ -47,6 +51,4 @@ export interface InsertOptionRange extends InsertOptionBase {
  * In a future revision, this will become strongly typed
  * Only parameters applicable to the given position will be accepted.
  */
-type InsertOption = InsertOptionRange | InsertOptionBasic;
-
-export default InsertOption;
+export type InsertOption = InsertOptionRange | InsertOptionBasic;

--- a/packages/roosterjs-html-sanitizer/lib/sanitizer/HtmlSanitizer.ts
+++ b/packages/roosterjs-html-sanitizer/lib/sanitizer/HtmlSanitizer.ts
@@ -1,8 +1,8 @@
-import cloneObject from '../utils/cloneObject';
 import getInheritableStyles from '../utils/getInheritableStyles';
 import HtmlSanitizerOptions from '../types/HtmlSanitizerOptions';
 import htmlToDom from '../utils/htmlToDom';
 import SanitizeHtmlOptions from '../types/SanitizeHtmlOptions';
+import { cloneObject } from '../utils/cloneObject';
 import {
     StringMap,
     StyleCallbackMap,

--- a/packages/roosterjs-html-sanitizer/lib/sanitizer/HtmlSanitizer.ts
+++ b/packages/roosterjs-html-sanitizer/lib/sanitizer/HtmlSanitizer.ts
@@ -16,6 +16,11 @@ import {
     getStyleCallbacks,
 } from '../utils/getAllowedValues';
 
+/**
+ * HTML sanitizer class provides two featuers:
+ * 1. Convert global CSS to inline CSS
+ * 2. Sanitize an HTML document, remove unnecessary/dangerous attribute/nodes
+ */
 export default class HtmlSanitizer {
     /**
      * Convert global CSS to inline CSS if any
@@ -58,6 +63,10 @@ export default class HtmlSanitizer {
     private additionalGlobalStyleNodes: HTMLStyleElement[];
     private allowPreserveWhiteSpace: boolean;
 
+    /**
+     * Construct a new instance of HtmlSanitizer
+     * @param options Options for HtmlSanitizer
+     */
     constructor(options?: HtmlSanitizerOptions) {
         options = options || {};
         this.elementCallbacks = cloneObject(options.elementCallbacks);
@@ -97,6 +106,12 @@ export default class HtmlSanitizer {
         return (doc && doc.body && doc.body.innerHTML) || '';
     }
 
+    /**
+     * Sanitize an HTML element, remove unnecessary or dangerous elements/attribute/CSS rules
+     * @param rootNode Root node to sanitize
+     * @param currentStyles Current CSS styles. Inheritable styles in the given node which has
+     * the same value with current styles will be ignored.
+     */
     sanitize(rootNode: HTMLElement, currentStyles?: StringMap) {
         if (!rootNode) {
             return '';
@@ -105,6 +120,10 @@ export default class HtmlSanitizer {
         this.processNode(rootNode, currentStyles, {});
     }
 
+    /**
+     * Convert global CSS into inline CSS
+     * @param rootNode The HTML Document
+     */
     convertGlobalCssToInlineCss(rootNode: HTMLDocument) {
         let styleNodes = toArray(rootNode.querySelectorAll('style'));
         let styleSheets = this.additionalGlobalStyleNodes

--- a/packages/roosterjs-html-sanitizer/lib/utils/cloneObject.ts
+++ b/packages/roosterjs-html-sanitizer/lib/utils/cloneObject.ts
@@ -14,6 +14,4 @@ function customClone<T>(source: Map<T>, existingObj?: Map<T>): Map<T> {
     return result;
 }
 
-const cloneObject = Object.assign ? nativeClone : customClone;
-
-export default cloneObject;
+export const cloneObject = Object.assign ? nativeClone : customClone;

--- a/packages/roosterjs-html-sanitizer/lib/utils/getAllowedValues.ts
+++ b/packages/roosterjs-html-sanitizer/lib/utils/getAllowedValues.ts
@@ -1,4 +1,4 @@
-import cloneObject from './cloneObject';
+import { cloneObject } from './cloneObject';
 import { StringMap, StyleCallbackMap } from '../types/maps';
 
 const ALLOWED_HTML_TAGS = (

--- a/packages/roosterjs-plugin-image-resize/lib/ImageResize.ts
+++ b/packages/roosterjs-plugin-image-resize/lib/ImageResize.ts
@@ -22,6 +22,9 @@ const SHIFT_KEYCODE = 16;
 const CTRL_KEYCODE = 17;
 const ALT_KEYCODE = 18;
 
+/**
+ * ImageResize plugin provides the ability to resize an inline image in editor
+ */
 export default class ImageResize implements EditorPlugin {
     private editor: Editor;
     private startPageX: number;

--- a/packages/roosterjs-plugin-picker/lib/PickerDataProvider.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerDataProvider.ts
@@ -1,70 +1,111 @@
 import { Editor } from 'roosterjs-editor-core';
 
+/**
+ * Options for PickerPlugin
+ */
 export interface PickerPluginOptions {
-    // Constant that defines the element ID prefix to look for.
-    // If it matches, this element should be handled by the plugin
+    /**
+     * Constant that defines the element ID prefix to look for.
+     * If it matches, this element should be handled by the plugin
+     */
     elementIdPrefix: string;
 
-    // Constant that defines the change source to be used when events are broadcasted.
+    /**
+     * When apply the selected item in picker, a ContentChangedEvent will be broadcasted.
+     * This value will be used as the ChangeSource of this event.
+     */
     changeSource: string;
 
-    // Constant that defines the character(s) that will trigger the suggesting state in the plugin.
-    // The @mentions case, for instance, uses a '@' symbol.
+    /**
+     * Constant that defines the character(s) that will trigger the suggesting state in the plugin.
+     */
     triggerCharacter: string;
 
-    // Option for using the picker in the horizontal state:
-    // Vertical (the default, when this is false), will call shiftHighlight with up (false) and down (true).
-    // Horizontal (when this is true), will call shiftHighlight with left (false) and right (true).
+    /**
+     * Option for using the picker in the horizontal state:
+     * Vertical (the default, when this is false), will call shiftHighlight with up (false) and down (true).
+     * Horizontal (when this is true), will call shiftHighlight with left (false) and right (true).
+     */
     isHorizontal?: boolean;
 
-    // Option for letting the editor handle autocomplete on node insertion
+    /**
+     * When apply the selected item in picker, perform as an auto-complete behavior (can be undone by BACKSPACE key)
+     * if this option is set to true
+     */
     handleAutoComplete?: boolean;
 
-    // Constant that defines the ID label for the picker.
-    // Used for setting the ariaOwns attribute of the editor when a picker is open.
+    /**
+     * Constant that defines the ID label for the picker.
+     * Used for setting the ariaOwns attribute of the editor when a picker is open.
+     */
     suggestionsLabel?: string;
 
-    // Constant that defines the prefix of the ID label for the picker's options.
-    // Used for setting the ariaActiveDescendant attribute of the editor when a picker option is selected.
+    /**
+     * Constant that defines the prefix of the ID label for the picker's options.
+     * Used for setting the ariaActiveDescendant attribute of the editor when a picker option is selected.
+     */
     suggestionLabelPrefix?: string;
 }
 
+/**
+ * Data provider for PickerPlugin
+ */
 export interface PickerDataProvider {
-    // Function called when the plugin is intialized to register two callbacks with the data provider and a reference to the Editor.
-    // The first is called in order to "commit" a new element to the editor body that isn't handled automatically by the editor plugin.
-    // The second sets the isSuggesting value for situations wherethe UX needs to manipulate the suggesting state that's otherwise plugin managed.
+    /**
+     * Function called when the plugin is intialized to register two callbacks with the data provider and a reference to the Editor.
+     * The first is called in order to "commit" a new element to the editor body that isn't handled automatically by the editor plugin.
+     * The second sets the isSuggesting value for situations wherethe UX needs to manipulate the suggesting state that's otherwise plugin managed.
+     */
     onInitalize: (
         insertNodeCallback: (nodeToInsert: HTMLElement) => void,
         setIsSuggestingCallback: (isSuggesting: boolean) => void,
         editor?: Editor
     ) => void;
 
-    // Function called when the plugin is disposed for the data provider to do any cleanup.
+    /**
+     * Function called when the plugin is disposed for the data provider to do any cleanup.
+     */
     onDispose: () => void;
 
-    // Function called when the picker changes suggesting state.
+    /**
+     * Function called when the picker changes suggesting state.
+     */
     onIsSuggestingChanged: (isSuggesting: boolean) => void;
 
-    // Function called when the query string (text after the trigger symbol) is updated.
+    /**
+     * Function called when the query string (text after the trigger symbol) is updated.
+     */
     queryStringUpdated: (queryString: string, isExactMatch: boolean) => void;
 
-    // Function called when a keypress is issued that would "select" a currently highlighted option.
+    /**
+     * Function called when a keypress is issued that would "select" a currently highlighted option.
+     */
     selectOption?: () => void;
 
-    // Function called when a keypress is issued that would move the highlight on any picker UX.
+    /**
+     * Function called when a keypress is issued that would move the highlight on any picker UX.
+     */
     shiftHighlight?: (isIncrement: boolean) => void;
 
-    // Function that is called when a delete command is issued.
-    // Returns the intended replacement node (if partial delete) or null (if full delete)
+    /**
+     * Function that is called when a delete command is issued.
+     * Returns the intended replacement node (if partial delete) or null (if full delete)
+     */
     onRemove: (nodeRemoved: Node, isBackwards: boolean) => Node;
 
-    // Function that returns the current cursor position as an anchor point for where to show UX.
+    /**
+     * Function that returns the current cursor position as an anchor point for where to show UX.
+     */
     setCursorPoint?: (targetPoint: { x: number; y: number }, buffer: number) => void;
 
-    // Function that is called when the plugin detects the editor's content has changed.
-    // Provides a list of current picker placed elements in the document.
+    /**
+     * Function that is called when the plugin detects the editor's content has changed.
+     * Provides a list of current picker placed elements in the document.
+     */
     onContentChanged?: (elementIds: string[]) => void;
 
-    // Function that returns the index of the option currently selected in the picker.
+    /**
+     * Function that returns the index of the option currently selected in the picker.
+     */
     getSelectedIndex?: () => number;
 }

--- a/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
+++ b/packages/roosterjs-plugin-picker/lib/PickerPlugin.ts
@@ -30,11 +30,25 @@ const RIGHT_ARROW_CHARCODE = !Browser.isIE ? 'ArrowRight' : 'Right';
 const DOWN_ARROW_CHARCODE = !Browser.isIE ? 'ArrowDown' : 'Down';
 const DELETE_CHARCODE = !Browser.isIE ? 'Delete' : 'Del';
 
+/**
+ * Interface for PickerPlugin
+ */
 export interface EditorPickerPluginInterface<T extends PickerDataProvider = PickerDataProvider>
     extends EditorPlugin {
     dataProvider: T;
 }
 
+/**
+ * PickerPlugin represents a plugin of editor which can handle picker related behaviors, including
+ * - Show picker when special trigger key is pressed
+ * - Hide picker
+ * - Change selection in picker by Up/Down/Left/Right
+ * - Apply selected item in picker
+ *
+ * PickerPlugin doesn't provide any UI, it just wraps related DOM events and invoke callback functions.
+ * To show a picker UI, you need to build your own UI component. Please reference to
+ * https://github.com/microsoft/roosterjs/tree/master/publish/samplesite/scripts/controls/samplepicker
+ */
 export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvider>
     implements EditorPickerPluginInterface<T> {
     private editor: Editor;


### PR DESCRIPTION
To help the typedoc tool to generate better API reference doc, I added more documents.
And we need to avoid using code like

```typescript
export default NAME;
export {NAME};
```

due the bug of the tool. Instead, we should use direct export, e.g.

```typescript
export interface MyInterface { ... }
export type MyType {...}
```