### PR TITLE
Fix shadow edit bug

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreApi/switchShadowEdit.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/switchShadowEdit.ts
@@ -14,12 +14,12 @@ export const switchShadowEdit: SwitchShadowEdit = (core: EditorCore, isOn: boole
             const range = core.api.getSelectionRange(core, true /*tryGetFromCache*/);
             shadowEditSelectionPath = range && getSelectionPath(contentDiv, range);
             shadowEditFragment = core.contentDiv.ownerDocument.createDocumentFragment();
-            shadowEditFragment.normalize();
 
             while (contentDiv.firstChild) {
                 shadowEditFragment.appendChild(contentDiv.firstChild);
             }
 
+            shadowEditFragment.normalize();
             core.api.triggerEvent(
                 core,
                 {


### PR DESCRIPTION
My previous fix https://github.com/microsoft/roosterjs/pull/555 cause an issue that shadow edit may focus on wrong selection. It is because we do text node normalization before content is really appended. Fix it by move the the normalization code.