### PR TITLE
Remove "references" from API reference doc

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "tslint-eslint-rules": "5.4.0",
         "tslint-microsoft-contrib": "6.2.0",
         "typedoc": "0.17.6",
+        "typedoc-plugin-exclude-references": "1.0.0",
         "typedoc-plugin-external-module-map": "1.2.1",
         "typescript": "3.8.3",
         "webpack": "4.43.0",

--- a/tools/build.js
+++ b/tools/build.js
@@ -305,7 +305,10 @@ function buildDoc() {
         'external-modulemap': '".*\\/(roosterjs[a-zA-Z0-9\\-]*)\\/lib\\/"',
     };
 
-    let cmd = path.join(nodeModulesPath, 'typedoc/bin/typedoc');
+    let cmd = path.join(
+        nodeModulesPath,
+        'typedoc/bin/typedoc --plugin typedoc-plugin-exclude-references --plugin typedoc-plugin-external-module-map'
+    );
     for (let key of Object.keys(config)) {
         let value = config[key];
         cmd += ` --${key} ${value}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5774,6 +5774,11 @@ typedoc-default-themes@^0.10.1:
   dependencies:
     lunr "^2.3.8"
 
+typedoc-plugin-exclude-references@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-exclude-references/-/typedoc-plugin-exclude-references-1.0.0.tgz#d4367e5f432d88077d0da51717e213b86e6539f0"
+  integrity sha512-1BqEOHxnLfBqImhVTqp74nWJ+cbI9uCBm43qFNkqypZ4ae6BSZv1I7N6dToinbl1u6YGUQHeHI/1lBkU0AGSIw==
+
 typedoc-plugin-external-module-map@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-external-module-map/-/typedoc-plugin-external-module-map-1.2.1.tgz#32669a6b81e57962d2dae80d7a6ef8f5d0be65dd"


### PR DESCRIPTION
We use typedoc to generate API reference doc. However, it will generate "References" sections for each "re-export" functions/interfaces/... and unfortunately, we re-export everything from index.ts file which means everything will have a duplicated "reference" in the API reference file:
![image](https://user-images.githubusercontent.com/23065085/90422141-49a89c80-e06f-11ea-9dc7-7bb724fa4a7d.png)

I found there is a plugin "typedoc-plugin-exclude-references" that can remove such references which works pretty well. So I add this plugin to our build script.