### PR TITLE
Improve image resize

### DIFF
--- a/demo/scripts/controls/BuildInPluginState.ts
+++ b/demo/scripts/controls/BuildInPluginState.ts
@@ -28,6 +28,7 @@ export default interface BuildInPluginState {
     watermarkText: string;
     showRibbon: boolean;
     experimentalFeatures: ExperimentalFeatures[];
+    forcePreserveRatio: boolean;
 }
 
 export interface BuildInPluginProps extends BuildInPluginState, SidePaneElementProps {}

--- a/demo/scripts/controls/editor/Editor.tsx
+++ b/demo/scripts/controls/editor/Editor.tsx
@@ -80,7 +80,9 @@ export default class Editor extends React.Component<EditorProps, BuildInPluginSt
             hyperlink: pluginList.hyperlink ? new HyperLink(this.getLinkCallback()) : null,
             paste: pluginList.paste ? new Paste() : null,
             watermark: pluginList.watermark ? new Watermark(this.state.watermarkText) : null,
-            imageResize: pluginList.imageResize ? new ImageResize() : null,
+            imageResize: pluginList.imageResize
+                ? new ImageResize(10, 10, undefined, this.state.forcePreserveRatio)
+                : null,
             cutPasteListChain: pluginList.cutPasteListChain ? new CutPasteListChain() : null,
             tableResize: pluginList.tableResize ? new TableResize() : null,
             pickerPlugin: pluginList.pickerPlugin

--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -22,6 +22,7 @@ const initialState: BuildInPluginState = {
     defaultFormat: {},
     linkTitle: 'Ctrl+Click to follow the link:' + UrlPlaceholder,
     watermarkText: 'Type content here ...',
+    forcePreserveRatio: false,
     showRibbon: true,
     experimentalFeatures: [
         ExperimentalFeatures.ListChain,

--- a/demo/scripts/controls/sidePane/editorOptions/OptionsPane.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/OptionsPane.tsx
@@ -136,6 +136,7 @@ export default class OptionsPane extends React.Component<BuildInPluginProps, Bui
             contentEditFeatures: { ...this.state.contentEditFeatures },
             defaultFormat: { ...this.state.defaultFormat },
             experimentalFeatures: this.state.experimentalFeatures,
+            forcePreserveRatio: this.state.forcePreserveRatio,
         };
 
         if (callback) {

--- a/demo/scripts/controls/sidePane/editorOptions/Plugins.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/Plugins.tsx
@@ -13,6 +13,7 @@ export interface PluginsProps {
 export default class Plugins extends React.Component<PluginsProps, {}> {
     private linkTitle = React.createRef<HTMLInputElement>();
     private watermarkText = React.createRef<HTMLInputElement>();
+    private forcePreserveRatio = React.createRef<HTMLInputElement>();
 
     render() {
         return (
@@ -42,7 +43,16 @@ export default class Plugins extends React.Component<PluginsProps, {}> {
                             (state, value) => (state.watermarkText = value)
                         )
                     )}
-                    {this.renderPluginItem('imageResize', 'Image Resize Plugin')}
+                    {this.renderPluginItem(
+                        'imageResize',
+                        'Image Resize Plugin',
+                        this.renderCheckBox(
+                            'Force preserve ratio',
+                            this.forcePreserveRatio,
+                            this.props.state.forcePreserveRatio,
+                            (state, value) => (state.forcePreserveRatio = value)
+                        )
+                    )}
                     {this.renderPluginItem('cutPasteListChain', 'CutPasteListChainPlugin')}
                     {this.renderPluginItem('tableResize', 'Table Resize Plugin')}
                     {this.renderPluginItem('pickerPlugin', 'Sample Picker Plugin')}
@@ -103,6 +113,28 @@ export default class Plugins extends React.Component<PluginsProps, {}> {
                     }
                     onBlur={() => this.props.resetState(null, true)}
                 />
+            </div>
+        );
+    }
+
+    private renderCheckBox(
+        label: string,
+        ref: React.RefObject<HTMLInputElement>,
+        value: boolean,
+        onChange: (state: BuildInPluginState, value: boolean) => void
+    ): JSX.Element {
+        return (
+            <div>
+                <input
+                    type="checkbox"
+                    ref={ref}
+                    checked={value}
+                    onChange={() =>
+                        this.props.resetState(state => onChange(state, ref.current.checked), false)
+                    }
+                    onBlur={() => this.props.resetState(null, true)}
+                />
+                {label}
             </div>
         );
     }

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
@@ -200,8 +200,16 @@ export default class ImageResize implements EditorPlugin {
             let heightChange = e.pageY - this.startPageY;
             let newWidth = this.calculateNewWidth(widthChange);
             let newHeight = this.calculateNewHeight(heightChange);
+            const isSingleDirection =
+                this.isSingleDirectionNS(this.direction) ||
+                this.isSingleDirectionWE(this.direction);
+            const shouldPreserveRatio =
+                !isSingleDirection && (this.forcePreserveRatio || e.shiftKey);
 
-            if (this.forcePreserveRatio || e.shiftKey) {
+            if (shouldPreserveRatio) {
+                newHeight = Math.min(newHeight, (newWidth * this.startHeight) / this.startWidth);
+                newWidth = Math.min(newWidth, (newHeight * this.startWidth) / this.startHeight);
+
                 let ratio =
                     this.startWidth > 0 && this.startHeight > 0
                         ? (this.startWidth * 1.0) / this.startHeight
@@ -219,7 +227,7 @@ export default class ImageResize implements EditorPlugin {
             img.style.height = newHeight + 'px';
 
             // double check
-            if (this.forcePreserveRatio || e.shiftKey) {
+            if (shouldPreserveRatio) {
                 let ratio =
                     this.startWidth > 0 && this.startHeight > 0
                         ? (this.startWidth * 1.0) / this.startHeight


### PR DESCRIPTION
Issues:

When force preserve ratio, can't do single dir resize, it always resize both directions
When force preserve ratio, single dir resize can't make image smaller
When force preserve ratio, hard to resize image smaller using corner handle
Fix:

Change the algorithm of size calculation
Add option in demo site to allow force preserve ratio