### PR TITLE
Fix #277 and #330

### DIFF
--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -40,6 +40,7 @@ export { default as wrap } from './utils/wrap';
 export { getNextLeafSibling, getPreviousLeafSibling } from './utils/getLeafSibling';
 export { getFirstLeafNode, getLastLeafNode } from './utils/getLeafNode';
 export { default as getTextContent } from './utils/getTextContent';
+export { default as splitTextNode } from './utils/splitTextNode';
 
 export { default as VTable, VCell } from './table/VTable';
 

--- a/packages/roosterjs-editor-dom/lib/utils/adjustNodeInsertPosition.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/adjustNodeInsertPosition.ts
@@ -1,13 +1,26 @@
 import changeElementTag from './changeElementTag';
+import contains from './contains';
+import createRange from '../selection/createRange';
 import findClosestElementAncestor from './findClosestElementAncestor';
+import getBlockElementAtNode from '../blockElements/getBlockElementAtNode';
 import getTagOfNode from './getTagOfNode';
+import isNodeEmpty from './isNodeEmpty';
 import isPositionAtBeginningOf from '../selection/isPositionAtBeginningOf';
 import isVoidHtmlElement from './isVoidHtmlElement';
 import Position from '../selection/Position';
+import queryElements from './queryElements';
+import splitTextNode from './splitTextNode';
 import unwrap from './unwrap';
 import VTable from '../table/VTable';
 import wrap from './wrap';
-import { NodePosition, NodeType, PositionType } from 'roosterjs-editor-types';
+import { NodePosition, NodeType, PositionType, QueryScope } from 'roosterjs-editor-types';
+import { splitBalancedNodeRange } from './splitParentNode';
+
+const adjustSteps: ((
+    root: HTMLElement,
+    nodeToInsert: Node,
+    position: NodePosition
+) => NodePosition)[] = [handleHyperLink, handleStructuredNode, handleParagraph, handleVoidElement];
 
 /**
  * Adjust the given position and return a better position (if any) or the given position
@@ -17,7 +30,76 @@ import { NodePosition, NodeType, PositionType } from 'roosterjs-editor-types';
  * @param position The original position to insert the node
  */
 export default function adjustNodeInsertPosition(
-    root: Node,
+    root: HTMLElement,
+    nodeToInsert: Node,
+    position: NodePosition
+): NodePosition {
+    adjustSteps.forEach(handler => {
+        position = handler(root, nodeToInsert, position);
+    });
+
+    return position;
+}
+
+function handleHyperLink(
+    root: HTMLElement,
+    nodeToInsert: Node,
+    position: NodePosition
+): NodePosition {
+    let blockElement = getBlockElementAtNode(root, position.node);
+
+    // Find the first <A> tag within current block which covers current selection
+    // If there are more than one nested, let's handle the first one only since that is not a common scenario.
+    let anchor = queryElements(
+        root,
+        'a[href]',
+        null /*forEachCallback*/,
+        QueryScope.OnSelection,
+        createRange(position)
+    ).filter(a => blockElement.contains(a))[0];
+
+    // If this is about to insert node to an empty A tag, clear the A tag and reset position
+    if (anchor && isNodeEmpty(anchor)) {
+        position = new Position(anchor, PositionType.Before);
+        safeRemove(anchor);
+        anchor = null;
+    }
+
+    // If this is about to insert nodes which contains A tag into another A tag, need to break current A tag
+    // otherwise we will have nested A tags which is a wrong HTML structure
+    if (
+        anchor &&
+        (<ParentNode>(<any>nodeToInsert)).querySelector &&
+        (<ParentNode>(<any>nodeToInsert)).querySelector('a[href]')
+    ) {
+        let normalizedPosition = position.normalize();
+        let parentNode = normalizedPosition.node.parentNode;
+        let nextNode =
+            normalizedPosition.node.nodeType == NodeType.Text
+                ? splitTextNode(
+                      <Text>normalizedPosition.node,
+                      normalizedPosition.offset,
+                      false /*returnFirstPart*/
+                  )
+                : normalizedPosition.isAtEnd
+                ? normalizedPosition.node.nextSibling
+                : normalizedPosition.node;
+        let splitter: Node = root.ownerDocument.createTextNode('');
+        parentNode.insertBefore(splitter, nextNode);
+
+        while (contains(anchor, splitter)) {
+            splitter = splitBalancedNodeRange(splitter);
+        }
+
+        position = new Position(splitter, PositionType.Before);
+        safeRemove(splitter);
+    }
+
+    return position;
+}
+
+function handleStructuredNode(
+    root: HTMLElement,
     nodeToInsert: Node,
     position: NodePosition
 ): NodePosition {
@@ -46,7 +128,7 @@ export default function adjustNodeInsertPosition(
         let shouldInsertListAsText = !rootNodeToInsert.firstChild.nextSibling && !hasBrNextToRoot;
 
         if (hasBrNextToRoot && rootNodeToInsert.parentNode) {
-            rootNodeToInsert.parentNode.removeChild(rootNodeToInsert.nextSibling);
+            safeRemove(rootNodeToInsert.nextSibling);
         }
 
         if (shouldInsertListAsText) {
@@ -84,6 +166,14 @@ export default function adjustNodeInsertPosition(
         }
     }
 
+    return position;
+}
+
+function handleParagraph(
+    root: HTMLElement,
+    nodeToInsert: Node,
+    position: NodePosition
+): NodePosition {
     if (getTagOfNode(position.node) == 'P') {
         // Insert into a P tag may cause issues when the inserted content contains any block element.
         // Change P tag to DIV to make sure it works well
@@ -94,6 +184,14 @@ export default function adjustNodeInsertPosition(
         }
     }
 
+    return position;
+}
+
+function handleVoidElement(
+    root: HTMLElement,
+    nodeToInsert: Node,
+    position: NodePosition
+): NodePosition {
     if (isVoidHtmlElement(position.node)) {
         position = new Position(
             position.node,
@@ -102,4 +200,10 @@ export default function adjustNodeInsertPosition(
     }
 
     return position;
+}
+
+function safeRemove(node: Node) {
+    if (node && node.parentNode) {
+        node.parentNode.removeChild(node);
+    }
 }

--- a/packages/roosterjs-editor-dom/lib/utils/applyTextStyle.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/applyTextStyle.ts
@@ -1,5 +1,6 @@
 import getTagOfNode from './getTagOfNode';
 import Position from '../selection/Position';
+import splitTextNode from './splitTextNode';
 import wrap from './wrap';
 import { getNextLeafSibling } from './getLeafSibling';
 import { NodePosition, NodeType, PositionType } from 'roosterjs-editor-types';
@@ -31,11 +32,15 @@ export default function applyTextStyle(
 
         if (formatNode.nodeType == NodeType.Text && ['TR', 'TABLE'].indexOf(parentTag) < 0) {
             if (formatNode == to.node && !to.isAtEnd) {
-                formatNode = splitTextNode(formatNode, to.offset, true /*returnFirstPart*/);
+                formatNode = splitTextNode(<Text>formatNode, to.offset, true /*returnFirstPart*/);
             }
 
             if (from.offset > 0) {
-                formatNode = splitTextNode(formatNode, from.offset, false /*returnFirstPart*/);
+                formatNode = splitTextNode(
+                    <Text>formatNode,
+                    from.offset,
+                    false /*returnFirstPart*/
+                );
             }
 
             formatNodes.push(formatNode);
@@ -81,13 +86,4 @@ function callStylerWithInnerNode(
     if (node && node.nodeType == NodeType.Element) {
         styler(node as HTMLElement, true /*isInnerNode*/);
     }
-}
-
-function splitTextNode(textNode: Node, offset: number, returnFirstPart: boolean) {
-    let firstPart = textNode.nodeValue.substr(0, offset);
-    let secondPart = textNode.nodeValue.substr(offset);
-    let newNode = textNode.ownerDocument.createTextNode(returnFirstPart ? firstPart : secondPart);
-    textNode.nodeValue = returnFirstPart ? secondPart : firstPart;
-    textNode.parentNode.insertBefore(newNode, returnFirstPart ? textNode : textNode.nextSibling);
-    return newNode;
 }

--- a/packages/roosterjs-editor-dom/lib/utils/splitTextNode.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/splitTextNode.ts
@@ -6,9 +6,9 @@
  * Otherwise return the second part, and the passed in textNode will become the first part
  */
 export default function splitTextNode(textNode: Text, offset: number, returnFirstPart: boolean) {
-    let firstPart = textNode.nodeValue.substr(0, offset);
-    let secondPart = textNode.nodeValue.substr(offset);
-    let newNode = textNode.ownerDocument.createTextNode(returnFirstPart ? firstPart : secondPart);
+    const firstPart = textNode.nodeValue.substr(0, offset);
+    const secondPart = textNode.nodeValue.substr(offset);
+    const newNode = textNode.ownerDocument.createTextNode(returnFirstPart ? firstPart : secondPart);
     textNode.nodeValue = returnFirstPart ? secondPart : firstPart;
     textNode.parentNode.insertBefore(newNode, returnFirstPart ? textNode : textNode.nextSibling);
     return newNode;

--- a/packages/roosterjs-editor-dom/lib/utils/splitTextNode.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/splitTextNode.ts
@@ -1,0 +1,15 @@
+/**
+ * Split a text node into two parts by an offset number, and return one of them
+ * @param textNode The text node to split
+ * @param offset The offset number to split at
+ * @param returnFirstPart True to return the first part, then the passed in textNode will become the second part.
+ * Otherwise return the second part, and the passed in textNode will become the first part
+ */
+export default function splitTextNode(textNode: Text, offset: number, returnFirstPart: boolean) {
+    let firstPart = textNode.nodeValue.substr(0, offset);
+    let secondPart = textNode.nodeValue.substr(offset);
+    let newNode = textNode.ownerDocument.createTextNode(returnFirstPart ? firstPart : secondPart);
+    textNode.nodeValue = returnFirstPart ? secondPart : firstPart;
+    textNode.parentNode.insertBefore(newNode, returnFirstPart ? textNode : textNode.nextSibling);
+    return newNode;
+}


### PR DESCRIPTION
#277 Insert <A> tag inside a [A] tag, should split outer [A] tag
The fix is to follow Chrome CED behavior:
- If the node to insert doesn't contain any [A] tag, no change.
- If the node to insert contains [A] tag, but there isn't any [A] tag around current insert position, no change
- If the node to insert contains [A] tag, and there is [A] tag around current position within current block, split the existing [A] tag into two and insert the new nodes between them.

#330 When replacing links using ctrl-v, link doesnt disappear
Before insert, let's check if there is an empty [A] tag around current insert position. If yes, remove it.