### PR TITLE
Fix table resizer position when adding new row/column

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -347,6 +347,11 @@ export default class TableResize implements EditorPlugin {
             vtable.writeBack();
             this.editor.select(start, end);
             this.setCurrentInsertTd(ResizeState.None);
+            // need to update the position of table resizer as new row/column has been added
+            if (this.currentTable) {
+                const rect = normalizeRect(this.currentTable.getBoundingClientRect());
+                this.setTableResizer(rect);
+            }
         }, ChangeSource.Format);
     };
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -95,6 +95,7 @@ export default class TableResize implements EditorPlugin {
             case PluginEventType.Input:
             case PluginEventType.ContentChanged:
             case PluginEventType.Scroll:
+                this.setTableResizer(null);
                 this.tableRectMap = null;
                 break;
         }


### PR DESCRIPTION
- When we add a new row/column to the table, the table size will be changed, as a result, we need to update the resizer position accordingly to avoid visual inconsistency. 
- Hide table resize on scrolling for the same reason