### PR TITLE
Fixing a Readme Issue containing incorrect formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Rooster provides DOM level APIs (in `roosterjs-editor-dom`), core APIs (in `roos
 `roosterjs-editor-dom` provides several levels of DOM operations:
 
 -   Perform basic DOM operations such as `fromHtml()`, `wrap()`, `unwrap()`, ...
--   Wrap a given DOM node with `InlineElemen`t or `BlockElement` and perform
+-   Wrap a given DOM node with `InlineElement` or `BlockElement` and perform
     operations with DOM Walker API.
 -   Perform DOM operations on a given scope using scopers.
 -   Travel among `InlineElements` and `BlockElements` with scope using


### PR DESCRIPTION
THe block formatting for "Inline Element was a bit incorrect in the Repo readme file. Raising a Pull request to correct that.