### PR TITLE
Fix list issue when paste from Teams

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/Paste.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/Paste.ts
@@ -1,4 +1,5 @@
 import convertPastedContentFromExcel from './excelConverter/convertPastedContentFromExcel';
+import convertPastedContentFromTeams from './teamsConverter/convertPastedContentFromTeams';
 import convertPastedContentFromWord from './wordConverter/convertPastedContentFromWord';
 import handleLineMerge from './lineMerge/handleLineMerge';
 import { EditorPlugin, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
@@ -83,6 +84,7 @@ export default class Paste implements EditorPlugin {
             } else if (fragment.querySelector(GOOGLE_SHEET_NODE_NAME)) {
                 sanitizingOption.additionalTagReplacements[GOOGLE_SHEET_NODE_NAME] = '*';
             } else {
+                convertPastedContentFromTeams(fragment);
                 handleLineMerge(fragment);
             }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/teamsConverter/convertPastedContentFromTeams.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/teamsConverter/convertPastedContentFromTeams.ts
@@ -1,0 +1,21 @@
+import { changeElementTag, getTagOfNode, toArray } from 'roosterjs-editor-dom';
+
+/**
+ * @internal
+ * Convert content copied from Teams to be well-formed
+ */
+export default function convertPastedContentFromTeams(fragment: DocumentFragment) {
+    const firstChild = fragment.firstChild;
+
+    // When copy from Teams, it is possible that we get LI nodes directly under DIV.
+    // In that case we need to convert DIV to UL. It is also possible to be OL, but we don't know it.
+    // So always assume it is UL here, and later user can change it.
+    if (
+        firstChild &&
+        !firstChild.nextSibling &&
+        getTagOfNode(firstChild) == 'DIV' &&
+        !toArray(firstChild.childNodes).some(node => getTagOfNode(node) != 'LI')
+    ) {
+        changeElementTag(firstChild as HTMLElement, 'UL');
+    }
+}


### PR DESCRIPTION
It is possible to paste LI tag directly under DIV when copy from Teams. We need to convert the DIV to UL tag.