### PR TITLE
Adding single direction resize

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
@@ -21,6 +21,7 @@ const ENTITY_TYPE = 'IMAGE_RESIZE_WRAPPER';
 
 const HANDLE_SIZE = 7;
 const HANDLE_MARGIN = 3;
+const HANDLE_POSITIONS = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
 
 /**
  * ImageResize plugin provides the ability to resize an inline image in editor
@@ -235,8 +236,6 @@ export default class ImageResize implements EditorPlugin {
                     img.style.height = newHeight + 'px';
                 }
             }
-
-            this.positionSingleDirectionHandles(img);
         }
         this.stopEvent(e);
     };
@@ -297,26 +296,27 @@ export default class ImageResize implements EditorPlugin {
         wrapper.style.display = 'inline-flex';
 
         const html =
-            ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w']
-                .map(
-                    pos =>
-                        `<div div id=${pos}-handle style="position:absolute;width:${HANDLE_SIZE}px;height:${HANDLE_SIZE}px;background-color: ${
-                            this.selectionBorderColor
-                        };cursor: ${pos}-resize;${
-                            this.isNorth(pos) ? 'top' : 'bottom'
-                        }:-${HANDLE_MARGIN}px;${
-                            this.isWest(pos) ? 'left' : 'right'
-                        }:-${HANDLE_MARGIN}px"></div>`
-                )
-                .join('') +
-            `<div style="position:absolute;left:0;right:0;top:0;bottom:0;border:solid 1px ${this.selectionBorderColor};pointer-events:none;"></div>`;
+            HANDLE_POSITIONS.map(
+                pos =>
+                    `<div style="position:absolute;${this.isWest(pos) ? 'left' : 'right'}:${
+                        this.isSingleDirectionNS(pos) ? '50%' : '0px'
+                    };${this.isNorth(pos) ? 'top' : 'bottom'}:${
+                        this.isSingleDirectionWE(pos) ? '50%' : '0px'
+                    }">
+                            <div id=${pos}-handle style="position:relative;width:${HANDLE_SIZE}px;height:${HANDLE_SIZE}px;background-color: ${
+                        this.selectionBorderColor
+                    };cursor: ${pos}-resize;${
+                        this.isNorth(pos) ? 'top' : 'bottom'
+                    }:-${HANDLE_MARGIN}px;${
+                        this.isWest(pos) ? 'left' : 'right'
+                    }:-${HANDLE_MARGIN}px"></div></div>`
+            ).join('') +
+            `<div style="position:absolute;left:0;right:0;top:0;bottom:0;border:solid 1px ${this.selectionBorderColor};pointer-events:none;">`;
 
         fromHtml(html, this.editor.getDocument()).forEach(div => {
             wrapper.appendChild(div);
             div.addEventListener('mousedown', this.startResize);
         });
-
-        this.positionSingleDirectionHandles(target);
 
         // If the resizeDiv's image has a transform, apply it to the container
         const selectedImage = this.getSelectedImage(wrapper);
@@ -326,22 +326,6 @@ export default class ImageResize implements EditorPlugin {
         }
 
         return wrapper;
-    }
-
-    private positionSingleDirectionHandles(target: HTMLElement) {
-        const middleWidth = Math.floor((target.clientWidth - HANDLE_SIZE) / 2);
-        const middleHeight = Math.floor((target.clientHeight - HANDLE_SIZE) / 2);
-
-        ['n', 's', 'e', 'w'].forEach(pos => {
-            const handle = document.getElementById(`${pos}-handle`);
-            if (handle) {
-                if (this.isSingleDirectionNS(pos)) {
-                    handle.style.left = `${middleWidth}px`;
-                } else {
-                    handle.style.top = `${middleHeight}px`;
-                }
-            }
-        });
     }
 
     private stopEvent = (e: Event) => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
@@ -183,7 +183,7 @@ export default class ImageResize implements EditorPlugin {
             let document = this.editor.getDocument();
             document.addEventListener('mousemove', this.doResize, true /*useCapture*/);
             document.addEventListener('mouseup', this.finishResize, true /*useCapture*/);
-            this.direction = (<HTMLElement>(e.srcElement || e.target)).style.cursor;
+            this.direction = (<HTMLElement>(e.srcElement || e.target)).dataset.direction;
         }
 
         this.stopEvent(e);
@@ -194,7 +194,6 @@ export default class ImageResize implements EditorPlugin {
         if (this.editor && img) {
             let widthChange = e.pageX - this.startPageX;
             let heightChange = e.pageY - this.startPageY;
-
             let newWidth = this.calculateNewWidth(widthChange);
             let newHeight = this.calculateNewHeight(heightChange);
 
@@ -303,7 +302,7 @@ export default class ImageResize implements EditorPlugin {
                     };${this.isNorth(pos) ? 'top' : 'bottom'}:${
                         this.isSingleDirectionWE(pos) ? '50%' : '0px'
                     }">
-                            <div id=${pos}-handle style="position:relative;width:${HANDLE_SIZE}px;height:${HANDLE_SIZE}px;background-color: ${
+                            <div id=${pos}-handle data-direction="${pos}" style="position:relative;width:${HANDLE_SIZE}px;height:${HANDLE_SIZE}px;background-color: ${
                         this.selectionBorderColor
                     };cursor: ${pos}-resize;${
                         this.isNorth(pos) ? 'top' : 'bottom'
@@ -359,16 +358,11 @@ export default class ImageResize implements EditorPlugin {
     }
 
     private isSingleDirectionNS(direction: string): boolean {
-        return (
-            direction &&
-            (direction.substr(0, 1) == 'n' || direction.substr(0, 1) == 's') &&
-            direction.substr(1, 1) != 'e' &&
-            direction.substr(1, 1) != 'w'
-        );
+        return direction && (direction == 'n' || direction == 's');
     }
 
     private isSingleDirectionWE(direction: string): boolean {
-        return direction && (direction.substr(0, 1) == 'w' || direction.substr(0, 1) == 'e');
+        return direction && (direction == 'w' || direction == 'e');
     }
 
     private onDragStart = (e: DragEvent) => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
@@ -354,7 +354,7 @@ export default class ImageResize implements EditorPlugin {
     }
 
     private isWest(direction: string): boolean {
-        return direction && (direction.substr(0, 1) == 'w' || direction.substr(1, 1) == 'w');
+        return direction && (direction.substr(1, 1) == 'w' || direction == 'w');
     }
 
     private isSingleDirectionNS(direction: string): boolean {


### PR DESCRIPTION
Adding ability to resize in single direction.
- Created new handles for n, s, e and w in the resizeDiv.
- When the resize is happening, reposition the handles in reference to the changing width and height of the image.
- When dragging the single direction handles, only allow the change in either width or height.
- Note: The forcePreserveRatio setting only applies to the corner handles and not the single direction ones.
