### PR TITLE
HtmlSanitizer: Handle unknown tags

### DIFF
--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
@@ -1,3 +1,4 @@
+import changeElementTag from '../utils/changeElementTag';
 import getInheritableStyles from './getInheritableStyles';
 import getTagOfNode from '../utils/getTagOfNode';
 import htmlToDom from './htmlToDom';
@@ -5,12 +6,13 @@ import safeInstanceOf from '../utils/safeInstanceOf';
 import toArray from '../utils/toArray';
 import { cloneObject } from './cloneObject';
 import {
-    getAllowedTags,
     getAllowedAttributes,
-    getDefaultStyleValues,
-    getStyleCallbacks,
     getAllowedCssClassesRegex,
+    getAllowedTags,
+    getDefaultStyleValues,
+    getDisallowedTags,
     getPredefinedCssForElement,
+    getStyleCallbacks,
 } from './getAllowedValues';
 import {
     HtmlSanitizerOptions,
@@ -64,11 +66,13 @@ export default class HtmlSanitizer {
     private styleCallbacks: StyleCallbackMap;
     private attributeCallbacks: AttributeCallbackMap;
     private allowedTags: string[];
+    private disallowedTags: string[];
     private allowedAttributes: string[];
     private allowedCssClassesRegex: RegExp;
     private defaultStyleValues: StringMap;
     private predefinedCssForElement: PredefinedCssMap;
     private additionalGlobalStyleNodes: HTMLStyleElement[];
+    private unknownTagReplacement: string;
 
     /**
      * Construct a new instance of HtmlSanitizer
@@ -80,6 +84,7 @@ export default class HtmlSanitizer {
         this.styleCallbacks = getStyleCallbacks(options.styleCallbacks);
         this.attributeCallbacks = cloneObject(options.attributeCallbacks);
         this.allowedTags = getAllowedTags(options.additionalAllowedTags);
+        this.disallowedTags = getDisallowedTags();
         this.allowedAttributes = getAllowedAttributes(options.additionalAllowedAttributes);
         this.allowedCssClassesRegex = getAllowedCssClassesRegex(
             options.additionalAllowedCssClasses
@@ -89,6 +94,7 @@ export default class HtmlSanitizer {
             options.additionalPredefinedCssForElement
         );
         this.additionalGlobalStyleNodes = options.additionalGlobalStyleNodes || [];
+        this.unknownTagReplacement = options.unknownTagReplacement;
     }
 
     /**
@@ -181,8 +187,39 @@ export default class HtmlSanitizer {
         const isFragment = nodeType == NodeType.DocumentFragment;
 
         let element = <HTMLElement>node;
+        let shouldKeep: boolean;
 
-        if (!this.shouldKeepNode(node, currentStyle, context)) {
+        if (isElement) {
+            const tag = getTagOfNode(node);
+            const callback = this.elementCallbacks[tag];
+            if (callback) {
+                shouldKeep = callback(node as HTMLElement, context);
+            } else if (this.allowedTags.indexOf(tag) >= 0 || tag.indexOf(':') > 0) {
+                shouldKeep = true;
+            } else if (this.disallowedTags.indexOf(tag) >= 0) {
+                shouldKeep = false;
+            } else if (this.unknownTagReplacement === '') {
+                shouldKeep = true;
+            } else if (this.unknownTagReplacement) {
+                node = changeElementTag(node as HTMLElement, this.unknownTagReplacement);
+                shouldKeep = true;
+            } else {
+                shouldKeep = false;
+            }
+        } else if (isText) {
+            const whiteSpace = currentStyle['white-space'];
+            shouldKeep =
+                whiteSpace == 'pre' ||
+                whiteSpace == 'pre-line' ||
+                whiteSpace == 'pre-wrap' ||
+                !/^[\r\n]*$/g.test(node.nodeValue);
+        } else if (isFragment) {
+            shouldKeep = true;
+        } else {
+            shouldKeep = false;
+        }
+
+        if (!shouldKeep) {
             node.parentNode.removeChild(node);
         } else if (
             isText &&
@@ -300,28 +337,5 @@ export default class HtmlSanitizer {
         });
 
         return calculatedClasses.length > 0 ? calculatedClasses.join(' ') : null;
-    }
-
-    private shouldKeepNode(node: Node, currentStyle: StringMap, context: Object) {
-        switch (node.nodeType) {
-            case NodeType.Element:
-                const tag = getTagOfNode(node);
-                const callback = this.elementCallbacks[tag];
-                return callback
-                    ? callback(node as HTMLElement, context)
-                    : this.allowedTags.indexOf(tag) >= 0 || tag.indexOf(':') > 0;
-            case NodeType.Text:
-                const whiteSpace = currentStyle['white-space'];
-                return (
-                    whiteSpace == 'pre' ||
-                    whiteSpace == 'pre-line' ||
-                    whiteSpace == 'pre-wrap' ||
-                    !/^[\r\n]*$/g.test(node.nodeValue)
-                );
-            case NodeType.DocumentFragment:
-                return true;
-            default:
-                return false;
-        }
     }
 }

--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
@@ -198,9 +198,12 @@ export default class HtmlSanitizer {
                 shouldKeep = true;
             } else if (this.disallowedTags.indexOf(tag) >= 0) {
                 shouldKeep = false;
-            } else if (this.unknownTagReplacement === '') {
+            } else if (this.unknownTagReplacement === '*') {
                 shouldKeep = true;
-            } else if (this.unknownTagReplacement) {
+            } else if (
+                this.unknownTagReplacement &&
+                /^[a-zA-Z][\w]*$/.test(this.unknownTagReplacement)
+            ) {
                 node = changeElementTag(node as HTMLElement, this.unknownTagReplacement);
                 shouldKeep = true;
             } else {

--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/createDefaultHtmlSanitizerOptions.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/createDefaultHtmlSanitizerOptions.ts
@@ -14,5 +14,6 @@ export default function createDefaultHtmlSanitizerOptions(): Required<HtmlSaniti
         additionalDefaultStyleValues: {},
         additionalGlobalStyleNodes: [],
         additionalPredefinedCssForElement: {},
+        unknownTagReplacement: null,
     };
 }

--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/getAllowedValues.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/getAllowedValues.ts
@@ -1,14 +1,134 @@
 import { cloneObject } from './cloneObject';
 import { PredefinedCssMap, StringMap, StyleCallbackMap } from 'roosterjs-editor-types';
 
-const ALLOWED_HTML_TAGS = (
-    'BODY,H1,H2,H3,H4,H5,H6,FORM,P,BR,NOBR,HR,ACRONYM,ABBR,ADDRESS,B,' +
-    'BDI,BDO,BIG,BLOCKQUOTE,CENTER,CITE,CODE,DEL,DFN,EM,FONT,I,INS,KBD,MARK,METER,PRE,PROGRESS,' +
-    'Q,RP,RT,RUBY,S,SAMP,SMALL,STRIKE,STRONG,SUB,SUP,TEMPLATE,TIME,TT,U,VAR,WBR,XMP,INPUT,TEXTAREA,' +
-    'BUTTON,SELECT,OPTGROUP,OPTION,LABEL,FIELDSET,LEGEND,DATALIST,OUTPUT,IMG,MAP,AREA,CANVAS,FIGCAPTION,' +
-    'FIGURE,PICTURE,A,NAV,UL,OL,LI,DIR,UL,DL,DT,DD,MENU,MENUITEM,TABLE,CAPTION,TH,TR,TD,THEAD,TBODY,' +
-    'TFOOT,COL,COLGROUP,DIV,SPAN,HEADER,FOOTER,MAIN,SECTION,ARTICLE,ASIDE,DETAILS,DIALOG,SUMMARY,DATA'
-).split(',');
+const ALLOWED_HTML_TAG_MAP = {
+    // Allowed tags
+    a: true,
+    abbr: true,
+    address: true,
+    area: true,
+    article: true,
+    aside: true,
+    b: true,
+    bdi: true,
+    bdo: true,
+    blockquote: true,
+    body: true,
+    br: true,
+    button: true,
+    canvas: true,
+    caption: true,
+    center: true,
+    cite: true,
+    code: true,
+    col: true,
+    colgroup: true,
+    data: true,
+    datalist: true,
+    dd: true,
+    del: true,
+    details: true,
+    dfn: true,
+    dialog: true,
+    dir: true,
+    div: true,
+    dl: true,
+    dt: true,
+    em: true,
+    fieldset: true,
+    figcaption: true,
+    figure: true,
+    font: true,
+    footer: true,
+    form: true,
+    h1: true,
+    h2: true,
+    h3: true,
+    h4: true,
+    h5: true,
+    h6: true,
+    head: true,
+    header: true,
+    hgroup: true,
+    hr: true,
+    html: true,
+    i: true,
+    img: true,
+    input: true,
+    ins: true,
+    kbd: true,
+    label: true,
+    legend: true,
+    li: true,
+    main: true,
+    map: true,
+    mark: true,
+    menu: true,
+    menuitem: true,
+    meter: true,
+    nav: true,
+    ol: true,
+    optgroup: true,
+    option: true,
+    output: true,
+    p: true,
+    picture: true,
+    pre: true,
+    progress: true,
+    q: true,
+    rp: true,
+    rt: true,
+    ruby: true,
+    s: true,
+    samp: true,
+    section: true,
+    select: true,
+    small: true,
+    span: true,
+    strike: true,
+    strong: true,
+    sub: true,
+    summary: true,
+    sup: true,
+    table: true,
+    tbody: true,
+    td: true,
+    template: true,
+    textarea: true,
+    tfoot: true,
+    th: true,
+    thead: true,
+    time: true,
+    tr: true,
+    tt: true,
+    u: true,
+    ul: true,
+    var: true,
+    wbr: true,
+    xmp: true,
+
+    // Disallowed tags
+    applet: false,
+    audio: false,
+    base: false,
+    basefont: false,
+    embed: false,
+    frame: false,
+    frameset: false,
+    iframe: false,
+    link: false,
+    meta: false,
+    noscript: false,
+    object: false,
+    param: false,
+    script: false,
+    slot: false,
+    source: false,
+    style: false,
+    title: false,
+    track: false,
+    video: false,
+};
 
 const ALLOWED_HTML_ATTRIBUTES = (
     'accept,align,alt,checked,cite,color,cols,colspan,contextmenu,' +
@@ -74,7 +194,19 @@ const PREDEFINED_CSS_FOR_ELEMENT: PredefinedCssMap = {
  * @internal
  */
 export function getAllowedTags(additionalTags: string[]): string[] {
-    return unique(ALLOWED_HTML_TAGS.concat(additionalTags || [])).map(tag => tag.toUpperCase());
+    return Object.keys(ALLOWED_HTML_TAG_MAP)
+        .filter((name: keyof typeof ALLOWED_HTML_TAG_MAP) => ALLOWED_HTML_TAG_MAP[name])
+        .concat(additionalTags || [])
+        .map(name => name.toUpperCase());
+}
+
+/**
+ * @internal
+ */
+export function getDisallowedTags(): string[] {
+    return Object.keys(ALLOWED_HTML_TAG_MAP)
+        .filter((name: keyof typeof ALLOWED_HTML_TAG_MAP) => !ALLOWED_HTML_TAG_MAP[name])
+        .map(name => name.toUpperCase());
 }
 
 /**

--- a/packages/roosterjs-editor-dom/test/htmlSanitizer/sanitizeHtmlTest.ts
+++ b/packages/roosterjs-editor-dom/test/htmlSanitizer/sanitizeHtmlTest.ts
@@ -366,19 +366,43 @@ describe('sanitizeHtml with white-space style', () => {
     });
 });
 
-describe('sanitizeHtml with unknown/disabled tags, keep unknown tags', () => {
+describe('sanitizeHtml with unknown/disabled tags and set unknownTagReplacement to *, keep unknown tags', () => {
     function runTest(source: string, exp: string) {
         let sanitizer: HtmlSanitizer = new HtmlSanitizer({
-            unknownTagReplacement: '',
+            unknownTagReplacement: '*',
         });
         let result = sanitizer.exec(source, false, false, { color: '' });
         expect(result).toBe(exp);
     }
 
-    it('Unknown tags, convert to SPAN', () => {
+    it('Unknown tags, keep as it is', () => {
         runTest(
             '<div>line 1<aaa style="color:red">line2<br>line3</aaa>line4</div>',
             '<div>line 1<aaa style="color:red">line2<br>line3</aaa>line4</div>'
+        );
+    });
+
+    it('Disabled tags, should remove', () => {
+        runTest(
+            '<div>line 1<object style="color:red">line2<br>line3</object>line4</div>',
+            '<div>line 1line4</div>'
+        );
+    });
+});
+
+describe('sanitizeHtml with unknown/disabled tags and set unknownTagReplacement to invalid string, remove unknown tags', () => {
+    function runTest(source: string, exp: string) {
+        let sanitizer: HtmlSanitizer = new HtmlSanitizer({
+            unknownTagReplacement: '!invalid!',
+        });
+        let result = sanitizer.exec(source, false, false, { color: '' });
+        expect(result).toBe(exp);
+    }
+
+    it('Unknown tags, keep as it is', () => {
+        runTest(
+            '<div>line 1<aaa style="color:red">line2<br>line3</aaa>line4</div>',
+            '<div>line 1line4</div>'
         );
     });
 

--- a/packages/roosterjs-editor-dom/test/htmlSanitizer/sanitizeHtmlTest.ts
+++ b/packages/roosterjs-editor-dom/test/htmlSanitizer/sanitizeHtmlTest.ts
@@ -365,3 +365,98 @@ describe('sanitizeHtml with white-space style', () => {
         );
     });
 });
+
+describe('sanitizeHtml with unknown/disabled tags, keep unknown tags', () => {
+    function runTest(source: string, exp: string) {
+        let sanitizer: HtmlSanitizer = new HtmlSanitizer({
+            unknownTagReplacement: '',
+        });
+        let result = sanitizer.exec(source, false, false, { color: '' });
+        expect(result).toBe(exp);
+    }
+
+    it('Unknown tags, convert to SPAN', () => {
+        runTest(
+            '<div>line 1<aaa style="color:red">line2<br>line3</aaa>line4</div>',
+            '<div>line 1<aaa style="color:red">line2<br>line3</aaa>line4</div>'
+        );
+    });
+
+    it('Disabled tags, should remove', () => {
+        runTest(
+            '<div>line 1<object style="color:red">line2<br>line3</object>line4</div>',
+            '<div>line 1line4</div>'
+        );
+    });
+});
+
+describe('sanitizeHtml with unknown/disabled tags, replace with SPAN', () => {
+    function runTest(source: string, exp: string) {
+        let sanitizer: HtmlSanitizer = new HtmlSanitizer({
+            unknownTagReplacement: 'SPAN',
+        });
+        let result = sanitizer.exec(source, false, false, { color: '' });
+        expect(result).toBe(exp);
+    }
+
+    it('Unknown tags, convert to SPAN', () => {
+        runTest(
+            '<div>line 1<aaa style="color:red">line2<br>line3</aaa>line4</div>',
+            '<div>line 1<span style="color:red">line2<br>line3</span>line4</div>'
+        );
+    });
+
+    it('Disabled tags, should remove', () => {
+        runTest(
+            '<div>line 1<object style="color:red">line2<br>line3</object>line4</div>',
+            '<div>line 1line4</div>'
+        );
+    });
+
+    it('Make sure all allowed tags are really allowed', () => {
+        const allowTags = 'H1,H2,H3,H4,H5,H6,FORM,P,ABBR,ADDRESS,B,BDI,BDO,BLOCKQUOTE,CITE,CODE,DEL,DFN,EM,FONT,I,INS,KBD,MARK,METER,PRE,PROGRESS,Q,RP,RT,RUBY,S,SAMP,SMALL,STRIKE,STRONG,SUB,SUP,TEMPLATE,TIME,TT,U,VAR,XMP,TEXTAREA,BUTTON,SELECT,OPTGROUP,OPTION,LABEL,FIELDSET,LEGEND,DATALIST,OUTPUT,MAP,CANVAS,FIGCAPTION,FIGURE,PICTURE,A,NAV,UL,OL,LI,DIR,UL,DL,DT,DD,MENU,MENUITEM,DIV,SPAN,HEADER,FOOTER,MAIN,SECTION,ARTICLE,ASIDE,DETAILS,DIALOG,SUMMARY,DATA'
+            .toLowerCase()
+            .split(',');
+
+        allowTags.forEach(tag => {
+            const html = `text before<${tag}>test text</${tag}>text after`;
+            runTest(html, html);
+        });
+    });
+
+    it('Make sure all allowed void tags are really allowed', () => {
+        const allowTags = 'BR,HR,WBR,INPUT,IMG,AREA'.toLowerCase().split(',');
+
+        allowTags.forEach(tag => {
+            const html = `text before<${tag}>text after`;
+            runTest(html, html);
+        });
+    });
+
+    it('Make sure all allowed table tags are really allowed', () => {
+        const html =
+            '<table><caption>test table</caption><colgroup><col><col></colgroup><thead><tr><th>head1</th><th>head2</th></tr></thead><tbody><tr><td>body1</td><td>body2</td></tr><tr><td>body3</td><td>body4</td></tr></tbody><tfoot><tr><td>foot1</td><td>foot2</td></tr></tfoot></table>';
+
+        runTest(html, html);
+    });
+
+    it('Make sure disallowed tags are really removed', () => {
+        const disallowedTags = 'applet,audio,iframe,noscript,object,script,slot,style,title,video'.split(
+            ','
+        );
+        disallowedTags.forEach(tag => {
+            const html = `text before<${tag}>test text</${tag}>text after`;
+            runTest(html, 'text beforetext after');
+        });
+    });
+
+    it('Make sure disallowed void tags are really removed', () => {
+        const disallowedTags = 'base,basefont,embed,frame,frameset,link,meta,param,source,track'.split(
+            ','
+        );
+        disallowedTags.forEach(tag => {
+            const html = `text before<${tag}>text after`;
+            runTest(html, 'text beforetext after');
+        });
+    });
+});

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/Paste.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/Paste.ts
@@ -23,6 +23,12 @@ const GOOGLE_SHEET_NODE_NAME = 'google-sheets-html-origin';
  */
 export default class Paste implements EditorPlugin {
     /**
+     * Construct a new instance of Paste class
+     * @param unknownTagReplacement Replace solution of unknown tags, default behavior is to replace with SPAN
+     */
+    constructor(private unknownTagReplacement: string = 'SPAN') {}
+
+    /**
      * Get a friendly name of  this plugin
      */
     getName() {
@@ -76,6 +82,9 @@ export default class Paste implements EditorPlugin {
             } else if (fragment.querySelector(GOOGLE_SHEET_NODE_NAME)) {
                 sanitizingOption.additionalAllowedTags.push(GOOGLE_SHEET_NODE_NAME);
             }
+
+            // Replace unknown tags with SPAN
+            sanitizingOption.unknownTagReplacement = this.unknownTagReplacement;
         }
     }
 }

--- a/packages/roosterjs-editor-types/lib/interface/HtmlSanitizerOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/HtmlSanitizerOptions.ts
@@ -54,4 +54,13 @@ export default interface HtmlSanitizerOptions {
      * Additional predefined CSS for element
      */
     additionalPredefinedCssForElement?: PredefinedCssMap;
+
+    /**
+     * Define a replacement tag name of unknown tags.
+     * A valid non-empty string means replace the tag name with this string.
+     * Empty string ('') means keep it as it is, no replacement.
+     * undefined or null means drop such elements and all its children
+     * @default undefined
+     */
+    unknownTagReplacement?: string;
 }

--- a/packages/roosterjs-editor-types/lib/interface/HtmlSanitizerOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/HtmlSanitizerOptions.ts
@@ -57,9 +57,9 @@ export default interface HtmlSanitizerOptions {
 
     /**
      * Define a replacement tag name of unknown tags.
-     * A valid non-empty string means replace the tag name with this string.
-     * Empty string ('') means keep it as it is, no replacement.
-     * undefined or null means drop such elements and all its children
+     * A star "*" means keep as it is, no replacement
+     * Other valid string means replace the tag name with this string.
+     * Empty string, undefined or null means drop such elements and all its children
      * @default undefined
      */
     unknownTagReplacement?: string;


### PR DESCRIPTION
Provide an option to decide how to handle unknown HTML tags when do sanitization.
- A valid string: replace unknown tags with this tag name
- An empty string: keep as it is
- null/undefined: Drop unknown tags and all its children