### PR TITLE
Fix cursor stuck at list issue

### DIFF
--- a/packages/roosterjs-editor-dom/lib/selection/isPositionAtBeginningOf.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/isPositionAtBeginningOf.ts
@@ -1,6 +1,6 @@
 import contains from '../utils/contains';
+import getTagOfNode from '../utils/getTagOfNode';
 import isNodeEmpty from '../utils/isNodeEmpty';
-import { getTagOfNode } from 'roosterjs/lib';
 import { NodePosition } from 'roosterjs-editor-types';
 
 /**

--- a/packages/roosterjs-editor-dom/lib/selection/isPositionAtBeginningOf.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/isPositionAtBeginningOf.ts
@@ -1,5 +1,6 @@
 import contains from '../utils/contains';
 import isNodeEmpty from '../utils/isNodeEmpty';
+import { getTagOfNode } from 'roosterjs/lib';
 import { NodePosition } from 'roosterjs-editor-types';
 
 /**
@@ -27,7 +28,7 @@ export default function isPositionAtBeginningOf(position: NodePosition, targetNo
 function areAllPrevousNodesEmpty(node: Node): boolean {
     while (node.previousSibling) {
         node = node.previousSibling;
-        if (!isNodeEmpty(node)) {
+        if (getTagOfNode(node) == 'BR' || !isNodeEmpty(node)) {
             return false;
         }
     }

--- a/packages/roosterjs-editor-dom/lib/test/selections/isPositionAtBeginningOfTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/selections/isPositionAtBeginningOfTest.ts
@@ -111,6 +111,16 @@ describe('isPositionAtBeginningOf()', () => {
             true
         );
     });
+
+    it('There is a BR before the position', () => {
+        runTest(
+            '<div id=id1><br><span id=span1></div>',
+            () => $('span1'),
+            0,
+            () => $('id1'),
+            false
+        );
+    });
 });
 
 function $(id: string) {


### PR DESCRIPTION
```html
<UL>
  <LI><BR>
     <CURSOR>test
  </LI>
</UL>
```
When backspace, today the content edit feature "MergeInNewLine" will treat it as the beginning of a list item so it will add a BR tag back. Acutally since there is already a BR tag before the cursor, we should not treat it as at beginning of list.