### PR TITLE
When paste before a link, make sure the pasted text is not inserted into link

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/TypeAfterLinkPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/TypeAfterLinkPlugin.ts
@@ -1,4 +1,4 @@
-import { Browser, LinkInlineElement, Position } from 'roosterjs-editor-dom';
+import { Browser, LinkInlineElement } from 'roosterjs-editor-dom';
 import {
     EditorPlugin,
     IEditor,
@@ -49,12 +49,13 @@ export default class TypeAfterLinkPlugin implements EditorPlugin {
         ) {
             let range = this.editor.getSelectionRange();
             if (range && range.collapsed && this.editor.getElementAtCursor('A[href]')) {
-                let searcher = this.editor.getContentSearcherOfCursor(event);
-                let inlineElement = searcher.getInlineElementBefore();
-                if (inlineElement instanceof LinkInlineElement) {
-                    this.editor.select(
-                        new Position(inlineElement.getContainerNode(), PositionType.After)
-                    );
+                const searcher = this.editor.getContentSearcherOfCursor(event);
+                const inlineElementBefore = searcher.getInlineElementBefore();
+                const inlineElementAfter = searcher.getInlineElementAfter();
+                if (inlineElementBefore instanceof LinkInlineElement) {
+                    this.editor.select(inlineElementBefore.getContainerNode(), PositionType.After);
+                } else if (inlineElementAfter instanceof LinkInlineElement) {
+                    this.editor.select(inlineElementAfter.getContainerNode(), PositionType.Before);
                 }
             }
         }

--- a/packages/roosterjs-editor-core/test/corePlugins/typeAfterLinkPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/typeAfterLinkPluginTest.ts
@@ -1,12 +1,13 @@
 import TypeAfterLinkPlugin from '../../lib/corePlugins/TypeAfterLinkPlugin';
-import { IEditor, PluginEventType } from 'roosterjs-editor-types';
+import { IEditor, PluginEventType, PositionType } from 'roosterjs-editor-types';
 import { LinkInlineElement, NodeInlineElement } from 'roosterjs-editor-dom';
 
-describe('TypeAfterLinkPlugin', () => {
+describe('TypeAfterLinkPlugin after a link', () => {
     let plugin: TypeAfterLinkPlugin;
     let div: HTMLElement;
     let select: jasmine.Spy;
     let getElementAtCursor: jasmine.Spy;
+    let a: HTMLAnchorElement;
 
     beforeEach(() => {
         plugin = new TypeAfterLinkPlugin();
@@ -14,7 +15,7 @@ describe('TypeAfterLinkPlugin', () => {
         document.body.appendChild(div);
         select = jasmine.createSpy('select');
         getElementAtCursor = jasmine.createSpy('getElementAtCursor').and.returnValue({});
-        const a = document.createElement('a');
+        a = document.createElement('a');
         div.appendChild(a);
 
         plugin.initialize(<IEditor>(<any>{
@@ -28,6 +29,7 @@ describe('TypeAfterLinkPlugin', () => {
                     getInlineElementBefore: () => {
                         return new LinkInlineElement(a, <any>{});
                     },
+                    getInlineElementAfter: () => <LinkInlineElement>null,
                 };
             },
             getElementAtCursor,
@@ -47,8 +49,8 @@ describe('TypeAfterLinkPlugin', () => {
         });
 
         expect(select).toHaveBeenCalledTimes(1);
-        expect(select.calls.argsFor(0)[0].node).toBe(div);
-        expect(select.calls.argsFor(0)[0].offset).toBe(1);
+        expect(select.calls.argsFor(0)[0]).toBe(a);
+        expect(select.calls.argsFor(0)[1]).toBe(PositionType.After);
 
         expect(getElementAtCursor).toHaveBeenCalledTimes(1);
         expect(getElementAtCursor).toHaveBeenCalledWith('A[href]');
@@ -66,8 +68,81 @@ describe('TypeAfterLinkPlugin', () => {
         });
 
         expect(select).toHaveBeenCalledTimes(1);
-        expect(select.calls.argsFor(0)[0].node).toBe(div);
-        expect(select.calls.argsFor(0)[0].offset).toBe(1);
+        expect(select.calls.argsFor(0)[0]).toBe(a);
+        expect(select.calls.argsFor(0)[1]).toBe(PositionType.After);
+        expect(getElementAtCursor).toHaveBeenCalledTimes(1);
+        expect(getElementAtCursor).toHaveBeenCalledWith('A[href]');
+    });
+});
+
+describe('TypeAfterLinkPlugin before a link', () => {
+    let plugin: TypeAfterLinkPlugin;
+    let div: HTMLElement;
+    let select: jasmine.Spy;
+    let getElementAtCursor: jasmine.Spy;
+    let a: HTMLAnchorElement;
+
+    beforeEach(() => {
+        plugin = new TypeAfterLinkPlugin();
+        div = document.createElement('div');
+        document.body.appendChild(div);
+        select = jasmine.createSpy('select');
+        getElementAtCursor = jasmine.createSpy('getElementAtCursor').and.returnValue({});
+        a = document.createElement('a');
+        div.appendChild(a);
+
+        plugin.initialize(<IEditor>(<any>{
+            getSelectionRange: () => {
+                return {
+                    collapsed: true,
+                };
+            },
+            getContentSearcherOfCursor: () => {
+                return <any>{
+                    getInlineElementAfter: () => {
+                        return new LinkInlineElement(a, <any>{});
+                    },
+                    getInlineElementBefore: () => <LinkInlineElement>null,
+                };
+            },
+            getElementAtCursor,
+            select,
+        }));
+    });
+
+    afterEach(() => {
+        plugin.dispose();
+        div.parentNode.removeChild(div);
+    });
+
+    it('type before link', () => {
+        plugin.onPluginEvent({
+            eventType: PluginEventType.KeyPress,
+            rawEvent: null,
+        });
+
+        expect(select).toHaveBeenCalledTimes(1);
+        expect(select.calls.argsFor(0)[0]).toBe(a);
+        expect(select.calls.argsFor(0)[1]).toBe(PositionType.Before);
+
+        expect(getElementAtCursor).toHaveBeenCalledTimes(1);
+        expect(getElementAtCursor).toHaveBeenCalledWith('A[href]');
+    });
+
+    it('paste before link', () => {
+        plugin.onPluginEvent({
+            eventType: PluginEventType.BeforePaste,
+            clipboardData: null,
+            fragment: null,
+            sanitizingOption: null,
+            htmlBefore: null,
+            htmlAfter: null,
+            htmlAttributes: null,
+        });
+
+        expect(select).toHaveBeenCalledTimes(1);
+        expect(select.calls.argsFor(0)[0]).toBe(a);
+        expect(select.calls.argsFor(0)[1]).toBe(PositionType.Before);
         expect(getElementAtCursor).toHaveBeenCalledTimes(1);
         expect(getElementAtCursor).toHaveBeenCalledWith('A[href]');
     });
@@ -97,6 +172,9 @@ describe('TypeAfterLinkPlugin not after link', () => {
             getContentSearcherOfCursor: () => {
                 return <any>{
                     getInlineElementBefore: () => {
+                        return new NodeInlineElement(span, <any>{});
+                    },
+                    getInlineElementAfter: () => {
                         return new NodeInlineElement(span, <any>{});
                     },
                 };
@@ -151,6 +229,8 @@ describe('TypeAfterLinkPlugin for expanded range', () => {
         getElementAtCursor = jasmine.createSpy('getElementAtCursor');
         const a = document.createElement('a');
         div.appendChild(a);
+        const span = document.createElement('span');
+        div.appendChild(span);
 
         plugin.initialize(<IEditor>(<any>{
             getSelectionRange: () => {
@@ -162,6 +242,9 @@ describe('TypeAfterLinkPlugin for expanded range', () => {
                 return <any>{
                     getInlineElementBefore: () => {
                         return new LinkInlineElement(a, <any>{});
+                    },
+                    getInlineElementAfter: () => {
+                        return new NodeInlineElement(span, <any>{});
                     },
                 };
             },


### PR DESCRIPTION
We have such check for "paste after link", now we also handle this for "before link"