### PR TITLE
All custom paste type

### DIFF
--- a/demo/scripts/controls/sidePane/eventViewer/EventViewPane.tsx
+++ b/demo/scripts/controls/sidePane/eventViewer/EventViewPane.tsx
@@ -176,6 +176,12 @@ export default class EventViewPane extends React.Component<
                                 ? JSON.stringify(event.clipboardData.linkPreview)
                                 : ''
                         )}
+                        {Object.keys(event.clipboardData.customValues).map(contentType =>
+                            this.renderPasteContent(
+                                contentType,
+                                event.clipboardData.customValues[contentType]
+                            )
+                        )}
                     </span>
                 );
             case PluginEventType.PendingFormatStateChanged:

--- a/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
@@ -9,11 +9,13 @@ import {
     ChangeSource,
     ClipboardData,
     ContentPosition,
-    EditorPlugin,
+    CopyPastePluginState,
+    EditorOptions,
     GetContentMode,
     IEditor,
     PluginEventType,
     ExperimentalFeatures,
+    PluginWithState,
 } from 'roosterjs-editor-types';
 
 const CONTAINER_HTML =
@@ -23,9 +25,20 @@ const CONTAINER_HTML =
  * @internal
  * Copy and paste plugin for handling onCopy and onPaste event
  */
-export default class CopyPastePlugin implements EditorPlugin {
+export default class CopyPastePlugin implements PluginWithState<CopyPastePluginState> {
     private editor: IEditor;
     private disposer: () => void;
+    private state: CopyPastePluginState;
+
+    /**
+     * Construct a new instance of CopyPastePlugin
+     * @param options The editor options
+     */
+    constructor(options: EditorOptions) {
+        this.state = {
+            allowedCustomPasteType: options.allowedCustomPasteType || [],
+        };
+    }
 
     /**
      * Get a friendly name of  this plugin
@@ -54,6 +67,13 @@ export default class CopyPastePlugin implements EditorPlugin {
         this.disposer();
         this.disposer = null;
         this.editor = null;
+    }
+
+    /**
+     * Get plugin state object
+     */
+    getState() {
+        return this.state;
     }
 
     private onCutCopy(event: Event, isCut: boolean) {
@@ -111,6 +131,7 @@ export default class CopyPastePlugin implements EditorPlugin {
                 allowLinkPreview: this.editor.isFeatureEnabled(
                     ExperimentalFeatures.PasteWithLinkPreview
                 ),
+                allowedCustomPasteType: this.state.allowedCustomPasteType,
             }
         );
     };

--- a/packages/roosterjs-editor-core/lib/corePlugins/createCorePlugins.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/createCorePlugins.ts
@@ -37,7 +37,7 @@ export default function createCorePlugins(
         domEvent: map.domEvent || new DOMEventPlugin(options, contentDiv),
         pendingFormatState: map.pendingFormatState || new PendingFormatStatePlugin(),
         mouseUp: map.mouseUp || new MouseUpPlugin(),
-        copyPaste: map.copyPaste || new CopyPastePlugin(),
+        copyPaste: map.copyPaste || new CopyPastePlugin(options),
         entity: map.entity || new EntityPlugin(),
         lifecycle: map.lifecycle || new LifecyclePlugin(options, contentDiv),
     };
@@ -56,5 +56,6 @@ export function getPluginState(corePlugins: CorePlugins): PluginState {
         lifecycle: corePlugins.lifecycle.getState(),
         undo: corePlugins.undo.getState(),
         entity: corePlugins.entity.getState(),
+        copyPaste: corePlugins.copyPaste.getState(),
     };
 }

--- a/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
@@ -35,6 +35,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);
@@ -55,6 +56,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);
@@ -75,6 +77,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, true, false);
         const html = getHTML(fragment);
@@ -95,6 +98,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: 'test',
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);
@@ -115,6 +119,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: 'test',
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);
@@ -135,6 +140,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: 'test',
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, true, false);
         const html = getHTML(fragment);
@@ -155,6 +161,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: 'test',
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);
@@ -175,6 +182,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: 'test',
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, true, false);
         const html = getHTML(fragment);
@@ -199,6 +207,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
 
@@ -242,6 +251,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
 

--- a/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
@@ -56,6 +56,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);
@@ -97,6 +98,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);
@@ -117,6 +119,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);
@@ -137,6 +140,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);
@@ -157,6 +161,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);
@@ -177,6 +182,7 @@ describe('createPasteFragment', () => {
             image: null,
             snapshotBeforePaste: null,
             imageDataUri: null,
+            customValues: {},
         };
         const fragment = createPasteFragment(core, clipboardData, null, false, false);
         const html = getHTML(fragment);

--- a/packages/roosterjs-editor-core/test/corePlugins/copyPastePluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/copyPastePluginTest.ts
@@ -16,7 +16,7 @@ describe('CopyPastePlugin paste', () => {
 
     beforeEach(() => {
         handler = null;
-        plugin = new CopyPastePlugin();
+        plugin = new CopyPastePlugin({});
 
         addDomEventHandler = jasmine
             .createSpy('addDomEventHandler')
@@ -70,6 +70,7 @@ describe('CopyPastePlugin paste', () => {
             text: '',
             image: null,
             types: [],
+            customValues: {},
         };
         spyOn(dom, 'extractClipboardEvent').and.callFake((event, callback) => {
             callback(items);
@@ -86,6 +87,7 @@ describe('CopyPastePlugin paste', () => {
             text: '',
             image: <any>{},
             types: [],
+            customValues: {},
         };
         spyOn(dom, 'extractClipboardEvent').and.callFake((event, callback) => {
             callback(items);
@@ -108,6 +110,7 @@ describe('CopyPastePlugin paste', () => {
             text: '',
             image: <any>{},
             types: [],
+            customValues: {},
         };
         const expected = { ...items };
         spyOn(dom, 'extractClipboardEvent').and.callFake((event, callback) => {
@@ -138,7 +141,7 @@ describe('CopyPastePlugin copy', () => {
 
     beforeEach(() => {
         handler = null;
-        plugin = new CopyPastePlugin();
+        plugin = new CopyPastePlugin({});
 
         addDomEventHandler = jasmine
             .createSpy('addDomEventHandler')

--- a/packages/roosterjs-editor-dom/lib/utils/extractClipboardEvent.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/extractClipboardEvent.ts
@@ -48,6 +48,7 @@ export default function extractClipboardEvent(
         text: dataTransfer.getData('text'),
         image: getImage(dataTransfer),
         rawHtml: undefined,
+        customValues: {},
     };
 
     const handlers: {
@@ -86,6 +87,13 @@ export default function extractClipboardEvent(
                         });
                     }
                     break;
+                default:
+                    if (options?.allowedCustomPasteType?.indexOf(item.type) >= 0) {
+                        handlers.push({
+                            promise: getAsString(item),
+                            callback: value => (result.customValues[item.type] = value),
+                        });
+                    }
             }
         }
     }

--- a/packages/roosterjs-editor-types/lib/corePluginState/CopyPastePluginState.ts
+++ b/packages/roosterjs-editor-types/lib/corePluginState/CopyPastePluginState.ts
@@ -4,6 +4,7 @@
 export default interface CopyPastePluginState {
     /**
      * Allowed custom content type when paste besides text/plain, text/html and images
+     * Only text types are supported, and do not add "text/" prefix to the type values
      */
     allowedCustomPasteType: string[];
 }

--- a/packages/roosterjs-editor-types/lib/corePluginState/CopyPastePluginState.ts
+++ b/packages/roosterjs-editor-types/lib/corePluginState/CopyPastePluginState.ts
@@ -1,0 +1,9 @@
+/**
+ * The state object for CopyPastePlugin
+ */
+export default interface CopyPastePluginState {
+    /**
+     * Allowed custom content type when paste besides text/plain, text/html and images
+     */
+    allowedCustomPasteType: string[];
+}

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -160,6 +160,7 @@ export { default as EntityPluginState } from './corePluginState/EntityPluginStat
 export { default as LifecyclePluginState } from './corePluginState/LifecyclePluginState';
 export { default as PendingFormatStatePluginState } from './corePluginState/PendingFormatStatePluginState';
 export { default as UndoPluginState } from './corePluginState/UndoPluginState';
+export { default as CopyPastePluginState } from './corePluginState/CopyPastePluginState';
 
 // Other type
 export {

--- a/packages/roosterjs-editor-types/lib/interface/ClipboardData.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ClipboardData.ts
@@ -45,4 +45,10 @@ export default interface ClipboardData {
      * BASE64 encoded data uri of the image if any
      */
     imageDataUri?: string;
+
+    /**
+     * Value of custom paste type. By default it is always empty.
+     * To allow custom paste type, pass the allowed types to EditorOptions.allowedCustomPasteType
+     */
+    customValues: Record<string, string>;
 }

--- a/packages/roosterjs-editor-types/lib/interface/CorePlugins.ts
+++ b/packages/roosterjs-editor-types/lib/interface/CorePlugins.ts
@@ -1,3 +1,4 @@
+import CopyPastePluginState from '../corePluginState/CopyPastePluginState';
 import DOMEventPluginState from '../corePluginState/DOMEventPluginState';
 import EditorPlugin from './EditorPlugin';
 import EditPluginState from '../corePluginState/EditPluginState';
@@ -51,7 +52,7 @@ export default interface CorePlugins {
     /**
      * Copy and paste plugin for handling onCopy and onPaste event
      */
-    readonly copyPaste: EditorPlugin;
+    readonly copyPaste: PluginWithState<CopyPastePluginState>;
 
     /**
      * Entity Plugin handles all operations related to an entity and generate entity specified events

--- a/packages/roosterjs-editor-types/lib/interface/EditorOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorOptions.ts
@@ -79,4 +79,9 @@ export default interface EditorOptions {
      * to be handled by ancestor nodes of editor.
      */
     allowKeyboardEventPropagation?: boolean;
+
+    /**
+     * Allowed custom content type when paste besides text/plain, text/html and images
+     */
+    allowedCustomPasteType?: string[];
 }

--- a/packages/roosterjs-editor-types/lib/interface/EditorOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorOptions.ts
@@ -82,6 +82,7 @@ export default interface EditorOptions {
 
     /**
      * Allowed custom content type when paste besides text/plain, text/html and images
+     * Only text types are supported, and do not add "text/" prefix to the type values
      */
     allowedCustomPasteType?: string[];
 }

--- a/packages/roosterjs-editor-types/lib/interface/ExtractClipboardEventOption.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ExtractClipboardEventOption.ts
@@ -9,6 +9,7 @@ export default interface ExtractClipboardEventOption {
 
     /**
      * Allowed custom content type when paste besides text/plain, text/html and images
+     * Only text types are supported, and do not add "text/" prefix to the type values
      */
     allowedCustomPasteType?: string[];
 }

--- a/packages/roosterjs-editor-types/lib/interface/ExtractClipboardEventOption.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ExtractClipboardEventOption.ts
@@ -6,4 +6,9 @@ export default interface ExtractClipboardEventOption {
      * Whether retrieving value of text/link-preview is allowed
      */
     allowLinkPreview?: boolean;
+
+    /**
+     * Allowed custom content type when paste besides text/plain, text/html and images
+     */
+    allowedCustomPasteType?: string[];
 }


### PR DESCRIPTION
Add a new editor option: allowedCustomPasteType. Use this option to allow retrieving more content type when paste besides default types.

To use it, pass your custom values when init editor.

```ts
const editor = new Editor(div, {
  ...
  allowedCustomPasteType: [ 'type1', 'type2' ],
};
```

Note that only **text types** as supported, and no need to add the "text/" prefix.

To get the custom value, use ClipboardData.customValues:

```ts
onPluginEvent(e) {
  if (e.eventType == PluginEventType.BeforePaste) {
     const valueOfType1 = e.clipboardData.customValues['type1'];
     ...
  }
}
```