### PR TITLE
7.11.2 - Fix issue when outdenting with no wrapping span

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.11.1",
+    "version": "7.11.2",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-api/lib/test/utils/processListTest.ts
+++ b/packages/roosterjs-editor-api/lib/test/utils/processListTest.ts
@@ -67,4 +67,22 @@ describe('processList()', () => {
             '<ul><li><span style="font-size: 20pt; font-family: &quot;Courier New&quot;;">​big font</span></li></ul><span id="level 2 content" style="font-size: 20pt; font-family: &quot;Courier New&quot;;"><br></span>'
         );
     });
+
+    it('doesnt move the whole LI out when there is no span with formatting content on it.', () => {
+        // Arrange
+        const originalContent =
+            '<div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="font-family: &quot;Times New Roman&quot;; font-size: medium; background-color: rgb(255, 255, 255)"><ul style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt"><li>test</li><li>test</li><li>test</li><li><img id="focus helper" /><br></li></ul></div>';
+        editor.setContent(originalContent);
+        const focusNode = document.getElementById('focus helper');
+        TestHelper.setSelection(focusNode, 0);
+        editor.deleteNode(focusNode);
+
+        // Act
+        processList(editor, DocumentCommand.Outdent);
+
+        // Assert
+        expect(editor.getContent()).toBe(
+            '<div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="background-color: rgb(255, 255, 255);"><ul style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt;"><li>test</li><li>test</li><li>test</li></ul><font face="Calibri, Helvetica, sans-serif"><br></font></div>'
+        );
+    });
 });

--- a/packages/roosterjs-editor-api/lib/utils/processList.ts
+++ b/packages/roosterjs-editor-api/lib/utils/processList.ts
@@ -36,12 +36,17 @@ export default function processList(
             ) {
                 relativeSelectionPath = getSelectionPath(parentLINode, currentRange);
                 if (parentLINode.textContent === '') {
-                    // If the node is empty, we need to handle this special case.
+                    const cursorNode = editor.getElementAtCursor();
+
+                    // If the cursor is inside of a span, we need to preserve that content somehow when the content is empty.
                     // Chromium will try to replace all empty spans with font tags
                     // We should preserve where our cursor is so that in this case, we can keep the span around.
-                    const cursorNode = editor.getElementAtCursor();
-                    clonedCursorNode = cursorNode.cloneNode(true);
-                    cursorSelectionPath = getSelectionPath(cursorNode, currentRange);
+                    // In some cases Chromium will still put a font tag at the document root,
+                    // But unless we have a span to replace it with, we should leave it be for now.
+                    if (cursorNode !== parentLINode) {
+                        clonedCursorNode = cursorNode.cloneNode(true);
+                        cursorSelectionPath = getSelectionPath(cursorNode, currentRange);
+                    }
                 }
                 clonedNode = parentLINode.cloneNode(true);
             }


### PR DESCRIPTION
This fixes a bug where the LI element was put into the document root instead of it's contents, when there were no contents.

This can sometimes leave a floating font tag, but it's harder to fix that problem and should be deferred so that we don't write this bad case HTML.

Adds a test case to ensure we don't accidentally regress this scenario again.

Also, this bumps the version to 7.11.2