### PR TITLE
Fix #362

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/EditPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/EditPlugin.ts
@@ -1,6 +1,7 @@
 import Editor from '../editor/Editor';
 import EditorPlugin from '../interfaces/EditorPlugin';
 import { GenericContentEditFeature, Keys } from '../interfaces/ContentEditFeature';
+import { isCtrlOrMetaPressed } from 'roosterjs-editor-core';
 import {
     ChangeSource,
     PluginEvent,
@@ -96,10 +97,12 @@ export default class EditPlugin implements EditorPlugin {
     private findFeature(event: PluginEvent) {
         let hasFunctionKey = false;
         let features: GenericContentEditFeature<PluginEvent>[];
+        let ctrlOrMeta = false;
 
         if (event.eventType == PluginEventType.KeyDown) {
             let rawEvent = event.rawEvent;
-            hasFunctionKey = rawEvent.ctrlKey || rawEvent.altKey || rawEvent.metaKey;
+            ctrlOrMeta = isCtrlOrMetaPressed(rawEvent);
+            hasFunctionKey = ctrlOrMeta || rawEvent.altKey;
             features = this.featureMap[rawEvent.which];
         } else if (event.eventType == PluginEventType.ContentChanged) {
             features = this.featureMap[Keys.CONTENTCHANGED];
@@ -109,7 +112,7 @@ export default class EditPlugin implements EditorPlugin {
             features.filter(
                 feature =>
                     (feature.allowFunctionKeys || !hasFunctionKey) &&
-                    feature.shouldHandleEvent(event, this.editor)
+                    feature.shouldHandleEvent(event, this.editor, ctrlOrMeta)
             )[0]
         );
     }

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -43,6 +43,7 @@ import {
     queryElements,
     setHtmlWithSelectionPath,
     wrap,
+    isPositionAtBeginningOf,
 } from 'roosterjs-editor-dom';
 
 /**
@@ -584,6 +585,16 @@ export default class Editor {
             startFrom = position && position.node;
         }
         return startFrom && findClosestElementAncestor(startFrom, this.core.contentDiv, selector);
+    }
+
+    /**
+     * Check if this position is at beginning of the editor.
+     * This will return true if all nodes between the beginning of target node and the position are empty.
+     * @param position The position to check
+     * @returns True if position is at beginning of the editor, otherwise false
+     */
+    public isPositionAtBeginning(position: NodePosition): boolean {
+        return isPositionAtBeginningOf(position, this.core.contentDiv);
     }
 
     //#endregion

--- a/packages/roosterjs-editor-core/lib/eventApi/isCtrlOrMetaPressed.ts
+++ b/packages/roosterjs-editor-core/lib/eventApi/isCtrlOrMetaPressed.ts
@@ -1,0 +1,11 @@
+import { Browser } from 'roosterjs-editor-dom';
+
+/**
+ * Check if Ctrl key (Windows) or Meta key (Mac) is pressed for the given Event
+ * @param event A Keyboard event or Mouse event object
+ * @returns True if Ctrl key is pressed on Windows or Meta key is pressed on Mac
+ */
+const isCtrlOrMetaPressed: (event: KeyboardEvent | MouseEvent) => boolean = Browser.isMac
+    ? event => event.metaKey
+    : event => event.ctrlKey;
+export default isCtrlOrMetaPressed;

--- a/packages/roosterjs-editor-core/lib/index.ts
+++ b/packages/roosterjs-editor-core/lib/index.ts
@@ -47,3 +47,4 @@ export {
 export { default as cacheGetElementAtCursor } from './eventApi/cacheGetElementAtCursor';
 export { default as isModifierKey } from './eventApi/isModifierKey';
 export { default as isCharacterValue } from './eventApi/isCharacterValue';
+export { default as isCtrlOrMetaPressed } from './eventApi/isCtrlOrMetaPressed';

--- a/packages/roosterjs-editor-core/lib/interfaces/ContentEditFeature.ts
+++ b/packages/roosterjs-editor-core/lib/interfaces/ContentEditFeature.ts
@@ -10,6 +10,7 @@ export const enum Keys {
     TAB = 9,
     ENTER = 13,
     SPACE = 32,
+    LEFT = 37,
     UP = 38,
     DOWN = 40,
     B = 66,

--- a/packages/roosterjs-editor-core/lib/interfaces/ContentEditFeature.ts
+++ b/packages/roosterjs-editor-core/lib/interfaces/ContentEditFeature.ts
@@ -12,6 +12,7 @@ export const enum Keys {
     SPACE = 32,
     LEFT = 37,
     UP = 38,
+    RIGHT = 39,
     DOWN = 40,
     B = 66,
     I = 73,
@@ -33,7 +34,7 @@ export const enum Keys {
  */
 export interface GenericContentEditFeature<TEvent extends PluginEvent> {
     keys: number[];
-    shouldHandleEvent: (event: TEvent, editor: Editor) => any;
+    shouldHandleEvent: (event: TEvent, editor: Editor, ctrlOrMeta: boolean) => any;
     handleEvent: (event: TEvent, editor: Editor) => ChangeSource | void;
     allowFunctionKeys?: boolean;
 }

--- a/packages/roosterjs-editor-core/lib/undo/Undo.ts
+++ b/packages/roosterjs-editor-core/lib/undo/Undo.ts
@@ -2,6 +2,7 @@ import Editor from '../editor/Editor';
 import UndoService from '../interfaces/UndoService';
 import UndoSnapshots from './UndoSnapshots';
 import UndoSnapshotsService from '../interfaces/UndoSnapshotsService';
+import { isCtrlOrMetaPressed } from 'roosterjs-editor-core';
 import { PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 
 const KEY_BACKSPACE = 8;
@@ -28,7 +29,7 @@ export default class Undo implements UndoService {
      * this object to be reused when editor is disposed and created again
      * @param maxBufferSize The max buffer size for snapshots. Default value is 10MB
      */
-    constructor(private preserveSnapshots?: boolean, private maxBufferSize: number = 1e7) { }
+    constructor(private preserveSnapshots?: boolean, private maxBufferSize: number = 1e7) {}
 
     /**
      * Get a friendly name of  this plugin
@@ -179,8 +180,7 @@ export default class Undo implements UndoService {
                 selectionRange &&
                 (!selectionRange.collapsed ||
                     this.lastKeyPress != evt.which ||
-                    evt.ctrlKey ||
-                    evt.metaKey)
+                    isCtrlOrMetaPressed(evt))
             ) {
                 this.addUndoSnapshot();
             }

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -30,6 +30,7 @@ export {
 export { default as getTagOfNode } from './utils/getTagOfNode';
 export { default as isBlockElement } from './utils/isBlockElement';
 export { default as isNodeEmpty } from './utils/isNodeEmpty';
+export { default as isRtl } from './utils/isRtl';
 export { default as isVoidHtmlElement } from './utils/isVoidHtmlElement';
 export { default as matchLink } from './utils/matchLink';
 export { default as adjustNodeInsertPosition } from './utils/adjustNodeInsertPosition';

--- a/packages/roosterjs-editor-dom/lib/test/selections/createRangeTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/selections/createRangeTest.ts
@@ -1,6 +1,6 @@
 import createRange from '../../selection/createRange';
 import Position from '../../selection/Position';
-import { PositionType } from 'roosterjs/lib';
+import { PositionType } from 'roosterjs-editor-types';
 
 describe('createRange() with nodes', () => {
     function runTest(

--- a/packages/roosterjs-editor-dom/lib/test/utils/applyTextStyleTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/utils/applyTextStyleTest.ts
@@ -1,6 +1,6 @@
 import applyTextStyle from '../../utils/applyTextStyle';
 import Position from '../../selection/Position';
-import { PositionType } from 'roosterjs/lib';
+import { PositionType } from 'roosterjs-editor-types';
 
 describe('applyTextStyle()', () => {
     function runTest1(

--- a/packages/roosterjs-editor-dom/lib/utils/isRtl.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/isRtl.ts
@@ -1,0 +1,10 @@
+import { getComputedStyle } from './getComputedStyles';
+
+/**
+ * Check if the given element is using right-to-left layout
+ * @param element An HTML element to check
+ * @returns True if the given element is using right-to-left layout, otherwise false
+ */
+export default function isRtl(element: HTMLElement): boolean {
+    return getComputedStyle(element, 'direction') == 'rtl';
+}

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/ContentEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/ContentEdit.ts
@@ -3,6 +3,7 @@ import { AutoLink, UnlinkWhenBackspaceAfterLink } from './features/autoLinkFeatu
 import { DefaultShortcut } from './features/shortcutFeatures';
 import { Editor, EditorPlugin, GenericContentEditFeature } from 'roosterjs-editor-core';
 import { InsertLineBeforeStructuredNodeFeature } from './features/insertLineBeforeStructuredNodeFeature';
+import { NoCycleCursorMove } from './features/noCycleCursorMove';
 import { PluginEvent } from 'roosterjs-editor-types';
 import { TabInTable, UpDownInTable } from './features/tableFeatures';
 
@@ -67,7 +68,7 @@ export default class ContentEdit implements EditorPlugin {
     private getFilteredFeatures(): GenericContentEditFeature<PluginEvent>[] {
         let featureSet = this.featureSet || getDefaultContentEditFeatures();
         let allFeatures: {
-            [key in keyof Partial<ContentEditFeatures>]: GenericContentEditFeature<PluginEvent>
+            [key in keyof Partial<ContentEditFeatures>]: GenericContentEditFeature<PluginEvent>;
         } = {
             indentWhenTab: IndentWhenTab,
             outdentWhenShiftTab: OutdentWhenShiftTab,
@@ -83,6 +84,7 @@ export default class ContentEdit implements EditorPlugin {
             autoLink: AutoLink,
             unlinkWhenBackspaceAfterLink: UnlinkWhenBackspaceAfterLink,
             defaultShortcut: DefaultShortcut,
+            noCycleCursorMove: NoCycleCursorMove,
             smartOrderedList: getSmartOrderedList(featureSet.smartOrderedListStyles),
         };
         let keys = Object.keys(allFeatures) as (keyof ContentEditFeatures)[];

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/ContentEditFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/ContentEditFeatures.ts
@@ -91,6 +91,12 @@ export default interface ContentEditFeatures {
     unlinkWhenBackspaceAfterLink: boolean;
 
     /**
+     * Chrome may make the cursor move the then end of document if press Ctrl+Left at the beginning of document
+     * Let's disable this behaivor
+     */
+    noCycleCursorMove: boolean;
+
+    /**
      * When generate ordered list, the list bullet will variare according its nesting level, in a loop of '1', 'a', 'i'
      * @default false
      */
@@ -122,6 +128,7 @@ export function getDefaultContentEditFeatures(): ContentEditFeatures {
         insertLineBeforeStructuredNodeFeature: false,
         defaultShortcut: true,
         unlinkWhenBackspaceAfterLink: false,
+        noCycleCursorMove: Browser.isChrome,
         smartOrderedList: false,
         smartOrderedListStyles: ['lower-alpha', 'lower-roman', 'decimal'],
     };

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/noCycleCursorMove.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/noCycleCursorMove.ts
@@ -1,17 +1,27 @@
 import { ContentEditFeature, Keys } from 'roosterjs-editor-core';
-import { Position } from 'roosterjs-editor-dom';
+import { isRtl, Position } from 'roosterjs-editor-dom';
 
 export const NoCycleCursorMove: ContentEditFeature = {
-    keys: [Keys.LEFT],
+    keys: [Keys.LEFT, Keys.RIGHT],
     allowFunctionKeys: true,
-    shouldHandleEvent: (event, editor) => {
+    shouldHandleEvent: (event, editor, ctrlOrMeta) => {
         let range: Range;
-        return (
-            event.rawEvent.ctrlKey &&
-            (range = editor.getSelectionRange()) &&
-            range.collapsed &&
-            editor.isPositionAtBeginning(Position.getStart(range))
-        );
+        let position: Position;
+
+        if (
+            !ctrlOrMeta ||
+            !(range = editor.getSelectionRange()) ||
+            !range.collapsed ||
+            !(position = Position.getStart(range)) ||
+            !editor.isPositionAtBeginning(position)
+        ) {
+            return false;
+        }
+
+        let rtl = isRtl(position.element);
+        let rawEvent = event.rawEvent;
+
+        return (!rtl && rawEvent.which == Keys.LEFT) || (rtl && rawEvent.which == Keys.RIGHT);
     },
     handleEvent: event => {
         event.rawEvent.preventDefault();

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/noCycleCursorMove.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/noCycleCursorMove.ts
@@ -1,0 +1,19 @@
+import { ContentEditFeature, Keys } from 'roosterjs-editor-core';
+import { Position } from 'roosterjs-editor-dom';
+
+export const NoCycleCursorMove: ContentEditFeature = {
+    keys: [Keys.LEFT],
+    allowFunctionKeys: true,
+    shouldHandleEvent: (event, editor) => {
+        let range: Range;
+        return (
+            event.rawEvent.ctrlKey &&
+            (range = editor.getSelectionRange()) &&
+            range.collapsed &&
+            editor.isPositionAtBeginning(Position.getStart(range))
+        );
+    },
+    handleEvent: event => {
+        event.rawEvent.preventDefault();
+    },
+};

--- a/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/HyperLink/HyperLink.ts
@@ -1,5 +1,5 @@
 import { Browser } from 'roosterjs-editor-dom';
-import { Editor, EditorPlugin } from 'roosterjs-editor-core';
+import { Editor, EditorPlugin, isCtrlOrMetaPressed } from 'roosterjs-editor-core';
 import { PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 
 /**
@@ -82,7 +82,7 @@ export default class HyperLink implements EditorPlugin {
                 if (
                     !Browser.isFirefox &&
                     (href = this.tryGetHref(anchor)) &&
-                    (Browser.isMac ? event.rawEvent.metaKey : event.rawEvent.ctrlKey) &&
+                    isCtrlOrMetaPressed(event.rawEvent) &&
                     event.rawEvent.button === 0
                 ) {
                     try {

--- a/packages/roosterjs-editor-plugins/lib/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/TableResize/TableResize.ts
@@ -1,4 +1,4 @@
-import { contains, fromHtml, getComputedStyle, VTable } from 'roosterjs-editor-dom';
+import { contains, fromHtml, isRtl, VTable } from 'roosterjs-editor-dom';
 import { Editor, EditorPlugin } from 'roosterjs-editor-core';
 import {
     ContentPosition,
@@ -94,8 +94,7 @@ export default class TableResize implements EditorPlugin {
                 let handle = this.getResizeHandle();
 
                 left +=
-                    this.td.offsetLeft +
-                    (this.isRtl(table) ? 0 : this.td.offsetWidth - HANDLE_WIDTH);
+                    this.td.offsetLeft + (isRtl(table) ? 0 : this.td.offsetWidth - HANDLE_WIDTH);
                 handle.style.display = '';
                 handle.style.top = top + 'px';
                 handle.style.height = table.offsetHeight + 'px';
@@ -179,7 +178,7 @@ export default class TableResize implements EditorPlugin {
             let newWidth =
                 this.td.clientWidth -
                 cellPadding * 2 +
-                (e.pageX - this.initialPageX) * (this.isRtl(table) ? -1 : 1);
+                (e.pageX - this.initialPageX) * (isRtl(table) ? -1 : 1);
             this.editor.addUndoSnapshot((start, end) => {
                 this.setTableColumnWidth(newWidth + 'px');
                 this.editor.select(start, end);
@@ -219,9 +218,5 @@ export default class TableResize implements EditorPlugin {
         });
         vtable.writeBack();
         return this.editor.contains(this.td) ? this.td : vtable.getCurrentTd();
-    }
-
-    private isRtl(element: HTMLElement) {
-        return getComputedStyle(element, 'direction') == 'rtl';
     }
 }


### PR DESCRIPTION
Chrome may move cursor to the end if press Ctrl+Left at the beginning.
So add a content edit feature to disable this behavior.

Open question: Shall we handle RTL?