### PR TITLE
Fix selectionPath bug

### DIFF
--- a/packages/roosterjs-editor-dom/lib/selection/getSelectionPath.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/getSelectionPath.ts
@@ -12,6 +12,9 @@ export default function getSelectionPath(rootNode: Node, range: Range): Selectio
         return null;
     }
 
+    // Merge sibling text nodes to avoid inaccuracy of text node offset
+    rootNode.normalize();
+
     let selectionPath: SelectionPath = {
         start: getPositionPath(Position.getStart(range), rootNode),
         end: getPositionPath(Position.getEnd(range), rootNode),

--- a/packages/roosterjs-editor-dom/test/selections/getSelectionPathTest.ts
+++ b/packages/roosterjs-editor-dom/test/selections/getSelectionPathTest.ts
@@ -288,5 +288,24 @@ describe('getPositionPath', () => {
                 end: [2],
             });
         });
+
+        it('Should merge continuous text nodes', () => {
+            const div = dom('<div><span>test1</span></div>');
+            div.firstChild.insertBefore(document.createTextNode(''), null);
+            div.firstChild.insertBefore(document.createTextNode('test2'), null);
+            const initialRange = div.ownerDocument.createRange();
+            initialRange.setStart(div, 0);
+            initialRange.setEnd(div, 1);
+
+            expect(div.firstChild.childNodes.length).toBe(3);
+            const paths = getSelectionPath(div, initialRange);
+
+            // Assert
+            expect(paths).toEqual({
+                start: [0],
+                end: [1],
+            });
+            expect(div.firstChild.childNodes.length).toBe(1);
+        });
     });
 });


### PR DESCRIPTION
When there are continuous text node, selection path will treat them as a single text node. This is fine when we get HTML with selection path and set them back into editor. However, if we want to clone the DOM tree and set selection with selection path (e.g. shadow edit scenario), it becomes a problem. To fix it, we can do text node normalization before getting selection path.