### PR TITLE
Fix regression in Editor.getContent() with selection path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.13.0",
+    "version": "7.13.1",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -355,6 +355,8 @@ export default class Editor {
         let content = '';
         if (triggerExtractContentEvent || this.core.inDarkMode) {
             const clonedRoot = this.core.contentDiv.cloneNode(true /*deep*/) as HTMLElement;
+            const path = includeSelectionMarker && this.getSelectionPath();
+            const range = path && createRange(clonedRoot, path.start, path.end);
 
             this.triggerPluginEvent(
                 PluginEventType.ExtractContentWithDom,
@@ -364,15 +366,18 @@ export default class Editor {
                 true /*broadcast*/
             );
 
-            content = clonedRoot.innerHTML;
-
             // TODO: Deprecated ExtractContentEvent once we have entity API ready in next major release
             if (triggerExtractContentEvent) {
                 content = this.triggerPluginEvent(
                     PluginEventType.ExtractContent,
-                    { content },
+                    { content: clonedRoot.innerHTML },
                     true /*broadcast*/
                 ).content;
+            } else if (range) {
+                // range is not null, which means we want to include a selection path in the content
+                content = getHtmlWithSelectionPath(clonedRoot, range);
+            } else {
+                content = clonedRoot.innerHTML;
             }
         } else {
             content = getHtmlWithSelectionPath(


### PR DESCRIPTION
In Editor.getContent(), when we want to include selection path in the content and editor is in dark mode, the selection path won't be included. 
This change fixed this issue.