### PR TITLE
8.2.8: Fix a bug when copy/cut with empty text node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "8.2.7",
+    "version": "8.2.8",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-core/lib/coreApi/getContent.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getContent.ts
@@ -33,6 +33,8 @@ export const getContent: GetContent = (core: EditorCore, mode: GetContentMode): 
         content = getTextContent(root);
     } else if (triggerExtractContentEvent || core.lifecycle.isDarkMode) {
         const clonedRoot = cloneNode(root);
+        clonedRoot.normalize();
+
         const originalRange = core.api.getSelectionRange(core, true /*tryGetFromCache*/);
         const path = !includeSelectionMarker
             ? null

--- a/packages/roosterjs-editor-core/lib/coreApi/switchShadowEdit.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/switchShadowEdit.ts
@@ -11,12 +11,11 @@ export const switchShadowEdit: SwitchShadowEdit = (core: EditorCore, isOn: boole
 
     if (isOn) {
         if (!wasInShadowEdit) {
-            // Merge sibling text nodes to avoid inaccuracy of text node offset
-            contentDiv.normalize();
-
             const range = core.api.getSelectionRange(core, true /*tryGetFromCache*/);
             shadowEditSelectionPath = range && getSelectionPath(contentDiv, range);
             shadowEditFragment = core.contentDiv.ownerDocument.createDocumentFragment();
+            shadowEditFragment.normalize();
+
             while (contentDiv.firstChild) {
                 shadowEditFragment.appendChild(contentDiv.firstChild);
             }

--- a/packages/roosterjs-editor-core/test/coreApi/getContentTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/getContentTest.ts
@@ -112,4 +112,33 @@ describe('getContent', () => {
         const html2 = getContent(core, GetContentMode.RawHTMLWithSelection);
         expect(html2).toBe('test0<!--{"start":[],"end":[]}-->');
     });
+
+    it('getContent with empty text node', () => {
+        const firstDiv = document.createElement('div');
+        firstDiv.appendChild(document.createTextNode(''));
+        const a = document.createElement('a');
+        a.href = '#';
+        const text1 = document.createTextNode('text1');
+        a.appendChild(text1);
+        firstDiv.appendChild(a);
+        const text2 = document.createTextNode('text2');
+        firstDiv.appendChild(text2);
+        const text3 = document.createTextNode('text3');
+        firstDiv.appendChild(text3);
+        div.appendChild(firstDiv);
+
+        const range = document.createRange();
+        range.setStart(text1, 0);
+        range.setEnd(text3, 5);
+        const core = createEditorCore(div, {
+            coreApiOverride: {
+                getSelectionRange: () => range,
+            },
+        });
+
+        const content = core.api.getContent(core, GetContentMode.RawHTMLWithSelection);
+        expect(content).toBe(
+            '<div><a href="#">text1</a>text2text3</div><!--{"start":[0,0,0,0],"end":[0,1,10]}-->'
+        );
+    });
 });


### PR DESCRIPTION
There is a bug when copy/cut content if there is empty text node insde or before the selection. Please see the new test case for the scenario.

Normally an empty text node means nothing, we should remove them. And when we get selection path, continuous text node will be treated as single text node, empty text node will be ignored. However, if we apply a selection path on the original DOM tree or a cloned DOM tree, this becomes a problem because those text node still exist.

e.g. DOM tree:
"text1"
"" <-- empty node
"text2"

It will be renderred as 
"text1text2"

But the offset inside text2 will be calculated together with "text1" and "". So if the original DOM tree or cloned DOM tree is not normalized (merge those text nodes), selection path becomes wrong.

To fix it, we can normalize the DOM tree when we know we will apply such selection path to the DOM tree directly. For those cases that selection path is applied to DOM tree generated from innerHTML, we don't need to fix it since when we get innerHTML, it is already normalized.