### PR TITLE
Fix bugs of 7.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.12.0",
+    "version": "7.12.1",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-dom/lib/utils/queryElements.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/queryElements.ts
@@ -25,10 +25,14 @@ export default function queryElements(
 
     if (scope != QueryScope.Body && range) {
         let { startContainer, startOffset, endContainer, endOffset } = range;
-        startContainer =
-            startContainer.nodeType == NodeType.Element && startContainer.firstChild
-                ? startContainer.childNodes[startOffset]
-                : startContainer;
+        if (startContainer.nodeType == NodeType.Element && startContainer.firstChild) {
+            const child = startContainer.childNodes[startOffset];
+
+            // range.startOffset can give a value of child.length+1 when selection is after the last child
+            // In that case we will use the last child instead
+            startContainer = child || startContainer.lastChild;
+        }
+
         endContainer =
             endContainer.nodeType == NodeType.Element && endContainer.firstChild && endOffset > 0
                 ? endContainer.childNodes[endOffset - 1]


### PR DESCRIPTION
Bugs found:
1. In queryElements.ts, we need to check if range.startContainer[range.startOffset] is valid because startOffset can be length + 1 when focus is after the last child node.