### PR TITLE
Fix insertNode at end

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -77,7 +77,8 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
                             isBegin ? refNode : refNode.nextSibling
                         );
                     } else {
-                        contentDiv.appendChild(node);
+                        // Inserting at the end on a new line - use appendChild to insert the content in contentDiv
+                        insertedNode = contentDiv.appendChild(node);
                     }
                 } else {
                     // if the refNode can have child, use appendChild (which is like to insert as first/last child)

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -71,10 +71,11 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
                     // For insert on new line, or refNode is text or void html element (HR, BR etc.)
                     // which cannot have children, i.e. <div>hello<br>world</div>. 'hello', 'world' are the
                     // first and last node. Insert before 'hello' or after 'world', but still inside DIV
-                    insertedNode = refNode.parentNode.insertBefore(
-                        node,
-                        isBegin ? refNode : refNode.nextSibling
-                    );
+                    if (isBegin) {
+                        insertedNode = refNode.parentNode.insertBefore(node, refNode);
+                    } else {
+                        contentDiv.appendChild(node);
+                    }
                 } else {
                     // if the refNode can have child, use appendChild (which is like to insert as first/last child)
                     // i.e. <div>hello</div>, the content will be inserted before/after hello

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -94,6 +94,7 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
             break;
         }
         case ContentPosition.DomEnd:
+            // Use appendChild to insert the node at the end of the content div.
             let insertedNode = contentDiv.appendChild(node);
             // Final check to see if the inserted node is a block. If not block and the ask is to insert on new line,
             // add a DIV wrapping

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -71,8 +71,11 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
                     // For insert on new line, or refNode is text or void html element (HR, BR etc.)
                     // which cannot have children, i.e. <div>hello<br>world</div>. 'hello', 'world' are the
                     // first and last node. Insert before 'hello' or after 'world', but still inside DIV
-                    if (isBegin) {
-                        insertedNode = refNode.parentNode.insertBefore(node, refNode);
+                    if (isBegin || !option.insertOnNewLine) {
+                        insertedNode = refNode.parentNode.insertBefore(
+                            node,
+                            isBegin ? refNode : refNode.nextSibling
+                        );
                     } else {
                         contentDiv.appendChild(node);
                     }

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -57,7 +57,7 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
 
     switch (option.position) {
         case ContentPosition.Begin:
-        case ContentPosition.End:
+        case ContentPosition.End: {
             let isBegin = option.position == ContentPosition.Begin;
             let block = getFirstLastBlockElement(contentDiv, isBegin);
             let insertedNode: Node;
@@ -71,15 +71,10 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
                     // For insert on new line, or refNode is text or void html element (HR, BR etc.)
                     // which cannot have children, i.e. <div>hello<br>world</div>. 'hello', 'world' are the
                     // first and last node. Insert before 'hello' or after 'world', but still inside DIV
-                    if (isBegin || !option.insertOnNewLine) {
-                        insertedNode = refNode.parentNode.insertBefore(
-                            node,
-                            isBegin ? refNode : refNode.nextSibling
-                        );
-                    } else {
-                        // Inserting at the end on a new line - use appendChild to insert the content in contentDiv
-                        insertedNode = contentDiv.appendChild(node);
-                    }
+                    insertedNode = refNode.parentNode.insertBefore(
+                        node,
+                        isBegin ? refNode : refNode.nextSibling
+                    );
                 } else {
                     // if the refNode can have child, use appendChild (which is like to insert as first/last child)
                     // i.e. <div>hello</div>, the content will be inserted before/after hello
@@ -96,6 +91,15 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
                 wrap(insertedNode);
             }
 
+            break;
+        }
+        case ContentPosition.DomEnd:
+            let insertedNode = contentDiv.appendChild(node);
+            // Final check to see if the inserted node is a block. If not block and the ask is to insert on new line,
+            // add a DIV wrapping
+            if (insertedNode && option.insertOnNewLine && !isBlockElement(insertedNode)) {
+                wrap(insertedNode);
+            }
             break;
         case ContentPosition.Range:
         case ContentPosition.SelectionStart:

--- a/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
+++ b/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
@@ -138,6 +138,52 @@ describe('Editor insertContent()', () => {
     });
 });
 
+describe('Editor insertNode() with multiple nodes', () => {
+    let originalContent = '<div id="text">text</div>';
+
+    beforeEach(() => {
+        editor = TestHelper.initEditor(testID);
+        editor.setContent(originalContent);
+    });
+
+    it('insert two nodes at the end', () => {
+        let node = document.createElement('div');
+        node.id = 'signature';
+        node.innerHTML =
+            'Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a>';
+
+        // Act
+        editor.insertNode(node, {
+            position: ContentPosition.DomEnd,
+            insertOnNewLine: true,
+            updateCursor: false,
+            replaceSelection: false,
+        });
+
+        // Assert
+        expect(editor.getContent()).toBe(
+            '<div id="text">text</div><div id="signature">Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a></div>'
+        );
+
+        node = document.createElement('div');
+        node.id = 'reference-message';
+        node.innerHTML = 'Hello<br>Lorem ipsum<br>Regards,<br>The roosterjs Team.';
+
+        // Act
+        editor.insertNode(node, {
+            position: ContentPosition.DomEnd,
+            insertOnNewLine: true,
+            updateCursor: false,
+            replaceSelection: false,
+        });
+
+        // Assert
+        expect(editor.getContent()).toBe(
+            '<div id="text">text</div><div id="signature">Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a></div><div id="reference-message">Hello<br>Lorem ipsum<br>Regards,<br>The roosterjs Team.</div>'
+        );
+    });
+});
+
 describe('Editor insertNode()', () => {
     let originalContent = '<div id="text">text</div>';
     let node = TestHelper.createElementFromContent('testNode', 'abc');
@@ -208,52 +254,6 @@ describe('Editor insertNode()', () => {
 
         // Assert
         expect(editor.getContent()).toBe('<div id="testNode">abc</div><div id="text">text</div>');
-    });
-});
-
-describe('Editor insertNode() with multiple nodes', () => {
-    let originalContent = '<div id="text">text</div>';
-
-    beforeEach(() => {
-        editor = TestHelper.initEditor(testID);
-        editor.setContent(originalContent);
-    });
-
-    it('insert two nodes at the end', () => {
-        let node = document.createElement('div');
-        node.id = 'signature';
-        node.innerHTML =
-            'Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a>';
-
-        // Act
-        editor.insertNode(node, {
-            position: ContentPosition.End,
-            insertOnNewLine: true,
-            updateCursor: false,
-            replaceSelection: false,
-        });
-
-        // Assert
-        expect(editor.getContent()).toBe(
-            '<div id="text">text</div><div id="signature">Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a></div>'
-        );
-
-        node = document.createElement('div');
-        node.id = 'reference-message';
-        node.innerHTML = 'Hello<br>Lorem ipsum<br>Regards,<br>The roosterjs Team.';
-
-        // Act
-        editor.insertNode(node, {
-            position: ContentPosition.End,
-            insertOnNewLine: true,
-            updateCursor: false,
-            replaceSelection: false,
-        });
-
-        // Assert
-        expect(editor.getContent()).toBe(
-            '<div id="text">text</div><div id="signature">Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a></div><div id="reference-message">Hello<br>Lorem ipsum<br>Regards,<br>The roosterjs Team.</div>'
-        );
     });
 });
 

--- a/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
+++ b/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
@@ -211,6 +211,51 @@ describe('Editor insertNode()', () => {
     });
 });
 
+describe('Editor insertNode() with multiple nodes', () => {
+    let originalContent = '<div id="text">text</div>';
+
+    beforeEach(() => {
+        editor = TestHelper.initEditor(testID);
+        editor.setContent(originalContent);
+    });
+
+    it('insert two nodes at the end', () => {
+        let node = document.createElement('div');
+        node.id = 'signature';
+        node.innerHTML = `Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a>`;
+
+        // Act
+        editor.insertNode(node, {
+            position: ContentPosition.End,
+            insertOnNewLine: true,
+            updateCursor: false,
+            replaceSelection: false,
+        });
+
+        // Assert
+        expect(editor.getContent()).toBe(
+            '<div id="text">text</div><div id="signature">Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a></div>'
+        );
+
+        node = document.createElement('div');
+        node.id = 'reference-message';
+        node.innerHTML = `Hello<br>Lorem ipsum<br>Regards,<br>The roosterjs Team.`;
+
+        // Act
+        editor.insertNode(node, {
+            position: ContentPosition.End,
+            insertOnNewLine: true,
+            updateCursor: false,
+            replaceSelection: false,
+        });
+
+        // Assert
+        expect(editor.getContent()).toBe(
+            '<div id="text">text</div><div id="signature">Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a></div><div id="reference-message">Hello<br>Lorem ipsum<br>Regards,<br>The roosterjs Team.</div>'
+        );
+    });
+});
+
 describe('Editor deleteNode()', () => {
     let originalContent = '<p id="first">abc</p><p id="second">123</p>';
 

--- a/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
+++ b/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
@@ -138,7 +138,7 @@ describe('Editor insertContent()', () => {
     });
 });
 
-describe('Editor insertNode() with multiple nodes', () => {
+describe('Editor insertNode() at end of content div', () => {
     let originalContent = '<div id="text">text</div>';
 
     beforeEach(() => {

--- a/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
+++ b/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
@@ -222,7 +222,8 @@ describe('Editor insertNode() with multiple nodes', () => {
     it('insert two nodes at the end', () => {
         let node = document.createElement('div');
         node.id = 'signature';
-        node.innerHTML = `Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a>`;
+        node.innerHTML =
+            'Thank you,<br><a href="https://github.com/microsoft/roosterjs">roosterjs</a>';
 
         // Act
         editor.insertNode(node, {
@@ -239,7 +240,7 @@ describe('Editor insertNode() with multiple nodes', () => {
 
         node = document.createElement('div');
         node.id = 'reference-message';
-        node.innerHTML = `Hello<br>Lorem ipsum<br>Regards,<br>The roosterjs Team.`;
+        node.innerHTML = 'Hello<br>Lorem ipsum<br>Regards,<br>The roosterjs Team.';
 
         // Act
         editor.insertNode(node, {

--- a/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionBlockScoper.ts
+++ b/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionBlockScoper.ts
@@ -55,6 +55,7 @@ export default class SelectionBlockScoper implements TraversingScoper {
             switch (this.startFrom) {
                 case ContentPosition.Begin:
                 case ContentPosition.End:
+                case ContentPosition.DomEnd:
                     return getFirstLastInlineElementFromBlockElement(
                         this.block,
                         this.startFrom == ContentPosition.Begin

--- a/packages/roosterjs-editor-types/lib/enum/ContentPosition.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ContentPosition.ts
@@ -15,6 +15,11 @@ export const enum ContentPosition {
     End,
 
     /**
+     * End of the content div domain.
+     */
+    DomEnd,
+
+    /**
      * Selection start
      */
     SelectionStart,

--- a/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
+++ b/packages/roosterjs-editor-types/lib/interface/InsertOption.ts
@@ -29,6 +29,7 @@ export interface InsertOptionBasic extends InsertOptionBase {
     position:
         | ContentPosition.Begin
         | ContentPosition.End
+        | ContentPosition.DomEnd
         | ContentPosition.Outside
         | ContentPosition.SelectionStart;
 }


### PR DESCRIPTION
Fixing an issue with the `insertNode()` function, where if two elements are inserted with `ContentPosition.End` then the last one is inserted inside the last child instead of inside the container.

Added unit tests to demonstrate the issue, and fixed in `coreApi/insertNode.ts`