### PR TITLE
Expose selection path related methods

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -101,9 +101,8 @@ export default class Editor {
         this.triggerPluginEvent(PluginEventType.EditorReady, {}, true /*broadcast*/);
 
         // 10. Before give editor to user, make sure there is at least one DIV element to accept typing
-        const range = this.getSelectionRange();
         this.core.corePlugins.typeInContainer.ensureTypeInElement(
-            range ? Position.getStart(range) : new Position(contentDiv, PositionType.Begin)
+            this.getFocusedPosition() || new Position(contentDiv, PositionType.Begin)
         );
     }
 

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -16,14 +16,12 @@ import {
     InlineElement,
     InsertOption,
     NodePosition,
-    NodeType,
     PluginEvent,
     PluginEventData,
     PluginEventFromType,
     PluginEventType,
     PositionType,
     QueryScope,
-    SelectionPath,
     Rect,
 } from 'roosterjs-editor-types';
 import {
@@ -34,16 +32,16 @@ import {
     findClosestElementAncestor,
     fromHtml,
     getBlockElementAtNode,
+    getHtmlWithSelectionPath,
     getTextContent,
     getInlineElementAtNode,
     getPositionRect,
-    getRangeFromSelectionPath,
-    getSelectionPath,
     getTagOfNode,
     isNodeEmpty,
     Position,
     PositionContentSearcher,
     queryElements,
+    setHtmlWithSelectionPath,
     wrap,
 } from 'roosterjs-editor-dom';
 
@@ -103,8 +101,9 @@ export default class Editor {
         this.triggerPluginEvent(PluginEventType.EditorReady, {}, true /*broadcast*/);
 
         // 10. Before give editor to user, make sure there is at least one DIV element to accept typing
+        const range = this.getSelectionRange();
         this.core.corePlugins.typeInContainer.ensureTypeInElement(
-            new Position(contentDiv, PositionType.Begin)
+            range ? Position.getStart(range) : new Position(contentDiv, PositionType.Begin)
         );
     }
 
@@ -345,16 +344,10 @@ export default class Editor {
         triggerExtractContentEvent: boolean = true,
         includeSelectionMarker: boolean = false
     ): string {
-        let contentDiv = this.core.contentDiv;
-        let content = contentDiv.innerHTML;
-        let selectionPath: SelectionPath;
-
-        if (
-            includeSelectionMarker &&
-            (selectionPath = getSelectionPath(contentDiv, this.getSelectionRange()))
-        ) {
-            content += `<!--${JSON.stringify(selectionPath)}-->`;
-        }
+        let content = getHtmlWithSelectionPath(
+            this.core.contentDiv,
+            includeSelectionMarker && this.getSelectionRange()
+        );
 
         if (triggerExtractContentEvent) {
             content = this.triggerPluginEvent(
@@ -388,19 +381,9 @@ export default class Editor {
         let contentDiv = this.core.contentDiv;
         let contentChanged = false;
         if (contentDiv.innerHTML != content) {
-            contentDiv.innerHTML = content || '';
+            let range = setHtmlWithSelectionPath(contentDiv, content);
+            this.select(range);
             contentChanged = true;
-
-            let pathComment = contentDiv.lastChild;
-
-            if (pathComment && pathComment.nodeType == NodeType.Comment) {
-                try {
-                    let path = JSON.parse(pathComment.nodeValue) as SelectionPath;
-                    this.deleteNode(pathComment);
-                    let range = getRangeFromSelectionPath(contentDiv, path);
-                    this.select(range);
-                } catch {}
-            }
         }
 
         // Convert content even if it hasn't changed.
@@ -436,10 +419,11 @@ export default class Editor {
     public insertContent(content: string, option?: InsertOption) {
         if (content) {
             let allNodes = fromHtml(content, this.core.document);
+
             // If it is to insert on new line, and there are more than one node in the collection, wrap all nodes with
             // a parent DIV before calling insertNode on each top level sub node. Otherwise, every sub node may get wrapped
             // separately to show up on its own line
-            if (option && option.insertOnNewLine && allNodes.length > 0) {
+            if (option && option.insertOnNewLine && allNodes.length > 1) {
                 allNodes = [wrap(allNodes)];
             }
             for (let i = 0; i < allNodes.length; i++) {

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -49,6 +49,8 @@ export { default as createRange, getRangeFromSelectionPath } from './selection/c
 export { default as getPositionRect } from './selection/getPositionRect';
 export { default as isPositionAtBeginningOf } from './selection/isPositionAtBeginningOf';
 export { default as getSelectionPath } from './selection/getSelectionPath';
+export { default as getHtmlWithSelectionPath } from './selection/getHtmlWithSelectionPath';
+export { default as setHtmlWithSelectionPath } from './selection/setHtmlWithSelectionPath';
 
 export { default as addSnapshot } from './snapshots/addSnapshot';
 export { default as canMoveCurrentSnapshot } from './snapshots/canMoveCurrentSnapshot';

--- a/packages/roosterjs-editor-dom/lib/selection/getHtmlWithSelectionPath.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/getHtmlWithSelectionPath.ts
@@ -1,0 +1,19 @@
+import getSelectionPath from './getSelectionPath';
+
+/**
+ * Get inner Html of a root node with a selection path which can be used for restore selection.
+ * The result string can be used by setHtmlWithSelectionPath() to restore the HTML and selection.
+ * @param rootNode Root node to get inner Html from
+ * @param range The range of selection. If pass null, no selection path will be added
+ * @returns Inner HTML of the root node, followed by HTML comment contains selection path if the given range is valid
+ */
+export default function getHtmlWithSelectionPath(rootNode: HTMLElement, range: Range): string {
+    if (!rootNode) {
+        return '';
+    }
+
+    const content = rootNode.innerHTML;
+    const selectionPath = range && getSelectionPath(rootNode, range);
+
+    return selectionPath ? `${content}<!--${JSON.stringify(selectionPath)}-->` : content;
+}

--- a/packages/roosterjs-editor-dom/lib/selection/setHtmlWithSelectionPath.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/setHtmlWithSelectionPath.ts
@@ -1,0 +1,29 @@
+import createRange from './createRange';
+import { NodeType, SelectionPath } from 'roosterjs-editor-types';
+
+/**
+ * Restore inner Html of a root element from given html string. If the string contains selection path,
+ * remove the selection path and return a range represented by the path
+ * @param root The root element
+ * @param html The html to restore
+ * @returns A selection range if the html contains a valid selection path, otherwise null
+ */
+export default function getHtmlWithSelectionPath(rootNode: HTMLElement, html: string): Range {
+    rootNode.innerHTML = html || '';
+    let path: SelectionPath = null;
+    let pathComment = rootNode.lastChild;
+
+    try {
+        path =
+            pathComment &&
+            pathComment.nodeType == NodeType.Comment &&
+            (JSON.parse(pathComment.nodeValue) as SelectionPath);
+        if (path && path.end && path.end.length > 0 && path.start && path.start.length > 0) {
+            rootNode.removeChild(pathComment);
+        } else {
+            path = null;
+        }
+    } catch {}
+
+    return path && createRange(rootNode, path.start, path.end);
+}


### PR DESCRIPTION
Expose two methods with selection path:
1. getHtmlWithSelectionPath(), return innerHTML of a root element with selection path if a valid range is passed
2. setHtmlWithSelectionPath(), restore the innerHTML with selection path, and return a range (or null if no valid selection path is included)
So that people can call them to generate HTML content with selection path, when pass it into Editor.setContent(), content will be auto selected.

Other fix:
1. When appy default format on initialize, use current cursor position rather than beginning position if current position exists
2. Editor.setContent() should not wrap a single node for "insertOnNewLine" scenario because it will call insertNode() which will wrap the node if it is not a block element.