### PR TITLE
Fix #366

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/Paste/textToHtml.ts
+++ b/packages/roosterjs-editor-plugins/lib/Paste/textToHtml.ts
@@ -32,6 +32,6 @@ export default function textToHtml(text: string): string {
             }
         });
     }
-    text = text.replace(/\s\s/g, ' &nbsp;');
+    text = text.replace(/ {2}/g, ' &nbsp;');
     return text;
 }


### PR DESCRIPTION
We replace \s\s to " &nbsp;", this will cause \t\t also replaced.
Fix to replace two spaces only.