### PR TITLE
Adding function to calculate which cell to select after inserting row…

### DIFF
--- a/packages/roosterjs-editor-api/lib/table/editTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/editTable.ts
@@ -16,7 +16,7 @@ export default function editTable(editor: Editor, operation: TableOperation) {
             vtable.writeBack();
             editor.focus();
 
-            let cellToSelect = CalculateCellToSelect(operation, vtable.row, vtable.col);
+            let cellToSelect = calculateCellToSelect(operation, vtable.row, vtable.col);
             editor.select(
                 vtable.getCell(cellToSelect.newRow, cellToSelect.newCol).td,
                 PositionType.Begin
@@ -25,7 +25,7 @@ export default function editTable(editor: Editor, operation: TableOperation) {
     }
 }
 
-function CalculateCellToSelect(operation: TableOperation, currentRow: number, currentCol: number) {
+function calculateCellToSelect(operation: TableOperation, currentRow: number, currentCol: number) {
     let newRow = currentRow;
     let newCol = currentCol;
     switch (operation) {

--- a/packages/roosterjs-editor-api/lib/table/editTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/editTable.ts
@@ -1,4 +1,4 @@
-import { ChangeSource, TableOperation } from 'roosterjs-editor-types';
+import { ChangeSource, TableOperation, PositionType } from 'roosterjs-editor-types';
 import { Editor } from 'roosterjs-editor-core';
 import { VTable } from 'roosterjs-editor-dom';
 
@@ -16,9 +16,37 @@ export default function editTable(editor: Editor, operation: TableOperation) {
             vtable.writeBack();
             editor.focus();
 
-            if (!editor.select(start, end)) {
-                editor.select(editor.contains(td) ? td : vtable.getCurrentTd());
-            }
+            let cellToSelect = CalculateCellToSelect(operation, vtable.row, vtable.col);
+            editor.select(
+                vtable.getCell(cellToSelect.newRow, cellToSelect.newCol).td,
+                PositionType.Begin
+            );
         }, ChangeSource.Format);
     }
+}
+
+function CalculateCellToSelect(operation: TableOperation, currentRow: number, currentCol: number) {
+    let newRow = currentRow;
+    let newCol = currentCol;
+    switch (operation) {
+        case TableOperation.InsertAbove:
+            newCol = 0;
+            break;
+        case TableOperation.InsertBelow:
+            newRow += 1;
+            newCol = 0;
+            break;
+        case TableOperation.InsertLeft:
+            newRow = 0;
+            break;
+        case TableOperation.InsertRight:
+            newRow = 0;
+            newCol += 1;
+            break;
+    }
+
+    return {
+        newRow,
+        newCol,
+    };
 }


### PR DESCRIPTION
… or column

This new function will calculate which cell to place the cursor in after insertion, either by tabbing or using the menu.
* If column was inserted, cursor will be placed in first row of the new column
* If row was inserted, cursor will be place in first column of the new row

Note: It does change the current Rooster behavior when deleting. Before this changes, whenever you delete a row or column, the content of the cell in the next row or column is selected:

![image](https://user-images.githubusercontent.com/15259586/90299358-9cedd580-de4a-11ea-8488-db59b3e3e579.png)

![image](https://user-images.githubusercontent.com/15259586/90299373-aaa35b00-de4a-11ea-82e2-1b8da1484953.png)

With these changes, the cursor would be placed at the beginning of that cell, instead of selecting it.