### PR TITLE
Fix insert DocumentFragment node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "7.15.0",
+    "version": "7.15.1",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -101,14 +101,15 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
             // add a DIV wrapping
             if (insertedNode && option.insertOnNewLine) {
                 let start = Array.isArray(insertedNode) ? insertedNode[0] : insertedNode;
-                let end = Array.isArray(insertedNode)
-                    ? insertedNode[insertNode.length - 1]
-                    : insertedNode;
+                // Check the last node if there're more than 1 node in list
+                let end =
+                    Array.isArray(insertedNode) && insertedNode.length > 1
+                        ? insertedNode[insertedNode.length - 1]
+                        : null;
                 if (start && !isBlockElement(start)) {
                     wrap(start);
                 }
-                // Check the last node if there're more than 1 node in list
-                if (insertNode.length > 1 && end && !isBlockElement(end)) {
+                if (end && !isBlockElement(end)) {
                     wrap(end);
                 }
             }

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -71,10 +71,20 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
                     // For insert on new line, or refNode is text or void html element (HR, BR etc.)
                     // which cannot have children, i.e. <div>hello<br>world</div>. 'hello', 'world' are the
                     // first and last node. Insert before 'hello' or after 'world', but still inside DIV
-                    insertedNode = refNode.parentNode.insertBefore(
-                        node,
-                        isBegin ? refNode : refNode.nextSibling
-                    );
+                    if (node instanceof DocumentFragment) {
+                        // if the node to be inserted is DocumentFragment, use its childNodes as insertedNode
+                        // because insertBefore() returns an empty DocumentFragment
+                        insertedNode = Array.prototype.slice.call(node.childNodes);
+                        refNode.parentNode.insertBefore(
+                            node,
+                            isBegin ? refNode : refNode.nextSibling
+                        );
+                    } else {
+                        insertedNode = refNode.parentNode.insertBefore(
+                            node,
+                            isBegin ? refNode : refNode.nextSibling
+                        );
+                    }
                 } else {
                     // if the refNode can have child, use appendChild (which is like to insert as first/last child)
                     // i.e. <div>hello</div>, the content will be inserted before/after hello

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -100,17 +100,9 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
             // Final check to see if the inserted node is a block. If not block and the ask is to insert on new line,
             // add a DIV wrapping
             if (insertedNode && option.insertOnNewLine) {
-                let start = Array.isArray(insertedNode) ? insertedNode[0] : insertedNode;
-                // Check the last node if there're more than 1 node in list
-                let end =
-                    Array.isArray(insertedNode) && insertedNode.length > 1
-                        ? insertedNode[insertedNode.length - 1]
-                        : null;
-                if (start && !isBlockElement(start)) {
-                    wrap(start);
-                }
-                if (end && !isBlockElement(end)) {
-                    wrap(end);
+                const nodes = Array.isArray(insertedNode) ? insertedNode : [insertedNode];
+                if (!isBlockElement(nodes[0]) || !isBlockElement(nodes[nodes.length - 1])) {
+                    wrap(nodes);
                 }
             }
 

--- a/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreAPI/insertNode.ts
@@ -100,11 +100,16 @@ export const insertNode: InsertNode = (core: EditorCore, node: Node, option: Ins
             // Final check to see if the inserted node is a block. If not block and the ask is to insert on new line,
             // add a DIV wrapping
             if (insertedNode && option.insertOnNewLine) {
-                // When insert on new line, all the nodes to be inserted have been wrapped with a DIV in insertContent(),
-                // so just check the first node of insertedNode.
-                let wrappedNode = Array.isArray(insertedNode) ? insertedNode[0] : insertedNode;
-                if (!isBlockElement(wrappedNode)) {
-                    wrap(wrappedNode);
+                let start = Array.isArray(insertedNode) ? insertedNode[0] : insertedNode;
+                let end = Array.isArray(insertedNode)
+                    ? insertedNode[insertNode.length - 1]
+                    : insertedNode;
+                if (start && !isBlockElement(start)) {
+                    wrap(start);
+                }
+                // Check the last node if there're more than 1 node in list
+                if (insertNode.length > 1 && end && !isBlockElement(end)) {
+                    wrap(end);
                 }
             }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/tableFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/tableFeatures.ts
@@ -1,6 +1,7 @@
 import { cacheGetEventData, ContentEditFeature, Editor, Keys } from 'roosterjs-editor-core';
 import { contains, getTagOfNode, isVoidHtmlElement, Position, VTable } from 'roosterjs-editor-dom';
-import { NodeType, PluginEvent, PositionType } from 'roosterjs-editor-types';
+import { NodeType, PluginEvent, PositionType, TableOperation } from 'roosterjs-editor-types';
+import { editTable } from 'roosterjs-editor-api';
 
 /**
  * TabInTable edit feature, provides the ability to jump between cells when user press TAB in table
@@ -21,8 +22,11 @@ export const TabInTable: ContentEditFeature = {
         ) {
             if (col < 0 || col >= vtable.cells[row].length) {
                 row += step;
-                if (row < 0 || row >= vtable.cells.length) {
-                    editor.select(vtable.table, shift ? PositionType.Before : PositionType.After);
+                if (row < 0) {
+                    editor.select(vtable.table, PositionType.Before);
+                    break;
+                } else if (row >= vtable.cells.length) {
+                    editTable(editor, TableOperation.InsertBelow);
                     break;
                 }
                 col = shift ? vtable.cells[row].length - 1 : 0;


### PR DESCRIPTION
When call Editor.insertContent() to insert some text on new line, the inserted text is still on the same line.

![CUDYN1P4vF](https://user-images.githubusercontent.com/67583056/90408538-88277100-e0da-11ea-8aa2-485aa4a5c0e7.gif)

This issue is related to [PR](https://github.com/microsoft/roosterjs/pull/401). The root cause is Node.insertBefore() returns an empty DocumentFragment if the node to be inserted is DocumentFragment, so the inserted node will not be wrapped with DIV.

The solution is use childNodes of DocumentFragment as insertedNode and pass them to wrap(), so that they can be wrapped.

@JiuqingSong Could you help review it? Thanks!