### PR TITLE
Fix Inline image resize bug for safari

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
@@ -1,4 +1,4 @@
-import { fromHtml, getEntitySelector, getTagOfNode, toArray } from 'roosterjs-editor-dom';
+import { Browser, fromHtml, getEntitySelector, getTagOfNode, toArray } from 'roosterjs-editor-dom';
 import { insertEntity } from 'roosterjs-editor-api';
 import {
     ChangeSource,
@@ -306,7 +306,7 @@ export default class ImageResize implements EditorPlugin {
         );
 
         wrapper.style.position = 'relative';
-        wrapper.style.display = 'inline-flex';
+        wrapper.style.display = Browser.isIE ? 'inline-flex' : 'inline-block';
 
         const html =
             (this.editor.isFeatureEnabled(ExperimentalFeatures.SingleDirectionResize)

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResize.ts
@@ -306,7 +306,7 @@ export default class ImageResize implements EditorPlugin {
         );
 
         wrapper.style.position = 'relative';
-        wrapper.style.display = Browser.isIE ? 'inline-flex' : 'inline-block';
+        wrapper.style.display = Browser.isSafari ? 'inline-block' : 'inline-flex';
 
         const html =
             (this.editor.isFeatureEnabled(ExperimentalFeatures.SingleDirectionResize)


### PR DESCRIPTION
For some special image, style inline-flex makes it shows incorrectly. So for safari, use inline-block instead.