### PR TITLE
7.11.1 Fix bug in Editor.insertContent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.11.0",
+    "version": "7.11.1",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -429,9 +429,11 @@ export default class Editor {
             if (option && option.insertOnNewLine && allNodes.length > 1) {
                 allNodes = [wrap(allNodes)];
             }
-            for (let i = 0; i < allNodes.length; i++) {
-                this.insertNode(allNodes[i], option);
-            }
+
+            let fragment = this.core.document.createDocumentFragment();
+            allNodes.forEach(node => fragment.appendChild(node));
+
+            this.insertNode(fragment, option);
         }
     }
 

--- a/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
+++ b/packages/roosterjs-editor-core/lib/test/editor/EditorTest.ts
@@ -92,6 +92,19 @@ describe('Editor insertContent()', () => {
         expect(editor.getContent()).toBe('<div id="text">hellotext</div>');
     });
 
+    it('insert begin with multiple nodes', () => {
+        // Act
+        editor.insertContent('hello<br>world', {
+            position: ContentPosition.Begin,
+            updateCursor: true,
+            replaceSelection: true,
+            insertOnNewLine: false,
+        });
+
+        // Assert
+        expect(editor.getContent()).toBe('<div id="text">hello<br>worldtext</div>');
+    });
+
     it('insert end', () => {
         // Act
         editor.insertContent('hello', {


### PR DESCRIPTION
When call Editor.insertContent() with HTML represents multiple HTML nodes, insertContent() will insert them in a reversed order, because we insert nodes one by one but cursor is not changed.

The fix is to create a fragment and put all nodes under it first, then insert the fragment with a single insertNode() call.