### PR TITLE
fix backspace in list issue

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -60,7 +60,9 @@ const MergeInNewLine: BuildInEditFeature<PluginKeyboardEvent> = {
     shouldHandleEvent: (event, editor) => {
         let li = editor.getElementAtCursor('LI', null /*startFrom*/, event);
         let range = editor.getSelectionRange();
-        return li && range && isPositionAtBeginningOf(Position.getStart(range), li);
+        return (
+            li && range && range.collapsed && isPositionAtBeginningOf(Position.getStart(range), li)
+        );
     },
     handleEvent: (event, editor) => {
         let li = editor.getElementAtCursor('LI', null /*startFrom*/, event);

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -60,9 +60,7 @@ const MergeInNewLine: BuildInEditFeature<PluginKeyboardEvent> = {
     shouldHandleEvent: (event, editor) => {
         let li = editor.getElementAtCursor('LI', null /*startFrom*/, event);
         let range = editor.getSelectionRange();
-        return (
-            li && range && range.collapsed && isPositionAtBeginningOf(Position.getStart(range), li)
-        );
+        return li && range?.collapsed && isPositionAtBeginningOf(Position.getStart(range), li);
     },
     handleEvent: (event, editor) => {
         let li = editor.getElementAtCursor('LI', null /*startFrom*/, event);


### PR DESCRIPTION
Repro:
1. Enable content edit feature "Merge in new line when Backspace on first char in list"
2. create a list
3. locate to the beginning of the second list item, shift+right to select some text
4. BackSpace

Expect: selected text is deleted, no other change
Actual: a new line is created

Reason: the content edit feature "Merge in new line when Backspace on first char in list" is run here which should not
Fix: check if the selection is collapsed.