### PR TITLE
Moving to 3001 to make it easier to run at same time

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const devServerPort = 3000;
+const devServerPort = 3001;
 
 module.exports = {
     entry: path.join(__dirname, './demo/scripts/index.ts'),


### PR DESCRIPTION
We sometimes need to run Rooster at the same time as we have something else running on port 3000.

Would it be ok to change Rooster to 3001?