### PR TITLE
fix pasting issue in table

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/Paste/officeOnlineConverter/convertPastedContentFromWordOnline.ts
+++ b/packages/roosterjs-editor-plugins/lib/Paste/officeOnlineConverter/convertPastedContentFromWordOnline.ts
@@ -4,7 +4,7 @@ import {
     WORD_ONLINE_IDENTIFYING_SELECTOR,
     LIST_CONTAINER_ELEMENT_CLASS_NAME,
     ORDERED_LIST_TAG_NAME,
-    UNORDERED_LIST_TAG_NAME
+    UNORDERED_LIST_TAG_NAME,
 } from './constants';
 
 import {
@@ -13,11 +13,10 @@ import {
     getFirstLeafNode,
     getTagOfNode,
     collapseNodes,
-    unwrap
+    unwrap,
 } from 'roosterjs-editor-dom';
 
 import ListItemBlock, { createListItemBlock } from './ListItemBlock';
-
 
 export function isWordOnlineWithList(node: HTMLElement): boolean {
     return !!(node && node.querySelector(WORD_ONLINE_IDENTIFYING_SELECTOR));
@@ -62,7 +61,6 @@ export default function convertPastedContentFromWordOnline(doc: HTMLDocument) {
     const listItemBlocks: ListItemBlock[] = getListItemBlocks(doc);
 
     listItemBlocks.forEach((itemBlock) => {
-
         // There are cases where consecutive List Elements are seperated into different divs:
         // <div>
         //   <div>
@@ -141,7 +139,9 @@ export default function convertPastedContentFromWordOnline(doc: HTMLDocument) {
  * @param doc pasted document that contains all the list element.
  */
 function sanitizeListItemContainer(doc: HTMLDocument) {
-    const listItemContainerListEl = doc.querySelectorAll(`${WORD_ORDERED_LIST_SELECTOR}, ${WORD_UNORDERED_LIST_SELECTOR}`);
+    const listItemContainerListEl = doc.querySelectorAll(
+        `${WORD_ORDERED_LIST_SELECTOR}, ${WORD_UNORDERED_LIST_SELECTOR}`
+    );
     listItemContainerListEl.forEach((el) => {
         const replaceRegex = new RegExp(`\\b${LIST_CONTAINER_ELEMENT_CLASS_NAME}\\b`, 'g');
         if (el.previousSibling) {
@@ -166,14 +166,17 @@ function getListItemBlocks(doc: HTMLDocument): ListItemBlock[] {
     for (let i = 0; i < listElements.length; i++) {
         let curItem = listElements[i];
         if (!curListItemBlock) {
-            curListItemBlock = createListItemBlock(curItem)
+            curListItemBlock = createListItemBlock(curItem);
         } else {
             const { listItemContainers } = curListItemBlock;
             const lastItemInCurBlock = listItemContainers[listItemContainers.length - 1];
-            if (curItem == lastItemInCurBlock.nextSibling
-                || getFirstLeafNode(curItem) == getNextLeafSibling(doc.body, lastItemInCurBlock)) {
+            if (
+                curItem == lastItemInCurBlock.nextSibling ||
+                getFirstLeafNode(curItem) ==
+                    getNextLeafSibling(lastItemInCurBlock.parentNode, lastItemInCurBlock)
+            ) {
                 listItemContainers.push(curItem);
-                curListItemBlock.endElement = curItem
+                curListItemBlock.endElement = curItem;
             } else {
                 curListItemBlock.endElement = lastItemInCurBlock;
                 result.push(curListItemBlock);
@@ -195,12 +198,17 @@ function getListItemBlocks(doc: HTMLDocument): ListItemBlock[] {
  * @param listItemBlock The list item block needed to be flattened.
  */
 function flattenListBlock(rootElement: Element, listItemBlock: ListItemBlock) {
-    const collapsedListItemSections = collapseNodes(rootElement, listItemBlock.startElement, listItemBlock.endElement, true);
+    const collapsedListItemSections = collapseNodes(
+        rootElement,
+        listItemBlock.startElement,
+        listItemBlock.endElement,
+        true
+    );
     collapsedListItemSections.forEach((section) => {
         if (getTagOfNode(section.firstChild) == 'DIV') {
-            unwrap(section)
+            unwrap(section);
         }
-    })
+    });
 }
 
 /**
@@ -219,9 +227,14 @@ function getContainerListType(listItemContainer: Element): 'OL' | 'UL' | null {
  * @param itemToInsert List item that needed to be inserted.
  * @param listType Type of list(ul/ol)
  */
-function insertListItem(listRootElement: Element, itemToInsert: HTMLElement, listType: string, doc: HTMLDocument): void {
+function insertListItem(
+    listRootElement: Element,
+    itemToInsert: HTMLElement,
+    listType: string,
+    doc: HTMLDocument
+): void {
     if (!listType) {
-        return
+        return;
     }
     // Get item level from 'data-aria-level' attribute
     let itemLevel = parseInt(itemToInsert.getAttribute('data-aria-level'));
@@ -244,7 +257,7 @@ function insertListItem(listRootElement: Element, itemToInsert: HTMLElement, lis
             } else {
                 // If the last child is not a list, then append a new list to the level
                 // and move the level iterator to the new level.
-                curListLevel.append(doc.createElement(listType))
+                curListLevel.append(doc.createElement(listType));
                 curListLevel = curListLevel.lastElementChild;
             }
         }
@@ -261,7 +274,11 @@ function insertListItem(listRootElement: Element, itemToInsert: HTMLElement, lis
  * @param rootElement Root element of that contains the converted listItemBlock
  * @param listItemBlock List item block that was converted.
  */
-function insertConvertedListToDoc(convertedListElement: Element, rootElement: Element, listItemBlock: ListItemBlock) {
+function insertConvertedListToDoc(
+    convertedListElement: Element,
+    rootElement: Element,
+    listItemBlock: ListItemBlock
+) {
     if (!convertedListElement) {
         return;
     }
@@ -275,7 +292,7 @@ function insertConvertedListToDoc(convertedListElement: Element, rootElement: El
     } else {
         const { parentElement } = listItemBlock.startElement;
         if (parentElement) {
-            parentElement.appendChild(convertedListElement)
+            parentElement.appendChild(convertedListElement);
         } else {
             rootElement.append(convertedListElement);
         }


### PR DESCRIPTION
When copy bullet in tables from word online. 
The issue is caused by when splitting for listblock. The root node is used as body, instead it should be the parent of the list block.