### PR TITLE
Fix bullet style loss when exiting a list

### DIFF
--- a/packages/roosterjs-editor-api/lib/test/utils/processListTest.ts
+++ b/packages/roosterjs-editor-api/lib/test/utils/processListTest.ts
@@ -1,0 +1,70 @@
+import * as TestHelper from '../TestHelper';
+import processList, { ValidProcessListDocumentCommands } from '../../utils/processList';
+import { DocumentCommand } from 'roosterjs-editor-types';
+import { Editor } from 'roosterjs-editor-core';
+
+describe('processList()', () => {
+    const testID = 'processList';
+    let editor: Editor;
+
+    beforeEach(() => {
+        editor = TestHelper.initEditor(testID);
+    });
+
+    afterEach(() => {
+        editor.dispose();
+        TestHelper.removeElement(testID);
+    });
+
+    it('calls exec command for any potential document command', () => {
+        const document = editor.getDocument();
+        spyOn(document, 'execCommand');
+        const randomCommand = Math.floor(Math.random() * 4);
+        const commands: ValidProcessListDocumentCommands[] = [
+            DocumentCommand.Indent,
+            DocumentCommand.Outdent,
+            DocumentCommand.InsertOrderedList,
+            DocumentCommand.InsertUnorderedList,
+        ];
+
+        processList(editor, commands[randomCommand]);
+
+        expect(document.execCommand).toHaveBeenCalledWith(commands[randomCommand], false, null);
+    });
+
+    it('moves the span, preserving its attributes after the exec command', () => {
+        // Arrange
+        const originalContent =
+            '<ul><li><span style="font-size: 20pt; font-family: &quot;Courier New&quot;;">​big font</span></li><ul><li id="level 2"><span id="level 2 content" style="font-size: 20pt; font-family: &quot;Courier New&quot;;"><img id="focus helper" /><br></span></li></ul></ul>';
+        editor.setContent(originalContent);
+        const focusNode = document.getElementById('focus helper');
+        TestHelper.setSelection(focusNode, 0);
+        editor.deleteNode(focusNode);
+
+        // Act
+        processList(editor, DocumentCommand.Outdent);
+
+        // Assert
+        expect(editor.getContent()).toBe(
+            '<ul><li><span style="font-size: 20pt; font-family: &quot;Courier New&quot;;">​big font</span></li><li id="level 2"><span id="level 2 content" style="font-size: 20pt; font-family: &quot;Courier New&quot;;"><br></span></li></ul>'
+        );
+    });
+
+    it('moves the span out of the list, preserving the span after the exec command', () => {
+        // Arrange
+        const originalContent =
+            '<ul><li><span style="font-size: 20pt; font-family: &quot;Courier New&quot;;">​big font</span></li><li id="level 2"><span id="level 2 content" style="font-size: 20pt; font-family: &quot;Courier New&quot;;"><img id="focus helper" /><br></span></li></ul>';
+        editor.setContent(originalContent);
+        const focusNode = document.getElementById('focus helper');
+        TestHelper.setSelection(focusNode, 0);
+        editor.deleteNode(focusNode);
+
+        // Act
+        processList(editor, DocumentCommand.Outdent);
+
+        // Assert
+        expect(editor.getContent()).toBe(
+            '<ul><li><span style="font-size: 20pt; font-family: &quot;Courier New&quot;;">​big font</span></li></ul><span id="level 2 content" style="font-size: 20pt; font-family: &quot;Courier New&quot;;"><br></span>'
+        );
+    });
+});

--- a/packages/roosterjs-editor-api/lib/utils/processList.ts
+++ b/packages/roosterjs-editor-api/lib/utils/processList.ts
@@ -29,7 +29,7 @@ export default function processList(
 ): Node {
     let clonedNode: Node;
     let relativeSelectionPath;
-    if (Browser.isChrome && command != DocumentCommand.Indent) {
+    if (Browser.isChrome && command == DocumentCommand.Outdent) {
         const parentLINode = editor.getElementAtCursor('LI');
         if (parentLINode) {
             let currentRange = editor.getSelectionRange();

--- a/packages/roosterjs-editor-api/lib/utils/processList.ts
+++ b/packages/roosterjs-editor-api/lib/utils/processList.ts
@@ -1,9 +1,9 @@
+import { Browser, getRangeFromSelectionPath, getSelectionPath } from 'roosterjs-editor-dom';
 import { DocumentCommand } from 'roosterjs-editor-types';
 import { Editor } from 'roosterjs-editor-core';
 import { isHTMLElement } from 'roosterjs-cross-window';
-import { Browser, getSelectionPath, getRangeFromSelectionPath } from 'roosterjs-editor-dom';
 
-type ValidProcessListDocumentCommands =
+export type ValidProcessListDocumentCommands =
     | DocumentCommand.Outdent
     | DocumentCommand.Indent
     | DocumentCommand.InsertOrderedList
@@ -29,9 +29,10 @@ export default function processList(
         if (parentLINode) {
             let currentRange = editor.getSelectionRange();
             if (
-                currentRange.collapsed ||
-                (editor.getElementAtCursor('LI', currentRange.startContainer) == parentLINode &&
-                    editor.getElementAtCursor('LI', currentRange.endContainer) == parentLINode)
+                currentRange &&
+                (currentRange.collapsed ||
+                    (editor.getElementAtCursor('LI', currentRange.startContainer) == parentLINode &&
+                        editor.getElementAtCursor('LI', currentRange.endContainer) == parentLINode))
             ) {
                 relativeSelectionPath = getSelectionPath(parentLINode, currentRange);
                 if (parentLINode.textContent === '') {
@@ -67,7 +68,7 @@ export default function processList(
                 ) {
                     newList.replaceChild(clonedNode, newParentNode);
                 }
-                if (relativeSelectionPath && editor.getDocument().body.contains(clonedNode)) {
+                if (relativeSelectionPath && editor.contains(clonedNode)) {
                     let newRange = getRangeFromSelectionPath(clonedNode, relativeSelectionPath);
                     editor.select(newRange);
                 }
@@ -82,7 +83,7 @@ export default function processList(
                 if (
                     cursorSelectionPath &&
                     isHTMLElement(clonedCursorNode) &&
-                    editor.getDocument().body.contains(clonedCursorNode)
+                    editor.contains(clonedCursorNode)
                 ) {
                     let newRange = getRangeFromSelectionPath(clonedCursorNode, cursorSelectionPath);
                     editor.select(newRange);

--- a/packages/roosterjs-editor-api/lib/utils/processList.ts
+++ b/packages/roosterjs-editor-api/lib/utils/processList.ts
@@ -12,6 +12,8 @@ import {
 
 const TEMP_NODE_CLASS = 'ROOSTERJS_TEMP_NODE_FOR_LIST';
 const TEMP_NODE_HTML = '<img class="' + TEMP_NODE_CLASS + '">';
+// const STYLE_PROTECTOR_CLASS = 'ROOSTERJS_STYLE_PROTECTOR_FOR_LIST';
+// const STYLE_PROTECTOR_HTML = '<span class="' + STYLE_PROTECTOR_CLASS + '">you should not see this.</span>';
 
 type ValidProcessListDocumentCommands =
     | DocumentCommand.Outdent
@@ -29,7 +31,7 @@ export default function processList(
 ): Node {
     let clonedNode: Node;
     let relativeSelectionPath;
-    if (Browser.isChrome && command == DocumentCommand.Outdent) {
+    if (Browser.isChrome && command != DocumentCommand.Indent) {
         const parentLINode = editor.getElementAtCursor('LI');
         if (parentLINode) {
             let currentRange = editor.getSelectionRange();
@@ -89,12 +91,12 @@ function workaroundForChrome(editor: Editor) {
         let container = block.getStartNode();
 
         if (container) {
-            // Add a temp <IMG> tag before all other nodes in the block to avoid Chrome remove existing format when toggle list
+            // Add a temp <IMG> tag after all other nodes in the block to avoid Chrome remove existing format when toggle list
             const tempNode = fromHtml(TEMP_NODE_HTML, editor.getDocument())[0];
             if (isVoidHtmlElement(container) || !isBlockElement(container)) {
-                container.parentNode.insertBefore(tempNode, container);
+                container.parentNode.appendChild(tempNode);
             } else {
-                container.insertBefore(tempNode, container.firstChild);
+                container.appendChild(tempNode);
             }
         }
 

--- a/packages/roosterjs-editor-api/lib/utils/processList.ts
+++ b/packages/roosterjs-editor-api/lib/utils/processList.ts
@@ -12,8 +12,6 @@ import {
 
 const TEMP_NODE_CLASS = 'ROOSTERJS_TEMP_NODE_FOR_LIST';
 const TEMP_NODE_HTML = '<img class="' + TEMP_NODE_CLASS + '">';
-// const STYLE_PROTECTOR_CLASS = 'ROOSTERJS_STYLE_PROTECTOR_FOR_LIST';
-// const STYLE_PROTECTOR_HTML = '<span class="' + STYLE_PROTECTOR_CLASS + '">you should not see this.</span>';
 
 type ValidProcessListDocumentCommands =
     | DocumentCommand.Outdent

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/ContentEditFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/ContentEditFeatures.ts
@@ -118,7 +118,7 @@ export function getDefaultContentEditFeatures(): ContentEditFeatures {
         indentWhenTab: true,
         outdentWhenShiftTab: true,
         outdentWhenBackspaceOnEmptyFirstLine: true,
-        outdentWhenEnterOnEmptyLine: Browser.isIE,
+        outdentWhenEnterOnEmptyLine: Browser.isIE || Browser.isChrome,
         mergeInNewLineWhenBackspaceOnFirstChar: false,
         unquoteWhenBackspaceOnEmptyFirstLine: true,
         unquoteWhenEnterOnEmptyLine: true,

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/ContentEditFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/ContentEditFeatures.ts
@@ -118,7 +118,7 @@ export function getDefaultContentEditFeatures(): ContentEditFeatures {
         indentWhenTab: true,
         outdentWhenShiftTab: true,
         outdentWhenBackspaceOnEmptyFirstLine: true,
-        outdentWhenEnterOnEmptyLine: Browser.isIE || Browser.isChrome,
+        outdentWhenEnterOnEmptyLine: Browser.isIE,
         mergeInNewLineWhenBackspaceOnFirstChar: false,
         unquoteWhenBackspaceOnEmptyFirstLine: true,
         unquoteWhenEnterOnEmptyLine: true,


### PR DESCRIPTION
Chromium has a bug (https://bugs.chromium.org/p/chromium/issues/detail?id=944178#c4) which nukes a bunch of stuff when you outdent. We added some logic in a prior PR to attempt to clone the node when we outdent in a list.

This PR further extends this work to
1) Apply when enter is pressed on the end of the list (in an attempt to preserve style information in these cases)
2) Append the image element to the end instead of to the beginning to prevent Chromium from thinking that the span element should be removed due to no content.