### PR TITLE
Fix exception in Position.normalize()

### DIFF
--- a/packages/roosterjs-editor-dom/lib/selection/Position.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/Position.ts
@@ -81,14 +81,20 @@ export default class Position implements NodePosition {
         let newOffset: number | PositionType.Begin | PositionType.End = this.isAtEnd
             ? PositionType.End
             : this.offset;
-        while (node.nodeType == NodeType.Element && node.firstChild) {
-            node =
+        while (node.nodeType == NodeType.Element) {
+            const nextNode =
                 newOffset == PositionType.Begin
                     ? node.firstChild
                     : newOffset == PositionType.End
                     ? node.lastChild
                     : node.childNodes[<number>newOffset];
-            newOffset = this.isAtEnd ? PositionType.End : PositionType.Begin;
+
+            if (nextNode) {
+                node = nextNode;
+                newOffset = this.isAtEnd ? PositionType.End : PositionType.Begin;
+            } else {
+                break;
+            }
         }
         return new Position(node, newOffset);
     }


### PR DESCRIPTION
In Position.normalize(), if the offset value is beyond a valid range, there will be exception. 
The fix is to check returned value of node, if it is null, stop and use the last good value.