### PR TITLE
Support pending format management, fix #224, #313

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/getFormatState.ts
+++ b/packages/roosterjs-editor-api/lib/format/getFormatState.ts
@@ -1,42 +1,13 @@
 import { cacheGetElementAtCursor, Editor } from 'roosterjs-editor-core';
 import { getComputedStyles, getTagOfNode, Position } from 'roosterjs-editor-dom';
+import { getPendableFormatState } from 'roosterjs-editor-dom';
 import {
-    DocumentCommand,
     ElementBasedFormatState,
     FormatState,
-    PendableFormatState,
     PluginEvent,
     QueryScope,
     StyleBasedFormatState,
 } from 'roosterjs-editor-types';
-
-type PendableFormatNames = keyof PendableFormatState;
-
-const PendableFormatCommandMap: { [key in PendableFormatNames]: DocumentCommand } = {
-    isBold: DocumentCommand.Bold,
-    isItalic: DocumentCommand.Italic,
-    isUnderline: DocumentCommand.Underline,
-    isStrikeThrough: DocumentCommand.StrikeThrough,
-    isSubscript: DocumentCommand.Subscript,
-    isSuperscript: DocumentCommand.Superscript,
-};
-
-/**
- * Get Pendable Format State at cursor.
- * @param document The HTML Document to get format state from
- * @returns A PendableFormatState object which contains the values of pendable format states
- */
-export function getPendableFormatState(document: Document): PendableFormatState {
-    let keys = Object.keys(PendableFormatCommandMap) as PendableFormatNames[];
-
-    return keys.reduce(
-        (state, key) => {
-            state[key] = document.queryCommandState(PendableFormatCommandMap[key]);
-            return state;
-        },
-        <PendableFormatState>{}
-    );
-}
 
 /**
  * Get element based Format State at cursor

--- a/packages/roosterjs-editor-api/lib/index.ts
+++ b/packages/roosterjs-editor-api/lib/index.ts
@@ -9,7 +9,6 @@ export { default as clearFormat } from './format/clearFormat';
 export { default as createLink } from './format/createLink';
 export {
     default as getFormatState,
-    getPendableFormatState,
     getElementBasedFormatState,
     getStyleBasedFormatState,
 } from './format/getFormatState';
@@ -38,3 +37,7 @@ export { default as toggleSubscript } from './format/toggleSubscript';
 export { default as toggleSuperscript } from './format/toggleSuperscript';
 export { default as toggleUnderline } from './format/toggleUnderline';
 export { default as toggleHeader } from './format/toggleHeader';
+
+// @deprecated the function getPendableFormatState will still be available from
+// roosterjs-editor-dom package, keep export it here just for compatibility
+export { getPendableFormatState } from 'roosterjs-editor-dom';

--- a/packages/roosterjs-editor-api/lib/utils/execCommand.ts
+++ b/packages/roosterjs-editor-api/lib/utils/execCommand.ts
@@ -1,5 +1,12 @@
-import { ChangeSource, DocumentCommand } from 'roosterjs-editor-types';
+import { ChangeSource, DocumentCommand, PluginEventType } from 'roosterjs-editor-types';
 import { Editor } from 'roosterjs-editor-core';
+import {
+    getPendableFormatState,
+    PendableFormatCommandMap,
+    PendableFormatNames,
+} from 'roosterjs-editor-dom';
+
+let pendableFormatCommands: string[] = null;
 
 /**
  * Execute a document command
@@ -18,7 +25,24 @@ export default function execCommand(editor: Editor, command: DocumentCommand) {
     if (range && range.collapsed) {
         editor.addUndoSnapshot();
         formatter();
+
+        if (isPendableFormatCommand(command)) {
+            // Trigger PendingFormatStateChanged event since we changed pending format state
+            editor.triggerEvent({
+                eventType: PluginEventType.PendingFormatStateChanged,
+                formatState: getPendableFormatState(editor.getDocument()),
+            });
+        }
     } else {
         editor.addUndoSnapshot(formatter, ChangeSource.Format);
     }
+}
+
+function isPendableFormatCommand(command: DocumentCommand): boolean {
+    if (!pendableFormatCommands) {
+        pendableFormatCommands = Object.keys(PendableFormatCommandMap).map(
+            key => PendableFormatCommandMap[key as PendableFormatNames]
+        );
+    }
+    return pendableFormatCommands.indexOf(command) >= 0;
 }

--- a/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
@@ -158,6 +158,7 @@ export default class DOMEventPlugin implements EditorPlugin {
     }
 
     private getCurrentPosition() {
-        return Position.getStart(this.editor.getSelectionRange()).normalize();
+        let range = this.editor.getSelectionRange();
+        return range && Position.getStart(range).normalize();
     }
 }

--- a/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
@@ -55,7 +55,7 @@ export default class DOMEventPlugin implements EditorPlugin {
             cut: this.onNativeEvent,
 
             // 3. Selection mangement
-            focus: !this.disableRestoreSelectionOnFocus && this.onFocus,
+            focus: this.onFocus,
             [Browser.isIEOrEdge ? 'beforedeactivate' : 'blur']: this.onBlur,
         });
     }
@@ -129,20 +129,22 @@ export default class DOMEventPlugin implements EditorPlugin {
     };
 
     private onFocus = () => {
-        this.editor.restoreSavedRange();
-
-        if (this.cachedPosition && this.cachedFormatState && this.editor) {
-            let range = this.editor.getSelectionRange();
-            if (
-                range.collapsed &&
-                Position.getStart(range)
-                    .normalize()
-                    .equalTo(this.cachedPosition)
-            ) {
-                this.restorePendingFormatState();
-            } else {
-                this.clear();
+        if (this.disableRestoreSelectionOnFocus) {
+            if (this.cachedPosition && this.cachedFormatState) {
+                let range = this.editor.getSelectionRange();
+                if (
+                    range.collapsed &&
+                    Position.getStart(range)
+                        .normalize()
+                        .equalTo(this.cachedPosition)
+                ) {
+                    this.restorePendingFormatState();
+                } else {
+                    this.clear();
+                }
             }
+        } else {
+            this.editor.restoreSavedRange();
         }
     };
 

--- a/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
@@ -1,18 +1,34 @@
 import Editor from '../editor/Editor';
 import EditorPlugin from '../interfaces/EditorPlugin';
-import { Browser } from 'roosterjs-editor-dom';
-import { ChangeSource, PluginCompositionEvent, PluginEventType } from 'roosterjs-editor-types';
+import {
+    Browser,
+    getPendableFormatState,
+    Position,
+    PendableFormatNames,
+    PendableFormatCommandMap,
+} from 'roosterjs-editor-dom';
+import {
+    ChangeSource,
+    PluginCompositionEvent,
+    PluginEventType,
+    NodePosition,
+    PendableFormatState,
+    PluginEvent,
+} from 'roosterjs-editor-types';
 
 /**
  * DOMEventPlugin handles customized DOM events, including:
  * 1. IME state management
  * 2. Selection management
  * 3. Cut and Drop management
+ * 4. Pending format state management
  */
 export default class DOMEventPlugin implements EditorPlugin {
     private editor: Editor;
     private inIme = false;
     private disposer: () => void;
+    private cachedPosition: NodePosition;
+    private cachedFormatState: PendableFormatState;
 
     constructor(private disableRestoreSelectionOnFocus: boolean) {}
 
@@ -34,13 +50,13 @@ export default class DOMEventPlugin implements EditorPlugin {
                 });
             },
 
-            // 2. Selection mangement
-            [Browser.isIEOrEdge ? 'beforedeactivate' : 'blur']: () => editor.saveSelectionRange(),
-            focus: !this.disableRestoreSelectionOnFocus && (() => editor.restoreSavedRange()),
-
-            // 3. Cut and drop management
+            // 2. Cut and drop management
             drop: this.onNativeEvent,
             cut: this.onNativeEvent,
+
+            // 3. Selection mangement
+            focus: !this.disableRestoreSelectionOnFocus && this.onFocus,
+            [Browser.isIEOrEdge ? 'beforedeactivate' : 'blur']: this.onBlur,
         });
     }
 
@@ -48,6 +64,51 @@ export default class DOMEventPlugin implements EditorPlugin {
         this.disposer();
         this.disposer = null;
         this.editor = null;
+        this.clear();
+    }
+
+    /**
+     * Handle events triggered from editor
+     * @param event PluginEvent object
+     */
+    onPluginEvent(event: PluginEvent) {
+        switch (event.eventType) {
+            case PluginEventType.PendingFormatStateChanged:
+                // Got PendingFormatStateChagned event, cache current position and pending format
+                this.cachedPosition = this.getCurrentPosition();
+                this.cachedFormatState = event.formatState;
+                break;
+            case PluginEventType.KeyDown:
+            case PluginEventType.MouseDown:
+            case PluginEventType.ContentChanged:
+                // If content or position is changed (by keyboard, mouse, or code),
+                // check if current position is still the same with the cached one (if exist),
+                // and clear cached format if position is changed since it is out-of-date now
+                if (
+                    this.cachedPosition &&
+                    !this.cachedPosition.equalTo(this.getCurrentPosition())
+                ) {
+                    this.clear();
+                }
+                break;
+        }
+    }
+
+    /**
+     * Restore cached pending format state (if exist) to current selection
+     */
+    public restorePendingFormatState() {
+        if (this.cachedFormatState) {
+            let formatState = getPendableFormatState(this.editor.getDocument());
+            (<PendableFormatNames[]>Object.keys(PendableFormatCommandMap)).forEach(key => {
+                if (this.cachedFormatState[key] != formatState[key]) {
+                    this.editor
+                        .getDocument()
+                        .execCommand(PendableFormatCommandMap[key], false, null);
+                }
+            });
+            this.cachedPosition = this.getCurrentPosition();
+        }
     }
 
     /**
@@ -66,4 +127,35 @@ export default class DOMEventPlugin implements EditorPlugin {
             );
         });
     };
+
+    private onFocus = () => {
+        this.editor.restoreSavedRange();
+
+        if (this.cachedPosition && this.cachedFormatState && this.editor) {
+            let range = this.editor.getSelectionRange();
+            if (
+                range.collapsed &&
+                Position.getStart(range)
+                    .normalize()
+                    .equalTo(this.cachedPosition)
+            ) {
+                this.restorePendingFormatState();
+            } else {
+                this.clear();
+            }
+        }
+    };
+
+    private onBlur = () => {
+        this.editor.saveSelectionRange();
+    };
+
+    private clear() {
+        this.cachedPosition = null;
+        this.cachedFormatState = null;
+    }
+
+    private getCurrentPosition() {
+        return Position.getStart(this.editor.getSelectionRange()).normalize();
+    }
 }

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -105,10 +105,10 @@ export default class Editor {
             if (Browser.isFirefox) {
                 this.core.document.execCommand(DocumentCommand.EnableObjectResizing, false, <
                     string
-                    >(<any>false));
+                >(<any>false));
                 this.core.document.execCommand(DocumentCommand.EnableInlineTableEditing, false, <
                     string
-                    >(<any>false));
+                >(<any>false));
             } else if (Browser.isIE) {
                 // Change the default paragraph separater to DIV. This is mainly for IE since its default setting is P
                 this.core.document.execCommand(
@@ -117,7 +117,7 @@ export default class Editor {
                     'div'
                 );
             }
-        } catch (e) { }
+        } catch (e) {}
 
         // 9. Let plugins know that we are ready
         this.triggerEvent(
@@ -407,7 +407,7 @@ export default class Editor {
                     this.deleteNode(pathComment);
                     let range = getRangeFromSelectionPath(contentDiv, path);
                     this.select(range);
-                } catch { }
+                } catch {}
             }
 
             if (triggerContentChangedEvent) {
@@ -522,7 +522,15 @@ export default class Editor {
 
     public select(arg1: any, arg2?: any, arg3?: any, arg4?: any): boolean {
         let range = arg1 instanceof Range ? arg1 : createRange(arg1, arg2, arg3, arg4);
-        return this.contains(range) && this.core.api.selectRange(this.core, range);
+        let result = this.contains(range) && this.core.api.selectRange(this.core, range);
+
+        if (result && range.collapsed) {
+            // If selected, and current selection is collapsed,
+            // need to restore pending format state if exists.
+            this.core.corePlugins.domEvent.restorePendingFormatState();
+        }
+
+        return result;
     }
 
     /**
@@ -622,8 +630,8 @@ export default class Editor {
         nameOrMap:
             | string
             | {
-                [eventName: string]: (event: UIEvent) => void;
-            },
+                  [eventName: string]: (event: UIEvent) => void;
+              },
         handler?: (event: UIEvent) => void
     ): () => void {
         if (nameOrMap instanceof Object) {

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -494,15 +494,7 @@ export default class Editor {
 
     public select(arg1: any, arg2?: any, arg3?: any, arg4?: any): boolean {
         let range = arg1 instanceof Range ? arg1 : createRange(arg1, arg2, arg3, arg4);
-        let result = this.contains(range) && this.core.api.selectRange(this.core, range);
-
-        if (result && range.collapsed) {
-            // If selected, and current selection is collapsed,
-            // need to restore pending format state if exists.
-            this.core.corePlugins.domEvent.restorePendingFormatState();
-        }
-
-        return result;
+        return this.contains(range) && this.core.api.selectRange(this.core, range);
     }
 
     /**

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -22,6 +22,11 @@ export { default as extractClipboardEvent } from './utils/extractClipboardEvent'
 export { default as findClosestElementAncestor } from './utils/findClosestElementAncestor';
 export { default as fromHtml } from './utils/fromHtml';
 export { default as getComputedStyles, getComputedStyle } from './utils/getComputedStyles';
+export {
+    default as getPendableFormatState,
+    PendableFormatCommandMap,
+    PendableFormatNames,
+} from './utils/getPendableFormatState';
 export { default as getTagOfNode } from './utils/getTagOfNode';
 export { default as isBlockElement } from './utils/isBlockElement';
 export { default as isNodeEmpty } from './utils/isNodeEmpty';

--- a/packages/roosterjs-editor-dom/lib/utils/getPendableFormatState.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/getPendableFormatState.ts
@@ -1,0 +1,58 @@
+import { DocumentCommand, PendableFormatState } from 'roosterjs-editor-types';
+
+/**
+ * Names of Pendable formats
+ */
+export type PendableFormatNames = keyof PendableFormatState;
+
+/**
+ * A map from pendable format name to document command
+ */
+export const PendableFormatCommandMap: { [key in PendableFormatNames]: DocumentCommand } = {
+    /**
+     * Bold
+     */
+    isBold: DocumentCommand.Bold,
+
+    /**
+     * Italic
+     */
+    isItalic: DocumentCommand.Italic,
+
+    /**
+     * Underline
+     */
+    isUnderline: DocumentCommand.Underline,
+
+    /**
+     * StrikeThrough
+     */
+    isStrikeThrough: DocumentCommand.StrikeThrough,
+
+    /**
+     * Subscript
+     */
+    isSubscript: DocumentCommand.Subscript,
+
+    /**
+     * Superscript
+     */
+    isSuperscript: DocumentCommand.Superscript,
+};
+
+/**
+ * Get Pendable Format State at cursor.
+ * @param document The HTML Document to get format state from
+ * @returns A PendableFormatState object which contains the values of pendable format states
+ */
+export default function getPendableFormatState(document: Document): PendableFormatState {
+    let keys = Object.keys(PendableFormatCommandMap) as PendableFormatNames[];
+
+    return keys.reduce(
+        (state, key) => {
+            state[key] = document.queryCommandState(PendableFormatCommandMap[key]);
+            return state;
+        },
+        <PendableFormatState>{}
+    );
+}

--- a/packages/roosterjs-editor-types/lib/event/PendingFormatStateChangedEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/PendingFormatStateChangedEvent.ts
@@ -1,0 +1,11 @@
+import BasePluginEvent from './BasePluginEvent';
+import { PendableFormatState } from '../interface/FormatState';
+import { PluginEventType } from './PluginEventType';
+
+/**
+ * An event fired when pending format state (bold, italic, underline, ... with collapsed selection) is changed
+ */
+export default interface PendingFormatStateChangedEvent
+    extends BasePluginEvent<PluginEventType.PendingFormatStateChanged> {
+    formatState: PendableFormatState;
+}

--- a/packages/roosterjs-editor-types/lib/event/PluginEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/PluginEvent.ts
@@ -3,6 +3,7 @@ import BeforePasteEvent from './BeforePasteEvent';
 import ContentChangedEvent from './ContentChangedEvent';
 import EditorReadyEvent from './EditorReadyEvent';
 import ExtractContentEvent from './ExtractContentEvent';
+import PendingFormatStateChangedEvent from './PendingFormatStateChangedEvent';
 import { PluginDomEvent } from './PluginDomEvent';
 
 /**
@@ -14,4 +15,5 @@ export type PluginEvent =
     | ExtractContentEvent
     | PluginDomEvent
     | EditorReadyEvent
-    | BeforeDisposeEvent;
+    | BeforeDisposeEvent
+    | PendingFormatStateChangedEvent;

--- a/packages/roosterjs-editor-types/lib/event/PluginEventType.ts
+++ b/packages/roosterjs-editor-types/lib/event/PluginEventType.ts
@@ -63,4 +63,9 @@ export const enum PluginEventType {
      * HTML Input / TextInput event
      */
     Input,
+
+    /**
+     * Pending format state (bold, italic, underline, ... with collapsed selection) is changed
+     */
+    PendingFormatStateChanged,
 }

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -23,6 +23,7 @@ export { default as BeforePasteEvent } from './event/BeforePasteEvent';
 export { default as ContentChangedEvent } from './event/ContentChangedEvent';
 export { default as EditorReadyEvent } from './event/EditorReadyEvent';
 export { default as ExtractContentEvent } from './event/ExtractContentEvent';
+export { default as PendingFormatStateChangedEvent } from './event/PendingFormatStateChangedEvent';
 export {
     PluginDomEvent,
     PluginCompositionEvent,

--- a/publish/samplesite/scripts/controls/sidePane/eventViewer/EventViewPane.tsx
+++ b/publish/samplesite/scripts/controls/sidePane/eventViewer/EventViewPane.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PluginEvent, PluginEventType } from 'roosterjs-editor-types';
+import { PendableFormatState, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import { SidePaneElementProps } from '../SidePaneElement';
 
 const styles = require('./EventViewPane.scss');
@@ -28,12 +28,13 @@ const EventTypeMap = {
     [PluginEventType.MouseDown]: 'MouseDown',
     [PluginEventType.MouseUp]: 'MouseUp',
     [PluginEventType.Input]: 'Input',
+    [PluginEventType.PendingFormatStateChanged]: 'PendingFormatStateChanged',
 };
 
 export default class EventViewPane extends React.Component<
     SidePaneElementProps,
     EventViewPaneState
-    > {
+> {
     private events: EventEntry[] = [];
     private displayCount = React.createRef<HTMLSelectElement>();
     private lasteIndex = 0;
@@ -147,6 +148,10 @@ export default class EventViewPane extends React.Component<
                         ))}
                     </span>
                 );
+            case PluginEventType.PendingFormatStateChanged:
+                const formatState = event.formatState;
+                const keys = Object.keys(formatState) as (keyof PendableFormatState)[];
+                return <span>{keys.map(key => `${key}=${event.formatState[key]}; `)}</span>;
         }
         return null;
     }


### PR DESCRIPTION
styles like bold, italic, underline, ... are pending style if selection is empty (collapsed), which means if selection is changed before user type something (apply the change), the pending style will be lost. This causes user can't set pending style at the same time with other formats like font and color since those styles needs open a picker which will cause editor loses focus.

The fix here is:
1. Add a new event "PendingFormatStateChangedEvent", and it is fired when user is change such styles
2. Handle the event in DomPlugin and cache current position and format
3. When editor got focused, or we call editor.select() to change selection, check if the selection is still the same with the cached one. If so, apply the cached format
