### PR TITLE
Fix potential null in tableFeatures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.11.2",
+    "version": "7.11.3",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/tableFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/tableFeatures.ts
@@ -1,11 +1,5 @@
 import { cacheGetEventData, ContentEditFeature, Editor, Keys } from 'roosterjs-editor-core';
-import {
-    contains,
-    getTagOfNode,
-    isVoidHtmlElement,
-    Position,
-    VTable
-    } from 'roosterjs-editor-dom';
+import { contains, getTagOfNode, isVoidHtmlElement, Position, VTable } from 'roosterjs-editor-dom';
 import { NodeType, PluginEvent, PositionType } from 'roosterjs-editor-types';
 
 /**
@@ -98,7 +92,7 @@ export const UpDownInTable: ContentEditFeature = {
 function cacheGetTableCell(event: PluginEvent, editor: Editor): HTMLTableCellElement {
     return cacheGetEventData(event, 'TABLECELL_FOR_TABLE_FEATURES', () => {
         let pos = editor.getFocusedPosition();
-        let firstTd = editor.getElementAtCursor('TD,TH,LI', pos.node);
+        let firstTd = pos && editor.getElementAtCursor('TD,TH,LI', pos.node);
         return getTagOfNode(firstTd) == 'LI' ? null : (firstTd as HTMLTableCellElement);
     });
 }

--- a/packages/roosterjs-editor-plugins/lib/ContentEdit/features/tableFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/ContentEdit/features/tableFeatures.ts
@@ -93,6 +93,8 @@ function cacheGetTableCell(event: PluginEvent, editor: Editor): HTMLTableCellEle
     return cacheGetEventData(event, 'TABLECELL_FOR_TABLE_FEATURES', () => {
         let pos = editor.getFocusedPosition();
         let firstTd = pos && editor.getElementAtCursor('TD,TH,LI', pos.node);
-        return getTagOfNode(firstTd) == 'LI' ? null : (firstTd as HTMLTableCellElement);
+        return (
+            firstTd && (getTagOfNode(firstTd) == 'LI' ? null : (firstTd as HTMLTableCellElement))
+        );
     });
 }


### PR DESCRIPTION
`editor.getFocusedPosition()` can return a null value. Without checking for it, we throw an exception inside of `cacheGetTableCell`. Adding an explicit null check should help.