### PR TITLE
VList implementation

### DIFF
--- a/packages/roosterjs-editor-api/lib/experiment/experimentSetIndentation.ts
+++ b/packages/roosterjs-editor-api/lib/experiment/experimentSetIndentation.ts
@@ -1,0 +1,76 @@
+import blockFormat from '../utils/blockFormat';
+import { BlockElement, Indentation, Region } from 'roosterjs-editor-types';
+import { Editor } from 'roosterjs-editor-core';
+import { getSelectedBlockElementsInRegion } from 'roosterjs-editor-dom';
+import {
+    collapseNodesInRegion,
+    createVListFromRegion,
+    findClosestElementAncestor,
+    getTagOfNode,
+    isNodeInRegion,
+    splitBalancedNodeRange,
+    toArray,
+    unwrap,
+    wrap,
+} from 'roosterjs-editor-dom';
+
+const BlockWrapper = '<blockquote style="margin-top:0;margin-bottom:0"></blockquote>';
+
+/**
+ * @internal
+ */
+export default function experimentSetIndentation(editor: Editor, indentation: Indentation) {
+    const handler = indentation == Indentation.Increase ? indent : outdent;
+
+    blockFormat(editor, (region, start, end) => {
+        const blocks = getSelectedBlockElementsInRegion(region);
+        const blockGroups: BlockElement[][] = [[]];
+
+        for (let i = 0; i < blocks.length; i++) {
+            const startNode = blocks[i].getStartNode();
+            const vList = createVListFromRegion(region, true /*includeSiblingLists*/, startNode);
+
+            if (vList) {
+                blockGroups.push([]);
+                while (blocks[i + 1] && vList.contains(blocks[i + 1].getStartNode())) {
+                    i++;
+                }
+                vList.setIndentation(start, end, indentation);
+                vList.writeBack();
+            } else {
+                blockGroups[blockGroups.length - 1].push(blocks[i]);
+            }
+        }
+
+        blockGroups.forEach(group => handler(region, group));
+    });
+}
+
+function indent(region: Region, blocks: BlockElement[]) {
+    if (blocks.length > 0) {
+        const startNode = blocks[0].getStartNode();
+        const endNode = blocks[blocks.length - 1].getEndNode();
+        const nodes = collapseNodesInRegion(region, [startNode, endNode]);
+        wrap(nodes, BlockWrapper);
+    }
+}
+
+function outdent(region: Region, blocks: BlockElement[]) {
+    blocks.forEach(blockElement => {
+        let node = blockElement.collapseToSingleElement();
+        const quote = findClosestElementAncestor(node, region.rootNode, 'blockquote');
+        if (quote) {
+            if (node == quote) {
+                node = wrap(toArray(node.childNodes));
+            }
+
+            while (isNodeInRegion(region, node) && getTagOfNode(node) != 'BLOCKQUOTE') {
+                node = splitBalancedNodeRange(node);
+            }
+
+            if (isNodeInRegion(region, node)) {
+                unwrap(node);
+            }
+        }
+    });
+}

--- a/packages/roosterjs-editor-api/lib/experiment/experimentToggleListType.ts
+++ b/packages/roosterjs-editor-api/lib/experiment/experimentToggleListType.ts
@@ -1,0 +1,17 @@
+import blockFormat from '../utils/blockFormat';
+import { createVListFromRegion } from 'roosterjs-editor-dom';
+import { Editor } from 'roosterjs-editor-core';
+import { ListType } from 'roosterjs-editor-types';
+
+/**
+ * @internal
+ */
+export default function experimentToggleListType(editor: Editor, listType: ListType) {
+    blockFormat(editor, (region, start, end) => {
+        const vList = createVListFromRegion(region, true /*includeSiblingLists*/);
+        if (vList) {
+            vList.changeListType(start, end, listType);
+            vList.writeBack();
+        }
+    });
+}

--- a/packages/roosterjs-editor-api/lib/format/setIndentation.ts
+++ b/packages/roosterjs-editor-api/lib/format/setIndentation.ts
@@ -1,3 +1,4 @@
+import experimentSetIndentation from '../experiment/experimentSetIndentation';
 import processList from '../utils/processList';
 import { ChangeSource, DocumentCommand, Indentation, QueryScope } from 'roosterjs-editor-types';
 import { Editor } from 'roosterjs-editor-core';
@@ -11,28 +12,32 @@ import { Editor } from 'roosterjs-editor-core';
  * Indentation.Increase to increase indentation or Indentation.Decrease to decrease indentation
  */
 export default function setIndentation(editor: Editor, indentation: Indentation) {
-    let command: DocumentCommand.Indent | DocumentCommand.Outdent =
-        indentation == Indentation.Increase ? DocumentCommand.Indent : DocumentCommand.Outdent;
-    editor.addUndoSnapshot(() => {
-        editor.focus();
-        let listNode = editor.getElementAtCursor('OL,UL');
-        let newNode: Node;
+    if (editor.useExperimentFeatures()) {
+        experimentSetIndentation(editor, indentation);
+    } else {
+        let command: DocumentCommand.Indent | DocumentCommand.Outdent =
+            indentation == Indentation.Increase ? DocumentCommand.Indent : DocumentCommand.Outdent;
+        editor.addUndoSnapshot(() => {
+            editor.focus();
+            let listNode = editor.getElementAtCursor('OL,UL');
+            let newNode: Node;
 
-        if (listNode) {
-            // There is already list node, setIndentation() will increase/decrease the list level,
-            // so we need to process the list when change indentation
-            newNode = processList(editor, command);
-        } else {
-            // No existing list node, browser will create <Blockquote> node for indentation.
-            // We need to set top and bottom margin to 0 to avoid unnecessary spaces
-            editor.getDocument().execCommand(command, false, null);
-            editor.queryElements('BLOCKQUOTE', QueryScope.OnSelection, node => {
-                newNode = newNode || node;
-                node.style.marginTop = '0px';
-                node.style.marginBottom = '0px';
-            });
-        }
+            if (listNode) {
+                // There is already list node, setIndentation() will increase/decrease the list level,
+                // so we need to process the list when change indentation
+                newNode = processList(editor, command);
+            } else {
+                // No existing list node, browser will create <Blockquote> node for indentation.
+                // We need to set top and bottom margin to 0 to avoid unnecessary spaces
+                editor.getDocument().execCommand(command, false, null);
+                editor.queryElements('BLOCKQUOTE', QueryScope.OnSelection, node => {
+                    newNode = newNode || node;
+                    node.style.marginTop = '0px';
+                    node.style.marginBottom = '0px';
+                });
+            }
 
-        return newNode;
-    }, ChangeSource.Format);
+            return newNode;
+        }, ChangeSource.Format);
+    }
 }

--- a/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
@@ -1,5 +1,6 @@
+import experimentToggleListType from '../experiment/experimentToggleListType';
 import processList from '../utils/processList';
-import { ChangeSource, DocumentCommand } from 'roosterjs-editor-types';
+import { ChangeSource, DocumentCommand, ListType } from 'roosterjs-editor-types';
 import { Editor } from 'roosterjs-editor-core';
 
 /**
@@ -11,9 +12,13 @@ import { Editor } from 'roosterjs-editor-core';
  * @param editor The editor instance
  */
 export default function toggleBullet(editor: Editor) {
-    editor.focus();
-    editor.addUndoSnapshot(
-        () => processList(editor, DocumentCommand.InsertUnorderedList),
-        ChangeSource.Format
-    );
+    if (editor.useExperimentFeatures()) {
+        experimentToggleListType(editor, ListType.Unordered);
+    } else {
+        editor.focus();
+        editor.addUndoSnapshot(
+            () => processList(editor, DocumentCommand.InsertUnorderedList),
+            ChangeSource.Format
+        );
+    }
 }

--- a/packages/roosterjs-editor-api/lib/format/toggleNumbering.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleNumbering.ts
@@ -1,5 +1,6 @@
+import experimentToggleListType from '../experiment/experimentToggleListType';
 import processList from '../utils/processList';
-import { ChangeSource, DocumentCommand } from 'roosterjs-editor-types';
+import { ChangeSource, DocumentCommand, ListType } from 'roosterjs-editor-types';
 import { Editor } from 'roosterjs-editor-core';
 
 /**
@@ -11,9 +12,13 @@ import { Editor } from 'roosterjs-editor-core';
  * @param editor The editor instance
  */
 export default function toggleNumbering(editor: Editor) {
-    editor.focus();
-    editor.addUndoSnapshot(
-        () => processList(editor, DocumentCommand.InsertOrderedList),
-        ChangeSource.Format
-    );
+    if (editor.useExperimentFeatures()) {
+        experimentToggleListType(editor, ListType.Ordered);
+    } else {
+        editor.focus();
+        editor.addUndoSnapshot(
+            () => processList(editor, DocumentCommand.InsertOrderedList),
+            ChangeSource.Format
+        );
+    }
 }

--- a/packages/roosterjs-editor-api/lib/utils/blockFormat.ts
+++ b/packages/roosterjs-editor-api/lib/utils/blockFormat.ts
@@ -1,0 +1,18 @@
+import { ChangeSource, NodePosition, Region } from 'roosterjs-editor-types';
+import { Editor } from 'roosterjs-editor-core';
+
+/**
+ * @internal
+ * Split selection into regions, and perform a block-wise formatting action for each region.
+ */
+export default function blockFormat(
+    editor: Editor,
+    callback: (region: Region, start: NodePosition, end: NodePosition) => void
+) {
+    editor.focus();
+    editor.addUndoSnapshot((start, end) => {
+        const regions = editor.getSelectedRegions();
+        regions.forEach(region => callback(region, start, end));
+        editor.select(start, end);
+    }, ChangeSource.Format);
+}

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -45,6 +45,8 @@ export { default as splitTextNode } from './utils/splitTextNode';
 export { default as toArray } from './utils/toArray';
 
 export { default as VTable, VCell } from './table/VTable';
+export { default as VList } from './list/VList';
+export { default as createVListFromRegion } from './list/createVListFromRegion';
 
 export { default as getRegionsFromRange } from './region/getRegionsFromRange';
 export { default as getSelectedBlockElementsInRegion } from './region/getSelectedBlockElementsInRegion';

--- a/packages/roosterjs-editor-dom/lib/list/VList.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VList.ts
@@ -1,0 +1,338 @@
+import getListTypeFromNode, { isListElement } from './getListTypeFromNode';
+import getTagOfNode from '../utils/getTagOfNode';
+import isBlockElement from '../utils/isBlockElement';
+import isNodeEmpty from '../utils/isNodeEmpty';
+import Position from '../selection/Position';
+import queryElements from '../utils/queryElements';
+import splitParentNode from '../utils/splitParentNode';
+import toArray from '../utils/toArray';
+import unwrap from '../utils/unwrap';
+import VListItem from './VListItem';
+import wrap from '../utils/wrap';
+import {
+    Indentation,
+    ListType,
+    NodePosition,
+    PositionType,
+    NodeType,
+} from 'roosterjs-editor-types';
+
+/**
+ * Represent a bullet or a numbering list
+ *
+ * @example
+ * A VList is a logical representation of list items, it contains an item array with node and list type stack.
+ * e.g. We have a list like this
+ * ```html
+ * <ol>
+ *   <li>item 1</li>
+ *   <li>item 2</li>
+ *   <ul>
+ *     <li>item 2.1</li>
+ *     <li>item 2.2</li>
+ *   <ul>
+ * </ol>
+ * ```
+ *
+ * A VList of this list will be like this:
+ * ```javascript
+ * {
+ *   rootList: (OL node),
+ *   items: [{
+ *       node: (LI node with 'item 1'),
+ *       listTypes: [null, OL],
+ *     }, {
+ *       node: (LI node with 'item 2'),
+ *       listTypes: [null, OL],
+ *     }, {
+ *       node: (LI node with 'item 2.1),
+ *       listTypes: [null, OL, UL],
+ *     }, {
+ *       node: (LI node with 'item 2.2'),
+ *       listTypes: [null, OL, UL],
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * When we want to outdent item 2.1, we just need to remove the last "UL" from listTypes of item 2.1, then
+ * the writeBack() function will handle everything related to DOM change
+ */
+export default class VList {
+    private items: VListItem[] = [];
+
+    /**
+     * Create a new instance of VList class
+     * @param rootList The root list element, can be either OL or UL tag
+     */
+    constructor(private rootList: HTMLOListElement | HTMLUListElement) {
+        if (!rootList) {
+            throw new Error('rootList must not be null');
+        }
+
+        // Before populate items, we need to normalize the list to make sure it is in a correct format
+        // otherwise further action may mass thing up.
+        //
+        // There are two kinds of normalization to perform.
+        // 1. Move nodes directly under OL/UL into a LI node, unless it is an orphan node
+        // Please see comment for VListItem.isOrphanItem() for more information about orphan node
+        // e.g.:
+        // ```HTML
+        // <ol>
+        //   <li>item 1</li>
+        //   <div>item 2</div>
+        // </ol>
+        // ```
+        // After this step, it should become:
+        // ```html
+        // <ol>
+        //   <li>item 1
+        //     <div>item 2</div>
+        //   <li>
+        // </ol>
+        // ```
+        moveChildNodesToLi(this.rootList);
+        queryElements(this.rootList, 'ol,ul', moveChildNodesToLi);
+
+        // 2. Move LI node embeded into another LI node out to directly under OL/UL node
+        // Ideally browser we do this for us automatically when out the HTML into DOM. However after
+        // step 1, it is possible that we move some LI node into another one. e.g:
+        // ```HTML
+        // <ol>
+        //   <li>item 1</li>
+        //   <div>
+        //     item 1.1
+        //     <li>item 3</li>
+        //   </div>
+        // </ol>
+        // ```
+        // See that the second LI tag is not directly under OL, so after step 1, this will become:
+        // ```html
+        // <ol>
+        //   <li>item 1
+        //     <div>
+        //       item 1.1
+        //       <li>item 2</li>
+        //     </div>
+        //   <li>
+        // </ol>
+        // ```
+        // Now we have a LI tag embeded into another LI tag. So we need step 2 to move the inner LI tag out to be:
+        // ```html
+        // <ol>
+        //   <li>item1
+        //     <div>item 1.1</div>
+        //   </li>
+        //   <li><div>item2</div></li>
+        // </ol>
+        // ```
+        queryElements(this.rootList, 'li', moveLiToList);
+
+        this.populateItems(this.rootList);
+    }
+
+    /**
+     * Check if this list contains the given node
+     * @param node The node to check
+     */
+    contains(node: Node) {
+        // We don't check if the node is contained by this.rootList here, because after some operation,
+        // it is possible a node is logically contained by this list but the container list item hasn't
+        // been put under this.rootList in DOM tree yet.
+        return this.items.some(item => item.contains(node));
+    }
+
+    /**
+     * Get the first or last node of this list
+     * @param isLast true to get last node, false to get first node
+     */
+    getFirstOrLastNode(isLast: boolean): Node {
+        const item = this.items[isLast ? this.items.length - 1 : 0];
+        return item?.getNode();
+    }
+
+    /**
+     * Write the result back into DOM tree
+     * After that, this VList becomes unavailable because we set this.rootList to null
+     */
+    writeBack() {
+        if (!this.rootList) {
+            throw new Error('rootList must not be null');
+        }
+
+        const listStack: Node[] = [this.rootList.ownerDocument.createDocumentFragment()];
+
+        this.items.forEach(item => item.writeBack(listStack));
+        this.rootList.parentNode.replaceChild(listStack[0], this.rootList);
+
+        // Set rootList to null to avoid this to be called again for the same VList, because
+        // after change the rootList may not be available any more (e.g. outdent all items).
+        this.rootList = null;
+    }
+
+    /**
+     * Set indentation of the given range of this list
+     * @param start Start position to operate from
+     * @param end End positon to operate to
+     * @param indentation Indent or outdent
+     */
+    setIndentation(start: NodePosition, end: NodePosition, indentation: Indentation) {
+        this.findListItems(start, end, item =>
+            indentation == Indentation.Decrease ? item.outdent() : item.indent()
+        );
+    }
+
+    /**
+     * Change list type of the given range of this list.
+     * If some of the items are not real list item yet, this will make them to be list item with given type
+     * If all items in the given range are already in the type to change to, this becomes an outdent operation
+     * @param start Start position to operate from
+     * @param end End position to operate to
+     * @param targetType Target list type
+     */
+    changeListType(start: NodePosition, end: NodePosition, targetType: ListType) {
+        let needChangeType = false;
+
+        this.findListItems(start, end, item => {
+            needChangeType = needChangeType || item.getListType() != targetType;
+        });
+        this.findListItems(start, end, item =>
+            needChangeType ? item.changeListType(targetType) : item.outdent()
+        );
+    }
+
+    /**
+     * Append a new item to this VList
+     * @param node node of the item to append. If it is not wrapped with LI tag, it will be wrapped
+     * @param type Type of this list item, can be ListType.None
+     */
+    appendItem(node: Node, type: ListType) {
+        node = getTagOfNode(node) == 'LI' ? node : wrap(node, 'li');
+        this.items.push(type == ListType.None ? new VListItem(node) : new VListItem(node, type));
+    }
+
+    /**
+     * Merge the given VList into current VList.
+     * - All list items will be removed from the given VList and added into this list.
+     * - The root node of the given VList will be removed from DOM tree
+     * - If there are orphan items in the given VList, they will be merged into the last item
+     *   of this list if any.
+     * @param list The vList to merge from
+     */
+    mergeVList(list: VList) {
+        if (list && list != this) {
+            const originalLength = this.items.length;
+            list.items.forEach(item => this.items.push(item));
+            list.items.splice(0, list.items.length);
+
+            this.mergeOrphanNodesAfter(originalLength - 1);
+            list.rootList.parentNode?.removeChild(list.rootList);
+        }
+    }
+
+    private mergeOrphanNodesAfter(startIndex: number) {
+        const item = this.items[startIndex];
+
+        if (item && !item.isOrphanItem()) {
+            for (let i = startIndex + 1; i <= this.items.length; i++) {
+                if (!item || !item.canMerge(this.items[i])) {
+                    item.mergeItems(this.items.splice(startIndex + 1, i - startIndex - 1));
+                    break;
+                }
+            }
+        }
+    }
+
+    private findListItems(
+        start: NodePosition,
+        end: NodePosition,
+        callback?: (item: VListItem) => any
+    ): VListItem[] {
+        if (this.items.length == 0) {
+            return [];
+        }
+
+        const listStartPos = new Position(this.items[0].getNode(), PositionType.Begin);
+        const listEndPos = new Position(
+            this.items[this.items.length - 1].getNode(),
+            PositionType.End
+        );
+
+        let startIndex = listStartPos.isAfter(start) ? 0 : -1;
+        let endIndex = this.items.length - (end.isAfter(listEndPos) ? 1 : 0);
+
+        this.items.forEach((item, index) => {
+            startIndex = item.contains(start.node) ? index : startIndex;
+            endIndex = item.contains(end.node) ? index : endIndex;
+        });
+
+        startIndex = endIndex < this.items.length ? Math.max(0, startIndex) : startIndex;
+        endIndex = startIndex >= 0 ? Math.min(this.items.length - 1, endIndex) : endIndex;
+
+        const result = startIndex <= endIndex ? this.items.slice(startIndex, endIndex + 1) : [];
+
+        if (callback) {
+            result.forEach(callback);
+            this.mergeOrphanNodesAfter(endIndex);
+        }
+
+        return result;
+    }
+
+    private populateItems(
+        list: HTMLOListElement | HTMLUListElement,
+        listTypes: (ListType.Ordered | ListType.Unordered)[] = []
+    ) {
+        const type = getListTypeFromNode(list);
+
+        for (let item = list.firstChild; !!item; item = item.nextSibling) {
+            const newListTypes = [...listTypes, type];
+
+            if (isListElement(item)) {
+                this.populateItems(item as HTMLOListElement | HTMLUListElement, newListTypes);
+            } else if (item.nodeType != NodeType.Text || item.nodeValue.trim() != '') {
+                this.items.push(new VListItem(item, ...newListTypes));
+            }
+        }
+    }
+}
+
+//Normalization
+
+// Step 1: Move all non-LI direct children under list into LI
+// e.g.
+// From: <ul><li>line 1</li>line 2</ul>
+// To:   <ul><li>line 1<div>line 2</div></li></ul>
+function moveChildNodesToLi(list: HTMLOListElement | HTMLUListElement) {
+    let currentItem: HTMLLIElement = null;
+
+    toArray(list.childNodes).forEach(child => {
+        if (getTagOfNode(child) == 'LI') {
+            currentItem = child as HTMLLIElement;
+        } else if (isListElement(child)) {
+            currentItem = null;
+        } else if (currentItem && !isNodeEmpty(child, true /*trimContent*/)) {
+            currentItem.appendChild(isBlockElement(child) ? child : wrap(child));
+        }
+    });
+}
+
+// Step 2: Move nested LI up to under list directly
+// e.g.
+// From: <ul><li>line 1<li>line 2</li>line 3</li></ul>
+// To:   <ul><li>line 1</li><li>line 2<div>line 3</div></li></ul>
+function moveLiToList(li: HTMLLIElement) {
+    while (!isListElement(li.parentNode)) {
+        splitParentNode(li, true /*splitBefore*/);
+        let furtherNodes: Node[] = toArray(li.parentNode.childNodes).slice(1);
+
+        if (furtherNodes.length > 0) {
+            if (!isBlockElement(furtherNodes[0])) {
+                furtherNodes = [wrap(furtherNodes)];
+            }
+            furtherNodes.forEach(node => li.appendChild(node));
+        }
+
+        unwrap(li.parentNode);
+    }
+}

--- a/packages/roosterjs-editor-dom/lib/list/VListItem.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VListItem.ts
@@ -1,0 +1,231 @@
+import contains from '../utils/contains';
+import getListTypeFromNode from './getListTypeFromNode';
+import getTagOfNode from '../utils/getTagOfNode';
+import isBlockElement from '../utils/isBlockElement';
+import toArray from '../utils/toArray';
+import unwrap from '../utils/unwrap';
+import wrap from '../utils/wrap';
+import { ListType } from 'roosterjs-editor-types';
+
+const orderListStyles = [null, 'lower-alpha', 'lower-roman'];
+
+/**
+ * @internal
+ * !!! Never directly create instance of this class. It should be created within VList class !!!
+ *
+ * Represent a list item.
+ *
+ * A list item is normally wrapped using a LI tag. But this class is only a logical item,
+ * it can be a LI tag, or another other type of node which means it is actually not a list item.
+ * That can happen after we do "outdent" on a 1-level list item, then it becomes not a list item.
+ * @internal
+ */
+export default class VListItem {
+    private listTypes: ListType[];
+
+    /**
+     * Construct a new instance of VListItem class
+     * @param node The DOM node for this item
+     * @param listTypes An array represnets list types of all parent and current level.
+     * Skip this parameter for a non-list item.
+     */
+    constructor(private node: Node, ...listTypes: (ListType.Ordered | ListType.Unordered)[]) {
+        if (!node) {
+            throw new Error('node must not be null');
+        }
+
+        // Always add a None list type in front of all other types to represent non-list scenario.
+        this.listTypes = [ListType.None, ...listTypes];
+    }
+
+    /**
+     * Get type of current list item
+     */
+    getListType(): ListType {
+        return this.listTypes[this.listTypes.length - 1];
+    }
+
+    /**
+     * Get DOM node of this list item
+     */
+    getNode(): Node {
+        return this.node;
+    }
+
+    /**
+     * Check if a given node is contained by this list item
+     * @param node The node to check
+     */
+    contains(node: Node): boolean {
+        return contains(this.node, node, true /*treateSameNodeAsContain*/);
+    }
+
+    /**
+     * Check if this item is an orphan item.
+     *
+     * Orphan item is not a normal case but could happen. It represents the DOM nodes directly under OL/UL tag
+     * and are in front of all other LI tags so that they cannot be merged into any existing LI tags.
+     *
+     * For example:
+     * ```html
+     * <ol>
+     *   <div>Orphan node</div>
+     *   <li>first item</li>
+     * </ol>
+     * ```
+     * Here the first DIV tag is an orphan item.
+     *
+     * There can also be nodes directly under OL/UL but between other LI tags in source HTML which should not be
+     * treated as orphan item because they can be merged into their previous LI tag. But when we build VList,
+     * those nodes will be merged into LI, so that ideally here they should not exist.
+     */
+    isOrphanItem(): boolean {
+        return getTagOfNode(this.node) != 'LI';
+    }
+
+    /**
+     * Check if the given item can be merged into this item.
+     * An item can be merged when it is an orphan item and its list type stack is exactly the same with current one.
+     * @param item The item to check
+     */
+    canMerge(item: VListItem): boolean {
+        if (!item?.isOrphanItem() || this.listTypes.length != item.listTypes.length) {
+            return false;
+        }
+
+        return this.listTypes.every((type, index) => item.listTypes[index] == type);
+    }
+
+    /**
+     * Merge items into this item.
+     * @example Before merge:
+     * ```html
+     * <ol>
+     *   <li>Current item</li>
+     *   <div>line 1</div>
+     *   <div>line 2</div>
+     * </ol>
+     * ```
+     * After merge then two DIVs into LI:
+     * ```html
+     * <ol>
+     *   <li>Current item
+     *     <div>line 1</div>
+     *     <div>line 2</div>
+     *   </li>
+     * </ol>
+     * ```
+     * @param items The items to merge
+     */
+    mergeItems(items: VListItem[]) {
+        const nodesToWrap = items?.map(item => item.node) || [];
+        const targetNodes = wrapIfNotBlockNode(
+            nodesToWrap,
+            true /*checkFirst*/,
+            false /*checkLast*/
+        );
+        targetNodes.forEach(node => this.node.appendChild(node));
+    }
+
+    /**
+     * Indent this item
+     * If this is not an list item, it will be no op
+     */
+    indent() {
+        const listType = this.getListType();
+        if (listType != ListType.None) {
+            this.listTypes.push(listType);
+        }
+    }
+
+    /**
+     * Outdent this item
+     * If this item is already not an list item, it will be no op
+     */
+    outdent() {
+        if (this.listTypes.length > 1) {
+            this.listTypes.pop();
+        }
+    }
+
+    /**
+     * Change list type of this item
+     * @param targetType The target list type to change to
+     */
+    changeListType(targetType: ListType) {
+        if (targetType == ListType.None) {
+            this.listTypes = [targetType];
+        } else {
+            this.outdent();
+            this.listTypes.push(targetType);
+        }
+    }
+
+    /**
+     * Write the change result back into DOM
+     * @param listStack current stack of list elements
+     */
+    writeBack(listStack: Node[]) {
+        const doc = this.node.ownerDocument;
+        let nextLevel = 1;
+
+        // 1. Determine list elements that we can reuse
+        // e.g.:
+        //    passed in listStack: Fragment > OL > UL > OL
+        //    local listTypes:     null     > OL > UL > UL > OL
+        //    then Fragment > OL > UL can be reused
+        for (; nextLevel < listStack.length; nextLevel++) {
+            if (getListTypeFromNode(listStack[nextLevel]) !== this.listTypes[nextLevel]) {
+                listStack.splice(nextLevel);
+                break;
+            }
+        }
+
+        // 2. Add new list elements
+        // e.g.:
+        //    passed in listStack: Fragment > OL > UL
+        //    local listTypes:     null     > OL > UL > UL > OL
+        //    then we need to create a UL and a OL tag
+        for (; nextLevel < this.listTypes.length; nextLevel++) {
+            const listType = this.listTypes[nextLevel];
+            const newList = doc.createElement(listType == ListType.Ordered ? 'ol' : 'ul');
+
+            if (listType == ListType.Ordered) {
+                newList.style.listStyle = orderListStyles[(nextLevel - 1) % orderListStyles.length];
+            }
+
+            listStack[listStack.length - 1].appendChild(newList);
+            listStack.push(newList);
+        }
+
+        // 3. Add current node into deepest list element
+        listStack[listStack.length - 1].appendChild(this.node);
+
+        // 4. If this is not a list item now, need to unwrap the LI node and do proper handling
+        if (this.listTypes.length <= 1) {
+            wrapIfNotBlockNode(
+                getTagOfNode(this.node) == 'LI' ? getChildrenAndUnwrap(this.node) : [this.node],
+                true /*checkFirst*/,
+                true /*checkLast*/
+            );
+        }
+    }
+}
+
+function wrapIfNotBlockNode(nodes: Node[], checkFirst: boolean, checkLast: boolean): Node[] {
+    if (
+        nodes.length > 0 &&
+        (!checkFirst || !isBlockElement(nodes[0])) &&
+        (!checkLast || !isBlockElement(nodes[nodes.length]))
+    ) {
+        nodes = [wrap(nodes)];
+    }
+
+    return nodes;
+}
+
+function getChildrenAndUnwrap(node: Node): Node[] {
+    const result = toArray(node.childNodes);
+    unwrap(node);
+    return result;
+}

--- a/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
+++ b/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
@@ -1,6 +1,6 @@
-import collapseNodesInRegion from '../region/collapseNodesInRegion';
 import findClosestElementAncestor from '../utils/findClosestElementAncestor';
 import getSelectedBlockElementsInRegion from '../region/getSelectedBlockElementsInRegion';
+import isNodeInRegion from '../region/isNodeInRegion';
 import shouldSkipNode from '../utils/shouldSkipNode';
 import VList from './VList';
 import { getLeafSibling } from '../utils/getLeafSibling';
@@ -53,8 +53,7 @@ export default function createVListFromRegion(
             tryIncludeSiblingNode(region, nodes, true /*isNext*/);
         }
 
-        nodes = collapseNodesInRegion(region, nodes);
-        nodes = nodes.filter(node => !shouldSkipNode(node));
+        nodes = nodes.filter(node => !shouldSkipNode(node, true /*ignoreSpace*/));
     }
 
     let vList: VList = null;
@@ -79,10 +78,9 @@ export default function createVListFromRegion(
 
 function tryIncludeSiblingNode(region: Region, nodes: Node[], isNext: boolean) {
     let node = nodes[isNext ? nodes.length - 1 : 0];
-    node = getLeafSibling(region.rootNode, node, isNext);
+    node = getLeafSibling(region.rootNode, node, isNext, region.skipTags, true /*ignoreSpace*/);
     node = getRootListNode(region, node);
-
-    if (isListElement(node)) {
+    if (isNodeInRegion(region, node) && isListElement(node)) {
         if (isNext) {
             nodes.push(node);
         } else {

--- a/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
+++ b/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
@@ -1,0 +1,123 @@
+import collapseNodesInRegion from '../region/collapseNodesInRegion';
+import findClosestElementAncestor from '../utils/findClosestElementAncestor';
+import getSelectedBlockElementsInRegion from '../region/getSelectedBlockElementsInRegion';
+import shouldSkipNode from '../utils/shouldSkipNode';
+import VList from './VList';
+import { getLeafSibling } from '../utils/getLeafSibling';
+import { isListElement } from './getListTypeFromNode';
+import { ListType, Region } from 'roosterjs-editor-types';
+
+type ListElement = HTMLOListElement | HTMLUListElement;
+const ListSelector = 'ol,ul';
+
+/**
+ * @internal
+ * @param region The region to get VList from
+ * @param includeSiblingLists True to also try get lists before and after the selection and merge them together,
+ * false to only include the list for the selected blocks
+ * @param startNode (Optional) When specified, try get VList which will contain this node.
+ * If not specified, get VList from selection of this region
+ */
+export default function createVListFromRegion(
+    region: Region,
+    includeSiblingLists?: boolean,
+    startNode?: Node
+): VList {
+    if (!region) {
+        return null;
+    }
+
+    let nodes: Node[] = [];
+
+    if (startNode) {
+        const list = getRootListNode(region, startNode);
+        if (list) {
+            nodes.push(list);
+        }
+    } else {
+        const blocks = getSelectedBlockElementsInRegion(region);
+        blocks.forEach(block => {
+            const list = getRootListNode(region, block.getStartNode());
+
+            if (list) {
+                if (nodes[nodes.length - 1] != list) {
+                    nodes.push(list);
+                }
+            } else {
+                nodes.push(block.collapseToSingleElement());
+            }
+        });
+
+        if (includeSiblingLists) {
+            tryIncludeSiblingNode(region, nodes, false /*isNext*/);
+            tryIncludeSiblingNode(region, nodes, true /*isNext*/);
+        }
+
+        nodes = collapseNodesInRegion(region, nodes);
+        nodes = nodes.filter(node => !shouldSkipNode(node));
+    }
+
+    let vList: VList = null;
+
+    if (nodes.length > 0) {
+        const firstNode = nodes.shift();
+        vList = isListElement(firstNode)
+            ? new VList(firstNode)
+            : createVListFromItemNode(firstNode);
+
+        nodes.forEach(node => {
+            if (isListElement(node)) {
+                vList.mergeVList(new VList(node));
+            } else {
+                vList.appendItem(node, ListType.None);
+            }
+        });
+    }
+
+    return vList;
+}
+
+function tryIncludeSiblingNode(region: Region, nodes: Node[], isNext: boolean) {
+    let node = nodes[isNext ? nodes.length - 1 : 0];
+    node = getLeafSibling(region.rootNode, node, isNext);
+    node = getRootListNode(region, node);
+
+    if (isListElement(node)) {
+        if (isNext) {
+            nodes.push(node);
+        } else {
+            nodes.unshift(node);
+        }
+    }
+}
+
+function getRootListNode(region: Region, node: Node): ListElement {
+    let list = findClosestElementAncestor(node, region.rootNode, ListSelector) as ListElement;
+
+    if (list) {
+        let ancestor: ListElement;
+        while (
+            (ancestor = findClosestElementAncestor(
+                list.parentNode,
+                region.rootNode,
+                ListSelector
+            ) as ListElement)
+        ) {
+            list = ancestor;
+        }
+    }
+
+    return list;
+}
+
+function createVListFromItemNode(node: Node): VList {
+    // Create a temporary OL root element for this list.
+    const listNode = node.ownerDocument.createElement('ol'); // Either OL or UL is ok here
+    node.parentNode?.insertBefore(listNode, node);
+
+    // Create the VList and append items
+    const vList = new VList(listNode);
+    vList.appendItem(node, ListType.None);
+
+    return vList;
+}

--- a/packages/roosterjs-editor-dom/lib/list/getListTypeFromNode.ts
+++ b/packages/roosterjs-editor-dom/lib/list/getListTypeFromNode.ts
@@ -1,0 +1,37 @@
+import getTagOfNode from '../utils/getTagOfNode';
+import { ListType } from 'roosterjs-editor-types';
+
+/**
+ * @internal
+ * Get list type from a list element. The result will be either Ordered or Unordered ListType
+ * @param listElement the element to get list type from
+ */
+export default function getListTypeFromNode(
+    listElement: HTMLOListElement | HTMLUListElement
+): ListType.Ordered | ListType.Unordered;
+
+/**
+ * Get list type from a DOM node. It is possible to return ListType.None
+ * @param node the node to get list type from
+ */
+export default function getListTypeFromNode(node: Node): ListType;
+
+export default function getListTypeFromNode(node: Node): ListType {
+    switch (getTagOfNode(node)) {
+        case 'OL':
+            return ListType.Ordered;
+        case 'UL':
+            return ListType.Unordered;
+        default:
+            return ListType.None;
+    }
+}
+
+/**
+ * @internal
+ * Check if the given DOM node is a list element (OL or UL)
+ * @param node The node to check
+ */
+export function isListElement(node: Node): node is HTMLUListElement | HTMLOListElement {
+    return getListTypeFromNode(node) != ListType.None;
+}

--- a/packages/roosterjs-editor-dom/lib/test/list/VListItemTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/list/VListItemTest.ts
@@ -1,0 +1,402 @@
+import VListItem from '../../list/VListItem';
+import { ListType } from 'roosterjs-editor-types';
+
+describe('VListItem.getListType', () => {
+    it('set ListType to None', () => {
+        const item = new VListItem(document.createTextNode('test'));
+        expect(item.getListType()).toBe(ListType.None);
+    });
+
+    it('set ListType to OL', () => {
+        const item = new VListItem(document.createTextNode('test'), ListType.Ordered);
+        expect(item.getListType()).toBe(ListType.Ordered);
+    });
+
+    it('set ListType to OL=>UL', () => {
+        const item = new VListItem(
+            document.createTextNode('test'),
+            ListType.Ordered,
+            ListType.Unordered
+        );
+        expect(item.getListType()).toBe(ListType.Unordered);
+    });
+});
+
+describe('VListItem.getNode', () => {
+    it('set node to a valid node', () => {
+        const node = document.createTextNode('test');
+        const item = new VListItem(node);
+        expect(item.getNode()).toBe(node);
+    });
+
+    it('set ListType to null', () => {
+        expect(() => new VListItem(null)).toThrow();
+    });
+});
+
+describe('VListItem.contains', () => {
+    it('check for same node', () => {
+        const node = document.createTextNode('test');
+        const item = new VListItem(node);
+        expect(item.contains(node)).toBeTruthy();
+    });
+
+    it('check for a contained node', () => {
+        const node = document.createTextNode('test');
+        const div = document.createElement('div');
+        div.appendChild(node);
+        const item = new VListItem(div);
+        expect(item.contains(node)).toBeTruthy();
+    });
+
+    it('check for a not contained node', () => {
+        const node = document.createTextNode('test');
+        const div = document.createElement('div');
+        const item = new VListItem(div);
+        expect(item.contains(node)).toBeFalsy();
+    });
+});
+
+describe('VListItem.isOrphanItem', () => {
+    it('check for non-orphan item', () => {
+        const li = document.createElement('li');
+        const item = new VListItem(li);
+        expect(item.isOrphanItem()).toBeFalsy();
+    });
+
+    it('check for orphan item', () => {
+        const div = document.createElement('div');
+        const item = new VListItem(div);
+        expect(item.isOrphanItem()).toBeTruthy();
+    });
+});
+
+describe('VListItem.canMerge', () => {
+    it('check for null', () => {
+        const thisItem = new VListItem(document.createElement('li'));
+        expect(thisItem.canMerge(null)).toBeFalsy();
+    });
+
+    it('check for non-orphan item', () => {
+        const li = document.createElement('li');
+        const targetItem = new VListItem(li);
+        const thisItem = new VListItem(document.createElement('li'));
+        expect(thisItem.canMerge(targetItem)).toBeFalsy();
+    });
+
+    it('check for item with different list depth', () => {
+        const li = document.createElement('div');
+        const targetItem = new VListItem(li, ListType.Ordered);
+        const thisItem = new VListItem(
+            document.createElement('li'),
+            ListType.Ordered,
+            ListType.Ordered
+        );
+        expect(thisItem.canMerge(targetItem)).toBeFalsy();
+    });
+
+    it('check for item with different list type', () => {
+        const li = document.createElement('div');
+        const targetItem = new VListItem(li, ListType.Ordered, ListType.Unordered);
+        const thisItem = new VListItem(
+            document.createElement('li'),
+            ListType.Ordered,
+            ListType.Ordered
+        );
+        expect(thisItem.canMerge(targetItem)).toBeFalsy();
+    });
+
+    it('check for item that can be merged, case 1: depth = 0', () => {
+        const li = document.createElement('div');
+        const targetItem = new VListItem(li);
+        const thisItem = new VListItem(document.createElement('li'));
+        expect(thisItem.canMerge(targetItem)).toBeTruthy();
+    });
+
+    it('check for item that can be merged, case 2: depth = 1', () => {
+        const li = document.createElement('div');
+        const targetItem = new VListItem(li, ListType.Ordered);
+        const thisItem = new VListItem(document.createElement('li'), ListType.Ordered);
+        expect(thisItem.canMerge(targetItem)).toBeTruthy();
+    });
+
+    it('check for item that can be merged, case 3: depth = 2 with different list types', () => {
+        const li = document.createElement('div');
+        const targetItem = new VListItem(li, ListType.Ordered, ListType.Unordered);
+        const thisItem = new VListItem(
+            document.createElement('li'),
+            ListType.Ordered,
+            ListType.Unordered
+        );
+        expect(thisItem.canMerge(targetItem)).toBeTruthy();
+    });
+});
+
+describe('VListItem.mergeItems', () => {
+    function runTest(targetTags: string[], expectedHtml: string) {
+        const li = document.createElement('li');
+        const thisItem = new VListItem(li);
+        const targetItems = targetTags
+            ? targetTags.map(tag => new VListItem(document.createElement(tag)))
+            : null;
+        thisItem.mergeItems(targetItems);
+        expect(li.innerHTML).toBe(expectedHtml);
+    }
+
+    it('null input', () => {
+        runTest(null, '');
+    });
+
+    it('empty aray input', () => {
+        runTest([], '');
+    });
+
+    it('Single item, block element input', () => {
+        runTest(['div'], '<div></div>');
+    });
+
+    it('Single item, inline element input', () => {
+        runTest(['span'], '<div><span></span></div>');
+    });
+
+    it('Multiple items, start with block, end with block', () => {
+        runTest(['div', 'span', 'div'], '<div></div><span></span><div></div>');
+    });
+
+    it('Multiple items, start with block, end with inline', () => {
+        runTest(['div', 'span', 'span'], '<div></div><span></span><span></span>');
+    });
+
+    it('Multiple items, start with inline, end with inline', () => {
+        runTest(['span', 'div', 'span'], '<div><span></span><div></div><span></span></div>');
+    });
+
+    it('Multiple items, start with inline, end with block', () => {
+        runTest(['span', 'div', 'div'], '<div><span></span><div></div><div></div></div>');
+    });
+});
+
+describe('VListItem.indent', () => {
+    function runTest(
+        sourceListTypes: (ListType.Ordered | ListType.Unordered)[],
+        expectedListTypes: ListType[]
+    ) {
+        const thisItem = new VListItem(document.createElement('li'), ...sourceListTypes);
+        thisItem.indent();
+        const listTypes = (<any>thisItem).listTypes;
+        expect(listTypes).toEqual(expectedListTypes);
+    }
+
+    it('Not a list, indent is no-op', () => {
+        runTest([], [ListType.None]);
+    });
+
+    it('OL', () => {
+        runTest([ListType.Ordered], [ListType.None, ListType.Ordered, ListType.Ordered]);
+    });
+
+    it('UL', () => {
+        runTest([ListType.Unordered], [ListType.None, ListType.Unordered, ListType.Unordered]);
+    });
+
+    it('OL=>UL', () => {
+        runTest(
+            [ListType.Ordered, ListType.Unordered],
+            [ListType.None, ListType.Ordered, ListType.Unordered, ListType.Unordered]
+        );
+    });
+});
+
+describe('VListItem.outdent', () => {
+    function runTest(
+        sourceListTypes: (ListType.Ordered | ListType.Unordered)[],
+        expectedListTypes: ListType[]
+    ) {
+        const thisItem = new VListItem(document.createElement('li'), ...sourceListTypes);
+        thisItem.outdent();
+        const listTypes = (<any>thisItem).listTypes;
+        expect(listTypes).toEqual(expectedListTypes);
+    }
+
+    it('Not a list, indent is no-op', () => {
+        runTest([], [ListType.None]);
+    });
+
+    it('OL', () => {
+        runTest([ListType.Ordered], [ListType.None]);
+    });
+
+    it('UL', () => {
+        runTest([ListType.Unordered], [ListType.None]);
+    });
+
+    it('OL=>UL', () => {
+        runTest([ListType.Ordered, ListType.Unordered], [ListType.None, ListType.Ordered]);
+    });
+});
+
+describe('VList.changeListType', () => {
+    function runTest(
+        sourceListTypes: (ListType.Ordered | ListType.Unordered)[],
+        targetType: ListType,
+        expectedListTypes: ListType[]
+    ) {
+        const thisItem = new VListItem(document.createElement('li'), ...sourceListTypes);
+        thisItem.changeListType(targetType);
+        const listTypes = (<any>thisItem).listTypes;
+        expect(listTypes).toEqual(expectedListTypes);
+    }
+
+    it('Not a list, change to not a list', () => {
+        runTest([], ListType.None, [ListType.None]);
+    });
+
+    it('Not a list, change to OL', () => {
+        runTest([], ListType.Ordered, [ListType.None, ListType.Ordered]);
+    });
+
+    it('Not a list, change to UL', () => {
+        runTest([], ListType.Unordered, [ListType.None, ListType.Unordered]);
+    });
+
+    it('OL, change to not list', () => {
+        runTest([ListType.Ordered], ListType.None, [ListType.None]);
+    });
+
+    it('OL, change to OL', () => {
+        runTest([ListType.Ordered], ListType.Ordered, [ListType.None, ListType.Ordered]);
+    });
+
+    it('OL, change to UL', () => {
+        runTest([ListType.Ordered], ListType.Unordered, [ListType.None, ListType.Unordered]);
+    });
+
+    it('UL, change to not list', () => {
+        runTest([ListType.Unordered], ListType.None, [ListType.None]);
+    });
+
+    it('UL, change to OL', () => {
+        runTest([ListType.Unordered], ListType.Ordered, [ListType.None, ListType.Ordered]);
+    });
+
+    it('UL, change to UL', () => {
+        runTest([ListType.Unordered], ListType.Unordered, [ListType.None, ListType.Unordered]);
+    });
+
+    it('OL=>UL, change to None', () => {
+        runTest([ListType.Ordered, ListType.Unordered], ListType.None, [ListType.None]);
+    });
+
+    it('OL=>UL, change to OL', () => {
+        runTest([ListType.Ordered, ListType.Unordered], ListType.Ordered, [
+            ListType.None,
+            ListType.Ordered,
+            ListType.Ordered,
+        ]);
+    });
+
+    it('OL=>UL, change to UL', () => {
+        runTest([ListType.Ordered, ListType.Unordered], ListType.Unordered, [
+            ListType.None,
+            ListType.Ordered,
+            ListType.Unordered,
+        ]);
+    });
+});
+
+describe('VListItem.writeBack', () => {
+    function runTest(
+        listStackTags: string[],
+        listTypes: (ListType.Ordered | ListType.Unordered)[],
+        expectedHtml: string
+    ) {
+        // Arrange
+        const listStack = listStackTags.map(tag => document.createElement(tag));
+        for (let i = 1; i < listStack.length; i++) {
+            listStack[i - 1].appendChild(listStack[i]);
+        }
+
+        const li = document.createElement('li');
+        li.appendChild(document.createElement('div'));
+        const thisItem = new VListItem(li, ...listTypes);
+
+        // Act
+        thisItem.writeBack(listStack);
+
+        // Assert
+        expect(listStack.length).toBe(listTypes.length + 1);
+        expect(listStack[0].innerHTML).toBe(expectedHtml);
+    }
+
+    it('not a list, no LI', () => {
+        runTest(['div'], [], '<div></div>');
+    });
+
+    it('not a list, has LI', () => {
+        runTest(['div'], [], '<div></div>');
+    });
+
+    it('pass in no list, this item is OL, has LI', () => {
+        runTest(['div'], [ListType.Ordered], '<ol><li><div></div></li></ol>');
+    });
+
+    it('pass in no list, this item is UL, has LI', () => {
+        runTest(['div'], [ListType.Unordered], '<ul><li><div></div></li></ul>');
+    });
+
+    it('pass in no list, this item is OL=>OL, has LI', () => {
+        runTest(
+            ['div'],
+            [ListType.Ordered, ListType.Ordered],
+            '<ol><ol style="list-style: lower-alpha;"><li><div></div></li></ol></ol>'
+        );
+    });
+
+    it('pass in no list, this item is OL=>OL=>OL=>OL, has LI', () => {
+        runTest(
+            ['div'],
+            [ListType.Ordered, ListType.Ordered, ListType.Ordered, ListType.Ordered],
+            '<ol><ol style="list-style: lower-alpha;"><ol style="list-style: lower-roman;"><ol><li><div></div></li></ol></ol></ol></ol>'
+        );
+    });
+
+    it('pass in OL, this item is OL, has LI', () => {
+        runTest(['div', 'ol'], [ListType.Ordered], '<ol><li><div></div></li></ol>');
+    });
+
+    it('pass in OL, this item is UL, has LI', () => {
+        runTest(['div', 'ol'], [ListType.Unordered], '<ol></ol><ul><li><div></div></li></ul>');
+    });
+
+    it('pass in OL, this item is OL=>UL, has LI', () => {
+        runTest(
+            ['div', 'ol'],
+            [ListType.Ordered, ListType.Unordered],
+            '<ol><ul><li><div></div></li></ul></ol>'
+        );
+    });
+
+    it('pass in OL=>OL, this item is OL=>UL, has LI', () => {
+        runTest(
+            ['div', 'ol', 'ol'],
+            [ListType.Ordered, ListType.Unordered],
+            '<ol><ol></ol><ul><li><div></div></li></ul></ol>'
+        );
+    });
+
+    it('pass in OL=>UL, this item is UL=>OL, has LI', () => {
+        runTest(
+            ['div', 'ol', 'ul'],
+            [ListType.Unordered, ListType.Ordered],
+            '<ol><ul></ul></ol><ul><ol style="list-style: lower-alpha;"><li><div></div></li></ol></ul>'
+        );
+    });
+
+    it('pass in OL=>OL, this item is OL, has LI', () => {
+        runTest(['div', 'ol', 'ol'], [ListType.Ordered], '<ol><ol></ol><li><div></div></li></ol>');
+    });
+
+    it('pass in OL=>OL, this item is not list, has LI', () => {
+        runTest(['div', 'ol', 'ol'], [], '<ol><ol></ol></ol><div></div>');
+    });
+});

--- a/packages/roosterjs-editor-dom/lib/test/list/VListTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/list/VListTest.ts
@@ -1,0 +1,1155 @@
+import * as DomTestHelper from '../DomTestHelper';
+import fromHtml from '../../utils/fromHtml';
+import Position from '../../selection/Position';
+import VList from '../../list/VList';
+import VListItem from '../../list/VListItem';
+import { Indentation, ListType, PositionType } from 'roosterjs-editor-types';
+
+describe('VList.ctor', () => {
+    const testId = 'VList_ctor';
+    const ListRoot = 'listRoot';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    it('null input', () => {
+        expect(() => new VList(null)).toThrow();
+    });
+
+    function runTest(sourceHtml: string, expected: { listTypes: ListType[]; outerHTML: string }[]) {
+        DomTestHelper.createElementFromContent(testId, sourceHtml);
+        const listRoot = document.getElementById(ListRoot) as HTMLOListElement | HTMLUListElement;
+        const vList = new VList(listRoot);
+        const items = (<any>vList).items as VListItem[];
+        const itemsMap = items.map(item => ({
+            listTypes: (<any>item).listTypes as ListType[],
+            outerHTML: (<HTMLElement>item.getNode()).outerHTML,
+        }));
+        expect(itemsMap).toEqual(expected);
+    }
+
+    it('single item OL', () => {
+        runTest(`<ol id="${ListRoot}"><li>test</li></ol>`, [
+            { listTypes: [ListType.None, ListType.Ordered], outerHTML: '<li>test</li>' },
+        ]);
+    });
+
+    it('OL including empty text node', () => {
+        runTest(`<ol id="${ListRoot}">\n \n<li>line1</li> \n <li>line2</li>  </ol>`, [
+            { listTypes: [ListType.None, ListType.Ordered], outerHTML: '<li>line1</li>' },
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line2</li>',
+            },
+        ]);
+    });
+
+    it('nested UL in OL', () => {
+        runTest(`<ol id="${ListRoot}"><li>line1</li><ul><li>line2</li></ul></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line1</li>',
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                outerHTML: '<li>line2</li>',
+            },
+        ]);
+    });
+
+    it('orphan item that will be merged', () => {
+        runTest(`<ol id="${ListRoot}"><li>line1</li><div>line2</div></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line1<div>line2</div></li>',
+            },
+        ]);
+    });
+
+    it('multiple orphan items that will be merged', () => {
+        runTest(`<ol id="${ListRoot}"><li>line1</li><div>line2</div><div>line3</div></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line1<div>line2</div><div>line3</div></li>',
+            },
+        ]);
+    });
+
+    it('inline orphan item that will be merged', () => {
+        runTest(`<ol id="${ListRoot}"><li>line1</li><span>line2</span></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line1<div><span>line2</span></div></li>',
+            },
+        ]);
+    });
+
+    it('orphan items is in front of list', () => {
+        runTest(`<ol id="${ListRoot}"><div>line1</div><li>line2</li><div>line3</div></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<div>line1</div>',
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line2<div>line3</div></li>',
+            },
+        ]);
+    });
+
+    it('nested list contains orphan items', () => {
+        runTest(
+            `<ol id="${ListRoot}">` +
+                '<li>line0</li>' +
+                '<ul>' +
+                '<div>line1</div>' +
+                '<li>line2</li>' +
+                '<div>line3</div>' +
+                '<li>line4</li>' +
+                '</ul></ol>',
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line0</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<div>line1</div>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line2<div>line3</div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line4</li>',
+                },
+            ]
+        );
+    });
+
+    it('move nested li out', () => {
+        runTest(`<ol id="${ListRoot}">` + '<li>line1<li>line2</li>line3</li>' + '</ol>', [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line1</li>',
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line2<div>line3</div></li>',
+            },
+        ]);
+    });
+
+    it('move nested li in orphan item out', () => {
+        runTest(
+            `<ol id="${ListRoot}">` +
+                '<li>line1</li>' +
+                '<div>line2<li>line3</li>line4</div>' +
+                '</ol>',
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1<div>line2</div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3<div>line4</div></li>',
+                },
+            ]
+        );
+    });
+
+    it('move deeper nested li in orphan item out', () => {
+        runTest(
+            `<ol id="${ListRoot}">` +
+                '<li>line1</li>' +
+                '<div>line2<div>line3<li>line4<div>line5' +
+                '<li>line6</li>' +
+                'line7</div>line8</li>line9</div>line10</div>' +
+                '</ol>',
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1<div>line2<div>line3</div></div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line4<div>line5</div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML:
+                        '<li>line6<div>line7<div>line8line9</div><div>line10</div></div></li>',
+                },
+            ]
+        );
+    });
+
+    it('disconnected nested list', () => {
+        runTest(
+            `<ol id="${ListRoot}">` +
+                '<li>line1<div><ul><li>line2</li><li>line3</li></ul></div>line4</li>' +
+                '<li>line5</li>' +
+                '</ol>',
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML:
+                        '<li>line1<div><ul><li>line2</li><li>line3</li></ul></div>line4</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line5</li>',
+                },
+            ]
+        );
+    });
+});
+
+describe('VList.contains', () => {
+    const testId = 'VList_contains';
+    const ListRoot = 'listRoot';
+    const TestNode = 'testNode';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    function runTest(sourceHtml: string, expected: boolean) {
+        DomTestHelper.createElementFromContent(testId, sourceHtml);
+        const listRoot = document.getElementById(ListRoot) as HTMLOListElement | HTMLUListElement;
+        const vList = new VList(listRoot);
+        const node = document.getElementById(TestNode);
+        const result = vList.contains(node);
+        expect(result).toBe(expected);
+    }
+
+    it('null node', () => {
+        runTest(`<ol id="${ListRoot}"></ol>`, false);
+    });
+
+    it('contains child node', () => {
+        runTest(
+            `<ol id="${ListRoot}"><li>line1</li><li><div id="${TestNode}">line2</div></li></ol>`,
+            true
+        );
+    });
+
+    it('contains li node', () => {
+        runTest(`<ol id="${ListRoot}"><li>line1</li><li id="${TestNode}">line2</li></ol>`, true);
+    });
+
+    it('contains orphan node', () => {
+        runTest(`<ol id="${ListRoot}"><div id="${TestNode}">line1</div><li>line2</li></ol>`, true);
+    });
+
+    it('Not contain a node ', () => {
+        runTest(`<ol id="${ListRoot}"><li>line1</li></ol><div id="${TestNode}">line2</div>`, false);
+    });
+});
+
+describe('VList.getFirstOrLastNode', () => {
+    const testId = 'VList_getFirstOrLastNode';
+    const ListRoot = 'listRoot';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    function runTest(sourceHtml: string, firstInnerHTML: string, lastInnerHTML: string) {
+        DomTestHelper.createElementFromContent(testId, sourceHtml);
+        const listRoot = document.getElementById(ListRoot) as HTMLOListElement | HTMLUListElement;
+        const vList = new VList(listRoot);
+        const first = vList.getFirstOrLastNode(false) as HTMLElement;
+        const last = vList.getFirstOrLastNode(true) as HTMLElement;
+        expect(first?.innerHTML).toBe(firstInnerHTML);
+        expect(last?.innerHTML).toBe(lastInnerHTML);
+    }
+
+    it('empty list', () => {
+        runTest(`<ol id="${ListRoot}"></ol>`, undefined, undefined);
+    });
+
+    it('single item list', () => {
+        runTest(`<ol id="${ListRoot}"><li>line1</li></ol>`, 'line1', 'line1');
+    });
+
+    it('multiple items list', () => {
+        runTest(
+            `<ol id="${ListRoot}"><li>line1</li><li>line2</li><li>line3</li></ol>`,
+            'line1',
+            'line3'
+        );
+    });
+
+    it('list with orphan items', () => {
+        runTest(
+            `<ol id="${ListRoot}"><div>line1</div><li>line2</li><div>line3</div></ol>`,
+            'line1',
+            'line2<div>line3</div>'
+        );
+    });
+});
+
+describe('VList.writeBack', () => {
+    const testId = 'VList_writeBack';
+    const ListRoot = 'listRoot';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    function runTest(
+        newItems: { html: string; listTypes: (ListType.Ordered | ListType.Unordered)[] }[],
+        expectedHtml: string
+    ) {
+        const div = DomTestHelper.createElementFromContent(testId, `<ol id="${ListRoot}"></ol>`);
+        const list = document.getElementById(ListRoot) as HTMLOListElement;
+        const vList = new VList(list);
+        const items = (<any>vList).items as VListItem[];
+
+        newItems.forEach(newItem =>
+            items.push(new VListItem(fromHtml(newItem.html, document)[0], ...newItem.listTypes))
+        );
+
+        vList.writeBack();
+        expect(div.innerHTML).toBe(expectedHtml);
+
+        // Write again on the same VList should throw
+        expect(() => vList.writeBack()).toThrow();
+    }
+
+    it('simple list, write back directly', () => {
+        runTest(
+            [
+                {
+                    html: '<li>test</li>',
+                    listTypes: [ListType.Ordered],
+                },
+            ],
+            '<ol><li>test</li></ol>'
+        );
+    });
+
+    it('Write back with multiple items', () => {
+        runTest(
+            [
+                {
+                    html: '<li>item1</li>',
+                    listTypes: [ListType.Ordered],
+                },
+                {
+                    html: '<li>item2</li>',
+                    listTypes: [ListType.Ordered],
+                },
+            ],
+            '<ol><li>item1</li><li>item2</li></ol>'
+        );
+    });
+
+    it('Write back with multiple items with different types', () => {
+        runTest(
+            [
+                {
+                    html: '<li>item1</li>',
+                    listTypes: [ListType.Unordered],
+                },
+                {
+                    html: '<li>item2</li>',
+                    listTypes: [ListType.Ordered],
+                },
+            ],
+            '<ul><li>item1</li></ul><ol><li>item2</li></ol>'
+        );
+    });
+
+    it('Write back with multiple items with different depth', () => {
+        runTest(
+            [
+                {
+                    html: '<li>item1</li>',
+                    listTypes: [ListType.Unordered, ListType.Ordered],
+                },
+                {
+                    html: '<li>item2</li>',
+                    listTypes: [ListType.Unordered],
+                },
+                {
+                    html: '<li>item3</li>',
+                    listTypes: [ListType.Ordered],
+                },
+            ],
+            '<ul><ol style="list-style: lower-alpha;"><li>item1</li></ol><li>item2</li></ul><ol><li>item3</li></ol>'
+        );
+    });
+
+    it('Write back with multiple items with orphan item', () => {
+        runTest(
+            [
+                {
+                    html: '<div>item1</div>',
+                    listTypes: [ListType.Unordered],
+                },
+                {
+                    html: '<li>item2</li>',
+                    listTypes: [ListType.Unordered],
+                },
+                {
+                    html: '<li>item3</li>',
+                    listTypes: [ListType.Ordered],
+                },
+            ],
+            '<ul><div>item1</div><li>item2</li></ul><ol><li>item3</li></ol>'
+        );
+    });
+
+    it('Write back with multiple items with orphan item', () => {
+        runTest(
+            [
+                {
+                    html: '<div>item1</div>',
+                    listTypes: [ListType.Unordered],
+                },
+                {
+                    html: '<li>item2</li>',
+                    listTypes: [ListType.Unordered],
+                },
+                {
+                    html: '<li>item3</li>',
+                    listTypes: [ListType.Ordered],
+                },
+            ],
+            '<ul><div>item1</div><li>item2</li></ul><ol><li>item3</li></ol>'
+        );
+    });
+
+    it('Write back with non-list item', () => {
+        runTest(
+            [
+                {
+                    html: '<li>item1</li>',
+                    listTypes: [ListType.Unordered],
+                },
+                {
+                    html: '<li>item2</li>',
+                    listTypes: [],
+                },
+                {
+                    html: '<li>item3</li>',
+                    listTypes: [ListType.Ordered],
+                },
+            ],
+            '<ul><li>item1</li></ul><div>item2</div><ol><li>item3</li></ol>'
+        );
+    });
+});
+
+describe('VList.setIndentation', () => {
+    const testId = 'VList_setIndentation';
+    const ListRoot = 'listRoot';
+    const FocusNode = 'focus';
+    const FocusNode1 = 'focus1';
+    const FocusNode2 = 'focus2';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    function runTest(
+        source: string,
+        increaseExpected: { listTypes: ListType[]; outerHTML: string }[],
+        decreaseExpected: { listTypes: ListType[]; outerHTML: string }[],
+        callTimes: number = 1
+    ) {
+        [Indentation.Increase, Indentation.Decrease].forEach(indentation => {
+            // Arrange
+            DomTestHelper.createElementFromContent(testId, source);
+            const list = document.getElementById(ListRoot) as HTMLOListElement;
+            const focus = document.getElementById(FocusNode);
+            const focus1 = document.getElementById(FocusNode1);
+            const focus2 = document.getElementById(FocusNode2);
+
+            if (!list) {
+                throw new Error('No root node');
+            }
+            if (!focus && (!focus1 || !focus2)) {
+                throw new Error('No focus node');
+            }
+
+            const vList = new VList(list);
+            const start = new Position(focus || focus1, PositionType.Begin);
+            const end = new Position(focus || focus2, PositionType.End);
+
+            // Act
+            for (let i = 0; i < callTimes; i++) {
+                vList.setIndentation(start, end, indentation);
+            }
+
+            // Assert
+            const items = (<any>vList).items as VListItem[];
+            const itemsMap = items.map(item => ({
+                listTypes: (<any>item).listTypes as ListType[],
+                outerHTML: (<HTMLElement>item.getNode()).outerHTML,
+            }));
+
+            expect(itemsMap).toEqual(
+                indentation == Indentation.Increase ? increaseExpected : decreaseExpected,
+                indentation == Indentation.Increase ? 'Indent' : 'Outdent'
+            );
+            DomTestHelper.removeElement(testId);
+        });
+    }
+
+    it('empty list', () => {
+        runTest(`<ol id="${ListRoot}"></ol><div id="${FocusNode}"></div>`, [], []);
+    });
+
+    it('single item list', () => {
+        runTest(
+            `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode}">test</li>`,
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode}">test</li>`,
+                },
+            ]
+        );
+    });
+
+    it('deep list', () => {
+        runTest(
+            `<ol id="${ListRoot}"><li id="${FocusNode1}">line1</li><ul><li id="${FocusNode2}">line2</li></ul></ol>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode1}">line1</li>`,
+                },
+                {
+                    listTypes: [
+                        ListType.None,
+                        ListType.Ordered,
+                        ListType.Unordered,
+                        ListType.Unordered,
+                    ],
+                    outerHTML: `<li id="${FocusNode2}">line2</li>`,
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode1}">line1</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode2}">line2</li>`,
+                },
+            ]
+        );
+    });
+
+    it('partially selected list', () => {
+        runTest(
+            `<ol id="${ListRoot}">` +
+                '<li>line1</li>' +
+                `<li id="${FocusNode1}">line2</li>` +
+                '<ul>' +
+                `<li id="${FocusNode2}">line3</li>` +
+                '<li>line4</li>' +
+                '</ul>' +
+                '</ol>',
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode1}">line2</li>`,
+                },
+                {
+                    listTypes: [
+                        ListType.None,
+                        ListType.Ordered,
+                        ListType.Unordered,
+                        ListType.Unordered,
+                    ],
+                    outerHTML: `<li id="${FocusNode2}">line3</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line4</li>',
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode1}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode2}">line3</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line4</li>',
+                },
+            ]
+        );
+    });
+
+    it('partially selected list, call twice', () => {
+        runTest(
+            `<ol id="${ListRoot}">` +
+                '<li>line1</li>' +
+                `<li id="${FocusNode1}">line2</li>` +
+                '<ul>' +
+                `<li id="${FocusNode2}">line3</li>` +
+                '<li>line4</li>' +
+                '</ul>' +
+                '</ol>',
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [
+                        ListType.None,
+                        ListType.Ordered,
+                        ListType.Ordered,
+                        ListType.Ordered,
+                    ],
+                    outerHTML: `<li id="${FocusNode1}">line2</li>`,
+                },
+                {
+                    listTypes: [
+                        ListType.None,
+                        ListType.Ordered,
+                        ListType.Unordered,
+                        ListType.Unordered,
+                        ListType.Unordered,
+                    ],
+                    outerHTML: `<li id="${FocusNode2}">line3</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line4</li>',
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode1}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode2}">line3</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line4</li>',
+                },
+            ],
+            2
+        );
+    });
+});
+
+describe('VList.changeListType', () => {
+    const testId = 'VList_changeListType';
+    const ListRoot = 'listRoot';
+    const FocusNode = 'focus';
+    const FocusNode1 = 'focus1';
+    const FocusNode2 = 'focus2';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    function runTest(
+        source: string,
+        noneExpected: { listTypes: ListType[]; outerHTML: string }[],
+        olExpected: { listTypes: ListType[]; outerHTML: string }[],
+        ulExpected: { listTypes: ListType[]; outerHTML: string }[]
+    ) {
+        [ListType.None, ListType.Ordered, ListType.Unordered].forEach(listType => {
+            // Arrange
+            DomTestHelper.createElementFromContent(testId, source);
+            const list = document.getElementById(ListRoot) as HTMLOListElement;
+            const focus = document.getElementById(FocusNode);
+            const focus1 = document.getElementById(FocusNode1);
+            const focus2 = document.getElementById(FocusNode2);
+
+            if (!list) {
+                throw new Error('No root node');
+            }
+            if (!focus && (!focus1 || !focus2)) {
+                throw new Error('No focus node');
+            }
+
+            const vList = new VList(list);
+            const start = new Position(focus || focus1, PositionType.Begin);
+            const end = new Position(focus || focus2, PositionType.End);
+
+            // Act
+            vList.changeListType(start, end, listType);
+
+            // Assert
+            const items = (<any>vList).items as VListItem[];
+            const itemsMap = items.map(item => ({
+                listTypes: (<any>item).listTypes as ListType[],
+                outerHTML: (<HTMLElement>item.getNode()).outerHTML,
+            }));
+            const expected =
+                listType == ListType.None
+                    ? noneExpected
+                    : listType == ListType.Ordered
+                    ? olExpected
+                    : ulExpected;
+
+            expect(itemsMap).toEqual(expected);
+            DomTestHelper.removeElement(testId);
+        });
+    }
+
+    it('empty list', () => {
+        runTest(`<ol id="${ListRoot}"></ol><div id="${FocusNode}"></div>`, [], [], []);
+    });
+
+    it('single item list', () => {
+        runTest(
+            `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol>`,
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode}">test</li>`,
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode}">test</li>`,
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None, ListType.Unordered],
+                    outerHTML: `<li id="${FocusNode}">test</li>`,
+                },
+            ]
+        );
+    });
+
+    it('deep list', () => {
+        runTest(
+            `<ol id="${ListRoot}"><li id="${FocusNode1}">line1</li><ul><li id="${FocusNode2}">line2</li></ul></ol>`,
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode1}">line1</li>`,
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode2}">line2</li>`,
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode1}">line1</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode2}">line2</li>`,
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None, ListType.Unordered],
+                    outerHTML: `<li id="${FocusNode1}">line1</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: `<li id="${FocusNode2}">line2</li>`,
+                },
+            ]
+        );
+    });
+
+    it('partially selected list', () => {
+        runTest(
+            `<ol id="${ListRoot}">` +
+                '<li>line1</li>' +
+                `<li id="${FocusNode1}">line2</li>` +
+                '<ul>' +
+                `<li id="${FocusNode2}">line3</li>` +
+                '<li>line4</li>' +
+                '</ul>' +
+                '</ol>',
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode1}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode2}">line3</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line4</li>',
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode1}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode2}">line3</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line4</li>',
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Unordered],
+                    outerHTML: `<li id="${FocusNode1}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: `<li id="${FocusNode2}">line3</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line4</li>',
+                },
+            ]
+        );
+    });
+
+    it('nested list with same type', () => {
+        runTest(
+            `<ol id="${ListRoot}">` +
+                `<li id="${FocusNode1}">line1</li>` +
+                '<ol>' +
+                '<li>line2</li>' +
+                '<ol>' +
+                `<li id="${FocusNode2}">line3</li>` +
+                '</ol>' +
+                '</ol>' +
+                '</ol>',
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode1}">line1</li>`,
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: '<li>line2</li>',
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode2}">line3</li>`,
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${FocusNode1}">line1</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line2</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode2}">line3</li>`,
+                },
+            ],
+            [
+                {
+                    listTypes: [ListType.None, ListType.Unordered],
+                    outerHTML: `<li id="${FocusNode1}">line1</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line2</li>',
+                },
+                {
+                    listTypes: [
+                        ListType.None,
+                        ListType.Ordered,
+                        ListType.Ordered,
+                        ListType.Unordered,
+                    ],
+                    outerHTML: `<li id="${FocusNode2}">line3</li>`,
+                },
+            ]
+        );
+    });
+});
+
+describe('VList.appendItem', () => {
+    const testId = 'VList_appendItem';
+    const ListRoot = 'listRoot';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    function runTest(
+        newNodeHtml: string,
+        newNodeType: ListType,
+        expected: { listTypes: ListType[]; outerHTML: string }[]
+    ) {
+        // Arrange
+        DomTestHelper.createElementFromContent(testId, `<ol id="${ListRoot}"></ol>`);
+        const list = document.getElementById(ListRoot) as HTMLOListElement;
+
+        if (!list) {
+            throw new Error('No root node');
+        }
+
+        const vList = new VList(list);
+        const node = fromHtml(newNodeHtml, document)[0];
+
+        // Act
+        vList.appendItem(node, newNodeType);
+
+        // Assert
+        const items = (<any>vList).items as VListItem[];
+        const itemsMap = items.map(item => ({
+            listTypes: (<any>item).listTypes as ListType[],
+            outerHTML: (<HTMLElement>item.getNode()).outerHTML,
+        }));
+
+        expect(itemsMap).toEqual(expected);
+    }
+
+    it('LI node + type none', () => {
+        runTest('<li>test</li>', ListType.None, [
+            {
+                listTypes: [ListType.None],
+                outerHTML: '<li>test</li>',
+            },
+        ]);
+    });
+
+    it('LI node + type OL', () => {
+        runTest('<li>test</li>', ListType.Ordered, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>test</li>',
+            },
+        ]);
+    });
+
+    it('LI node + type UL', () => {
+        runTest('<li>test</li>', ListType.Unordered, [
+            {
+                listTypes: [ListType.None, ListType.Unordered],
+                outerHTML: '<li>test</li>',
+            },
+        ]);
+    });
+
+    it('DIV node + type none', () => {
+        runTest('<div>test</div>', ListType.None, [
+            {
+                listTypes: [ListType.None],
+                outerHTML: '<li><div>test</div></li>',
+            },
+        ]);
+    });
+
+    it('DIV node + type OL', () => {
+        runTest('<div>test</div>', ListType.Ordered, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li><div>test</div></li>',
+            },
+        ]);
+    });
+
+    it('DIV node + type UL', () => {
+        runTest('<div>test</div>', ListType.Unordered, [
+            {
+                listTypes: [ListType.None, ListType.Unordered],
+                outerHTML: '<li><div>test</div></li>',
+            },
+        ]);
+    });
+});
+
+describe('VList.mergeVList', () => {
+    const testId = 'VList_mergeVList';
+    const ListRoot1 = 'listRoot1';
+    const ListRoot2 = 'listRoot2';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    function runTest(sourceHtml: string, expected: { listTypes: ListType[]; outerHTML: string }[]) {
+        // Arrange
+        DomTestHelper.createElementFromContent(testId, sourceHtml);
+        const list1 = document.getElementById(ListRoot1) as HTMLOListElement;
+        const list2 = document.getElementById(ListRoot2) as HTMLOListElement;
+
+        if (!list1) {
+            throw new Error('No root node');
+        }
+
+        const vList1 = new VList(list1);
+        const vList2 = list2 && new VList(list2);
+
+        // Act
+        vList1.mergeVList(vList2);
+
+        // Assert
+        const items = (<any>vList1).items as VListItem[];
+        const itemsMap = items.map(item => ({
+            listTypes: (<any>item).listTypes as ListType[],
+            outerHTML: (<HTMLElement>item.getNode()).outerHTML,
+        }));
+
+        expect(itemsMap).toEqual(expected);
+
+        if (vList2) {
+            expect((<any>vList2).items.length).toEqual(0);
+        }
+    }
+
+    it('null list2', () => {
+        runTest(`<ol id="${ListRoot1}"></ol>`, []);
+    });
+
+    it('Two empty lists', () => {
+        runTest(`<ol id="${ListRoot1}"></ol><ol id="${ListRoot2}"></ol>`, []);
+    });
+
+    it('List 1 is empty', () => {
+        runTest(`<ol id="${ListRoot1}"></ol><ol id="${ListRoot2}"><li>test</li></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>test</li>',
+            },
+        ]);
+    });
+
+    it('List 2 is empty', () => {
+        runTest(`<ol id="${ListRoot1}"><li>test</li></ol><ol id="${ListRoot2}"></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>test</li>',
+            },
+        ]);
+    });
+
+    it('Both have items', () => {
+        runTest(
+            `<ol id="${ListRoot1}"><li>line1</li></ol><ol id="${ListRoot2}"><li>line2</li></ol>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line2</li>',
+                },
+            ]
+        );
+    });
+
+    it('List 2 has orphan item', () => {
+        runTest(
+            `<ol id="${ListRoot1}"><li>line1</li></ol>` +
+                `<ol id="${ListRoot2}"><div>line2<li>line3</li>line4</div><li>line5</li></ol>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1<div>line2</div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3<div>line4</div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line5</li>',
+                },
+            ]
+        );
+    });
+
+    it('List 2 has deep orphan item that cannot be merged', () => {
+        runTest(
+            `<ol id="${ListRoot1}"><li>line1</li></ol>` +
+                `<ol id="${ListRoot2}"><ul><div>line2</div><li>line3</li></ul></ol>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<div>line2</div>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line3</li>',
+                },
+            ]
+        );
+    });
+
+    it('List 2 has deep orphan item that can be merged', () => {
+        runTest(
+            `<ol id="${ListRoot1}"><ul><li>line1</li></ul></ol>` +
+                `<ol id="${ListRoot2}"><ul><div>line2</div><li>line3</li></ul></ol>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line1<div>line2</div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line3</li>',
+                },
+            ]
+        );
+    });
+});

--- a/packages/roosterjs-editor-dom/lib/test/list/createVListFromRegionTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/list/createVListFromRegionTest.ts
@@ -1,0 +1,510 @@
+import * as DomTestHelper from '../DomTestHelper';
+import createRange from '../../selection/createRange';
+import createVListFromRegion from '../../list/createVListFromRegion';
+import getRegionsFromRange from '../../region/getRegionsFromRange';
+import VListItem from '../../list/VListItem';
+import { ListType, RegionType } from 'roosterjs-editor-types';
+
+describe('createVListFromRegion from selection, no sibling list', () => {
+    it('null inputs', () => {
+        expect(createVListFromRegion(null)).toBeNull();
+    });
+
+    const testId = 'createVListFromRegion';
+    const FocusNode = 'focus';
+    const FocusNode1 = 'focus1';
+    const FocusNode2 = 'focus2';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    function runTest(sourceHtml: string, expected: { listTypes: ListType[]; outerHTML: string }[]) {
+        // Arrange
+        const root = DomTestHelper.createElementFromContent(testId, sourceHtml);
+        const focusNode = document.getElementById(FocusNode);
+        const focusNode1 = document.getElementById(FocusNode1);
+        const focusNode2 = document.getElementById(FocusNode2);
+
+        if (!focusNode && (!focusNode1 || !focusNode2)) {
+            throw new Error('must specify focus node');
+        }
+
+        const regions = getRegionsFromRange(
+            root,
+            createRange(focusNode || focusNode1, focusNode || focusNode2),
+            RegionType.Table
+        );
+
+        // Act
+        const vList = createVListFromRegion(regions[0]);
+
+        // Assert
+        if (expected === null) {
+            expect(vList).toBeNull();
+        } else {
+            const items = (<any>vList).items as VListItem[];
+            const itemsMap = items.map(item => ({
+                listTypes: (<any>item).listTypes as ListType[],
+                outerHTML: (<HTMLElement>item.getNode()).outerHTML,
+            }));
+
+            expect(itemsMap).toEqual(expected);
+        }
+    }
+
+    it('empty DIV', () => {
+        runTest(`<div id="${FocusNode}"></div>`, null);
+    });
+
+    it('non-list', () => {
+        runTest(`<div id="${FocusNode}"><br></div>`, [
+            {
+                listTypes: [ListType.None],
+                outerHTML: `<li><div id="${FocusNode}"><br></div></li>`,
+            },
+        ]);
+    });
+
+    it('Single list, no item', () => {
+        runTest(`<ol id="${FocusNode}"></ol>`, []);
+    });
+
+    it('Single list with items', () => {
+        runTest(`<ol id="${FocusNode}"><li>line1</li></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line1</li>',
+            },
+        ]);
+    });
+
+    it('Single list with items, select inside', () => {
+        runTest(`<ol><li><div id="${FocusNode}">line1</div></li></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: `<li><div id="${FocusNode}">line1</div></li>`,
+            },
+        ]);
+    });
+
+    it('list and non-list co-exist, select inside, list first', () => {
+        runTest(
+            `<div>line1</div><ol><li><div id="${FocusNode1}">line2</div></li></ol>` +
+                `<div id="${FocusNode2}">line3</div><div>line4</div>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li><div id="${FocusNode1}">line2</div></li>`,
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li><div id="${FocusNode2}">line3</div></li>`,
+                },
+            ]
+        );
+    });
+
+    it('list and non-list co-exist, select inside, non-list first', () => {
+        runTest(
+            `<div>line1</div><div id="${FocusNode1}">line2</div>` +
+                `<ol><li><div id="${FocusNode2}">line3</div></li></ol><div>line4</div>`,
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li><div id="${FocusNode1}">line2</div></li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li><div id="${FocusNode2}">line3</div></li>`,
+                },
+            ]
+        );
+    });
+
+    it('list and non-list co-exist, select inside, list|non-list|list', () => {
+        runTest(
+            `<div>line1</div><ol><li><div id="${FocusNode1}">line2</div></li></ol>` +
+                '<div>line3</div>' +
+                `<ol><li><div id="${FocusNode2}">line4</div></li></ol><div>line5</div>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li><div id="${FocusNode1}">line2</div></li>`,
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: '<li><div>line3</div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li><div id="${FocusNode2}">line4</div></li>`,
+                },
+            ]
+        );
+    });
+
+    it('non-list contains "StartEndBlockElement"', () => {
+        runTest(
+            `<div>line1</div><div id="${FocusNode1}">line2<br><span>line3<br><span id="${FocusNode2}">line4</span></span></div>`,
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li><div id="${FocusNode1}">line2<br></div></li>`,
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: '<li><div><span>line3<br></span></div></li>',
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li><div><span><span id="${FocusNode2}">line4</span></span></div></li>`,
+                },
+            ]
+        );
+    });
+
+    it('non-list contains empty nodes', () => {
+        runTest(
+            `<div>line1</div>\n\n<div id="${FocusNode1}">line2<br>  \n  <span>line3<br><div></div>\n<span id="${FocusNode2}">line4</span></span></div>`,
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li><div id="${FocusNode1}">line2<br></div></li>`,
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: '<li><div>  \n  <span>line3<br></span></div></li>',
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li><div><span>\n<span id="${FocusNode2}">line4</span></span></div></li>`,
+                },
+            ]
+        );
+    });
+
+    it('selection is in middle of list', () => {
+        runTest(`<ol><li>line1</li><ul><li id="${FocusNode}">line2</li></ul><li>line3</li></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line1</li>',
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                outerHTML: `<li id="${FocusNode}">line2</li>`,
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line3</li>',
+            },
+        ]);
+    });
+
+    it('selection is in a disconnected nest list', () => {
+        runTest(
+            `<ol><li>line1</li><li><ul><li id="${FocusNode}">line2</li></ul></li><li>line3</li></ol>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li><ul><li id="${FocusNode}">line2</li></ul></li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3</li>',
+                },
+            ]
+        );
+    });
+});
+
+describe('createVListFromRegion from selection, with sibling list', () => {
+    const testId = 'createVListFromRegion';
+    const FocusNode = 'focus';
+    const FocusNode1 = 'focus1';
+    const FocusNode2 = 'focus2';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    function runTest(
+        sourceHtml: string,
+        expected: { listTypes: ListType[]; outerHTML: string }[],
+        regionIndex: number = 0
+    ) {
+        // Arrange
+        const root = DomTestHelper.createElementFromContent(testId, sourceHtml);
+        const focusNode = document.getElementById(FocusNode);
+        const focusNode1 = document.getElementById(FocusNode1);
+        const focusNode2 = document.getElementById(FocusNode2);
+
+        if (!focusNode && (!focusNode1 || !focusNode2)) {
+            throw new Error('must specify focus node');
+        }
+
+        const regions = getRegionsFromRange(
+            root,
+            createRange(focusNode || focusNode1, focusNode || focusNode2),
+            RegionType.Table
+        );
+
+        // Act
+        const vList = createVListFromRegion(regions[regionIndex], true /*includingSiblingLists*/);
+
+        // Assert
+        if (expected === null) {
+            expect(vList).toBeNull();
+        } else {
+            const items = (<any>vList).items as VListItem[];
+            const itemsMap = items.map(item => ({
+                listTypes: (<any>item).listTypes as ListType[],
+                outerHTML: (<HTMLElement>item.getNode()).outerHTML,
+            }));
+
+            expect(itemsMap).toEqual(expected);
+        }
+    }
+
+    it('no sibling nodes', () => {
+        runTest(`<ol><li>line1</li><li id="${FocusNode}">line2</li><li>line3</li></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line1</li>',
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: `<li id="${FocusNode}">line2</li>`,
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line3</li>',
+            },
+        ]);
+    });
+
+    it('has sibling nodes, no sibling list', () => {
+        runTest(
+            `<div>previous sibling</div><ol><li>line1</li><li id="${FocusNode}">line2</li><li>line3</li></ol><div>next sibling</div>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3</li>',
+                },
+            ]
+        );
+    });
+
+    it('has sibling nodes, has previous sibling list', () => {
+        runTest(
+            `<ul><li>previous sibling</li></ul><ol><li>line1</li><li id="${FocusNode}">line2</li><li>line3</li></ol><div>next sibling</div>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Unordered],
+                    outerHTML: '<li>previous sibling</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3</li>',
+                },
+            ]
+        );
+    });
+
+    it('has sibling nodes, has next sibling list', () => {
+        runTest(
+            `<div>previous sibling</div><ol><li>line1</li><li id="${FocusNode}">line2</li><li>line3</li></ol><ul><li>next sibling</li></ul>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Unordered],
+                    outerHTML: '<li>next sibling</li>',
+                },
+            ]
+        );
+    });
+
+    it('has sibling list, has orphan items to merge', () => {
+        runTest(
+            '<ol><li>previous sibling</li></ol>' +
+                `<ol><div>line1</div><li id="${FocusNode}">line2</li><li>line3</li></ol>` +
+                '<ol><div>next sibling</div></ol>',
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>previous sibling<div>line1</div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3<div>next sibling</div></li>',
+                },
+            ]
+        );
+    });
+
+    it('has sibling list, has empty div between lists', () => {
+        runTest(
+            '<ol><li>line1</li></ol><div></div>\n\n<div></div>' +
+                `<ol><li id="${FocusNode}">line2</li><li>line3</li></ol>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3</li>',
+                },
+            ]
+        );
+    });
+
+    it('selection cross multiple regions', () => {
+        runTest(
+            `<table><tr><td><ol><li id="${FocusNode1}">test</li></ol></td></tr></table>` +
+                '<ol><li>line1</li><li>line2</li></ol>' +
+                `<table><tr><td><ol><li id="${FocusNode2}">test</li></ol></td></tr></table>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line2</li>',
+                },
+            ],
+            1
+        );
+    });
+});
+
+describe('createVListFromRegion from node', () => {
+    const testId = 'createVListFromRegion';
+    const FocusNode = 'focus';
+
+    afterEach(() => {
+        DomTestHelper.removeElement(testId);
+    });
+
+    function runTest(sourceHtml: string, expected: { listTypes: ListType[]; outerHTML: string }[]) {
+        // Arrange
+        const root = DomTestHelper.createElementFromContent(testId, sourceHtml);
+        const focusNode = document.getElementById(FocusNode);
+
+        if (!focusNode) {
+            throw new Error('must specify focus node');
+        }
+
+        const regions = getRegionsFromRange(root, createRange(focusNode), RegionType.Table);
+
+        // Act
+        const vList = createVListFromRegion(regions[0], true /*includingSiblingLists*/);
+
+        // Assert
+        if (expected === null) {
+            expect(vList).toBeNull();
+        } else {
+            const items = (<any>vList).items as VListItem[];
+            const itemsMap = items.map(item => ({
+                listTypes: (<any>item).listTypes as ListType[],
+                outerHTML: (<HTMLElement>item.getNode()).outerHTML,
+            }));
+
+            expect(itemsMap).toEqual(expected);
+        }
+    }
+
+    it('node in list', () => {
+        runTest(`<ol><li>line1</li><li id="${FocusNode}">line2</li><li>line3</li></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line1</li>',
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: `<li id="${FocusNode}">line2</li>`,
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line3</li>',
+            },
+        ]);
+    });
+
+    it('node in nested list', () => {
+        runTest(`<ol><li>line1</li><ul><li id="${FocusNode}">line2</li></ul><li>line3</li></ol>`, [
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line1</li>',
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                outerHTML: `<li id="${FocusNode}">line2</li>`,
+            },
+            {
+                listTypes: [ListType.None, ListType.Ordered],
+                outerHTML: '<li>line3</li>',
+            },
+        ]);
+    });
+
+    it('node in disconnected nested list', () => {
+        runTest(
+            `<ol><li>line1</li><li><ul><li id="${FocusNode}">line2</li></ul></li><li>line3</li></ol>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li><ul><li id="${FocusNode}">line2</li></ul></li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3</li>',
+                },
+            ]
+        );
+    });
+});

--- a/packages/roosterjs-editor-dom/lib/test/list/createVListFromRegionTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/list/createVListFromRegionTest.ts
@@ -416,6 +416,137 @@ describe('createVListFromRegion from selection, with sibling list', () => {
             1
         );
     });
+
+    it('lists are in asymmetric containers', () => {
+        runTest(
+            '<div>' +
+                '<div>line1</div>' +
+                '<div>' +
+                '<ul>' +
+                '<li>line2</li>' +
+                '</ul>' +
+                '</div>' +
+                '</div>' +
+                '<ol>' +
+                '<li>line3</li>' +
+                `<li id="${FocusNode1}">line4</li>` +
+                '</ol>' +
+                '<div>' +
+                '<div>line 5' +
+                '<ol>' +
+                `<li id="${FocusNode2}">line6</li>` +
+                '<li>line7</li>' +
+                '</ol>' +
+                '</div>' +
+                '</div>' +
+                '<ol>' +
+                '<li>line8</li>' +
+                '<ul><li>line9</li></ul>' +
+                '</ol>',
+            [
+                {
+                    listTypes: [ListType.None, ListType.Unordered],
+                    outerHTML: '<li>line2</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode1}">line4</li>`,
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: '<li><div>line 5</div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode2}">line6</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line7</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line8</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line9</li>',
+                },
+            ]
+        );
+    });
+
+    it('lists are in asymmetric containers, with spaces in HTML', () => {
+        runTest(
+            '<div>\n' +
+                '    <div>line1</div>\n' +
+                '    <div>\n' +
+                '        <ul>\n' +
+                '            <li>line2</li>\n' +
+                '        </ul>\n' +
+                '    </div>\n' +
+                '</div>\n' +
+                '<ol>\n' +
+                '    <li>line3</li>\n' +
+                `    <li id="${FocusNode1}">line4</li>\n` +
+                '</ol>\n' +
+                '<div>&nbsp;</div>\n' +
+                '<div>\n' +
+                '    <div>line 5\n' +
+                '        <ol>\n' +
+                `            <li id="${FocusNode2}">line6</li>\n` +
+                '            <li>line7</li>\n' +
+                '        </ol>\n' +
+                '    </div>\n' +
+                '</div>\n' +
+                '<ol>\n' +
+                '    <li>line8</li>\n' +
+                '    <ul><li>line9</li></ul>\n' +
+                '</ol>\n',
+            [
+                {
+                    listTypes: [ListType.None, ListType.Unordered],
+                    outerHTML: '<li>line2</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode1}">line4</li>`,
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: '<li><div>&nbsp;</div></li>',
+                },
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: '<li><div>line 5\n        </div></li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode2}">line6</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line7</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line8</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li>line9</li>',
+                },
+            ]
+        );
+    });
 });
 
 describe('createVListFromRegion from node', () => {

--- a/packages/roosterjs-editor-dom/lib/test/list/getListTypeFromNodeTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/list/getListTypeFromNodeTest.ts
@@ -1,0 +1,38 @@
+import getListTypeFromNode, { isListElement } from '../../list/getListTypeFromNode';
+import { ListType } from 'roosterjs-editor-types';
+
+describe('getListTypeFromNode', () => {
+    function runTest(tag: string, expected: ListType) {
+        expect(getListTypeFromNode(document.createElement(tag))).toBe(expected);
+    }
+
+    it('OL', () => {
+        runTest('ol', ListType.Ordered);
+    });
+
+    it('UL', () => {
+        runTest('ul', ListType.Unordered);
+    });
+
+    it('Others', () => {
+        runTest('div', ListType.None);
+    });
+});
+
+describe('isListElement', () => {
+    function runTest(tag: string, expected: boolean) {
+        expect(isListElement(document.createElement(tag))).toBe(expected);
+    }
+
+    it('OL', () => {
+        runTest('ol', true);
+    });
+
+    it('UL', () => {
+        runTest('ul', true);
+    });
+
+    it('Others', () => {
+        runTest('div', false);
+    });
+});

--- a/packages/roosterjs-editor-dom/lib/test/utils/shouldSkipNodeTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/utils/shouldSkipNodeTest.ts
@@ -65,4 +65,28 @@ describe('shouldSkipNode, shouldSkipNode()', () => {
         // Assert
         expect(shouldSkip).toBe(false);
     });
+
+    it('Node contains empty DIV/SPAN only', () => {
+        // Arrange
+        const node = document.createElement('div');
+        node.innerHTML = '<span><div></div><div></div></span>';
+
+        // Act
+        const shouldSkip = shouldSkipNode(node);
+
+        // Assert
+        expect(shouldSkip).toBe(true);
+    });
+
+    it('Node contains space only, set trim to true', () => {
+        // Arrange
+        const node = document.createElement('div');
+        node.innerHTML = '  <div>  </div>  ';
+
+        // Act
+        const shouldSkip = shouldSkipNode(node, true /*ignoreSpace*/);
+
+        // Assert
+        expect(shouldSkip).toBe(true);
+    });
 });

--- a/packages/roosterjs-editor-dom/lib/utils/getLeafSibling.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/getLeafSibling.ts
@@ -8,12 +8,14 @@ import shouldSkipNode from './shouldSkipNode';
  * @param startNode current node to get sibling node from
  * @param isNext True to get next leaf sibling node, false to get previous leaf sibling node
  * @param skipTags (Optional) tags that child elements will be skipped
+ * @param ignoreSpace (Optional) Ignore pure space text node when check if the node should be skipped
  */
 export function getLeafSibling(
     rootNode: Node,
     startNode: Node,
     isNext: boolean,
-    skipTags?: string[]
+    skipTags?: string[],
+    ignoreSpace?: boolean
 ): Node {
     let result = null;
     let getSibling = isNext
@@ -44,7 +46,7 @@ export function getLeafSibling(
             }
 
             // Check special nodes (i.e. node that has a display:none etc.) and continue looping if so
-            shouldContinue = curNode && shouldSkipNode(curNode);
+            shouldContinue = curNode && shouldSkipNode(curNode, ignoreSpace);
             if (!shouldContinue) {
                 // Found a good leaf node, assign and exit
                 result = curNode;

--- a/packages/roosterjs-editor-dom/lib/utils/isBlockElement.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/isBlockElement.ts
@@ -10,7 +10,7 @@ const BLOCK_DISPLAY_STYLES = ['block', 'list-item', 'table-cell'];
  * @param node The node to check
  * @returns True if the node is a block element, otherwise false
  */
-export default function isBlockElement(node: Node): boolean {
+export default function isBlockElement(node: Node): node is HTMLElement {
     let tag = getTagOfNode(node);
     return !!(
         tag &&

--- a/packages/roosterjs-editor-dom/lib/utils/shouldSkipNode.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/shouldSkipNode.ts
@@ -3,6 +3,7 @@ import { getComputedStyle } from './getComputedStyles';
 import { NodeType } from 'roosterjs-editor-types';
 
 const CRLF = /^[\r\n]+$/gm;
+const CRLFSPACE = /[\t\r\n\u0020\u200B]/gm; // We should only find new line, real space or ZeroWidthSpace (TAB, %20, but not &nbsp;)
 
 /**
  * Skip a node when any of following conditions are true
@@ -11,22 +12,33 @@ const CRLF = /^[\r\n]+$/gm;
  * - it is a text node but contains just CRLF (noisy text node that often comes in-between elements)
  * - has a display:none
  * - it is just <div></div>
+ * @param node The node to check
+ * @param ignoreSpace (Optional) True to ignore pure space text node of the node when check.
+ * If the value of a node value is only space, set this to true will treat this node as skippable.
+ * Default value is false
  */
-export default function shouldSkipNode(node: Node): boolean {
+export default function shouldSkipNode(node: Node, ignoreSpace?: boolean): boolean {
     if (node.nodeType == NodeType.Text) {
-        return !node.nodeValue || node.textContent == '' || CRLF.test(node.nodeValue);
+        if (!node.nodeValue || node.textContent == '' || CRLF.test(node.nodeValue)) {
+            return true;
+        } else if (ignoreSpace && node.nodeValue.replace(CRLFSPACE, '') == '') {
+            return true;
+        } else {
+            return false;
+        }
     } else if (node.nodeType == NodeType.Element) {
-        const tag = getTagOfNode(node);
-        if (tag == 'SPAN' || tag == 'DIV') {
-            if (getComputedStyle(node, 'display') == 'none') {
-                return true;
-            }
+        if (getComputedStyle(node, 'display') == 'none') {
+            return true;
+        }
 
+        const tag = getTagOfNode(node);
+
+        if (tag == 'DIV' || tag == 'SPAN') {
             // Empty SPAN/DIV or SPAN/DIV with only unmeaningful children is unmeaningful,
             // because it can render nothing. If we keep them here, there may be unexpected
             // LI elements added for those unmeaningful nodes.
             for (let child = node.firstChild; !!child; child = child.nextSibling) {
-                if (!shouldSkipNode(child)) {
+                if (!shouldSkipNode(child, ignoreSpace)) {
                     return false;
                 }
             }

--- a/packages/roosterjs-editor-types/lib/enum/ListType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ListType.ts
@@ -1,0 +1,22 @@
+/**
+ * Type of list (numbering or bullet)
+ */
+export const enum ListType {
+    /**
+     * None list type
+     * It means this is not a list
+     */
+    None = 0,
+
+    /**
+     * Ordered List type (numbering list)
+     * Represented by "OL" tag
+     */
+    Ordered = 1,
+
+    /**
+     * Unordered List type (bullet list)
+     * Represented by "UL" tag
+     */
+    Unordered = 2,
+}

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -11,6 +11,7 @@ export { ContentPosition } from './enum/ContentPosition';
 export { Direction } from './enum/Direction';
 export { FontSizeChange } from './enum/FontSizeChange';
 export { Indentation } from './enum/Indentation';
+export { ListType } from './enum/ListType';
 export { PasteOption } from './enum/PasteOption';
 export { PositionType } from './enum/PositionType';
 export { QueryScope } from './enum/QueryScope';


### PR DESCRIPTION
This is the implementation of VList and VListItem.

The design:
Each list item will map to a VListItem object. For example:
```html
<ol>
  <li>line 1</li>
  <ul>
      <li>line 2</li>
  </ul>
  <li>line 3</li>
</ol>
```

This will be mapped to a VList object: (pseudo code)
```json
{
  "items": [{
      "listTypes": ["None", "OL"],
      "node": "line 1"
  }, {
      "listTypes": ["None", "OL", "UL"],
      "node": "line 2"
  }, {
      "listTypes": ["None", "OL"],
      "node": "line 3"
  }],
}
```

For convience, we always put a "None" as the first element of list type so that even we outdent the list item to top level, we can still easily know the list type.

Then when we need to do action to the list, like indent, outdent, ..., we just need to change the list type array, then call writeBack() to write the change back to DOM.

Related test cases added.

Format API setIndentation, toggleBullet, toggleNumber are hooked with the new experiment API. When useExperimentFeatures flag is true, they will be used.