### PR TITLE
Fix JS error if !ExperimentalFeatures.SingleDirectionResize

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResizeHandler.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResizeHandler.ts
@@ -116,6 +116,9 @@ export default class ImageResizeHandler {
         const wrapper = this.getResizeWrapper();
 
         for (let i = 0; i < this.resizeHelpers.length; i++) {
+            if (!this.resizeHelpers[i]) {
+                continue;
+            }
             for (let j = 0; j < this.resizeHelpers[i].length; j++) {
                 const helper = this.resizeHelpers[i][j];
                 helper?.dispose();


### PR DESCRIPTION
Hello,

If `ExperimentalFeatures.SingleDirectionResize` is disabled, there is a JS error when disposing of the resize handlers here
https://github.com/microsoft/roosterjs/blob/a79ba502b6a53a8a625b538eed6428a3dbf9f3d3/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResizeHandler.ts#L118-L121

because we are skipping an index in here (step = 2)

https://github.com/microsoft/roosterjs/blob/a79ba502b6a53a8a625b538eed6428a3dbf9f3d3/packages/roosterjs-editor-plugins/lib/plugins/ImageResize/ImageResizeHandler.ts#L149-L150

resulting in `this.resizeHelpers` having undefined on every odd index