### PR TITLE
Support "dummy list item"

### DIFF
--- a/packages/roosterjs-editor-dom/test/list/VListItemTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/VListItemTest.ts
@@ -26,11 +26,33 @@ describe('VListItem.getNode', () => {
     it('set node to a valid node', () => {
         const node = document.createTextNode('test');
         const item = new VListItem(node);
-        expect(item.getNode()).toBe(node);
+        expect(item.getNode().firstChild).toBe(node);
+        expect(item.isDummy()).toBe(true);
     });
 
     it('set ListType to null', () => {
         expect(() => new VListItem(null)).toThrow();
+    });
+});
+
+describe('VListItem.isDummy', () => {
+    it('set node to a valid node', () => {
+        const node = document.createTextNode('test');
+        const li = document.createElement('li');
+        li.appendChild(node);
+        const item = new VListItem(li);
+        expect(item.getNode()).toBe(li);
+        expect(item.isDummy()).toBe(false);
+    });
+
+    it('set node to a valid node', () => {
+        const node = document.createTextNode('test');
+        const li = document.createElement('li');
+        li.appendChild(node);
+        li.style.display = 'block';
+        const item = new VListItem(li);
+        expect(item.getNode()).toBe(li);
+        expect(item.isDummy()).toBe(true);
     });
 });
 
@@ -54,125 +76,6 @@ describe('VListItem.contains', () => {
         const div = document.createElement('div');
         const item = new VListItem(div);
         expect(item.contains(node)).toBeFalsy();
-    });
-});
-
-describe('VListItem.isOrphanItem', () => {
-    it('check for non-orphan item', () => {
-        const li = document.createElement('li');
-        const item = new VListItem(li);
-        expect(item.isOrphanItem()).toBeFalsy();
-    });
-
-    it('check for orphan item', () => {
-        const div = document.createElement('div');
-        const item = new VListItem(div);
-        expect(item.isOrphanItem()).toBeTruthy();
-    });
-});
-
-describe('VListItem.canMerge', () => {
-    it('check for null', () => {
-        const thisItem = new VListItem(document.createElement('li'));
-        expect(thisItem.canMerge(null)).toBeFalsy();
-    });
-
-    it('check for non-orphan item', () => {
-        const li = document.createElement('li');
-        const targetItem = new VListItem(li);
-        const thisItem = new VListItem(document.createElement('li'));
-        expect(thisItem.canMerge(targetItem)).toBeFalsy();
-    });
-
-    it('check for item with different list depth', () => {
-        const li = document.createElement('div');
-        const targetItem = new VListItem(li, ListType.Ordered);
-        const thisItem = new VListItem(
-            document.createElement('li'),
-            ListType.Ordered,
-            ListType.Ordered
-        );
-        expect(thisItem.canMerge(targetItem)).toBeFalsy();
-    });
-
-    it('check for item with different list type', () => {
-        const li = document.createElement('div');
-        const targetItem = new VListItem(li, ListType.Ordered, ListType.Unordered);
-        const thisItem = new VListItem(
-            document.createElement('li'),
-            ListType.Ordered,
-            ListType.Ordered
-        );
-        expect(thisItem.canMerge(targetItem)).toBeFalsy();
-    });
-
-    it('check for item that can be merged, case 1: depth = 0', () => {
-        const li = document.createElement('div');
-        const targetItem = new VListItem(li);
-        const thisItem = new VListItem(document.createElement('li'));
-        expect(thisItem.canMerge(targetItem)).toBeTruthy();
-    });
-
-    it('check for item that can be merged, case 2: depth = 1', () => {
-        const li = document.createElement('div');
-        const targetItem = new VListItem(li, ListType.Ordered);
-        const thisItem = new VListItem(document.createElement('li'), ListType.Ordered);
-        expect(thisItem.canMerge(targetItem)).toBeTruthy();
-    });
-
-    it('check for item that can be merged, case 3: depth = 2 with different list types', () => {
-        const li = document.createElement('div');
-        const targetItem = new VListItem(li, ListType.Ordered, ListType.Unordered);
-        const thisItem = new VListItem(
-            document.createElement('li'),
-            ListType.Ordered,
-            ListType.Unordered
-        );
-        expect(thisItem.canMerge(targetItem)).toBeTruthy();
-    });
-});
-
-describe('VListItem.mergeItems', () => {
-    function runTest(targetTags: string[], expectedHtml: string) {
-        const li = document.createElement('li');
-        const thisItem = new VListItem(li);
-        const targetItems = targetTags
-            ? targetTags.map(tag => new VListItem(document.createElement(tag)))
-            : null;
-        thisItem.mergeItems(targetItems);
-        expect(li.innerHTML).toBe(expectedHtml);
-    }
-
-    it('null input', () => {
-        runTest(null, '');
-    });
-
-    it('empty aray input', () => {
-        runTest([], '');
-    });
-
-    it('Single item, block element input', () => {
-        runTest(['div'], '<div></div>');
-    });
-
-    it('Single item, inline element input', () => {
-        runTest(['span'], '<div><span></span></div>');
-    });
-
-    it('Multiple items, start with block, end with block', () => {
-        runTest(['div', 'span', 'div'], '<div></div><span></span><div></div>');
-    });
-
-    it('Multiple items, start with block, end with inline', () => {
-        runTest(['div', 'span', 'span'], '<div></div><span></span><span></span>');
-    });
-
-    it('Multiple items, start with inline, end with inline', () => {
-        runTest(['span', 'div', 'span'], '<div><span></span><div></div><span></span></div>');
-    });
-
-    it('Multiple items, start with inline, end with block', () => {
-        runTest(['span', 'div', 'div'], '<div><span></span><div></div><div></div></div>');
     });
 });
 

--- a/packages/roosterjs-editor-dom/test/list/VListTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/VListTest.ts
@@ -89,7 +89,7 @@ describe('VList.ctor', () => {
         runTest(`<ol id="${ListRoot}"><div>line1</div><li>line2</li><div>line3</div></ol>`, [
             {
                 listTypes: [ListType.None, ListType.Ordered],
-                outerHTML: '<div>line1</div>',
+                outerHTML: '<li style="display:block"><div>line1</div></li>',
             },
             {
                 listTypes: [ListType.None, ListType.Ordered],
@@ -115,7 +115,7 @@ describe('VList.ctor', () => {
                 },
                 {
                     listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
-                    outerHTML: '<div>line1</div>',
+                    outerHTML: '<li style="display:block"><div>line1</div></li>',
                 },
                 {
                     listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
@@ -380,7 +380,7 @@ describe('VList.writeBack', () => {
                     listTypes: [ListType.Ordered],
                 },
             ],
-            '<ul><div>item1</div><li>item2</li></ul><ol><li>item3</li></ol>'
+            '<ul><li style="display:block"><div>item1</div></li><li>item2</li></ul><ol><li>item3</li></ol>'
         );
     });
 
@@ -400,7 +400,7 @@ describe('VList.writeBack', () => {
                     listTypes: [ListType.Ordered],
                 },
             ],
-            '<ul><div>item1</div><li>item2</li></ul><ol><li>item3</li></ol>'
+            '<ul><li style="display:block"><div>item1</div></li><li>item2</li></ul><ol><li>item3</li></ol>'
         );
     });
 
@@ -1153,7 +1153,11 @@ describe('VList.mergeVList', () => {
             [
                 {
                     listTypes: [ListType.None, ListType.Ordered],
-                    outerHTML: '<li>line1<div>line2</div></li>',
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li style="display:block"><div>line2</div></li>',
                 },
                 {
                     listTypes: [ListType.None, ListType.Ordered],
@@ -1178,7 +1182,7 @@ describe('VList.mergeVList', () => {
                 },
                 {
                     listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
-                    outerHTML: '<div>line2</div>',
+                    outerHTML: '<li style="display:block"><div>line2</div></li>',
                 },
                 {
                     listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
@@ -1195,7 +1199,11 @@ describe('VList.mergeVList', () => {
             [
                 {
                     listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
-                    outerHTML: '<li>line1<div>line2</div></li>',
+                    outerHTML: '<li>line1</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],
+                    outerHTML: '<li style="display:block"><div>line2</div></li>',
                 },
                 {
                     listTypes: [ListType.None, ListType.Ordered, ListType.Unordered],

--- a/packages/roosterjs-editor-dom/test/list/createVListFromRegionTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/createVListFromRegionTest.ts
@@ -408,7 +408,11 @@ describe('createVListFromRegion from selection, with sibling list', () => {
             [
                 {
                     listTypes: [ListType.None, ListType.Ordered],
-                    outerHTML: '<li>previous sibling<div>line1</div></li>',
+                    outerHTML: '<li>previous sibling</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li style="display:block"><div>line1</div></li>',
                 },
                 {
                     listTypes: [ListType.None, ListType.Ordered],
@@ -416,7 +420,11 @@ describe('createVListFromRegion from selection, with sibling list', () => {
                 },
                 {
                     listTypes: [ListType.None, ListType.Ordered],
-                    outerHTML: '<li>line3<div>next sibling</div></li>',
+                    outerHTML: '<li>line3</li>',
+                },
+                {
+                    listTypes: [ListType.None, ListType.Ordered],
+                    outerHTML: '<li style="display:block"><div>next sibling</div></li>',
                 },
             ]
         );


### PR DESCRIPTION
A "dummy" list item is a list item without a bullet or a number. In below example "line 2" is a dummy list item.
![image](https://user-images.githubusercontent.com/23065085/117889224-067b0300-b268-11eb-9621-686a86234e28.png)

To create a dummy list item:
1. Enable content edit feature "Merge in new line when Backspace on first char in list":
![image](https://user-images.githubusercontent.com/23065085/117889292-23afd180-b268-11eb-8e7c-fac5aaea61a1.png)
2. Create a regular list
3. Put cursor at the beginning of a list item
4. Press backspace

Also fix auto bullet bug on iOS. (#532 )