### PR TITLE
Deprecate experimental feature EdgeLinkPreview

### DIFF
--- a/packages/roosterjs-editor-dom/lib/utils/extractClipboardEvent.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/extractClipboardEvent.ts
@@ -29,7 +29,7 @@ interface WindowForIE extends Window {
  * Extract a Clipboard event
  * @param event The paste event
  * @param callback Callback function when data is ready
- * @param fallbackHtmlRetriever If direct HTML retriving is not support (e.g. Internet Explorer), as a fallback,
+ * @param fallbackHtmlRetriever If direct HTML retrieving is not support (e.g. Internet Explorer), as a fallback,
  * using this helper function to retrieve HTML content
  * @returns An object with the following properties:
  *  types: Available types from the clipboard event
@@ -85,6 +85,7 @@ export default function extractClipboardEvent(
                             promise: getAsString(item),
                             callback: value => {
                                 try {
+                                    result.customValues[LINKPREVIEW_TYPE] = value;
                                     result.linkPreview = JSON.parse(value) as EdgeLinkPreview;
                                 } catch {}
                             },

--- a/packages/roosterjs-editor-dom/lib/utils/extractClipboardEvent.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/extractClipboardEvent.ts
@@ -79,6 +79,8 @@ export default function extractClipboardEvent(
                         },
                     });
                     break;
+                // TODO: Remove this branch and deprecate EdgeLinkPreview feature since it can be
+                // covered with ClipboardData.customValues and EditorOptions.allowedCustomPasteType
                 case LINKPREVIEW_TYPE:
                     if (options?.allowLinkPreview) {
                         handlers.push({

--- a/packages/roosterjs-editor-types/lib/browser/EdgeLinkPreview.ts
+++ b/packages/roosterjs-editor-types/lib/browser/EdgeLinkPreview.ts
@@ -1,4 +1,7 @@
-/** @internal */
+/**
+ * @internal
+ * @deprecated
+ */
 export default interface EdgeLinkPreview {
     domain: string;
     preferred_format: string;

--- a/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
@@ -33,7 +33,7 @@ export const enum ExperimentalFeatures {
     SingleDirectionResize = 'SingleDirectionResize',
 
     /**
-     * Try retrieve link preview information when paste
+     * @deprecated Use EditorOptions.allowedCustomPasteType with value "link-preview" instead
      */
     PasteWithLinkPreview = 'PasteWithLinkPreview',
 }

--- a/packages/roosterjs-editor-types/lib/interface/ClipboardData.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ClipboardData.ts
@@ -22,6 +22,7 @@ export default interface ClipboardData {
     rawHtml: string;
 
     /**
+     * @deprecated
      * Link Preview information provided by Edge
      */
     linkPreview?: EdgeLinkPreview;

--- a/packages/roosterjs-editor-types/lib/interface/ExtractClipboardEventOption.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ExtractClipboardEventOption.ts
@@ -3,6 +3,7 @@
  */
 export default interface ExtractClipboardEventOption {
     /**
+     * @deprecated
      * Whether retrieving value of text/link-preview is allowed
      */
     allowLinkPreview?: boolean;


### PR DESCRIPTION
We already have EditorOptions.allowedCustomPasteType and ClipboardData.customValues which can already cover this senario, so no need to have a special attribute and feature for this feature.