### PR TITLE
Allow editing of link URLs through display text

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -5,7 +5,7 @@ import {
     isCtrlOrMetaPressed,
     cacheGetElementAtCursor,
 } from 'roosterjs-editor-core';
-import { PluginEvent, PluginEventType, ChangeSource } from 'roosterjs-editor-types';
+import { PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 
 const PAGEUP_KEYCODE = 33;
 const DOWN_KEYCODE = 40;
@@ -163,16 +163,18 @@ export default class HyperLink implements EditorPlugin {
      */
     private updateLinkHref(event: PluginEvent, editor: Editor) {
         let originalLink = this.trackedLink; // keep the element available for the auto complete function
-        let anchor = originalLink.cloneNode(true /*deep*/) as HTMLAnchorElement;
 
         let linkData = matchLink(this.trackedLink.innerText.trim());
-        anchor.href = linkData.normalizedUrl;
+        if (linkData !== null) {
+            let anchor = originalLink.cloneNode(true /*deep*/) as HTMLAnchorElement;
+            anchor.href = linkData.normalizedUrl;
 
-        editor.runAsync(() => {
-            editor.performAutoComplete(() => {
-                editor.replaceNode(originalLink, anchor);
-                return anchor;
+            editor.runAsync(() => {
+                editor.performAutoComplete(() => {
+                    editor.replaceNode(originalLink, anchor);
+                    return anchor;
+                });
             });
-        });
+        }
     }
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -7,6 +7,9 @@ import {
 } from 'roosterjs-editor-core';
 import { PluginEvent, PluginEventType, ChangeSource } from 'roosterjs-editor-types';
 
+const PAGEUP_KEYCODE = 33;
+const DOWN_KEYCODE = 40;
+
 /**
  * An editor plugin that show a tooltip for existing link
  */
@@ -76,7 +79,9 @@ export default class HyperLink implements EditorPlugin {
     public onPluginEvent(event: PluginEvent): void {
         if (
             event.eventType == PluginEventType.MouseUp ||
-            event.eventType == PluginEventType.KeyUp
+            (event.eventType == PluginEventType.KeyUp &&
+                event.rawEvent.which >= PAGEUP_KEYCODE &&
+                event.rawEvent.which <= DOWN_KEYCODE)
         ) {
             const anchor = cacheGetElementAtCursor(
                 this.editor,

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -145,7 +145,7 @@ export default class HyperLink implements EditorPlugin {
     }
 
     /**
-     * Compares the normalized URL of inner text of element to its href to see if they match
+     * Compares the URL of inner text of element to its href to see if they match
      */
     private doesLinkDisplayMatchHref(element: HTMLAnchorElement): boolean {
         let display = element.innerText.trim();
@@ -162,7 +162,7 @@ export default class HyperLink implements EditorPlugin {
      * Update href of an element in place to new display text if it's a valid URL
      */
     private updateLinkHref(event: PluginEvent, editor: Editor) {
-        let originalLink = this.trackedLink;
+        let originalLink = this.trackedLink; // keep the element available for the auto complete function
         let anchor = originalLink.cloneNode(true /*deep*/) as HTMLAnchorElement;
 
         let linkData = matchLink(this.trackedLink.innerText.trim());

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -172,7 +172,7 @@ export default class HyperLink implements EditorPlugin {
             editor.performAutoComplete(() => {
                 editor.replaceNode(originalLink, anchor);
                 return anchor;
-            }, ChangeSource.AutoLink);
+            });
         });
     }
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -143,8 +143,14 @@ export default class HyperLink implements EditorPlugin {
      * Compares the normalized URL of inner text of element to its href to see if they match
      */
     private doesLinkDisplayMatchHref(element: HTMLAnchorElement): boolean {
-        let url = matchLink(element.innerText.trim()).normalizedUrl;
-        return url === element.href || url + '/' === element.href;
+        let display = element.innerText.trim();
+        let rule = new RegExp(`^(?:https?:\\/\\/)?${display}\\/?`, 'i');
+        let href = this.tryGetHref(element);
+        if (href !== null) {
+            return rule.test(href);
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
This is an attempted fix for #254 where editing a link's URL does not update the href attribute.

The fix has the following behavior:

In the Hyperlink plugin, if we have either mouse up or key up events and the keycode is a directional key (pageup, pagedown, home, end, left/up/right/down), the code checks if the link's display text matches the href value of the link. If it does, it stores the link element away so that we can know if the cursor has moved away from the link. When we receive another event of the same kind, we will check if the current element at the cursor is different from the one that was stored away. If it is different, and the display text is a valid URL, then we will clone the element, update the href attribute on the cloned element to match the display text URL, and then replace the old element with the new one in the editor.

Some details:
- The reason that the keys are restricted to directional keys is so that we don't run a bunch of work if the user is typing in the editor.
- A match is defined as: the display text can be missing the http(s) portion or a backslash at the end of the URL, but otherwise must exactly match the href value. This means that if the display text says “www.bing.com” and the href value is “http://www.bing.com/” then it will match and allow the editing behavior, but it will not kick in if the “www.” is missing from the display text.
- The behavior kicks in if the link has extra formatting like changed text color or italicization. It will keep previous formatting that was applied to it.
- This behavior is done with the auto-correct behavior so that the user can undo it with backspace or ctrl-z. This can have some weird behavior in cases like: you have two links in the editor, you edit one link, use the mouse to put the cursor into another link (behavior kicks in), and then press backspace to edit the second link, which seems to do nothing. However what it does is undo the href editing that just happened because that's how the auto correct works, but it's not very obvious because the href editing is not a visible change. If people have suggestions on how I can fix this behavior, I would love to hear them.

I have tested:
- Editing a link which matches the href attribute exactly
- Editing a link which has the http(s) and backslash missing
- Editing a link which has the "www." portion missing, the behavior did not kick in
- Editing a link with red text, the red text was kept
- Behavior is undo-able in two stages (the href update and the display text edits are different undo steps)

If there are other test cases that I should run, let me know and I'd be happy to try them out.
I also just noticed that I should update the wiki page on the Hyperlink plugin to account for this behavior. I'd also be open to moving this into its own plugin - let me know what would be best.