### PR TITLE
Hide inserter when moving mouse to another component

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -135,6 +135,10 @@ export default class TableResize implements EditorPlugin {
         this.tableResizerContainer = null;
     }
 
+    private onMouseOutInserter = () => {
+        this.setCurrentInsertTd(ResizeState.None);
+    };
+
     private onMouseMove = (e: MouseEvent) => {
         if (this.resizingState != ResizeState.None) {
             return;
@@ -146,8 +150,8 @@ export default class TableResize implements EditorPlugin {
 
         if (this.tableRectMap) {
             this.setCurrentTable(null);
-            let i = this.tableRectMap.length - 1;
-            while (i >= 0) {
+
+            for (let i = this.tableRectMap.length - 1; i >= 0; i--) {
                 const { table, rect } = this.tableRectMap[i];
 
                 if (
@@ -161,8 +165,6 @@ export default class TableResize implements EditorPlugin {
                     this.setCurrentTable(table);
                     break;
                 }
-
-                i--;
             }
 
             if (this.currentTable) {
@@ -181,7 +183,11 @@ export default class TableResize implements EditorPlugin {
                             e.pageY <= tdRect.bottom
                         ) {
                             // check vertical inserter
-                            if (i == 0 && e.pageY <= tdRect.top + INSERTER_HOVER_OFFSET) {
+                            if (
+                                i == 0 &&
+                                e.pageY >= tdRect.top - INSERTER_HOVER_OFFSET &&
+                                e.pageY <= tdRect.top + INSERTER_HOVER_OFFSET
+                            ) {
                                 let verticalInserterTd: HTMLTableCellElement = null;
                                 // set inserter at current td
                                 if (
@@ -286,6 +292,7 @@ export default class TableResize implements EditorPlugin {
             this.currentInsertTd = td;
             if (this.currentInsertTd) {
                 this.inserter = this.createInserter(tableRect);
+                this.inserter.addEventListener('mouseout', this.onMouseOutInserter);
                 this.resizerContainer.appendChild(this.inserter);
             }
         }

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -292,7 +292,6 @@ export default class TableResize implements EditorPlugin {
             this.currentInsertTd = td;
             if (this.currentInsertTd) {
                 this.inserter = this.createInserter(tableRect);
-                this.inserter.addEventListener('mouseout', this.onMouseOutInserter);
                 this.resizerContainer.appendChild(this.inserter);
             }
         }
@@ -348,6 +347,7 @@ export default class TableResize implements EditorPlugin {
         }
 
         inserter.addEventListener('click', this.insertTd);
+        inserter.addEventListener('mouseout', this.onMouseOutInserter);
 
         return inserter;
     }

--- a/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
+++ b/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
@@ -100,7 +100,7 @@ describe('TableResize plugin tests', () => {
     it('removes the vertical inserter when moving the cursor out of the offset zone with culture language RTL', () => {
         const rect = initialize(true);
         runTest(
-            { x: rect.left, y: rect.top },
+            { x: rect.left + insideTheOffset, y: rect.top },
             { x: (rect.right - rect.left) / 2, y: rect.bottom },
             false
         );
@@ -109,8 +109,8 @@ describe('TableResize plugin tests', () => {
     it('keeps the vertical inserter when moving the cursor inside the safe zone with culture language RTL', () => {
         const rect = initialize(true);
         runTest(
-            { x: rect.left, y: rect.top },
-            { x: rect.left, y: rect.top + insideTheOffset },
+            { x: rect.left + insideTheOffset, y: rect.top },
+            { x: rect.left + insideTheOffset, y: rect.top + insideTheOffset },
             true
         );
     });

--- a/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
+++ b/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
@@ -62,16 +62,34 @@ describe('TableResize plugin tests', () => {
         expect(body.innerHTML.includes(ADD_BUTTON)).toBe(expectedResult);
     }
 
-    it('removes the inserter when moving the cursor out of the offset zone', () => {
+    it('removes the vertical inserter when moving the cursor out of the offset zone', () => {
         const rect = initialize();
         runTest({ x: rect.right, y: rect.top }, { x: rect.right / 2, y: rect.bottom }, false);
     });
 
-    it('keeps the inserter when moving the cursor inside the sage zone', () => {
+    it('keeps the vertical inserter when moving the cursor inside the safe zone', () => {
         const rect = initialize();
         runTest(
             { x: rect.right, y: rect.top },
             { x: rect.right - insideTheOffset, y: rect.top },
+            true
+        );
+    });
+
+    it('removes the horizontal inserter when moving the cursor out of the offset zone', () => {
+        const rect = initialize();
+        runTest(
+            { x: rect.left, y: rect.bottom },
+            { x: (rect.right - rect.left) / 2, y: (rect.bottom - rect.top) / 2 },
+            false
+        );
+    });
+
+    it('keeps the horizontal inserter when moving the cursor out of the offset zone', () => {
+        const rect = initialize();
+        runTest(
+            { x: rect.left, y: rect.bottom },
+            { x: rect.left, y: rect.bottom - insideTheOffset },
             true
         );
     });

--- a/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
+++ b/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
@@ -1,0 +1,78 @@
+import * as TestHelper from '../../../roosterjs-editor-api/test/TestHelper';
+import { IEditor } from 'roosterjs-editor-types/lib';
+import { TableResize } from '../../lib/TableResize';
+
+describe('TableResize plugin tests', () => {
+    let editor: IEditor;
+    let plugin: TableResize;
+    const insideTheOffset = 5;
+
+    const TABLE =
+        '<div><table cellspacing="0" cellpadding="1" style="border-collapse: collapse;"><tbody><tr style="background-color: rgb(255, 255, 255);"><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr><tr style="background-color: rgb(255, 255, 255);"><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr><tr style="background-color: rgb(255, 255, 255);"><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr></tbody></table><br></div>';
+    const ADD_BUTTON = '</div>+</div>';
+    const TEST_ID = 'inserterTest';
+
+    beforeEach(() => {
+        editor = TestHelper.initEditor(TEST_ID);
+        plugin = new TableResize();
+        plugin.initialize(editor);
+    });
+
+    afterEach(() => {
+        editor.dispose();
+        plugin.dispose();
+        TestHelper.removeElement(TEST_ID);
+        document.body = document.createElement('body');
+    });
+
+    type Position = {
+        x: number;
+        y: number;
+    };
+
+    function initialize(): DOMRect {
+        editor.setContent(TABLE);
+        let tableRect: DOMRect = null;
+        editor.queryElements('table', table => {
+            const rect = table.getBoundingClientRect();
+            tableRect = rect;
+        });
+        return tableRect;
+    }
+
+    function runTest(mouseStart: Position, mouseEnd: Position, expectedResult: boolean) {
+        const editorDiv = editor.getDocument().getElementById(TEST_ID);
+
+        let mouseEvent = new MouseEvent('mousemove', {
+            clientX: mouseStart.x,
+            clientY: mouseStart.y,
+        });
+
+        editorDiv.dispatchEvent(mouseEvent);
+
+        const body = editor.getDocument().body;
+
+        expect(body.innerHTML.includes(ADD_BUTTON)).toBe(true);
+
+        mouseEvent = new MouseEvent('mousemove', {
+            clientX: mouseEnd.x,
+            clientY: mouseEnd.y,
+        });
+        editorDiv.dispatchEvent(mouseEvent);
+        expect(body.innerHTML.includes(ADD_BUTTON)).toBe(expectedResult);
+    }
+
+    it('removes the inserter when moving the cursor out of the offset zone', () => {
+        const rect = initialize();
+        runTest({ x: rect.right, y: rect.top }, { x: rect.right / 2, y: rect.bottom }, false);
+    });
+
+    it('keeps the inserter when moving the cursor inside the sage zone', () => {
+        const rect = initialize();
+        runTest(
+            { x: rect.right, y: rect.top },
+            { x: rect.right - insideTheOffset, y: rect.top },
+            true
+        );
+    });
+});

--- a/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
+++ b/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
@@ -124,11 +124,11 @@ describe('TableResize plugin tests', () => {
         );
     });
 
-    it('keeps the horitzontal inserter when moving the cursor inside the safe zone with culture language RTL', () => {
+    it('keeps the horizontal inserter when moving the cursor inside the safe zone with culture language RTL', () => {
         const rect = initialize(true);
         runTest(
-            { x: rect.left, y: rect.top },
-            { x: rect.left + insideTheOffset, y: rect.top },
+            { x: rect.right, y: rect.bottom },
+            { x: rect.right + insideTheOffset, y: rect.bottom },
             true
         );
     });

--- a/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
+++ b/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
@@ -8,7 +8,7 @@ describe('TableResize plugin tests', () => {
     const insideTheOffset = 5;
 
     const TABLE =
-        '<div><table cellspacing="0" cellpadding="1" style="border-collapse: collapse;"><tbody><tr style="background-color: rgb(255, 255, 255);"><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr><tr style="background-color: rgb(255, 255, 255);"><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr><tr style="background-color: rgb(255, 255, 255);"><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr></tbody></table><br></div>';
+        '<div style="margin: 50px"><table cellspacing="0" cellpadding="1" style="border-collapse: collapse;"><tbody><tr style="background-color: rgb(255, 255, 255);"><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr><tr style="background-color: rgb(255, 255, 255);"><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr><tr style="background-color: rgb(255, 255, 255);"><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr></tbody></table><br></div>';
     const ADD_BUTTON = '</div>+</div>';
     const TEST_ID = 'inserterTest';
 
@@ -30,7 +30,10 @@ describe('TableResize plugin tests', () => {
         y: number;
     };
 
-    function initialize(): DOMRect {
+    function initialize(isRtl: boolean = false): DOMRect {
+        if (isRtl) {
+            editor.getDocument().body.style.direction = 'rtl';
+        }
         editor.setContent(TABLE);
         let tableRect: DOMRect = null;
         editor.queryElements('table', table => {
@@ -85,11 +88,47 @@ describe('TableResize plugin tests', () => {
         );
     });
 
-    it('keeps the horizontal inserter when moving the cursor out of the offset zone', () => {
+    it('keeps the horizontal inserter when moving the cursor inside the safe zone', () => {
         const rect = initialize();
         runTest(
             { x: rect.left, y: rect.bottom },
             { x: rect.left, y: rect.bottom - insideTheOffset },
+            true
+        );
+    });
+
+    it('removes the vertical inserter when moving the cursor out of the offset zone with culture language RTL', () => {
+        const rect = initialize(true);
+        runTest(
+            { x: rect.left, y: rect.top },
+            { x: (rect.right - rect.left) / 2, y: rect.bottom },
+            false
+        );
+    });
+
+    it('keeps the vertical inserter when moving the cursor inside the safe zone with culture language RTL', () => {
+        const rect = initialize(true);
+        runTest(
+            { x: rect.left, y: rect.top },
+            { x: rect.left, y: rect.top + insideTheOffset },
+            true
+        );
+    });
+
+    it('removes the horizontal inserter when moving the cursor out of the offset zone with culture language RTL', () => {
+        const rect = initialize(true);
+        runTest(
+            { x: rect.right, y: rect.bottom },
+            { x: (rect.right - rect.left) / 2, y: (rect.bottom - rect.top) / 2 },
+            false
+        );
+    });
+
+    it('keeps the horitzontal inserter when moving the cursor inside the safe zone with culture language RTL', () => {
+        const rect = initialize(true);
+        runTest(
+            { x: rect.left, y: rect.top },
+            { x: rect.left + insideTheOffset, y: rect.top },
             true
         );
     });


### PR DESCRIPTION
**Description**

When we move the mouse out of the inserter and land on other components, we need to hide the inserter element.

**Bug description:** 
When moving the mouse to other components the inserter bar was not being removed from the table and this was causing issues when resizing the screen.

**Solution** 

This bug is an edge case when the table is touching a border of the editor.

My approach is to add add a "mouseout" event handler in the [inserterTd ](https://github.com/microsoft/roosterjs/blob/master/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts#L288) element to avoid the bug when the "+" button is rendered passing the border of the editing zone 

I also modified the [current](https://github.com/microsoft/roosterjs/blob/cfe4f3515833480b66f4c0214f93bc337410bddb/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts#L146)  validation to hide the inserter button using the box approach

![image](https://user-images.githubusercontent.com/2343465/124664534-33ffb980-de71-11eb-850a-e897402492ee.png)





