### PR TITLE
Allow move image

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
@@ -1,4 +1,4 @@
-import { contains, fromHtml, getEntitySelector, getTagOfNode, toArray } from 'roosterjs-editor-dom';
+import { fromHtml, getEntitySelector, getTagOfNode, toArray } from 'roosterjs-editor-dom';
 import { insertEntity } from 'roosterjs-editor-api';
 import {
     ChangeSource,
@@ -91,6 +91,10 @@ export default class ImageResize implements EditorPlugin {
      */
     onPluginEvent(e: PluginEvent) {
         if (e.eventType == PluginEventType.MouseDown) {
+            if (this.resizeDiv) {
+                this.hideResizeHandle();
+            }
+        } else if (e.eventType == PluginEventType.MouseUp) {
             const event = e.rawEvent;
             const target = <HTMLElement>(event.srcElement || event.target);
 
@@ -111,8 +115,6 @@ export default class ImageResize implements EditorPlugin {
                 if (!this.resizeDiv) {
                     this.showResizeHandle(<HTMLImageElement>target);
                 }
-            } else if (this.resizeDiv && !contains(this.resizeDiv, target)) {
-                this.hideResizeHandle();
             }
         } else if (e.eventType == PluginEventType.KeyDown && this.resizeDiv) {
             const event = e.rawEvent;


### PR DESCRIPTION
Moving image is natively supported by browser, but our ImageResize plugin has event handler for MouseDown plugin and make change to the image, which causes the image can't be moved.
The fix is to split the action of mouse down event into mouse down and mouse up. For mouse down, we deselect image if any, then reselect when mouse up. So that for drag event, the image can be detected by browser.