### PR TITLE
Manual handling for bulleting for Chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.11.1",
+    "version": "7.11.2",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-api/lib/test/utils/processListTest.ts
+++ b/packages/roosterjs-editor-api/lib/test/utils/processListTest.ts
@@ -30,7 +30,7 @@ describe('processList()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li></ul><span style="font-family: &quot;Courier New&quot;; font-size: 20pt; color: rgb(208, 92, 18);"><br></span></div>'
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li></ul><div><span style="font-family: &quot;Courier New&quot;; font-size: 20pt; color: rgb(208, 92, 18);"><br></span></div></div>'
         );
     });
 
@@ -48,7 +48,7 @@ describe('processList()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li></ul><span style="font-family: &quot;Courier New&quot;; font-size: 20pt; color: rgb(208, 92, 18);"><br></span><ul><li>test</li></ul></div>'
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li></ul><div><span style="font-family: &quot;Courier New&quot;; font-size: 20pt; color: rgb(208, 92, 18);"><br></span></div><ul><li>test</li></ul></div>'
         );
     });
 
@@ -66,7 +66,7 @@ describe('processList()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li><li>test</li></ul><br></div>'
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li><li>test</li></ul><div><br></div></div>'
         );
     });
 
@@ -84,7 +84,7 @@ describe('processList()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li></ul><br><ul><li>test</li></ul></div>'
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li></ul><div><br></div><ul><li>test</li></ul></div>'
         );
     });
 });

--- a/packages/roosterjs-editor-api/lib/test/utils/processListTest.ts
+++ b/packages/roosterjs-editor-api/lib/test/utils/processListTest.ts
@@ -67,4 +67,22 @@ describe('processList()', () => {
             '<ul><li><span style="font-size: 20pt; font-family: &quot;Courier New&quot;;">​big font</span></li></ul><span id="level 2 content" style="font-size: 20pt; font-family: &quot;Courier New&quot;;"><br></span>'
         );
     });
+
+    it('doesnt move the whole LI out when there is no span with formatting content on it.', () => {
+        // Arrange
+        const originalContent =
+            '<div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="font-family: &quot;Times New Roman&quot;; font-size: medium; background-color: rgb(255, 255, 255)"><ul style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt"><li>test</li><li>test</li><li>test</li><li><img id="focus helper" /><br></li></ul></div>';
+        editor.setContent(originalContent);
+        const focusNode = document.getElementById('focus helper');
+        TestHelper.setSelection(focusNode, 0);
+        editor.deleteNode(focusNode);
+
+        // Act
+        processList(editor, DocumentCommand.Outdent);
+
+        // Assert
+        expect(editor.getContent()).toBe(
+            '<div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="background-color: rgb(255, 255, 255);"><ul style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt;"><li>test</li><li>test</li><li>test</li></ul><font face="Calibri, Helvetica, sans-serif"><br></font></div>'
+        );
+    });
 });

--- a/packages/roosterjs-editor-api/lib/test/utils/processListTest.ts
+++ b/packages/roosterjs-editor-api/lib/test/utils/processListTest.ts
@@ -1,5 +1,5 @@
 import * as TestHelper from '../TestHelper';
-import processList, { ValidProcessListDocumentCommands } from '../../utils/processList';
+import processList from '../../utils/processList';
 import { DocumentCommand } from 'roosterjs-editor-types';
 import { Editor } from 'roosterjs-editor-core';
 
@@ -16,26 +16,10 @@ describe('processList()', () => {
         TestHelper.removeElement(testID);
     });
 
-    it('calls exec command for any potential document command', () => {
-        const document = editor.getDocument();
-        spyOn(document, 'execCommand');
-        const randomCommand = Math.floor(Math.random() * 4);
-        const commands: ValidProcessListDocumentCommands[] = [
-            DocumentCommand.Indent,
-            DocumentCommand.Outdent,
-            DocumentCommand.InsertOrderedList,
-            DocumentCommand.InsertUnorderedList,
-        ];
-
-        processList(editor, commands[randomCommand]);
-
-        expect(document.execCommand).toHaveBeenCalledWith(commands[randomCommand], false, null);
-    });
-
-    it('moves the span, preserving its attributes after the exec command', () => {
+    it('properly outdents, preserving the span', () => {
         // Arrange
         const originalContent =
-            '<ul><li><span style="font-size: 20pt; font-family: &quot;Courier New&quot;;">​big font</span></li><ul><li id="level 2"><span id="level 2 content" style="font-size: 20pt; font-family: &quot;Courier New&quot;;"><img id="focus helper" /><br></span></li></ul></ul>';
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li><li><span style="font-family: &quot;Courier New&quot;; font-size: 20pt; color: rgb(208, 92, 18);"><img id="focus helper" /><br></span></li></ul></div>';
         editor.setContent(originalContent);
         const focusNode = document.getElementById('focus helper');
         TestHelper.setSelection(focusNode, 0);
@@ -46,14 +30,14 @@ describe('processList()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<ul><li><span style="font-size: 20pt; font-family: &quot;Courier New&quot;;">​big font</span></li><li id="level 2"><span id="level 2 content" style="font-size: 20pt; font-family: &quot;Courier New&quot;;"><br></span></li></ul>'
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li></ul><span style="font-family: &quot;Courier New&quot;; font-size: 20pt; color: rgb(208, 92, 18);"><br></span></div>'
         );
     });
 
-    it('moves the span out of the list, preserving the span after the exec command', () => {
+    it('properly outdents from the middle, preserving the span.', () => {
         // Arrange
         const originalContent =
-            '<ul><li><span style="font-size: 20pt; font-family: &quot;Courier New&quot;;">​big font</span></li><li id="level 2"><span id="level 2 content" style="font-size: 20pt; font-family: &quot;Courier New&quot;;"><img id="focus helper" /><br></span></li></ul>';
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li><li><span style="font-family: &quot;Courier New&quot;; font-size: 20pt; color: rgb(208, 92, 18);"><img id="focus helper" /><br></span></li><li>test</li></ul></div>';
         editor.setContent(originalContent);
         const focusNode = document.getElementById('focus helper');
         TestHelper.setSelection(focusNode, 0);
@@ -64,14 +48,14 @@ describe('processList()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<ul><li><span style="font-size: 20pt; font-family: &quot;Courier New&quot;;">​big font</span></li></ul><span id="level 2 content" style="font-size: 20pt; font-family: &quot;Courier New&quot;;"><br></span>'
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li></ul><span style="font-family: &quot;Courier New&quot;; font-size: 20pt; color: rgb(208, 92, 18);"><br></span><ul><li>test</li></ul></div>'
         );
     });
 
-    it('doesnt move the whole LI out when there is no span with formatting content on it.', () => {
+    it('properly outdents when default format is applied', () => {
         // Arrange
         const originalContent =
-            '<div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="font-family: &quot;Times New Roman&quot;; font-size: medium; background-color: rgb(255, 255, 255)"><ul style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt"><li>test</li><li>test</li><li>test</li><li><img id="focus helper" /><br></li></ul></div>';
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li><li>test</li><li><img id="focus helper" /><br></li></ul></div>';
         editor.setContent(originalContent);
         const focusNode = document.getElementById('focus helper');
         TestHelper.setSelection(focusNode, 0);
@@ -82,7 +66,25 @@ describe('processList()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)">test</div><div style="font-size: 12pt; font-family: Calibri, Helvetica, sans-serif; background-color: rgb(255, 255, 255)"><br></div><div style="background-color: rgb(255, 255, 255);"><ul style="font-family: Calibri, Helvetica, sans-serif; font-size: 12pt;"><li>test</li><li>test</li><li>test</li></ul><font face="Calibri, Helvetica, sans-serif"><br></font></div>'
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li><li>test</li></ul><br></div>'
+        );
+    });
+
+    it('properly outdents from the middle when default format is applied', () => {
+        // Arrange
+        const originalContent =
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li><li><img id="focus helper" /><br></li><li>test</li></ul></div>';
+        editor.setContent(originalContent);
+        const focusNode = document.getElementById('focus helper');
+        TestHelper.setSelection(focusNode, 0);
+        editor.deleteNode(focusNode);
+
+        // Act
+        processList(editor, DocumentCommand.Outdent);
+
+        // Assert
+        expect(editor.getContent()).toBe(
+            '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">default format</div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div><div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><ul><li>test</li></ul><br><ul><li>test</li></ul></div>'
         );
     });
 });

--- a/packages/roosterjs-editor-api/lib/utils/processList.ts
+++ b/packages/roosterjs-editor-api/lib/utils/processList.ts
@@ -1,7 +1,13 @@
-import { Browser, getRangeFromSelectionPath, getSelectionPath } from 'roosterjs-editor-dom';
-import { DocumentCommand } from 'roosterjs-editor-types';
+import {
+    Browser,
+    createRange,
+    getSelectionPath,
+    splitBalancedNodeRange,
+    unwrap,
+    wrap,
+} from 'roosterjs-editor-dom';
+import { DocumentCommand, PositionType } from 'roosterjs-editor-types';
 import { Editor } from 'roosterjs-editor-core';
-import { isHTMLElement } from 'roosterjs-cross-window';
 
 export type ValidProcessListDocumentCommands =
     | DocumentCommand.Outdent
@@ -17,16 +23,15 @@ export default function processList(
     editor: Editor,
     command: ValidProcessListDocumentCommands
 ): Node {
-    let clonedNode: Node;
-    let relativeSelectionPath;
-    let clonedCursorNode: Node;
-    let cursorSelectionPath;
-
-    // Chrome has a bug where certain infromation about elements are deleted when outdent or enter on empty line occurs.
-    // We need to clone our current LI node so we can replace the new LI node with it post outdent / enter.
-    if (Browser.isChrome) {
+    let existingList = editor.getElementAtCursor('OL,UL');
+    if (Browser.isChrome && command !== DocumentCommand.Indent) {
+        // Chrome has a bug where certain infromation about elements are deleted when outdent or enter on empty line occurs.
+        // We need to clone our current LI node so we can replace the new LI node with it post outdent / enter.
         const parentLINode = editor.getElementAtCursor('LI');
+        // We must first be in an LI node to do something to fix this.
         if (parentLINode) {
+            // We also don't want to try to handle the multi select outdent case at this time.
+            // These are already pretty stable in Chromium.
             let currentRange = editor.getSelectionRange();
             if (
                 currentRange &&
@@ -34,67 +39,57 @@ export default function processList(
                     (editor.getElementAtCursor('LI', currentRange.startContainer) == parentLINode &&
                         editor.getElementAtCursor('LI', currentRange.endContainer) == parentLINode))
             ) {
-                relativeSelectionPath = getSelectionPath(parentLINode, currentRange);
-                if (parentLINode.textContent === '') {
-                    const cursorNode = editor.getElementAtCursor();
+                // Get the next highest list element.
+                // In well formed HTML, this should just be the existing list's parent container.
+                const listParent = existingList.parentElement;
+                if (listParent.tagName == 'OL' || listParent.tagName == 'UL') {
+                    const currentSelectionPath = getSelectionPath(parentLINode, currentRange);
 
-                    // If the cursor is inside of a span, we need to preserve that content somehow when the content is empty.
-                    // Chromium will try to replace all empty spans with font tags
-                    // We should preserve where our cursor is so that in this case, we can keep the span around.
-                    // In some cases Chromium will still put a font tag at the document root,
-                    // But unless we have a span to replace it with, we should leave it be for now.
-                    if (cursorNode !== parentLINode) {
-                        clonedCursorNode = cursorNode.cloneNode(true);
-                        cursorSelectionPath = getSelectionPath(cursorNode, currentRange);
+                    existingList.insertAdjacentElement('afterend', parentLINode);
+
+                    let newRange = createRange(
+                        parentLINode,
+                        currentSelectionPath.start,
+                        currentSelectionPath.end
+                    );
+                    editor.select(newRange);
+                } else {
+                    // In this case, we're going out to the parent root.
+                    if (parentLINode.nextElementSibling) {
+                        splitBalancedNodeRange(parentLINode);
+                        editor.select(parentLINode, PositionType.Begin);
                     }
-                }
-                clonedNode = parentLINode.cloneNode(true);
-            }
-        }
-    }
 
-    let existingList = editor.getElementAtCursor('OL,UL');
-    editor.getDocument().execCommand(command, false, null);
-    const newParentNode = editor.getElementAtCursor('LI');
+                    const wrappedContents = wrap([].slice.call(parentLINode.childNodes));
+                    const currentSelectionPath = getSelectionPath(wrappedContents, currentRange);
+
+                    existingList.insertAdjacentElement('afterend', wrappedContents);
+                    editor.deleteNode(parentLINode);
+
+                    let newRange = createRange(
+                        wrappedContents,
+                        currentSelectionPath.start,
+                        currentSelectionPath.end
+                    );
+                    editor.select(newRange);
+                    unwrap(wrappedContents);
+                }
+
+                if (existingList.childElementCount == 0) {
+                    editor.deleteNode(existingList);
+                }
+            } else {
+                editor.getDocument().execCommand(command, false, null);
+            }
+        } else {
+            editor.getDocument().execCommand(command, false, null);
+        }
+    } else {
+        editor.getDocument().execCommand(command, false, null);
+    }
     let newList = editor.getElementAtCursor('OL,UL');
     if (newList == existingList) {
         newList = null;
-    }
-
-    if (Browser.isChrome) {
-        // This is the normal case for indenting/outdenting within a list
-        if (clonedNode && newList && newParentNode) {
-            // if the clonedNode and the newLIParent share the same tag name
-            // we can 1:1 swap them
-            if (isHTMLElement(clonedNode)) {
-                if (
-                    isHTMLElement(newParentNode) &&
-                    clonedNode.tagName == (<HTMLElement>newParentNode).tagName
-                ) {
-                    newList.replaceChild(clonedNode, newParentNode);
-                }
-                if (relativeSelectionPath && editor.contains(clonedNode)) {
-                    let newRange = getRangeFromSelectionPath(clonedNode, relativeSelectionPath);
-                    editor.select(newRange);
-                }
-            }
-            // This is the special handling
-        } else if (clonedCursorNode) {
-            // Rooster should never be creating FONT tags on it's own,
-            // and chromium's behavior is consistant with empty nodes outdenting to a non list block element root.
-            const chromeFontTag = editor.getElementAtCursor('FONT');
-            if (chromeFontTag) {
-                chromeFontTag.parentNode.replaceChild(clonedCursorNode, chromeFontTag);
-                if (
-                    cursorSelectionPath &&
-                    isHTMLElement(clonedCursorNode) &&
-                    editor.contains(clonedCursorNode)
-                ) {
-                    let newRange = getRangeFromSelectionPath(clonedCursorNode, cursorSelectionPath);
-                    editor.select(newRange);
-                }
-            }
-        }
     }
     return newList;
 }

--- a/packages/roosterjs-editor-api/lib/utils/processList.ts
+++ b/packages/roosterjs-editor-api/lib/utils/processList.ts
@@ -36,12 +36,17 @@ export default function processList(
             ) {
                 relativeSelectionPath = getSelectionPath(parentLINode, currentRange);
                 if (parentLINode.textContent === '') {
-                    // If the node is empty, we need to handle this special case.
+                    const cursorNode = editor.getElementAtCursor();
+
+                    // If the cursor is inside of a span, we need to preserve that content somehow when the content is empty.
                     // Chromium will try to replace all empty spans with font tags
                     // We should preserve where our cursor is so that in this case, we can keep the span around.
-                    const cursorNode = editor.getElementAtCursor();
-                    clonedCursorNode = cursorNode.cloneNode(true);
-                    cursorSelectionPath = getSelectionPath(cursorNode, currentRange);
+                    // In some cases Chromium will still put a font tag at the document root,
+                    // But unless we have a span to replace it with, we should leave it be for now.
+                    if (cursorNode !== parentLINode) {
+                        clonedCursorNode = cursorNode.cloneNode(true);
+                        cursorSelectionPath = getSelectionPath(cursorNode, currentRange);
+                    }
                 }
                 clonedNode = parentLINode.cloneNode(true);
             }


### PR DESCRIPTION
Chromium's CED implementation is lacking, and I've decided to give up on using `execCommand` as much as possible and instead use our own behaviors. With a couple utility functions we use elsewhere in the code, this should fix the bulk of issues we've been seeing recently.