### PR TITLE
Fix #388 (2nd try)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.10.4",
+    "version": "7.10.5",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-html-sanitizer/lib/sanitizer/HtmlSanitizer.ts
+++ b/packages/roosterjs-html-sanitizer/lib/sanitizer/HtmlSanitizer.ts
@@ -257,7 +257,7 @@ export default class HtmlSanitizer {
             if (
                 value === null ||
                 value === undefined ||
-                value.toLowerCase().indexOf('script:') >= 0
+                value.match(/s\n*c\n*r\n*i\n*p\n*t\n*:/i) // match script: with any NewLine inside. Browser will ignore those NewLine char and still treat it as script prefix
             ) {
                 element.removeAttribute(name);
             } else {

--- a/packages/roosterjs-html-sanitizer/lib/test/sanitizeHtmlTest.ts
+++ b/packages/roosterjs-html-sanitizer/lib/test/sanitizeHtmlTest.ts
@@ -52,6 +52,7 @@ describe('sanitizeHtml', () => {
     it('Html contains event handler', () => {
         runTest('<div onclick=alert("test")>bb</div>aa', '<div>bb</div>aa');
         runTest('aa<a href=javascript:alert("test")>cc</a>bb', 'aa<a>cc</a>bb');
+        runTest('aa<a href="javas\nc\nr\ni\np\nt\n: alert("test")">cc</a>bb', 'aa<a>cc</a>bb');
         runTest('aa<form action=/>cc</form>bb', 'aa<form>cc</form>bb');
     });
     it('Html contains unnecessary CSS', () => {

--- a/packages/roosterjs-html-sanitizer/package.json
+++ b/packages/roosterjs-html-sanitizer/package.json
@@ -5,5 +5,5 @@
         "roosterjs-cross-window": ""
     },
     "main": "./lib/index.ts",
-    "version": "1.1.3"
+    "version": "1.1.4"
 }


### PR DESCRIPTION
I was misunderstanding the bug. Now fix it again inside HtmlSanitizer.
The fix is to use a regex to be able to match any NewLine char inside the script prefix since browser will ignore them.
e.g:
```
javascript
:
```
will be treated as 
```
javascript:
```
by browser. So we need to match the NewLine and also treat as "javascript:".
