### PR TITLE
Add HtmlSanitizer preserveHtmlComments option

### DIFF
--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
@@ -66,6 +66,7 @@ export default class HtmlSanitizer {
     private defaultStyleValues: StringMap;
     private additionalPredefinedCssForElement: PredefinedCssMap;
     private additionalGlobalStyleNodes: HTMLStyleElement[];
+    private preserveHtmlComments: boolean;
     private unknownTagReplacement: string;
 
     /**
@@ -85,6 +86,7 @@ export default class HtmlSanitizer {
         this.defaultStyleValues = getDefaultStyleValues(options.additionalDefaultStyleValues);
         this.additionalPredefinedCssForElement = options.additionalPredefinedCssForElement;
         this.additionalGlobalStyleNodes = options.additionalGlobalStyleNodes || [];
+        this.preserveHtmlComments = options.preserveHtmlComments;
         this.unknownTagReplacement = options.unknownTagReplacement;
     }
 
@@ -172,6 +174,7 @@ export default class HtmlSanitizer {
         const isElement = nodeType == NodeType.Element;
         const isText = nodeType == NodeType.Text;
         const isFragment = nodeType == NodeType.DocumentFragment;
+        const isComment = nodeType == NodeType.Comment;
 
         let shouldKeep = false;
 
@@ -203,6 +206,8 @@ export default class HtmlSanitizer {
                 !/^[\r\n]*$/g.test(node.nodeValue);
         } else if (isFragment) {
             shouldKeep = true;
+        } else if (isComment) {
+            shouldKeep = this.preserveHtmlComments;
         } else {
             shouldKeep = false;
         }

--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/createDefaultHtmlSanitizerOptions.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/createDefaultHtmlSanitizerOptions.ts
@@ -14,6 +14,7 @@ export default function createDefaultHtmlSanitizerOptions(): Required<HtmlSaniti
         additionalDefaultStyleValues: {},
         additionalGlobalStyleNodes: [],
         additionalPredefinedCssForElement: {},
+        preserveHtmlComments: false,
         unknownTagReplacement: null,
     };
 }

--- a/packages/roosterjs-editor-dom/test/htmlSanitizer/sanitizeHtmlTest.ts
+++ b/packages/roosterjs-editor-dom/test/htmlSanitizer/sanitizeHtmlTest.ts
@@ -81,6 +81,9 @@ describe('sanitizeHtml', () => {
             '<span dir="ltr">aa</span>'
         );
     });
+    it('Html contains comments', () => {
+        runTest('<div>aa</div><!-- html-comment --><div>bb</div>', '<div>aa</div><div>bb</div>');
+    });
     it('Html contains CSS with escaped quoted values', () => {
         let testIn: string =
             "<span style='background:url" +
@@ -319,6 +322,32 @@ describe('sanitizeHtml with additionalGlobalStyleNodes', () => {
 
     it('global styles with conflict inline style', () => {
         runTest('<div class="test" style="color: blue"></div>', '<div style="color:blue"></div>');
+    });
+});
+
+describe('sanitizeHtml with preserveHtmlComments', () => {
+    let sanitizer: HtmlSanitizer;
+
+    beforeAll(() => {
+        sanitizer = new HtmlSanitizer({
+            preserveHtmlComments: true,
+        });
+    });
+
+    afterAll(() => {
+        sanitizer = null;
+    });
+
+    function runTest(source: string, exp: string) {
+        let result = sanitizer.exec(source, false, { color: '' });
+        expect(result).toBe(exp);
+    }
+
+    it('preserve HTML comments', () => {
+        runTest(
+            '<div>aa</div><!-- html-comment --><div>bb</div>',
+            '<div>aa</div><!-- html-comment --><div>bb</div>'
+        );
     });
 });
 

--- a/packages/roosterjs-editor-types/lib/interface/HtmlSanitizerOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/HtmlSanitizerOptions.ts
@@ -63,6 +63,11 @@ export default interface HtmlSanitizerOptions {
     additionalPredefinedCssForElement?: PredefinedCssMap;
 
     /**
+     * Preserve HTML comments
+     */
+    preserveHtmlComments?: boolean;
+
+    /**
      * Define a replacement tag name of unknown tags.
      * A star "*" means keep as it is, no replacement
      * Other valid string means replace the tag name with this string.


### PR DESCRIPTION
Hello,
this is a proposal to add an option to keep HTML comments when using `sanitizeHtml`.
I don't think HTML comments are a risk, but if I'm wrong I'd love to know why.
