### PR TITLE
Remove initialize method from edit feature

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/EditPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/EditPlugin.ts
@@ -93,10 +93,6 @@ export default class EditPlugin implements EditorPlugin {
      * @param feature The feature to add
      */
     addFeature(feature: GenericContentEditFeature<PluginEvent>) {
-        if (feature.initialize) {
-            feature.initialize(this.editor);
-        }
-
         feature.keys.forEach(key => {
             let array = this.featureMap[key] || [];
             array.push(feature);

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -1,13 +1,14 @@
+import adjustBrowserBehavior from './adjustBrowserBehavior';
 import createEditorCore from './createEditorCore';
 import EditorCore from '../interfaces/EditorCore';
 import EditorOptions from '../interfaces/EditorOptions';
+import mapPluginEvents from './mapPluginEvents';
 import { GenericContentEditFeature } from '../interfaces/ContentEditFeature';
 import {
     BlockElement,
     ChangeSource,
     ContentPosition,
     DefaultFormat,
-    DocumentCommand,
     ExtractContentEvent,
     InlineElement,
     InsertOption,
@@ -21,7 +22,6 @@ import {
     Rect,
 } from 'roosterjs-editor-types';
 import {
-    Browser,
     collapseNodes,
     contains,
     ContentTraverser,
@@ -73,17 +73,7 @@ export default class Editor {
         this.setContent(options.initialContent || contentDiv.innerHTML || '');
 
         // 5. Create event handler to bind DOM events
-        this.eventDisposers = [
-            this.core.api.attachDomEvent(this.core, 'keypress', PluginEventType.KeyPress),
-            this.core.api.attachDomEvent(this.core, 'keydown', PluginEventType.KeyDown),
-            this.core.api.attachDomEvent(this.core, 'keyup', PluginEventType.KeyUp),
-            this.core.api.attachDomEvent(this.core, 'mousedown', PluginEventType.MouseDown),
-            this.core.api.attachDomEvent(
-                this.core,
-                !Browser.isIE ? 'input' : 'textinput',
-                PluginEventType.Input
-            ),
-        ];
+        this.eventDisposers = mapPluginEvents(this.core);
 
         // 6. Add additional content edit features to the editor if specified
         if (options.additionalEditFeatures) {
@@ -99,25 +89,7 @@ export default class Editor {
         }
 
         // 8. Do proper change for browsers to disable some browser-specified behaviors.
-        // Catch any possible exception since this should not block the initialization of editor
-        try {
-            // Disable these object resizing for firefox since other browsers don't have these behaviors
-            if (Browser.isFirefox) {
-                this.core.document.execCommand(DocumentCommand.EnableObjectResizing, false, <
-                    string
-                    >(<any>false));
-                this.core.document.execCommand(DocumentCommand.EnableInlineTableEditing, false, <
-                    string
-                    >(<any>false));
-            } else if (Browser.isIE) {
-                // Change the default paragraph separater to DIV. This is mainly for IE since its default setting is P
-                this.core.document.execCommand(
-                    DocumentCommand.DefaultParagraphSeparator,
-                    false,
-                    'div'
-                );
-            }
-        } catch (e) { }
+        adjustBrowserBehavior();
 
         // 9. Let plugins know that we are ready
         this.triggerEvent(
@@ -407,7 +379,7 @@ export default class Editor {
                     this.deleteNode(pathComment);
                     let range = getRangeFromSelectionPath(contentDiv, path);
                     this.select(range);
-                } catch { }
+                } catch {}
             }
 
             if (triggerContentChangedEvent) {
@@ -622,8 +594,8 @@ export default class Editor {
         nameOrMap:
             | string
             | {
-                [eventName: string]: (event: UIEvent) => void;
-            },
+                  [eventName: string]: (event: UIEvent) => void;
+              },
         handler?: (event: UIEvent) => void
     ): () => void {
         if (nameOrMap instanceof Object) {

--- a/packages/roosterjs-editor-core/lib/editor/adjustBrowserBehavior.ts
+++ b/packages/roosterjs-editor-core/lib/editor/adjustBrowserBehavior.ts
@@ -1,0 +1,38 @@
+import { Browser } from 'roosterjs-editor-dom';
+import { DocumentCommand } from 'roosterjs-editor-types';
+
+const COMMANDS: {
+    [command: string]: any;
+} = Browser.isFirefox
+    ? {
+          /**
+           * Disable these object resizing for firefox since other browsers don't have these behaviors
+           */
+          [DocumentCommand.EnableObjectResizing]: false,
+          [DocumentCommand.EnableInlineTableEditing]: false,
+      }
+    : Browser.isIE
+    ? {
+          /**
+           * Change the default paragraph separater to DIV. This is mainly for IE since its default setting is P
+           */
+          [DocumentCommand.DefaultParagraphSeparator]: 'div',
+
+          /**
+           * Disable auto link feature in IE since we have our own implementation
+           */
+          [DocumentCommand.AutoUrlDetect]: false,
+      }
+    : {};
+
+/**
+ * Execute document command to adjust browser default behavior
+ */
+export default function adjustBrowserBehavior() {
+    Object.keys(COMMANDS).forEach(command => {
+        // Catch any possible exception since this should not block the initialization of editor
+        try {
+            document.execCommand(command, false, COMMANDS[command]);
+        } catch {}
+    });
+}

--- a/packages/roosterjs-editor-core/lib/editor/mapPluginEvents.ts
+++ b/packages/roosterjs-editor-core/lib/editor/mapPluginEvents.ts
@@ -1,0 +1,21 @@
+import { Browser } from 'roosterjs-editor-dom';
+import { EditorCore } from '..';
+import { PluginEventType } from 'roosterjs-editor-types';
+
+const EVENT_MAPPING: { [domEvent: string]: PluginEventType } = {
+    keypress: PluginEventType.KeyPress,
+    keydown: PluginEventType.KeyDown,
+    keyup: PluginEventType.KeyUp,
+    mousedown: PluginEventType.MouseDown,
+    [Browser.isIE ? 'textinput' : 'input']: PluginEventType.Input,
+};
+
+/**
+ * Map DOM events to editor plugin events
+ * @param core The EditorCore object
+ */
+export default function mapPluginEvents(core: EditorCore): (() => void)[] {
+    return Object.keys(EVENT_MAPPING).map(pluginEvent =>
+        core.api.attachDomEvent(core, pluginEvent, EVENT_MAPPING[pluginEvent])
+    );
+}

--- a/packages/roosterjs-editor-core/lib/interfaces/ContentEditFeature.ts
+++ b/packages/roosterjs-editor-core/lib/interfaces/ContentEditFeature.ts
@@ -32,7 +32,6 @@ export const enum Keys {
  */
 export interface GenericContentEditFeature<TEvent extends PluginEvent> {
     keys: number[];
-    initialize?: (editor: Editor) => any;
     shouldHandleEvent: (event: TEvent, editor: Editor) => any;
     handleEvent: (event: TEvent, editor: Editor) => ChangeSource | void;
     allowFunctionKeys?: boolean;

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/autoLinkFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/autoLinkFeatures.ts
@@ -1,4 +1,4 @@
-import { Browser, LinkInlineElement, matchLink } from 'roosterjs-editor-dom';
+import { LinkInlineElement, matchLink } from 'roosterjs-editor-dom';
 import { removeLink, replaceWithNode } from 'roosterjs-editor-api';
 import {
     ChangeSource,
@@ -30,9 +30,6 @@ const MINIMUM_LENGTH = 5;
  */
 export const AutoLink: GenericContentEditFeature<PluginEvent> = {
     keys: [Keys.ENTER, Keys.SPACE, Keys.CONTENTCHANGED],
-    initialize: editor =>
-        Browser.isIE &&
-        editor.getDocument().execCommand('AutoUrlDetect', false, <string>(<any>false)),
     shouldHandleEvent: cacheGetLinkData,
     handleEvent: autoLink,
 };

--- a/packages/roosterjs-editor-types/lib/browser/DocumentCommand.ts
+++ b/packages/roosterjs-editor-types/lib/browser/DocumentCommand.ts
@@ -4,6 +4,11 @@
  */
 export const enum DocumentCommand {
     /**
+     * Changes the browser auto-link behavior (Internet Explorer only)
+     */
+    AutoUrlDetect = 'AutoUrlDetect',
+
+    /**
      * Changes the document background color. In styleWithCss mode, it affects the background color of the containing block instead.
      * This requires a &lt;color&gt; value string to be passed in as a value argument. Note that Internet Explorer uses this to set the
      * text background color.


### PR DESCRIPTION
The regression in 7.4.0 is caused by ContentEditFeature.initialize(). I realized this function can potentially break editor since when call it, EditPlugin.initialize() may not been called yet so EditPlugin.editor is null.

So I decide  to remove this method. And actually it is only used in one place -- AutoLinkPlugin, to run a command for IE. So I also move all initial "execCommand" call to a new function "adjustBrowserBeahvior"

Also move the event mapping part to a new file to make Editor.ts a little shorter.