### PR TITLE
Fix cross window typing issue.

### DIFF
--- a/packages/roosterjs-cross-window/lib/typeUtils/safeInstanceOf.ts
+++ b/packages/roosterjs-cross-window/lib/typeUtils/safeInstanceOf.ts
@@ -37,5 +37,10 @@ export default function safeInstanceOf<T extends keyof TargetWindow>(
 ): obj is TargetWindow[T] {
     const targetWindow = getTargetWindow(obj);
     const targetType = targetWindow && (targetWindow[typeName] as any);
-    return targetType && obj instanceof targetType;
+    const mainWindow = (window as any) as TargetWindow;
+    const mainWindowType = mainWindow && (mainWindow[typeName] as any);
+    return (
+        (mainWindowType && obj instanceof mainWindowType) ||
+        (targetType && obj instanceof targetType)
+    );
 }

--- a/packages/roosterjs-editor-dom/lib/utils/contains.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/contains.ts
@@ -1,4 +1,4 @@
-import { isNode } from 'roosterjs-cross-window';
+import { isRange } from 'roosterjs-cross-window';
 import { NodeType } from 'roosterjs-editor-types';
 
 /**
@@ -37,7 +37,7 @@ export default function contains(
         return true;
     }
 
-    if (!isNode(contained)) {
+    if (isRange(contained)) {
         contained = contained && contained.commonAncestorContainer;
         treatSameNodeAsContain = true;
     }


### PR DESCRIPTION
1) Elements created in the parent window and inserted into the child window will fail our current type checks. Instead, let's check both the parent and the child window's type.
2) Make the check in `contains` a positive check instead of a negative check.