### PR TITLE
Fix OWA 57080

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/CustomReplace/CustomReplace.ts
+++ b/packages/roosterjs-editor-plugins/lib/CustomReplace/CustomReplace.ts
@@ -91,7 +91,7 @@ export default class CustomReplacePlugin implements EditorPlugin {
         }
 
         // Exit early on input events that do not insert a replacement's final character.
-        if (event.rawEvent.data && !this.replacementEndCharacters.has(event.rawEvent.data)) {
+        if (!event.rawEvent.data || !this.replacementEndCharacters.has(event.rawEvent.data)) {
             return;
         }
 


### PR DESCRIPTION
Bug 57080: Backspace should not convert text back into emoji

In CustomReplace plugin, we should not perform the auto complete action if user input is "backspace".

So the fix is to check input event data should not be null