### PR TITLE
7.13.2 Fix some entity bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.13.1",
+    "version": "7.13.2",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-cross-window/package.json
+++ b/packages/roosterjs-cross-window/package.json
@@ -1,10 +1,10 @@
 {
     "name": "roosterjs-cross-window",
-    "description": "This is a deprecated package",
+    "description": "This package is deprecated, and this is the last version of this package.",
     "dependencies": {
-        "roosterjs-editor-types": "",
-        "roosterjs-editor-dom": ""
+        "roosterjs-editor-types": "^7.13.2",
+        "roosterjs-editor-dom": "^7.13.2"
     },
     "main": "./lib/index.ts",
-    "version": "1.4.0"
+    "version": "1.6.0"
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/Entity/EntityFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Entity/EntityFeatures.ts
@@ -156,7 +156,7 @@ function cacheGetNeighborEntityElement(
 
                 if (checkForSameLine) {
                     const block = editor.getBlockElementAtNode(pos.node);
-                    if (!block.contains(node)) {
+                    if (!block || !block.contains(node)) {
                         node = null;
                     }
                 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/Entity/EntityInfo.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Entity/EntityInfo.ts
@@ -46,17 +46,19 @@ export function deserialzeEntityInfo(
     let id = '';
     let isReadonly = false;
 
-    entityInfo.split(' ').forEach(name => {
-        if (name == ENTITY_INFO_NAME) {
-            isEntity = true;
-        } else if (name.indexOf(ENTITY_TYPE_PREFIX) == 0) {
-            type = name.substr(ENTITY_TYPE_PREFIX.length);
-        } else if (name.indexOf(ENTITY_ID_PREFIX) == 0) {
-            id = name.substr(ENTITY_ID_PREFIX.length);
-        } else if (name.indexOf(ENTITY_READONLY_PREFIX) == 0) {
-            isReadonly = name.substr(ENTITY_READONLY_PREFIX.length) == '1';
-        }
-    });
+    if (entityInfo) {
+        entityInfo.split(' ').forEach(name => {
+            if (name == ENTITY_INFO_NAME) {
+                isEntity = true;
+            } else if (name.indexOf(ENTITY_TYPE_PREFIX) == 0) {
+                type = name.substr(ENTITY_TYPE_PREFIX.length);
+            } else if (name.indexOf(ENTITY_ID_PREFIX) == 0) {
+                id = name.substr(ENTITY_ID_PREFIX.length);
+            } else if (name.indexOf(ENTITY_READONLY_PREFIX) == 0) {
+                isReadonly = name.substr(ENTITY_READONLY_PREFIX.length) == '1';
+            }
+        });
+    }
 
     return isEntity && type
         ? {

--- a/packages/roosterjs-editor-plugins/lib/plugins/Entity/insertEntity.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Entity/insertEntity.ts
@@ -32,7 +32,13 @@ export default function insertEntity(
     const wrapper = wrap(contentNode, isBlock ? 'DIV' : 'SPAN');
     wrapper.className = serializeEntityInfo(editor, type, isReadonly);
 
-    if (!isBlock) {
+    // For inline & readonly entity, we need to set display to "inline-block" otherwise
+    // there will be some weird behavior when move cursor around the entity node.
+    // And we should only do this for readonly entity since "inline-block" has some side effect
+    // in IE that there will be a resize border around the inline-block element. We made some
+    // workaround for readonly entity for this issue but for editable entity, keep it as "inline"
+    // will just work fine.
+    if (!isBlock && isReadonly) {
         wrapper.style.display = 'inline-block';
     }
 

--- a/packages/roosterjs-html-sanitizer/package.json
+++ b/packages/roosterjs-html-sanitizer/package.json
@@ -1,10 +1,10 @@
 {
     "name": "roosterjs-html-sanitizer",
-    "description": "This package is deprecated",
+    "description": "This package is deprecated, and this is the last version of this package.",
     "dependencies": {
-        "roosterjs-editor-dom": "",
-        "roosterjs-editor-types": ""
+        "roosterjs-editor-dom": "^7.13.2",
+        "roosterjs-editor-types": "^7.13.2"
     },
     "main": "./lib/index.ts",
-    "version": "1.5.0"
+    "version": "1.6.0"
 }

--- a/packages/roosterjs-plugin-image-resize/package.json
+++ b/packages/roosterjs-plugin-image-resize/package.json
@@ -1,8 +1,9 @@
 {
     "name": "roosterjs-plugin-image-resize",
-    "description": "This package is deprecated",
+    "description": "This package is deprecated, and this is the last version of this package.",
     "dependencies": {
-        "roosterjs-editor-plugins": ""
+        "roosterjs-editor-plugins": "^7.13.2"
     },
-    "main": "./lib/index.ts"
+    "main": "./lib/index.ts",
+    "version": "7.13.2"
 }

--- a/packages/roosterjs-plugin-picker/package.json
+++ b/packages/roosterjs-plugin-picker/package.json
@@ -1,8 +1,9 @@
 {
     "name": "roosterjs-plugin-picker",
-    "description": "This package is deprecated",
+    "description": "This package is deprecated, and this is the last version of this package.",
     "dependencies": {
-        "roosterjs-editor-plugins": ""
+        "roosterjs-editor-plugins": "^7.13.2"
     },
-    "main": "./lib/index.ts"
+    "main": "./lib/index.ts",
+    "version": "7.13.2"
 }

--- a/tools/build.js
+++ b/tools/build.js
@@ -144,7 +144,9 @@ function normalize() {
         var packageJson = readPackageJson(package, true /*readFromSourceFolder*/);
 
         Object.keys(packageJson.dependencies).forEach(dep => {
-            if (knownCustomizedPackages[dep]) {
+            if (packageJson.dependencies[dep]) {
+                // No op, keep the specified value
+            } else if (knownCustomizedPackages[dep]) {
                 packageJson.dependencies[dep] = knownCustomizedPackages[dep];
             } else if (packages.indexOf(dep) > -1) {
                 packageJson.dependencies[dep] = mainPackageJson.version;


### PR DESCRIPTION
Fix two null-check issues
Don't set display to "inline-block" for editable entity since it will cause a resize border in IE
Modify the build script to respect the explicitly specified dependency version
Modify the dependency versions to make a final version of deprecated packages