### PR TITLE
do not trigger event when set initial content

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -75,7 +75,10 @@ export default class Editor {
         this.core.plugins.forEach(plugin => plugin.initialize(this));
 
         // 4. Ensure initial content and its format
-        this.setContent(options.initialContent || contentDiv.innerHTML || '');
+        this.setContent(
+            options.initialContent || contentDiv.innerHTML || '',
+            false /*triggerContentChangedEvent*/
+        );
 
         // 5. Create event handler to bind DOM events
         this.eventDisposers = mapPluginEvents(this.core);


### PR DESCRIPTION
When set initial content, we should not trigger ContentChangedEvent, otherwise plugin will think content is always changed on init, and it can break the "restore editor" scenario which allows bring back an editor with existing undo snapshots, a ContentChangedEvent will cause undo plugin clear all redo snapshots so that redo will be broken.