### PR TITLE
Trigger scroll event when window scroll

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
@@ -89,12 +89,14 @@ export default class DOMEventPlugin implements PluginWithState<DOMEventPluginSta
 
         // 7. Scroll event
         this.state.scrollContainer.addEventListener('scroll', this.onScroll);
+        this.editor.getDocument().defaultView?.addEventListener('scroll', this.onScroll);
     }
 
     /**
      * Dispose this plugin
      */
     dispose() {
+        this.editor.getDocument().defaultView?.removeEventListener('scroll', this.onScroll);
         this.state.scrollContainer.removeEventListener('scroll', this.onScroll);
         this.disposer();
         this.disposer = null;

--- a/packages/roosterjs-editor-core/test/corePlugins/domEventPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/domEventPluginTest.ts
@@ -7,6 +7,8 @@ import {
     PluginEventType,
 } from 'roosterjs-editor-types';
 
+const getDocument = () => document;
+
 describe('DOMEventPlugin', () => {
     it('init and dispose', () => {
         const addEventListener = jasmine.createSpy('addEventListener');
@@ -22,6 +24,7 @@ describe('DOMEventPlugin', () => {
             .and.returnValue(disposer);
         const state = plugin.getState();
         plugin.initialize(<IEditor>(<any>{
+            getDocument,
             addDomEventHandler,
         }));
 
@@ -69,6 +72,7 @@ describe('DOMEventPlugin', () => {
             .createSpy('addDomEventHandler')
             .and.returnValue(jasmine.createSpy('disposer'));
         plugin.initialize(<IEditor>(<any>{
+            getDocument,
             addDomEventHandler,
         }));
 
@@ -115,6 +119,7 @@ describe('DOMEventPlugin verify event handlers while allow keyboard event propag
         select = jasmine.createSpy('select');
         getSelectionRange = jasmine.createSpy().and.returnValue(getSelectionRangeResult);
         const editor = <IEditor>(<any>{
+            getDocument,
             addDomEventHandler: (map: Record<string, any>) => {
                 eventMap = map;
                 return jasmine.createSpy('disposer');
@@ -204,6 +209,7 @@ describe('DOMEventPlugin verify event handlers while disallow keyboard event pro
         plugin = new DOMEventPlugin({}, div);
         state = plugin.getState();
         plugin.initialize(<IEditor>(<any>{
+            getDocument,
             addDomEventHandler: (map: Record<string, any>) => {
                 eventMap = map;
                 return jasmine.createSpy('disposer');


### PR DESCRIPTION
We have a lot of duplicated code to listen to scroll event from both scroll container and window. We can trigger the same event from window scroll from roosterjs, so that plugins just need to listen to one event.