### PR TITLE
Fix #355:  when paste from Word and empty lines are dropped

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/Paste/wordConverter/convertPastedContentFromWord.ts
+++ b/packages/roosterjs-editor-plugins/lib/Paste/wordConverter/convertPastedContentFromWord.ts
@@ -7,7 +7,7 @@ import { processNodeConvert, processNodesDiscovery } from './converterUtils';
 export default function convertPastedContentFromWord(doc: HTMLDocument) {
     let sanitizer = new HtmlSanitizer({
         elementCallbacks: {
-            ['O:P']: () => false,
+            ['O:P']: element => element.innerHTML == '&nbsp;', // Preserve <o:p> when its innerHTML is "&nbsp;" to avoid dropping an empty line
         },
         additionalAllowAttributes: ['class'],
     });

--- a/packages/roosterjs-html-sanitizer/lib/test/getInheritableStylesTest.ts
+++ b/packages/roosterjs-html-sanitizer/lib/test/getInheritableStylesTest.ts
@@ -40,7 +40,8 @@ describe('getInheritableStyles', () => {
         node.style.fontFamily = '"Times New Roman"';
         let styles = getInheritableStyles(node);
         document.body.removeChild(node);
-        expect(styles).toEqual({
+
+        const expectedResult: any = {
             ['border-spacing']: '0px 0px',
             ['caption-side']: 'top',
             color: 'rgb(0, 0, 0)',
@@ -68,6 +69,17 @@ describe('getInheritableStyles', () => {
             ['white-space']: 'normal',
             widows: '2',
             ['word-spacing']: '0px',
+        };
+        Object.keys(styles).forEach(key => {
+            const value = styles[key];
+            expect(sort(value)).toEqual(sort(expectedResult[key]), key);
         });
     });
 });
+
+function sort(str: string) {
+    return str
+        .split(' ')
+        .sort()
+        .join(' ');
+}


### PR DESCRIPTION
Previously I added code to remove <o:p> tag for Word to make it work with bullet list. Now let's preserve it if its inner html is &nbsp;.