### PR TITLE
Make the Transform on Initialize option do something useful, and default to true.

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -73,9 +73,10 @@ export default class Editor {
         this.core.plugins.forEach(plugin => plugin.initialize(this));
 
         // 4. Ensure initial content and its format
-        this.setContent(
+        this.setContentInternal(
             options.initialContent || contentDiv.innerHTML || '',
-            false /*triggerContentChangedEvent*/
+            false /*triggerContentChangedEvent*/,
+            true /* firstRun */
         );
 
         // 5. Create event handler to bind DOM events
@@ -377,6 +378,14 @@ export default class Editor {
      * @param triggerContentChangedEvent True to trigger a ContentChanged event. Default value is true
      */
     public setContent(content: string, triggerContentChangedEvent: boolean = true) {
+        this.setContentInternal(content, triggerContentChangedEvent);
+    }
+
+    private setContentInternal(
+        content: string,
+        triggerContentChangedEvent: boolean,
+        firstRun?: boolean
+    ) {
         let contentDiv = this.core.contentDiv;
         let contentChanged = false;
         if (contentDiv.innerHTML != content) {
@@ -385,9 +394,13 @@ export default class Editor {
             contentChanged = true;
         }
 
-        // Convert content even if it hasn't changed.
-        if (this.core.inDarkMode) {
-            const darkModeOptions = this.getDarkModeOptions();
+        const darkModeOptions = this.getDarkModeOptions();
+        // Convert when...
+        // It's in dark mode, AND it's either not the first run OR transformOnInitialze is true
+        if (
+            this.core.inDarkMode &&
+            (!firstRun || (darkModeOptions && darkModeOptions.transformOnInitialize))
+        ) {
             const convertFunction = convertContentToDarkMode(
                 contentDiv,
                 darkModeOptions && darkModeOptions.onExternalContentTransform

--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -43,6 +43,10 @@ export default function createEditorCore(
     let eventHandlerPlugins = allPlugins.filter(
         plugin => plugin.onPluginEvent || plugin.willHandleEventExclusively
     );
+    if (options.darkModeOptions && options.darkModeOptions.transformOnInitialize === undefined) {
+        // Since you can't provide default values on interfaces, provide the default here.
+        options.darkModeOptions.transformOnInitialize = true;
+    }
     return {
         contentDiv,
         scrollContainer: options.scrollContainer || contentDiv,

--- a/packages/roosterjs-editor-types/lib/interface/DarkModeOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/DarkModeOptions.ts
@@ -5,6 +5,7 @@ interface DarkModeOptions {
     /** Transform on insert controls if, when the editor is initialized, content should be transformed for dark mode.
      *  Set this to true to run the content being set to the editor through an initial transform into dark mode.
      *  Set this to false if you are setting dark mode compliant content initialy.
+     *  If this value is undefined, it will default to true.
      */
     transformOnInitialize?: boolean;
 


### PR DESCRIPTION
The current option is a no-op due to a bug where having it undefined would cause it to not transform anything (which was un-intuitive). Now we respect the option again, and this time include a check for if the function is in its first run.

I am open to alternatively passing in the transformOnInitialize value in directly, but I think making it an internal function and making it a consequence of first run makes more sense. Feel free to disagree, as I'm not wedded to this approach 💃 