### PR TITLE
Fix exception in HyperLink plugin

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
@@ -56,8 +56,10 @@ export default class HyperLink implements EditorPlugin {
      * Dispose this plugin
      */
     public dispose(): void {
-        this.disposer();
-        this.disposer = null;
+        if (this.disposer) {
+            this.disposer();
+            this.disposer = null;
+        }
         this.editor = null;
     }
 


### PR DESCRIPTION
When getTooltipCallback is null, we didn't initialize this.disposer in HyperLink plugin. So we need to do null check when dispose.