### PR TITLE
Fix icons in demo site

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = {
                 loader: 'url-loader',
                 options: {
                     mimetype: 'image/svg+xml',
+                    esModule: false,
                 },
             },
             {


### PR DESCRIPTION
There is a breaking change in url-loader 3.0.0: https://github.com/webpack-contrib/url-loader/releases/tag/v3.0.0

So let's follow their change and make demo site icon works.