### PR TITLE
Fix Safari lost focus issue

### DIFF
--- a/demo/scripts/controls/ribbon/RibbonButton.tsx
+++ b/demo/scripts/controls/ribbon/RibbonButton.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import MainPaneBase from '../MainPaneBase';
 import RibbonButtonType from './RibbonButtonType';
 import RibbonPlugin from './RibbonPlugin';
-import { Browser } from 'roosterjs-editor-dom';
 import { FormatState, IEditor } from 'roosterjs-editor-types';
 
 const styles = require('./RibbonButton.scss');
@@ -19,8 +18,6 @@ export interface RibbonButtonState {
 }
 
 export default class RibbonButton extends React.Component<RibbonButtonProps, RibbonButtonState> {
-    private range: Range;
-
     constructor(props: RibbonButtonProps) {
         super(props);
         this.state = {
@@ -78,10 +75,6 @@ export default class RibbonButton extends React.Component<RibbonButtonProps, Rib
     };
 
     private onShowDropDown = () => {
-        if (Browser.isSafari) {
-            this.range = this.props.plugin.getEditor().getSelectionRange();
-        }
-
         if (!this.props.button.preserveOnClickAway) {
             this.getDocument().addEventListener('click', this.onHideDropDown);
         }
@@ -92,10 +85,6 @@ export default class RibbonButton extends React.Component<RibbonButtonProps, Rib
 
     private onHideDropDown = () => {
         this.props.plugin.getEditor().stopShadowEdit();
-
-        if (Browser.isSafari) {
-            this.props.plugin.getEditor().select(this.range);
-        }
 
         this.getDocument().removeEventListener('click', this.onHideDropDown);
         this.setState({

--- a/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
@@ -103,6 +103,7 @@ export default class DOMEventPlugin implements PluginWithState<DOMEventPluginSta
         // 8. Scroll event
         this.state.scrollContainer.addEventListener('scroll', this.onScroll);
         document.defaultView?.addEventListener('scroll', this.onScroll);
+        document.defaultView?.addEventListener('resize', this.onScroll);
     }
 
     /**
@@ -120,6 +121,7 @@ export default class DOMEventPlugin implements PluginWithState<DOMEventPluginSta
             document.defaultView?.removeEventListener('blur', this.cacheSelection);
         }
 
+        document.defaultView?.removeEventListener('resize', this.onScroll);
         document.defaultView?.removeEventListener('scroll', this.onScroll);
         this.state.scrollContainer.removeEventListener('scroll', this.onScroll);
         this.disposer();

--- a/packages/roosterjs-editor-core/test/corePlugins/domEventPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/domEventPluginTest.ts
@@ -150,7 +150,6 @@ describe('DOMEventPlugin verify event handlers while allow keyboard event propag
         expect(eventMap.compositionend).toBeDefined();
         expect(eventMap.drop).toBeDefined();
         expect(eventMap.focus).toBeDefined();
-        expect(eventMap.blur).toBeDefined();
     });
 
     it('verify composition event', () => {
@@ -184,14 +183,6 @@ describe('DOMEventPlugin verify event handlers while allow keyboard event propag
         expect(select).toHaveBeenCalledTimes(1);
         expect(select.calls.argsFor(0)[0]).toBe(range);
         expect(state.selectionRange).toBeNull();
-    });
-
-    it('verify blur event', () => {
-        expect(state.selectionRange).toBeNull();
-        eventMap.blur(<Event>{});
-
-        expect(getSelectionRange).toHaveBeenCalledWith(false);
-        expect(state.selectionRange).toBe(getSelectionRangeResult);
     });
 });
 


### PR DESCRIPTION
We save selection range when editor got onblur event. But this doesn't work for safari. When we get selection range when blur in Safari, it will return the range of new focus, so we can't get the range to save. Currently we have a lot of workaround to fix this issue. Here I'd like to make a final fix.

The idea is to get selection range before any chance of losing focus, including:
- Press TAB key
- Click on other part of the page
- The whole window is blurred
When one of these conditions happens, we get currente selection range and save it. Then next time when we call editor.focus(), it will retrieve this saved range and restore it.