### PR TITLE
Allow editing of link URLs through display text

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -58,12 +58,11 @@ export default class HyperLink implements EditorPlugin {
     };
 
     protected onBlur = (e: FocusEvent) => {
-        if (this.trackedLink && !this.doesLinkDisplayMatchHref(this.trackedLink)) {
-            this.updateLinkHref();
+        if (this.trackedLink) {
+            this.updateLinkHrefIfShouldUpdate();
         }
 
-        this.trackedLink = null;
-        this.originalHref = '';
+        this.resetLinkTracking();
     };
 
     /**
@@ -104,15 +103,12 @@ export default class HyperLink implements EditorPlugin {
                     this.trackedLink &&
                     (anchor !== this.trackedLink || event.eventType == PluginEventType.KeyUp)
                 ) {
-                    if (!this.doesLinkDisplayMatchHref(this.trackedLink)) {
-                        this.updateLinkHref();
-                    }
+                    this.updateLinkHrefIfShouldUpdate();
                 }
 
                 // If the link's href value was edited, or the cursor has moved out of the previously tracked link,
                 // stop tracking the link.
-                this.trackedLink = null;
-                this.originalHref = '';
+                this.resetLinkTracking();
             }
 
             // Cache link and href value if its href attribute currently matches its display text
@@ -168,6 +164,23 @@ export default class HyperLink implements EditorPlugin {
         return (
             isCharacterValue(event) || event.which == Keys.BACKSPACE || event.which == Keys.DELETE
         );
+    }
+
+    /**
+     * Updates the href of the tracked link if the display text doesn't match href anymore
+     */
+    private updateLinkHrefIfShouldUpdate() {
+        if (!this.doesLinkDisplayMatchHref(this.trackedLink)) {
+            this.updateLinkHref();
+        }
+    }
+
+    /**
+     * Clears the tracked link and its original href value so that it's back to default state
+     */
+    private resetLinkTracking() {
+        this.trackedLink = null;
+        this.originalHref = '';
     }
 
     /**

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -68,10 +68,14 @@ export default class HyperLink implements EditorPlugin {
      * @param event PluginEvent object
      */
     public onPluginEvent(event: PluginEvent): void {
-        if (event.eventType == PluginEventType.MouseUp) {
+        if (
+            event.eventType == PluginEventType.MouseUp ||
+            event.eventType == PluginEventType.KeyUp
+        ) {
             const anchor = this.editor.getElementAtCursor(
-                'A',
-                <Node>event.rawEvent.srcElement
+                'A[href]',
+                null /*startFrom*/,
+                event
             ) as HTMLAnchorElement;
 
             // If cursor has moved out of previously tracked link
@@ -84,12 +88,19 @@ export default class HyperLink implements EditorPlugin {
                 this.trackedLink = null;
             }
 
-            if (anchor) {
-                // Cache link if its href attribute currently matches its display text
-                if (!this.trackedLink && this.doesLinkDisplayMatchHref(anchor)) {
-                    this.trackedLink = anchor;
-                }
+            // Cache link if its href attribute currently matches its display text
+            if (!this.trackedLink && this.doesLinkDisplayMatchHref(anchor)) {
+                this.trackedLink = anchor;
+            }
+        }
 
+        if (event.eventType == PluginEventType.MouseUp) {
+            const anchor = this.editor.getElementAtCursor(
+                'A',
+                <Node>event.rawEvent.srcElement
+            ) as HTMLAnchorElement;
+
+            if (anchor) {
                 if (this.onLinkClick && this.onLinkClick(anchor, event.rawEvent) !== false) {
                     return;
                 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -1,5 +1,5 @@
 import { Browser, isCtrlOrMetaPressed, matchLink } from 'roosterjs-editor-dom';
-import { EditorPlugin, IEditor, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
+import { EditorPlugin, IEditor, Keys, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 
 /**
  * An editor plugin that show a tooltip for existing link
@@ -70,7 +70,9 @@ export default class HyperLink implements EditorPlugin {
     public onPluginEvent(event: PluginEvent): void {
         if (
             event.eventType == PluginEventType.MouseUp ||
-            event.eventType == PluginEventType.KeyUp
+            (event.eventType == PluginEventType.KeyUp &&
+                event.rawEvent.which >= Keys.PAGEUP &&
+                event.rawEvent.which <= Keys.DOWN)
         ) {
             const anchor = this.editor.getElementAtCursor(
                 'A[href]',

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -137,8 +137,14 @@ export default class HyperLink implements EditorPlugin {
      * Compares the normalized URL of inner text of element to its href to see if they match
      */
     private doesLinkDisplayMatchHref(element: HTMLAnchorElement): boolean {
-        let url = matchLink(element.innerText.trim()).normalizedUrl;
-        return url === element.href || url + '/' === element.href;
+        let display = element.innerText.trim();
+        let rule = new RegExp(`^(?:https?:\\/\\/)?${display}\\/?`, 'i');
+        let href = this.tryGetHref(element);
+        if (href !== null) {
+            return rule.test(href);
+        }
+
+        return false;
     }
 
     /**

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -84,7 +84,7 @@ export default class HyperLink implements EditorPlugin {
             // update link href if applicable and then reset tracked state
             if (this.trackedLink && anchor !== this.trackedLink) {
                 if (!this.doesLinkDisplayMatchHref(this.trackedLink)) {
-                    this.updateLinkHref(event, this.editor);
+                    this.updateLinkHref(event);
                 }
 
                 this.trackedLink = null;
@@ -152,7 +152,7 @@ export default class HyperLink implements EditorPlugin {
     /**
      * Update href of an element in place to new display text if it's a valid URL
      */
-    private updateLinkHref(event: PluginEvent, editor: IEditor) {
+    private updateLinkHref(event: PluginEvent) {
         let originalLink = this.trackedLink; // keep the element available for the auto complete function
 
         let linkData = matchLink(this.trackedLink.innerText.trim());
@@ -160,9 +160,9 @@ export default class HyperLink implements EditorPlugin {
             let anchor = originalLink.cloneNode(true /*deep*/) as HTMLAnchorElement;
             anchor.href = linkData.normalizedUrl;
 
-            editor.runAsync(() => {
-                editor.addUndoSnapshot(() => {
-                    editor.replaceNode(originalLink, anchor);
+            this.editor.runAsync(() => {
+                this.editor.addUndoSnapshot(() => {
+                    this.editor.replaceNode(originalLink, anchor);
                     return anchor;
                 });
             });


### PR DESCRIPTION
This is an attempted fix for #254 where editing a link's URL does not update the href attribute.

The fix has the following behavior:

In the Hyperlink plugin, if we have either mouse up or key up events and the keycode is a directional key (pageup, pagedown, home, end, left/up/right/down), the code checks if the link's display text matches the href value of the link. If it does, it stores the link element away so that we can know if the cursor has moved away from the link. When we receive another event of the same kind, we will check if the current element at the cursor is different from the one that was stored away. If it is different, and the display text is a valid URL, then we will clone the element, update the href attribute on the cloned element to match the display text URL, and then replace the old element with the new one in the editor.

Some details:
- The reason that the keys are restricted to directional keys is so that we don't run a bunch of work if the user is typing in the editor. I think I got all of the ways the cursor can move via keyboard, but there may be cases I'm missing. If there's an easier way to listen to cursor position changes I'd be open to using that instead.
- A match is defined as: the display text can be missing the http(s) portion or a backslash at the end of the URL, but otherwise must exactly match the href value. This means that if the display text says “www.bing.com” and the href value is “http://www.bing.com/” then it will match and allow the editing behavior, but it will not kick in if the “www.” is missing from the display text.
- The behavior kicks in if the link has extra formatting like changed text color or italicization. It will keep previous formatting that was applied to it.
- This behavior is done with the auto-correct behavior so that the user can undo it with ctrl-z but not backspace.

I have tested:
- Editing a link which matches the href attribute exactly
- Editing a link which has the http(s) and backslash missing
- Editing a link which has the "www." portion missing, the behavior did not kick in
- Editing a link with red text, the red text was kept
- Behavior is undo-able in two stages (the href update and the display text edits are different undo steps)
- If you edit the href field of the link using the link dialog and then change the display text, the link is not updated.
- Link is updated after bringing focus out of the editor
- Link is updated after arrowing arround
- Link is updated if space is pressed at the end of a link
- Link is updated if content is pasted at the end of a link and middle of a link

If there are other test cases that I should run, let me know and I'd be happy to try them out.
I also just noticed that I should update the wiki page on the Hyperlink plugin to account for this behavior. I'd also be open to moving this into its own plugin - let me know what would be best.