### PR TITLE
Fix lose format issue from VList

### DIFF
--- a/packages/roosterjs-editor-dom/lib/list/VList.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VList.ts
@@ -208,18 +208,16 @@ export default class VList {
      * @param type Type of this list item, can be ListType.None
      */
     appendItem(node: Node, type: ListType) {
-        let newListNode = node;
         const nodeTag = getTagOfNode(node);
 
-        if (nodeTag != 'LI' && nodeTag != 'TABLE') {
-            newListNode = changeElementTag(<HTMLElement>node, 'LI');
-        } else if (nodeTag == 'TABLE') {
-            newListNode = wrap(node, 'li');
+        // Change DIV tag to SPAN. Otherwise we can create new list item by Enter key in Safari
+        if (nodeTag == 'DIV') {
+            node = changeElementTag(<HTMLElement>node, 'LI');
+        } else if (nodeTag != 'LI') {
+            node = wrap(node, 'LI');
         }
 
-        this.items.push(
-            type == ListType.None ? new VListItem(newListNode) : new VListItem(newListNode, type)
-        );
+        this.items.push(type == ListType.None ? new VListItem(node) : new VListItem(node, type));
     }
 
     /**

--- a/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
+++ b/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
@@ -2,7 +2,9 @@ import findClosestElementAncestor from '../utils/findClosestElementAncestor';
 import getSelectedBlockElementsInRegion from '../region/getSelectedBlockElementsInRegion';
 import isNodeInRegion from '../region/isNodeInRegion';
 import shouldSkipNode from '../utils/shouldSkipNode';
+import toArray from '../utils/toArray';
 import VList from './VList';
+import wrap from '../utils/wrap';
 import { getLeafSibling } from '../utils/getLeafSibling';
 import { isListElement } from './getListTypeFromNode';
 import { ListType, Region } from 'roosterjs-editor-types';
@@ -109,13 +111,18 @@ function getRootListNode(region: Region, node: Node): ListElement {
 }
 
 function createVListFromItemNode(node: Node): VList {
+    // Wrap all child nodes under a single one, and put the new list under original root node
+    // so that the list can carry over styles under the root node.
+    const childNodes = toArray(node.childNodes);
+    const nodeForItem = childNodes.length == 1 ? childNodes[0] : wrap(childNodes, 'SPAN');
+
     // Create a temporary OL root element for this list.
     const listNode = node.ownerDocument.createElement('ol'); // Either OL or UL is ok here
-    node.parentNode?.insertBefore(listNode, node);
+    node.appendChild(listNode);
 
     // Create the VList and append items
     const vList = new VList(listNode);
-    vList.appendItem(node, ListType.None);
+    vList.appendItem(nodeForItem, ListType.None);
 
     return vList;
 }

--- a/packages/roosterjs-editor-dom/lib/test/list/createVListFromRegionTest.ts
+++ b/packages/roosterjs-editor-dom/lib/test/list/createVListFromRegionTest.ts
@@ -61,7 +61,7 @@ describe('createVListFromRegion from selection, no sibling list', () => {
         runTest(`<div id="${FocusNode}"><br></div>`, [
             {
                 listTypes: [ListType.None],
-                outerHTML: `<li id="${FocusNode}"><br></li>`,
+                outerHTML: '<li><br></li>',
             },
         ]);
     });
@@ -112,7 +112,7 @@ describe('createVListFromRegion from selection, no sibling list', () => {
             [
                 {
                     listTypes: [ListType.None],
-                    outerHTML: `<li id="${FocusNode1}">line2</li>`,
+                    outerHTML: '<li>line2</li>',
                 },
                 {
                     listTypes: [ListType.None, ListType.Ordered],
@@ -150,7 +150,7 @@ describe('createVListFromRegion from selection, no sibling list', () => {
             [
                 {
                     listTypes: [ListType.None],
-                    outerHTML: `<li id="${FocusNode1}">line2<br></li>`,
+                    outerHTML: '<li><span>line2<br></span></li>',
                 },
                 {
                     listTypes: [ListType.None],
@@ -170,7 +170,7 @@ describe('createVListFromRegion from selection, no sibling list', () => {
             [
                 {
                     listTypes: [ListType.None],
-                    outerHTML: `<li id="${FocusNode1}">line2<br></li>`,
+                    outerHTML: '<li><span>line2<br></span></li>',
                 },
                 {
                     listTypes: [ListType.None],


### PR DESCRIPTION
When exit a list, if the format is specified from LI tag, we will drop it.

Fix:
1. when create a list, preserve the original block element so that if it contains any styles, we keep it out of list and the whole list will be under that style
2. when add new list item, only do change element tag if it is a DIV
3. test cases fixed