### PR TITLE
Skip Empty DIV when traverse

### DIFF
--- a/packages/roosterjs-editor-dom/lib/test/utils/shouldSkipNodeTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/utils/shouldSkipNodeTest.ts
@@ -44,6 +44,17 @@ describe('shouldSkipNode, shouldSkipNode()', () => {
         expect(shouldSkip).toBe(true);
     });
 
+    it('Empty DIV node', () => {
+        // Arrange
+        let node = DomTestHelper.createElementFromContent(testID, '<div></div>');
+
+        // Act
+        let shouldSkip = shouldSkipNode(node.firstChild);
+
+        // Assert
+        expect(shouldSkip).toBe(true);
+    });
+
     it('Regular node', () => {
         // Arrange
         let node = document.createTextNode('abc');

--- a/packages/roosterjs-editor-dom/lib/utils/shouldSkipNode.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/shouldSkipNode.ts
@@ -17,9 +17,7 @@ export default function shouldSkipNode(node: Node): boolean {
         return !node.nodeValue || node.textContent == '' || CRLF.test(node.nodeValue);
     } else if (node.nodeType == NodeType.Element) {
         return (
-            (getTagOfNode(node) == 'DIV' &&
-                (node as HTMLElement).getAttribute('style') == null &&
-                !node.firstChild) ||
+            (getTagOfNode(node) == 'DIV' && !node.firstChild) ||
             getComputedStyle(node, 'display') == 'none'
         );
     } else {

--- a/packages/roosterjs-editor-dom/lib/utils/shouldSkipNode.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/shouldSkipNode.ts
@@ -1,3 +1,4 @@
+import getTagOfNode from './getTagOfNode';
 import { getComputedStyle } from './getComputedStyles';
 import { NodeType } from 'roosterjs-editor-types';
 
@@ -9,12 +10,18 @@ const CRLF = /^[\r\n]+$/gm;
  * - it is a text node but is empty
  * - it is a text node but contains just CRLF (noisy text node that often comes in-between elements)
  * - has a display:none
+ * - it is just <div></div>
  */
 export default function shouldSkipNode(node: Node): boolean {
     if (node.nodeType == NodeType.Text) {
         return !node.nodeValue || node.textContent == '' || CRLF.test(node.nodeValue);
     } else if (node.nodeType == NodeType.Element) {
-        return getComputedStyle(node, 'display') == 'none';
+        return (
+            (getTagOfNode(node) == 'DIV' &&
+                (node as HTMLElement).getAttribute('style') == null &&
+                !node.firstChild) ||
+            getComputedStyle(node, 'display') == 'none'
+        );
     } else {
         return true;
     }


### PR DESCRIPTION
Empty div "< div>< /div>" renders nothing. So it should not be treated as a block element. We should skip it when get next/previous inline/block element