### PR TITLE
Bump version to 7.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.6.1",
+    "version": "7.7.0",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",


### PR DESCRIPTION
New release info:

New API/options:
1. Expose selection path related API so that it can be called outside editor
- getHtmlWithSelectionPath
- setHtmlWithSelectionPath
2. Add a new insert node position option "DomEnd" which allows inserting a node at the end of DOM structure within editor

Bug fixes:
1. Fix format issue when Cut and Paste in dark mode
2. Fix an exception in HyperLink plugin when getTooltipCallback is not specified
3. Fix Editor.insertContent() API, don't wrap with a DIV when there is only 1 top level node to insert
