### PR TITLE
Continued List -- VListChain

### DIFF
--- a/demo/scripts/controls/BuildInPluginState.ts
+++ b/demo/scripts/controls/BuildInPluginState.ts
@@ -9,6 +9,7 @@ export interface BuildInPluginList {
     paste: boolean;
     watermark: boolean;
     imageResize: boolean;
+    cutPasteListChain: boolean;
     tableResize: boolean;
     customReplace: boolean;
     pickerPlugin: boolean;

--- a/demo/scripts/controls/editor/Editor.tsx
+++ b/demo/scripts/controls/editor/Editor.tsx
@@ -3,6 +3,7 @@ import BuildInPluginState, { UrlPlaceholder } from '../BuildInPluginState';
 import SampleColorPickerPluginDataProvider from '../samplepicker/SampleColorPickerPluginDataProvider';
 import { ContentEdit } from 'roosterjs-editor-plugins/lib/ContentEdit';
 import { CustomReplace as CustomReplacePlugin } from 'roosterjs-editor-plugins/lib/CustomReplace';
+import { CutPasteListChain } from 'roosterjs-editor-plugins/lib/CutPasteListChain';
 import { Editor as RoosterJsEditor } from 'roosterjs-editor-core';
 import { EditorInstanceToggleablePlugins } from './EditorInstanceToggleablePlugins';
 import { EditorOptions, EditorPlugin, UndoSnapshotsService } from 'roosterjs-editor-types';
@@ -76,6 +77,7 @@ export default class Editor extends React.Component<EditorProps, BuildInPluginSt
             paste: pluginList.paste ? new Paste() : null,
             watermark: pluginList.watermark ? new Watermark(this.state.watermarkText) : null,
             imageResize: pluginList.imageResize ? new ImageResize() : null,
+            cutPasteListChain: pluginList.cutPasteListChain ? new CutPasteListChain() : null,
             tableResize: pluginList.tableResize ? new TableResize() : null,
             pickerPlugin: pluginList.pickerPlugin
                 ? new PickerPlugin(new SampleColorPickerPluginDataProvider(), {

--- a/demo/scripts/controls/editor/EditorInstanceToggleablePlugins.ts
+++ b/demo/scripts/controls/editor/EditorInstanceToggleablePlugins.ts
@@ -1,5 +1,6 @@
 import { ContentEdit } from 'roosterjs-editor-plugins/lib/ContentEdit';
 import { CustomReplace } from 'roosterjs-editor-plugins/lib/CustomReplace';
+import { CutPasteListChain } from 'roosterjs-editor-plugins/lib/CutPasteListChain';
 import { HyperLink } from 'roosterjs-editor-plugins/lib/HyperLink';
 import { ImageResize } from 'roosterjs-editor-plugins/lib/ImageResize';
 import { Paste } from 'roosterjs-editor-plugins/lib/Paste';
@@ -13,6 +14,7 @@ export type EditorInstanceToggleablePlugins = {
     paste: Paste;
     watermark: Watermark;
     imageResize: ImageResize;
+    cutPasteListChain: CutPasteListChain;
     tableResize: TableResize;
     customReplace: CustomReplace;
     pickerPlugin: PickerPlugin;

--- a/demo/scripts/controls/sidePane/editorOptions/ContentEditFeatures.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/ContentEditFeatures.tsx
@@ -14,6 +14,7 @@ const EditFeatureDescriptionMap: Record<keyof ContentEditFeatureSettings, string
     outdentWhenEnterOnEmptyLine: 'Outdent list when Enter on empty line',
     mergeInNewLineWhenBackspaceOnFirstChar:
         'Merge in new line when Backspace on first char in list',
+    maintainListChain: 'Maintain the continued list numbers',
     unquoteWhenBackspaceOnEmptyFirstLine: 'Unquote when Backspace on empty first line',
     unquoteWhenEnterOnEmptyLine: 'Unquote when Enter on empty line',
     tabInTable: 'Tab to jump cell in table',

--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -11,6 +11,7 @@ const initialState: BuildInPluginState = {
         paste: true,
         watermark: false,
         imageResize: true,
+        cutPasteListChain: true,
         tableResize: true,
         customReplace: true,
         pickerPlugin: true,

--- a/demo/scripts/controls/sidePane/editorOptions/Plugins.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/Plugins.tsx
@@ -43,6 +43,7 @@ export default class Plugins extends React.Component<PluginsProps, {}> {
                         )
                     )}
                     {this.renderPluginItem('imageResize', 'Image Resize Plugin')}
+                    {this.renderPluginItem('cutPasteListChain', 'CutPasteListChainPlugin')}
                     {this.renderPluginItem('tableResize', 'Table Resize Plugin')}
                     {this.renderPluginItem('pickerPlugin', 'Sample Picker Plugin')}
                     {this.renderPluginItem('customReplace', 'Custom Replace Plugin (autocomplete)')}

--- a/demo/scripts/controls/sidePane/editorOptions/codes/PluginsCode.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/codes/PluginsCode.ts
@@ -4,7 +4,13 @@ import ContentEditCode from './ContentEditCode';
 import HyperLinkCode from './HyperLinkCode';
 import PickerPluginCode from './PickerPluginCode';
 import WatermarkCode from './WatermarkCode';
-import { CustomReplaceCode, ImageResizeCode, PasteCode, TableResizeCode } from './SimplePluginCode';
+import {
+    CustomReplaceCode,
+    CutPasteListChainCode,
+    ImageResizeCode,
+    PasteCode,
+    TableResizeCode,
+} from './SimplePluginCode';
 
 export default class PluginsCode extends CodeElement {
     private plugins: CodeElement[];
@@ -19,6 +25,7 @@ export default class PluginsCode extends CodeElement {
             pluginList.paste && new PasteCode(),
             pluginList.watermark && new WatermarkCode(this.state.watermarkText),
             pluginList.imageResize && new ImageResizeCode(),
+            pluginList.cutPasteListChain && new CutPasteListChainCode(),
             pluginList.tableResize && new TableResizeCode(),
             pluginList.pickerPlugin && new PickerPluginCode(),
             pluginList.customReplace && new CustomReplaceCode(),

--- a/demo/scripts/controls/sidePane/editorOptions/codes/SimplePluginCode.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/codes/SimplePluginCode.ts
@@ -22,6 +22,12 @@ export class ImageResizeCode extends SimplePluginCode {
     }
 }
 
+export class CutPasteListChainCode extends SimplePluginCode {
+    constructor() {
+        super('CutPasteListChain');
+    }
+}
+
 export class TableResizeCode extends SimplePluginCode {
     constructor() {
         super('TableResize');

--- a/packages/roosterjs-editor-api/lib/experiment/experimentCommitListChains.ts
+++ b/packages/roosterjs-editor-api/lib/experiment/experimentCommitListChains.ts
@@ -1,0 +1,16 @@
+import { ChangeSource, IEditor } from 'roosterjs-editor-types';
+import { VListChain } from 'roosterjs-editor-dom';
+
+/**
+ * Commit changes of all list changes when experiment features are allowed
+ * @param editor The Editor object
+ * @param chains List chains to commit
+ */
+export default function experimentCommitListChains(editor: IEditor, chains: VListChain[]) {
+    if (chains?.length > 0) {
+        editor.addUndoSnapshot((start, end) => {
+            chains.forEach(chain => chain.commit());
+            editor.select(start, end);
+        }, ChangeSource.ListChain);
+    }
+}

--- a/packages/roosterjs-editor-api/lib/experiment/experimentToggleListType.ts
+++ b/packages/roosterjs-editor-api/lib/experiment/experimentToggleListType.ts
@@ -1,13 +1,33 @@
 import blockFormat from '../utils/blockFormat';
-import { createVListFromRegion } from 'roosterjs-editor-dom';
+import { createVListFromRegion, getBlockElementAtNode } from 'roosterjs-editor-dom';
 import { IEditor, ListType } from 'roosterjs-editor-types';
 
 /**
  * @internal
  */
-export default function experimentToggleListType(editor: IEditor, listType: ListType) {
-    blockFormat(editor, (region, start, end) => {
-        const vList = createVListFromRegion(region, true /*includeSiblingLists*/);
+export default function experimentToggleListType(editor: IEditor, listType: ListType): void;
+export default function experimentToggleListType(
+    editor: IEditor,
+    listType: ListType.Ordered,
+    startNumber: number
+): void;
+
+export default function experimentToggleListType(
+    editor: IEditor,
+    listType: ListType,
+    startNumber?: number
+) {
+    blockFormat(editor, (region, start, end, chains) => {
+        const chain =
+            startNumber > 0 && chains.filter(chain => chain.canAppendAtCursor(startNumber))[0];
+        const vList =
+            chain && start.equalTo(end)
+                ? chain.createVListAtBlock(
+                      getBlockElementAtNode(region.rootNode, start.node)?.collapseToSingleElement(),
+                      startNumber
+                  )
+                : createVListFromRegion(region, true /*includeSiblingLists*/);
+
         if (vList) {
             vList.changeListType(start, end, listType);
             vList.writeBack();

--- a/packages/roosterjs-editor-api/lib/index.ts
+++ b/packages/roosterjs-editor-api/lib/index.ts
@@ -30,3 +30,5 @@ export { default as toggleSubscript } from './format/toggleSubscript';
 export { default as toggleSuperscript } from './format/toggleSuperscript';
 export { default as toggleUnderline } from './format/toggleUnderline';
 export { default as toggleHeader } from './format/toggleHeader';
+
+export { default as experimentCommitListChains } from './experiment/experimentCommitListChains';

--- a/packages/roosterjs-editor-api/lib/utils/blockFormat.ts
+++ b/packages/roosterjs-editor-api/lib/utils/blockFormat.ts
@@ -1,4 +1,6 @@
+import experimentCommitListChains from '../experiment/experimentCommitListChains';
 import { ChangeSource, IEditor, NodePosition, Region } from 'roosterjs-editor-types';
+import { VListChain } from 'roosterjs-editor-dom';
 
 /**
  * @internal
@@ -6,14 +8,23 @@ import { ChangeSource, IEditor, NodePosition, Region } from 'roosterjs-editor-ty
  */
 export default function blockFormat(
     editor: IEditor,
-    callback: (region: Region, start: NodePosition, end: NodePosition) => void,
+    callback: (
+        region: Region,
+        start: NodePosition,
+        end: NodePosition,
+        chains: VListChain[]
+    ) => void,
     beforeRunCallback?: () => boolean
 ) {
     editor.focus();
     editor.addUndoSnapshot((start, end) => {
         if (!beforeRunCallback || beforeRunCallback()) {
             const regions = editor.getSelectedRegions();
-            regions.forEach(region => callback(region, start, end));
+            const chains = editor.useExperimentFeatures()
+                ? VListChain.createListChains(regions)
+                : [];
+            regions.forEach(region => callback(region, start, end, chains));
+            experimentCommitListChains(editor, chains);
         }
         editor.select(start, end);
     }, ChangeSource.Format);

--- a/packages/roosterjs-editor-api/lib/utils/blockFormat.ts
+++ b/packages/roosterjs-editor-api/lib/utils/blockFormat.ts
@@ -21,7 +21,7 @@ export default function blockFormat(
         if (!beforeRunCallback || beforeRunCallback()) {
             const regions = editor.getSelectedRegions();
             const chains = editor.useExperimentFeatures()
-                ? VListChain.createListChains(regions)
+                ? VListChain.createListChains(regions, start?.node)
                 : [];
             regions.forEach(region => callback(region, start, end, chains));
             experimentCommitListChains(editor, chains);

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -47,6 +47,7 @@ export { default as readFile } from './utils/readFile';
 export { default as VTable } from './table/VTable';
 export { default as VList } from './list/VList';
 export { default as createVListFromRegion } from './list/createVListFromRegion';
+export { default as VListChain } from './list/VListChain';
 
 export { default as getRegionsFromRange } from './region/getRegionsFromRange';
 export { default as getSelectedBlockElementsInRegion } from './region/getSelectedBlockElementsInRegion';

--- a/packages/roosterjs-editor-dom/lib/list/VListChain.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VListChain.ts
@@ -1,0 +1,170 @@
+import arrayPush from '../utils/arrayPush';
+import getRootListNode from './getRootListNode';
+import isNodeAfter from '../utils/isNodeAfter';
+import isNodeInRegion from '../region/isNodeInRegion';
+import queryElements from '../utils/queryElements';
+import VList from './VList';
+import { ListType, RegionBase } from 'roosterjs-editor-types';
+
+const CHAIN_NAME_PREFIX = '__List_Chain_';
+const CHAIN_DATASET_NAME = 'listchain';
+const AFTER_CURSOR_DATASET_NAME = 'listchainafter';
+let lastChainIndex = 0;
+
+/**
+ * Represent a chain of list nodes.
+ * A chain of lists is a virtual link of lists that have continuous numbers, when editor one of them,
+ * all others should also be updated in order to main the list number to be continuous.
+ */
+export default class VListChain {
+    private lastNumber = 0;
+    private lastNumberBeforeCursor = 0;
+
+    /**
+     * Create an array of VListChain from current region in editor
+     * @param region The region to create VListChain from
+     * @param currentNode Optional current node, used for mark lists that are after this node
+     * @param nameGenerator Used by test code only
+     */
+    static createListChains(
+        region: RegionBase | RegionBase[],
+        currentNode?: Node,
+        nameGenerator?: () => string
+    ): VListChain[] {
+        const regions = Array.isArray(region) ? region : region ? [region] : [];
+        const result: VListChain[] = [];
+        regions.forEach(region => {
+            const chains: VListChain[] = [];
+            let lastList: HTMLOListElement;
+
+            queryElements(region.rootNode, 'ol', ol => {
+                const list = getRootListNode(region, 'ol', ol);
+
+                if (lastList != list) {
+                    const chain =
+                        chains.filter(c => c.canAppendToTail(list))[0] ||
+                        new VListChain(region, (nameGenerator || createListChainName)());
+                    const index = chains.indexOf(chain);
+                    const afterCurrentNode = currentNode && isNodeAfter(list, currentNode);
+
+                    if (!afterCurrentNode) {
+                        // Make sure current one is at the front if current block has not been met, so that
+                        // the first chain is always the nearest one from current node
+                        if (index >= 0) {
+                            chains.splice(index, 1);
+                        }
+
+                        chains.unshift(chain);
+                    } else if (index < 0) {
+                        chains.push(chain);
+                    }
+
+                    chain.append(list, afterCurrentNode);
+                    lastList = list;
+                }
+            });
+
+            arrayPush(result, chains);
+        });
+
+        return result;
+    }
+
+    /**
+     * Check if a list with the given start number can be appended next to the last list before cursor
+     * @param startNumber The start number of the new list
+     */
+    canAppendAtCursor(startNumber: number): boolean {
+        return this.lastNumberBeforeCursor + 1 == startNumber;
+    }
+
+    /**
+     * Create a VList to wrap the block of the given node, and append to current chain
+     * @param container The container node to create list at
+     * @param startNumber Start number of the new list
+     */
+    createVListAtBlock(container: Node, startNumber: number): VList {
+        if (container) {
+            const list = container.ownerDocument.createElement('ol');
+
+            list.start = startNumber;
+            this.applyChainName(list);
+            container.parentNode.insertBefore(list, container);
+
+            const vList = new VList(list);
+
+            vList.appendItem(container, ListType.None);
+            return vList;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * After change the lists, commit the change to all lists in this chain to update the list number,
+     * and clear the temporary dataset values added to list node
+     */
+    commit() {
+        const lists = this.getLists();
+        let lastNumber = 0;
+
+        for (let i = 0; i < lists.length; i++) {
+            const list = lists[i];
+            list.start = lastNumber + 1;
+
+            const vlist = new VList(list);
+
+            lastNumber = vlist.getLastItemNumber();
+
+            delete list.dataset[CHAIN_DATASET_NAME];
+            delete list.dataset[AFTER_CURSOR_DATASET_NAME];
+
+            vlist.writeBack();
+        }
+    }
+
+    /**
+     * Contruct a new instance of VListChain class
+     * @param editor Editor object
+     */
+    private constructor(private region: RegionBase, private name: string) {}
+
+    /**
+     * Check if the given list node is can be appended into current list chain
+     * @param list The list node to check
+     */
+    private canAppendToTail(list: HTMLOListElement) {
+        return this.lastNumber + 1 == list.start;
+    }
+
+    /**
+     * Append the given list node into this VListChain
+     * @param list The list node to append
+     * @param isAfterCurrentNode Whether this list is after current node
+     */
+    private append(list: HTMLOListElement, isAfterCurrentNode: boolean) {
+        this.applyChainName(list);
+        this.lastNumber = new VList(list).getLastItemNumber();
+
+        if (isAfterCurrentNode) {
+            list.dataset[AFTER_CURSOR_DATASET_NAME] = 'true';
+        } else {
+            this.lastNumberBeforeCursor = this.lastNumber;
+        }
+    }
+
+    private applyChainName(list: HTMLOListElement) {
+        list.dataset[CHAIN_DATASET_NAME] = this.name;
+    }
+
+    private getLists() {
+        return queryElements(
+            this.region.rootNode,
+            `ol[data-${CHAIN_DATASET_NAME}=${this.name}]`
+        ).filter(node => isNodeInRegion(this.region, node)) as HTMLOListElement[];
+    }
+}
+
+function createListChainName() {
+    return CHAIN_NAME_PREFIX + lastChainIndex++;
+}

--- a/packages/roosterjs-editor-dom/lib/list/getRootListNode.ts
+++ b/packages/roosterjs-editor-dom/lib/list/getRootListNode.ts
@@ -1,0 +1,48 @@
+import findClosestElementAncestor from '../utils/findClosestElementAncestor';
+import { RegionBase } from 'roosterjs-editor-types';
+
+/**
+ * @internal
+ * A type map from selector string to HTML element type
+ */
+export interface SelectorToTypeMap {
+    ol: HTMLOListElement;
+    ul: HTMLUListElement;
+    'ol,ul': HTMLOListElement | HTMLUListElement;
+}
+
+/**
+ * @internal
+ * Get Root list node from the given node within the given region
+ * @param region Region to scope the search inot
+ * @param selector The selector to search
+ * @param node The start node
+ */
+export default function getRootListNode<TSelector extends keyof SelectorToTypeMap>(
+    region: RegionBase,
+    selector: TSelector,
+    node: Node
+): SelectorToTypeMap[TSelector] {
+    let list =
+        region &&
+        (findClosestElementAncestor(
+            node,
+            region.rootNode,
+            selector
+        ) as SelectorToTypeMap[TSelector]);
+
+    if (list) {
+        let ancestor: SelectorToTypeMap[TSelector];
+        while (
+            (ancestor = findClosestElementAncestor(
+                list.parentNode,
+                region.rootNode,
+                selector
+            ) as SelectorToTypeMap[TSelector])
+        ) {
+            list = ancestor;
+        }
+    }
+
+    return list;
+}

--- a/packages/roosterjs-editor-dom/test/list/VListChainTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/VListChainTest.ts
@@ -1,0 +1,407 @@
+import getBlockElementAtNode from '../../lib/blockElements/getBlockElementAtNode';
+import VListChain from '../../lib/list/VListChain';
+import VListItem from '../../lib/list/VListItem';
+import { ListType, PositionType } from 'roosterjs-editor-types';
+import { Position } from 'roosterjs/lib';
+
+const CurrentNode = 'CurrentNode';
+
+describe('createListChains', () => {
+    let startIndex: number;
+    const CHAIN_NAME_PREFIX = 'TestChain';
+
+    beforeEach(() => {
+        startIndex = 0;
+    });
+
+    function nameGenerator() {
+        return CHAIN_NAME_PREFIX + startIndex++;
+    }
+
+    it('null input', () => {
+        const chains = VListChain.createListChains(null);
+        expect(chains).toEqual([]);
+    });
+
+    function runTest(html: string, expectedHtml: string) {
+        const div = document.createElement('div');
+        document.body.appendChild(div);
+        div.innerHTML = html;
+
+        const currentNode = document.getElementById(CurrentNode);
+        VListChain.createListChains(
+            {
+                rootNode: div,
+                skipTags: [],
+            },
+            currentNode,
+            nameGenerator
+        );
+
+        expect(div.innerHTML).toBe(expectedHtml);
+        document.body.removeChild(div);
+    }
+
+    it('No list', () => {
+        runTest('<div>test</div>', '<div>test</div>');
+    });
+
+    it('One list', () => {
+        runTest(
+            '<div>test</div><ol><li>item1</li></ol>',
+            `<div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li></ol>`
+        );
+    });
+
+    it('One nested list', () => {
+        runTest(
+            '<div>test</div><ol><li>item1</li><ol><li>item1.1</li</ol></ol>',
+            `<div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><ol><li>item1.1</li></ol></ol>`
+        );
+    });
+
+    it('Two separated lists', () => {
+        runTest(
+            '<ol><li>item1</li></ol><div>test</div><ol><li>item2</li>',
+            `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}1"><li>item2</li></ol>`
+        );
+    });
+
+    it('Two continuously lists', () => {
+        runTest(
+            '<ol><li>item1</li><li>item2</li></ol><div>test</div><ol start="3"><li>item3</li></ol>',
+            `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><li>item2</li></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}0" start="3"><li>item3</li></ol>`
+        );
+    });
+
+    it('Two list chains', () => {
+        runTest(
+            '<ol><li>item1</li><li>item2</li><li>item3</li></ol><div>test</div><ol><li>itemA</li><li>itemB</li></ol><ol start="4"><li>item4</li></ol><div>test</div><ol start="3"><li>itemC</li></ol>',
+            `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><li>item2</li><li>item3</li></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}1"><li>itemA</li><li>itemB</li></ol><ol data-listchain="${CHAIN_NAME_PREFIX}0" start="4"><li>item4</li></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}1" start="3"><li>itemC</li></ol>`
+        );
+    });
+
+    it('Unordered list in a chain', () => {
+        runTest(
+            '<ol><li>item1</li><li>item2</li></ol><div>test</div><ul><li>test</li></ul><div>test</div><ol start="3"><li>item3</li></ol>',
+            `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><li>item2</li></ol><div>test</div><ul><li>test</li></ul><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}0" start="3"><li>item3</li></ol>`
+        );
+    });
+
+    it('Nested list', () => {
+        runTest(
+            '<ol><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div>test</div><ol start="2"><li>item2</li></ol>',
+            `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}0" start="2"><li>item2</li></ol>`
+        );
+    });
+
+    it('Nested list for separated lists', () => {
+        runTest(
+            '<ol><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div>test</div><ol start="3"><li>item2</li></ol>',
+            `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}1" start="3"><li>item2</li></ol>`
+        );
+    });
+
+    it('Current node', () => {
+        runTest(
+            `<ol><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div id="${CurrentNode}">test</div><ol start="2"><li>item2</li></ol>`,
+            `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div id="${CurrentNode}">test</div><ol data-listchain="${CHAIN_NAME_PREFIX}0" data-listchainafter="true" start="2"><li>item2</li></ol>`
+        );
+    });
+});
+
+describe('VListChain.canAppendAtCursor', () => {
+    function runTest(html: string, num: number, expectedResult: boolean) {
+        const div = document.createElement('div');
+        document.body.appendChild(div);
+        div.innerHTML = html;
+
+        const currentNode = document.getElementById(CurrentNode);
+        const chains = VListChain.createListChains(
+            {
+                rootNode: div,
+                skipTags: [],
+            },
+            currentNode
+        );
+        const result = chains[0].canAppendAtCursor(num);
+
+        expect(result).toBe(expectedResult);
+        document.body.removeChild(div);
+    }
+
+    it('No current node', () => {
+        runTest('<ol><li>item1</li></ol>', 1, false);
+        runTest('<ol><li>item1</li></ol>', 2, true);
+        runTest('<ol><li>item1</li></ol>', 3, false);
+    });
+
+    it('Current node is before list', () => {
+        runTest(`<div id="${CurrentNode}">test</div><ol><li>item1</li></ol>`, 1, true);
+        runTest(`<div id="${CurrentNode}">test</div><ol><li>item1</li></ol>`, 2, false);
+        runTest(`<div id="${CurrentNode}">test</div><ol><li>item1</li></ol>`, 3, false);
+    });
+
+    it('Current node is list', () => {
+        runTest(`<ol id="${CurrentNode}"><li>item1</li></ol>`, 1, false);
+        runTest(`<ol id="${CurrentNode}"><li>item1</li></ol>`, 2, true);
+        runTest(`<ol id="${CurrentNode}"><li>item1</li></ol>`, 3, false);
+    });
+
+    it('Current node is after list', () => {
+        runTest(`<ol><li>item1</li></ol><div id="${CurrentNode}">test</div>`, 1, false);
+        runTest(`<ol><li>item1</li></ol><div id="${CurrentNode}">test</div>`, 2, true);
+        runTest(`<ol><li>item1</li></ol><div id="${CurrentNode}">test</div>`, 3, false);
+    });
+
+    it('Current node is between lists', () => {
+        runTest(
+            `<ol><li>item1</li></ol><div id="${CurrentNode}">test</div><ol start="2"><li>item2</li></ol>`,
+            1,
+            false
+        );
+        runTest(
+            `<ol><li>item1</li></ol><div id="${CurrentNode}">test</div><ol start="2"><li>item2</li></ol>`,
+            2,
+            true
+        );
+        runTest(
+            `<ol><li>item1</li></ol><div id="${CurrentNode}">test</div><ol start="2"><li>item2</li></ol>`,
+            3,
+            false
+        );
+    });
+
+    it('Current node is between multiple item lists', () => {
+        runTest(
+            `<ol><li>item1</li><li>item2</li><ol><li>item2.1</li></ol></ol><div id="${CurrentNode}">test</div><ol start="3"><li>item3</li></ol>`,
+            1,
+            false
+        );
+        runTest(
+            `<ol><li>item1</li><li>item2</li><ol><li>item2.1</li></ol></ol><div id="${CurrentNode}">test</div><ol start="3"><li>item3</li></ol>`,
+            2,
+            false
+        );
+        runTest(
+            `<ol><li>item1</li><li>item2</li><ol><li>item2.1</li></ol></ol><div id="${CurrentNode}">test</div><ol start="3"><li>item3</li></ol>`,
+            3,
+            true
+        );
+    });
+});
+
+describe('VListChain.createVListAtNode', () => {
+    let startIndex: number;
+    const CHAIN_NAME_PREFIX = 'TestChain';
+
+    beforeEach(() => {
+        startIndex = 0;
+    });
+
+    function nameGenerator() {
+        return CHAIN_NAME_PREFIX + startIndex++;
+    }
+
+    function runTest(
+        html: string,
+        startNumber: number,
+        expectedHtml: string,
+        expectedItems: { listTypes: ListType[]; outerHTML: string }[]
+    ) {
+        const div = document.createElement('div');
+
+        document.body.appendChild(div);
+        div.innerHTML = html;
+
+        const chain = VListChain.createListChains(
+            {
+                rootNode: div,
+                skipTags: [],
+            },
+            null,
+            nameGenerator
+        )[0];
+        const node = document.getElementById(CurrentNode);
+        const block = node && getBlockElementAtNode(div, node);
+        const vList = chain.createVListAtBlock(block?.collapseToSingleElement(), startNumber);
+
+        if (expectedItems) {
+            const items = (<any>vList).items as VListItem[];
+            const itemsMap = items.map(item => ({
+                listTypes: (<any>item).listTypes as ListType[],
+                outerHTML: (<HTMLElement>item.getNode()).outerHTML,
+            }));
+
+            expect(itemsMap).toEqual(expectedItems);
+        } else {
+            expect(vList).toBeNull();
+        }
+
+        expect(div.innerHTML).toBe(expectedHtml);
+
+        document.body.removeChild(div);
+    }
+
+    it('null input', () => {
+        runTest(
+            '<ol><li>item</li></ol>',
+            1,
+            `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item</li></ol>`,
+            null
+        );
+    });
+
+    it('Single list', () => {
+        runTest(
+            `<ol><li>item</li></ol><div id="${CurrentNode}">test</div>`,
+            2,
+            `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item</li></ol><ol data-listchain="${CHAIN_NAME_PREFIX}0" start="2"></ol><li id="${CurrentNode}">test</li>`,
+            [
+                {
+                    listTypes: [ListType.None],
+                    outerHTML: `<li id="${CurrentNode}">test</li>`,
+                },
+            ]
+        );
+    });
+});
+
+describe('VListChain.commit', () => {
+    function runTest(
+        html: string,
+        operation: (chains: VListChain[]) => void,
+        expectedHtml: string
+    ) {
+        const div = document.createElement('div');
+
+        document.body.appendChild(div);
+        div.innerHTML = html;
+
+        const chains = VListChain.createListChains(
+            {
+                rootNode: div,
+                skipTags: [],
+            },
+            null
+        );
+
+        operation(chains);
+        chains.forEach(chain => chain.commit());
+        expect(div.innerHTML).toBe(expectedHtml);
+
+        document.body.removeChild(div);
+    }
+
+    it('No op', () => {
+        runTest('<ol><li>test</li></ol>', () => {}, '<ol><li>test</li></ol>');
+    });
+
+    it('Add a new list', () => {
+        runTest(
+            '<ol><li>test</li></ol><div id="div1">test2</div>',
+            chains => {
+                const div = document.getElementById('div1');
+                const vList = chains[0].createVListAtBlock(div, 1); // Specify a wrong start number, it should still work
+                vList.changeListType(
+                    new Position(div, PositionType.Begin),
+                    new Position(div, PositionType.End),
+                    ListType.Ordered
+                );
+                vList.writeBack();
+            },
+            '<ol><li>test</li></ol><ol start="2"><li id="div1">test2</li></ol>'
+        );
+    });
+
+    it('Add a new list between two existing lists', () => {
+        runTest(
+            '<ol><li>item1</li></ol><div id="div1">item2</div><ol start="2"><li>item3</li></ol>',
+            chains => {
+                const div = document.getElementById('div1');
+                const vList = chains[0].createVListAtBlock(div, 1); // Specify a wrong start number, it should still work
+                vList.changeListType(
+                    new Position(div, PositionType.Begin),
+                    new Position(div, PositionType.End),
+                    ListType.Ordered
+                );
+                vList.writeBack();
+            },
+            '<ol><li>item1</li></ol><ol start="2"><li id="div1">item2</li></ol><ol start="3"><li>item3</li></ol>'
+        );
+    });
+
+    it('Add a new list between two existing lists with two chains', () => {
+        runTest(
+            '<ol><li>item1</li></ol><ol><li>itemA</li><li>itemB</li><li>itemC</li></ol><div id="div1">item2</div><ol start="2"><li>item3</li></ol>',
+            chains => {
+                const div = document.getElementById('div1');
+                const vList = chains[0].createVListAtBlock(div, 1); // Specify a wrong start number, it should still work
+                vList.changeListType(
+                    new Position(div, PositionType.Begin),
+                    new Position(div, PositionType.End),
+                    ListType.Ordered
+                );
+                vList.writeBack();
+            },
+            '<ol><li>item1</li></ol><ol><li>itemA</li><li>itemB</li><li>itemC</li></ol><ol start="2"><li id="div1">item2</li></ol><ol start="3"><li>item3</li></ol>'
+        );
+    });
+
+    it('Add a new list item', () => {
+        runTest(
+            '<ol id="ol1"><li>item1</li></ol><ol start="2"><li>item3</li></ol>',
+            chains => {
+                const ol1 = document.getElementById('ol1');
+                const li = document.createElement('li');
+                li.innerHTML = 'item2';
+                ol1.appendChild(li);
+            },
+            '<ol id="ol1"><li>item1</li><li>item2</li></ol><ol start="3"><li>item3</li></ol>'
+        );
+    });
+
+    it('Remove a list item', () => {
+        runTest(
+            '<ol><li>item1</li><li id="li2">item2</li></ol><ol start="3"><li>item3</li></ol>',
+            chains => {
+                const li = document.getElementById('li2');
+                li.parentNode.removeChild(li);
+            },
+            '<ol><li>item1</li></ol><ol start="2"><li>item3</li></ol>'
+        );
+    });
+
+    it('Remove a list', () => {
+        runTest(
+            '<ol><li>item1</li><li>item2</li></ol><ol start="3" id="ol2"><li>item3</li></ol><ol start="4"><li>item4</li></ol>',
+            chains => {
+                const ol = document.getElementById('ol2');
+                ol.parentNode.removeChild(ol);
+            },
+            '<ol><li>item1</li><li>item2</li></ol><ol start="3"><li>item4</li></ol>'
+        );
+    });
+
+    it('Remove the first list item', () => {
+        runTest(
+            '<ol><li id="li1">item1</li><li>item2</li></ol><ol start="3"><li>item3</li></ol>',
+            chains => {
+                const li = document.getElementById('li1');
+                li.parentNode.removeChild(li);
+            },
+            '<ol><li>item2</li></ol><ol start="2"><li>item3</li></ol>'
+        );
+    });
+
+    it('Remove the first list', () => {
+        runTest(
+            '<ol id="ol1"><li>item1</li><li>item2</li></ol><ol start="3"><li>item3</li></ol><ol start="4"><li>item4</li></ol>',
+            chains => {
+                const ol = document.getElementById('ol1');
+                ol.parentNode.removeChild(ol);
+            },
+            '<ol><li>item3</li></ol><ol start="2"><li>item4</li></ol>'
+        );
+    });
+});

--- a/packages/roosterjs-editor-dom/test/list/createVListFromRegionTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/createVListFromRegionTest.ts
@@ -336,6 +336,26 @@ describe('createVListFromRegion from selection, with sibling list', () => {
         );
     });
 
+    it('has sibling nodes, has previous sibling list, but current list do not start frm 1', () => {
+        runTest(
+            `<ul><li>previous sibling</li></ul><ol start="2"><li>line1</li><li id="${FocusNode}">line2</li><li>line3</li></ol><div>next sibling</div>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3</li>',
+                },
+            ]
+        );
+    });
+
     it('has sibling nodes, has next sibling list', () => {
         runTest(
             `<div>previous sibling</div><ol><li>line1</li><li id="${FocusNode}">line2</li><li>line3</li></ol><ul><li>next sibling</li></ul>`,
@@ -355,6 +375,26 @@ describe('createVListFromRegion from selection, with sibling list', () => {
                 {
                     listTypes: [ListType.None, ListType.Unordered],
                     outerHTML: '<li>next sibling</li>',
+                },
+            ]
+        );
+    });
+
+    it('has sibling nodes, has next sibling list, but current list do not start frm 1', () => {
+        runTest(
+            `<div>previous sibling</div><ol start="2"><li>line1</li><li id="${FocusNode}">line2</li><li>line3</li></ol><ul><li>next sibling</li></ul>`,
+            [
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: `<li id="${FocusNode}">line2</li>`,
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li>line3</li>',
                 },
             ]
         );

--- a/packages/roosterjs-editor-dom/test/list/getRootListNodeTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/getRootListNodeTest.ts
@@ -1,0 +1,116 @@
+import getRootListNode, { SelectorToTypeMap } from '../../lib/list/getRootListNode';
+
+describe('getRootListNode', () => {
+    it('null input', () => {
+        expect(getRootListNode(null, 'ol', null)).toBeNull();
+        expect(getRootListNode(null, 'ol', document.createElement('div'))).toBeNull();
+        expect(
+            getRootListNode(
+                {
+                    rootNode: document.createElement('div'),
+                    skipTags: [],
+                },
+                'ol',
+                null
+            )
+        ).toBeNull();
+    });
+
+    const StartNode = 'StartNode';
+
+    function runTest(html: string, selector: keyof SelectorToTypeMap, expectedOuterHTML: string) {
+        const div = document.createElement('div');
+        document.body.appendChild(div);
+        div.innerHTML = html;
+
+        const startNode = document.getElementById(StartNode);
+        if (!startNode) {
+            throw new Error('StartNode not found');
+        }
+
+        const result = getRootListNode(
+            {
+                rootNode: div,
+                skipTags: [],
+            },
+            selector,
+            startNode
+        );
+
+        if (expectedOuterHTML === null) {
+            expect(result).toBeNull();
+        } else {
+            expect(result.outerHTML).toBe(expectedOuterHTML);
+        }
+
+        document.body.removeChild(div);
+    }
+
+    it('No list node', () => {
+        runTest(`<div id="${StartNode}"></div>`, 'ol', null);
+    });
+
+    it('List node does not contain start node', () => {
+        runTest(`<ol><li>test</li></ol><div id="${StartNode}"></div>`, 'ol', null);
+    });
+
+    it('List node is start node', () => {
+        runTest(
+            `<ol id="${StartNode}"><li>test</li></ol><div></div>`,
+            'ol',
+            `<ol id="${StartNode}"><li>test</li></ol>`
+        );
+    });
+
+    it('List node contains start node', () => {
+        runTest(
+            `<ol><li>test<div id="${StartNode}"></div></li></ol>`,
+            'ol',
+            `<ol><li>test<div id="${StartNode}"></div></li></ol>`
+        );
+    });
+
+    it('List node contains list node', () => {
+        runTest(
+            `<ol><li>test</li><ol id="${StartNode}"></ol></ol>`,
+            'ol',
+            `<ol><li>test</li><ol id="${StartNode}"></ol></ol>`
+        );
+    });
+
+    it('List node is of different tag name', () => {
+        runTest(`<ul><li>test</li><ul id="${StartNode}"></ul></ul>`, 'ol', null);
+    });
+
+    it('Outer list node is of different tag name', () => {
+        runTest(
+            `<ul><li>test</li><ol id="${StartNode}"></ol></ul>`,
+            'ol',
+            `<ol id="${StartNode}"></ol>`
+        );
+    });
+
+    it('Multiple levels of list node', () => {
+        runTest(
+            `<ol><li>test</li><ol><li><div id="${StartNode}"></div></li></ol></ol>`,
+            'ol',
+            `<ol><li>test</li><ol><li><div id="${StartNode}"></div></li></ol></ol>`
+        );
+    });
+
+    it('Multiple levels of list node with different tag names', () => {
+        runTest(
+            `<ol><li>test</li><ul><li><div id="${StartNode}"></div></li></ul></ol>`,
+            'ol',
+            `<ol><li>test</li><ul><li><div id="${StartNode}"></div></li></ul></ol>`
+        );
+    });
+
+    it('Multiple levels of list node with different tag names and selector for both', () => {
+        runTest(
+            `<ol><li>test</li><ul><li><div id="${StartNode}"></div></li></ul></ol>`,
+            'ol,ul',
+            `<ol><li>test</li><ul><li><div id="${StartNode}"></div></li></ul></ol>`
+        );
+    });
+});

--- a/packages/roosterjs-editor-plugins/lib/CutPasteListChain.ts
+++ b/packages/roosterjs-editor-plugins/lib/CutPasteListChain.ts
@@ -1,0 +1,1 @@
+export * from './plugins/CutPasteListChain/index';

--- a/packages/roosterjs-editor-plugins/lib/index.ts
+++ b/packages/roosterjs-editor-plugins/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './ContentEdit';
 export * from './CustomReplace';
+export * from './CutPasteListChain';
 export * from './HyperLink';
 export * from './ImageResize';
 export * from './Paste';

--- a/packages/roosterjs-editor-plugins/lib/plugins/CutPasteListChain/CutPasteListChain.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/CutPasteListChain/CutPasteListChain.ts
@@ -1,0 +1,81 @@
+import { experimentCommitListChains } from 'roosterjs-editor-api';
+import { VListChain } from 'roosterjs-editor-dom';
+import {
+    ChangeSource,
+    EditorPlugin,
+    IEditor,
+    PluginEvent,
+    PluginEventType,
+} from 'roosterjs-editor-types';
+
+/**
+ * Maintain list numbers of list chain when content is modified by cut/paste/drag&drop
+ */
+export default class CutPasteListChain implements EditorPlugin {
+    private chains: VListChain[];
+    private expectedChangeSource: ChangeSource;
+    private editor: IEditor;
+    private disposer: () => void;
+
+    /**
+     * Get a friendly name of this plugin
+     */
+    getName() {
+        return 'CutPasteListChain';
+    }
+
+    /**
+     * Initialize this plugin
+     * @param editor The editor instance
+     */
+    initialize(editor: IEditor) {
+        this.editor = editor;
+        this.disposer = this.editor.addDomEventHandler('drop', this.onDrop);
+    }
+
+    /**
+     * Dispose this plugin
+     */
+    dispose() {
+        this.disposer?.();
+        this.disposer = null;
+        this.editor = null;
+    }
+
+    /**
+     * Handle events triggered from editor
+     * @param event PluginEvent object
+     */
+    onPluginEvent(event: PluginEvent) {
+        switch (event.eventType) {
+            case PluginEventType.BeforeCutCopy:
+                if (event.isCut) {
+                    this.cacheListChains(ChangeSource.Cut);
+                }
+                break;
+
+            case PluginEventType.BeforePaste:
+                this.cacheListChains(ChangeSource.Paste);
+                break;
+
+            case PluginEventType.ContentChanged:
+                if (this.chains?.length > 0 && this.expectedChangeSource == event.source) {
+                    experimentCommitListChains(this.editor, this.chains);
+                    this.chains = null;
+                    this.expectedChangeSource = null;
+                }
+                break;
+        }
+    }
+
+    private onDrop = () => {
+        this.cacheListChains(ChangeSource.Drop);
+    };
+
+    private cacheListChains(source: ChangeSource) {
+        if (this.editor.useExperimentFeatures()) {
+            this.chains = VListChain.createListChains(this.editor.getSelectedRegions());
+            this.expectedChangeSource = source;
+        }
+    }
+}

--- a/packages/roosterjs-editor-plugins/lib/plugins/CutPasteListChain/index.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/CutPasteListChain/index.ts
@@ -1,0 +1,1 @@
+export { default as CutPasteListChain } from './CutPasteListChain';

--- a/packages/roosterjs-editor-types/lib/enum/ChangeSource.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ChangeSource.ts
@@ -57,4 +57,9 @@ export const enum ChangeSource {
      * Editor is switched to light mode, content color is changed
      */
     SwitchToLightMode = 'SwitchToLightMode',
+
+    /**
+     * List chain reorganized numbers of lists
+     */
+    ListChain = 'ListChain',
 }

--- a/packages/roosterjs-editor-types/lib/interface/ContentEditFeatureSettings.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ContentEditFeatureSettings.ts
@@ -103,6 +103,11 @@ export interface ListFeatureSettings {
      * @default false
      */
     mergeInNewLineWhenBackspaceOnFirstChar: boolean;
+
+    /**
+     * When edit with lists, maintain the list numbers of list chain
+     */
+    maintainListChain: boolean;
 }
 
 /**


### PR DESCRIPTION
Introduce the new VListChain concept.

e.g, we have two lists:
1
2
3
and
4
5
6
VListChain will chain them together so that if we make any change to the first list, the second one can also be maintained.

This change can handle the following changes:

- Enter in list to generate new item
- Delete/Backspace in list to remove/merge item
- Select some lists then type to replace items
- Tab/Shift+Tab to indent/outdent list items
- Auto start new list item (type number + "." + Space)
- Enter/Backspace on empty list item to quite current list
- Cut from list
- Paste into list
- Drag and drop with list

All features can only work when "useExperimetalFeatures" flag is on (by default enabled in demo site)