### PR TITLE
Fix for dark mode undo

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -365,7 +365,7 @@ export default class Editor {
         }
 
         if (this.core.inDarkMode) {
-            content = this.getColorNormalizedContent(content);
+            content = getColorNormalizedContent(content);
         }
 
         return content;

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -345,7 +345,6 @@ export default class Editor {
     public getContent(
         triggerExtractContentEvent: boolean = true,
         includeSelectionMarker: boolean = false,
-        normalizeColor: boolean = true
     ): string {
         let contentDiv = this.core.contentDiv;
         let content = contentDiv.innerHTML;
@@ -367,7 +366,7 @@ export default class Editor {
             content = extractContentEvent.content;
         }
 
-        if (this.core.inDarkMode && normalizeColor) {
+        if (this.core.inDarkMode) {
             content = this.getColorNormalizedContent(content);
         }
 
@@ -434,7 +433,6 @@ export default class Editor {
     public setContent(
         content: string,
         triggerContentChangedEvent: boolean = true,
-        convertToDarkMode?: boolean
     ) {
         let contentDiv = this.core.contentDiv;
         let contentChanged = false;
@@ -450,12 +448,12 @@ export default class Editor {
                     this.deleteNode(pathComment);
                     let range = getRangeFromSelectionPath(contentDiv, path);
                     this.select(range);
-                } catch {}
+                } catch { }
             }
         }
 
         // Convert content even if it hasn't changed.
-        if (convertToDarkMode) {
+        if (this.core.inDarkMode) {
             const convertFunction = this.convertContentToDarkMode(
                 contentDiv,
                 true /* skipRootElement */
@@ -677,8 +675,8 @@ export default class Editor {
         nameOrMap:
             | string
             | {
-                  [eventName: string]: (event: UIEvent) => void;
-              },
+                [eventName: string]: (event: UIEvent) => void;
+            },
         handler?: (event: UIEvent) => void
     ): () => void {
         if (nameOrMap instanceof Object) {
@@ -982,16 +980,16 @@ export default class Editor {
 
         return childElements.length > 0
             ? () => {
-                  const darkModeOptions = this.getDarkModeOptions();
-                  childElements.forEach(element => {
-                      if (darkModeOptions && darkModeOptions.onExternalContentTransform) {
-                          darkModeOptions.onExternalContentTransform(element);
-                      } else {
-                          element.style.color = null;
-                          element.style.backgroundColor = null;
-                      }
-                  });
-              }
+                const darkModeOptions = this.getDarkModeOptions();
+                childElements.forEach(element => {
+                    if (darkModeOptions && darkModeOptions.onExternalContentTransform) {
+                        darkModeOptions.onExternalContentTransform(element);
+                    } else {
+                        element.style.color = null;
+                        element.style.backgroundColor = null;
+                    }
+                });
+            }
             : null;
     }
 

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -338,8 +338,6 @@ export default class Editor {
      * before return. Use this parameter to remove any temporary content added by plugins.
      * @param includeSelectionMarker Set to true if need include selection marker inside the content.
      * When restore this content, editor will set the selection to the position marked by these markers
-     * @param normalizeColor Set to false if you want to get the content of the editor "as is" with no normalization.
-     * This is a no-op when in light mode. If false, instead of normalizing the colors to light mode, it will return the 'real' editor content.
      * @returns HTML string representing current editor content
      */
     public getContent(
@@ -385,7 +383,6 @@ export default class Editor {
      * Set HTML content to this editor. All existing content will be replaced. A ContentChanged event will be triggered
      * @param content HTML content to set in
      * @param triggerContentChangedEvent True to trigger a ContentChanged event. Default value is true
-     * @param convertToDarkMode True to conver the editor's new content to dark mode formatting. Default value is false.
      */
     public setContent(
         content: string,

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -74,7 +74,6 @@ export default class Editor {
         this.setContent(
             options.initialContent || contentDiv.innerHTML || '',
             true /* triggerContentChangedEvent */,
-            this.core.inDarkMode
         );
 
         // 5. Create event handler to bind DOM events
@@ -935,7 +934,6 @@ export default class Editor {
             this.setContent(
                 currentContent,
                 undefined /* triggerContentChangedEvent */,
-                true /* convertToDarkMode */
             );
         } else {
             this.setContent(currentContent);

--- a/packages/roosterjs-editor-core/lib/undo/Undo.ts
+++ b/packages/roosterjs-editor-core/lib/undo/Undo.ts
@@ -134,8 +134,7 @@ export default class Undo implements UndoService {
     public addUndoSnapshot(): string {
         let snapshot = this.editor.getContent(
             false /*triggerExtractContentEvent*/,
-            true /*markSelection*/,
-            !this.editor.isDarkMode() /*normalizeColor*/
+            true /* includeSelectionmarker */
         );
         this.getSnapshotsManager().addSnapshot(snapshot);
         this.hasNewContent = false;
@@ -155,7 +154,11 @@ export default class Undo implements UndoService {
         if (snapshot != null) {
             try {
                 this.isRestoring = true;
-                this.editor.setContent(snapshot);
+                this.editor.setContent(
+                    snapshot,
+                    undefined /* triggerContentChangedEvent */,
+                    this.editor.isDarkMode()
+                );
             } finally {
                 this.isRestoring = false;
             }

--- a/packages/roosterjs-editor-core/lib/undo/Undo.ts
+++ b/packages/roosterjs-editor-core/lib/undo/Undo.ts
@@ -28,7 +28,7 @@ export default class Undo implements UndoService {
      * this object to be reused when editor is disposed and created again
      * @param maxBufferSize The max buffer size for snapshots. Default value is 10MB
      */
-    constructor(private preserveSnapshots?: boolean, private maxBufferSize: number = 1e7) {}
+    constructor(private preserveSnapshots?: boolean, private maxBufferSize: number = 1e7) { }
 
     /**
      * Get a friendly name of  this plugin
@@ -134,7 +134,7 @@ export default class Undo implements UndoService {
     public addUndoSnapshot(): string {
         let snapshot = this.editor.getContent(
             false /*triggerExtractContentEvent*/,
-            true /* includeSelectionmarker */
+            true /* includeSelectionMarker */
         );
         this.getSnapshotsManager().addSnapshot(snapshot);
         this.hasNewContent = false;

--- a/packages/roosterjs-editor-core/lib/undo/Undo.ts
+++ b/packages/roosterjs-editor-core/lib/undo/Undo.ts
@@ -157,7 +157,6 @@ export default class Undo implements UndoService {
                 this.editor.setContent(
                     snapshot,
                     undefined /* triggerContentChangedEvent */,
-                    this.editor.isDarkMode()
                 );
             } finally {
                 this.isRestoring = false;

--- a/packages/roosterjs-editor-core/lib/undo/Undo.ts
+++ b/packages/roosterjs-editor-core/lib/undo/Undo.ts
@@ -154,10 +154,7 @@ export default class Undo implements UndoService {
         if (snapshot != null) {
             try {
                 this.isRestoring = true;
-                this.editor.setContent(
-                    snapshot,
-                    undefined /* triggerContentChangedEvent */,
-                );
+                this.editor.setContent(snapshot);
             } finally {
                 this.isRestoring = false;
             }

--- a/packages/roosterjs-editor-plugins/lib/Paste/Paste.ts
+++ b/packages/roosterjs-editor-plugins/lib/Paste/Paste.ts
@@ -156,7 +156,7 @@ export default class Paste implements EditorPlugin {
                     true /*markSelection*/
                 );
             } else {
-                this.editor.setContent(clipboardData.snapshotBeforePaste, undefined, this.editor.isDarkMode());
+                this.editor.setContent(clipboardData.snapshotBeforePaste, undefined);
             }
 
             switch (pasteOption) {
@@ -205,14 +205,14 @@ export default class Paste implements EditorPlugin {
         let format = getFormatState(this.editor);
         return format
             ? {
-                  fontFamily: format.fontName,
-                  fontSize: format.fontSize,
-                  textColor: format.textColor,
-                  backgroundColor: format.backgroundColor,
-                  bold: format.isBold,
-                  italic: format.isItalic,
-                  underline: format.isUnderline,
-              }
+                fontFamily: format.fontName,
+                fontSize: format.fontSize,
+                textColor: format.textColor,
+                backgroundColor: format.backgroundColor,
+                bold: format.isBold,
+                italic: format.isItalic,
+                underline: format.isUnderline,
+            }
             : {};
     }
 


### PR DESCRIPTION
I fixed dark mode undo so the undo buffer always has normalized content, and when inserted back into the editor, it is normalized appropriately.