### PR TITLE
Fix paste from Excel issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.14.1",
+    "version": "7.14.2",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-core/lib/coreAPI/createPasteFragment.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/createPasteFragment.ts
@@ -31,7 +31,7 @@ export const createPasteFragment: CreatePasteFragment = (
 ) => {
     // Step 1: Prepare BeforePasteEvent object
     const event = createBeforePasteEvent(core, clipboardData, pasteAsText);
-    const { fragment, pasteOption } = event;
+    const { fragment, pasteOption, sanitizingOption } = event;
     const { rawHtml, text, imageDataUri } = clipboardData;
     let doc: HTMLDocument;
 
@@ -64,10 +64,12 @@ export const createPasteFragment: CreatePasteFragment = (
             );
         }
 
-        const styles = toArray(doc.querySelectorAll('style'));
+        const styles = doc.querySelectorAll('style');
+        for (let i = 0; i < styles.length; i++) {
+            doc.head.appendChild(styles[i]);
+            sanitizingOption.additionalGlobalStyleNodes.push(styles[i]);
+        }
 
-        // Append all styles nodes, included those under <HEAD> tag so that we can convert them to inline CSS
-        styles.forEach(style => fragment.appendChild(style));
         while (doc.body.firstChild) {
             fragment.appendChild(doc.body.firstChild);
         }

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/Paste.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/Paste.ts
@@ -17,6 +17,8 @@ const WORD_ATTRIBUTE_NAME = 'xmlns:w';
 const WORD_ATTRIBUTE_VALUE = 'urn:schemas-microsoft-com:office:word';
 const EXCEL_ATTRIBUTE_NAME = 'xmlns:x';
 const EXCEL_ATTRIBUTE_VALUE = 'urn:schemas-microsoft-com:office:excel';
+const EXCEL_ONLINE_ATTRIBUTE_NAME = 'ProgId';
+const EXCEL_ONLINE_ATTRIBUTE_VALUE = 'Excel.Sheet';
 
 /**
  * Paste plugin, handles BeforePaste event and reformat some special content, including:
@@ -68,7 +70,10 @@ export default class Paste implements EditorPlugin {
             if (htmlAttributes[WORD_ATTRIBUTE_NAME] == WORD_ATTRIBUTE_VALUE) {
                 // Handle HTML copied from Word
                 convertPastedContentFromWord(event);
-            } else if (htmlAttributes[EXCEL_ATTRIBUTE_NAME] == EXCEL_ATTRIBUTE_VALUE) {
+            } else if (
+                htmlAttributes[EXCEL_ATTRIBUTE_NAME] == EXCEL_ATTRIBUTE_VALUE ||
+                htmlAttributes[EXCEL_ONLINE_ATTRIBUTE_NAME] == EXCEL_ONLINE_ATTRIBUTE_VALUE
+            ) {
                 // Handle HTML copied from Excel
                 convertPastedContentFromExcel(event);
             } else if ((wacListElements = fragment.querySelectorAll(WAC_IDENTIFING_SELECTOR))[0]) {

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/excelConverter/convertPastedContentFromExcel.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/excelConverter/convertPastedContentFromExcel.ts
@@ -43,7 +43,7 @@ export default function convertPastedContentFromExcel(event: BeforePasteEvent) {
     }
 
     chainSanitizerCallback(sanitizingOption.elementCallbacks, 'TD', element => {
-        if (element.style.border == 'none') {
+        if (element.style.borderStyle == 'none') {
             element.style.border = DEFAULT_BORDER_STYLE;
         }
         return true;


### PR DESCRIPTION
The issue is when move a STYLE tag from a document into a fragment, it will lose all style sheets.
The fix is to consume the sanitizer options and use "additionalGlobalStyleNodes" to include the style nodes to avoid it lose info.