### PR TITLE
Fix for issue #483 - Problems with multiple trigger characters in Picker Plugin 

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
@@ -398,6 +398,13 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                 this.setIsSuggesting(false);
                 this.blockSuggestions = true;
                 this.cancelDefaultKeyDownEvent(event);
+            } else if (keyboardEvent.key == BACKSPACE_CHARCODE) {
+                // #483: If we are backspacing over the trigger character that triggered this Picker
+                // then we need to hide the Picker
+                const wordBeforeCursor = this.getWord(event);
+                if (wordBeforeCursor == this.pickerOptions.triggerCharacter) {
+                    this.setIsSuggesting(false);
+                }
             } else if (
                 this.dataProvider.shiftHighlight &&
                 (this.pickerOptions.isHorizontal


### PR DESCRIPTION
If a Picker is active (isSuggesting == true), and a user backspaces over the trigger character we do not immediately deactivate the Picker. The result is that we continue calling the getRangeUntilAt method and look for all the text between the current cursor and the previous trigger character.  If the result is empty, then we deactivate the Picker. If there happens to be another trigger character located earlier in the selection context, we return that incorrect result and display it in the active Picker. 

This PR stops that behavior by detecting the backspace over the trigger character and deactivating the Picker. I tested this in the Rooster demo (using the sample color picker) and then in OWA using the emoji and at mentions pickers.

See Issue #483 
