### PR TITLE
Add additional patterns to autobullet feature

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -127,10 +127,7 @@ const AutoBullet: BuildInEditFeature<PluginKeyboardEvent> = {
             // Auto list is triggered if:
             // 1. Text before cursor exactly matches '*', '-' or '1.'
             // 2. There's no non-text inline entities before cursor
-            return (
-                /^(\*|-|[0-9]{1,2}\.)$/.test(textBeforeCursor) &&
-                !searcher.getNearestNonTextInlineElement()
-            );
+            return isAListPattern(textBeforeCursor) && !searcher.getNearestNonTextInlineElement();
         }
         return false;
     },
@@ -155,7 +152,7 @@ const AutoBullet: BuildInEditFeature<PluginKeyboardEvent> = {
                 ) {
                     prepareAutoBullet(editor, rangeToDelete);
                     toggleBullet(editor);
-                } else if (textBeforeCursor.indexOf('1.') == 0) {
+                } else if (isAListPattern(textBeforeCursor)) {
                     prepareAutoBullet(editor, rangeToDelete);
                     toggleNumbering(editor);
                 } else if ((regions = editor.getSelectedRegions()) && regions.length == 1) {
@@ -186,6 +183,17 @@ const MaintainListChain: BuildInEditFeature<PluginKeyboardEvent> = {
         editor.runAsync(editor => experimentCommitListChains(editor, chains));
     },
 };
+
+/**
+ * Validate if a block of text is considered a list pattern
+ * The regex expression will look for patterns of the form:
+ * 1.  1>  1)  1-  (1)
+ * @returns if a text is considered a list pattern
+ */
+function isAListPattern(textBeforeCursor: string) {
+    const REGEX: RegExp = /^(\*|-|[0-9]{1,2}\.|[0-9]{1,2}\>|[0-9]{1,2}\)|[0-9]{1,2}\-|\([0-9]{1,2}\))$/;
+    return REGEX.test(textBeforeCursor);
+}
 
 function getListChains(editor: IEditor) {
     return VListChain.createListChains(editor.getSelectedRegions());

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/listFeaturesTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/listFeaturesTest.ts
@@ -1,0 +1,53 @@
+import { ListFeatures } from '../../../lib/plugins/ContentEdit/features/listFeatures';
+import * as TestHelper from '../../../../roosterjs-editor-api/test/TestHelper';
+import { IEditor } from 'roosterjs-editor-types/lib';
+import { PositionContentSearcher, Position } from 'roosterjs-editor-dom';
+
+describe('listFeatures', () => {
+    let editor: IEditor;
+    const TEST_ID = 'listFeatureTests';
+    let editorSearchCursorSpy: any;
+    beforeEach(() => {
+        editor = TestHelper.initEditor(TEST_ID);
+        spyOn(editor, 'getElementAtCursor').and.returnValue(null);
+        editorSearchCursorSpy = spyOn(editor, 'getContentSearcherOfCursor');
+    });
+
+    afterEach(() => {
+        editor.dispose();
+    });
+
+    function runListPatternTest(text: string, expectedResult: boolean) {
+        const root = document.createElement('div');
+        const mockedPosition = new PositionContentSearcher(root, new Position(root, 4));
+        spyOn(mockedPosition, 'getSubStringBefore').and.returnValue(text);
+        editorSearchCursorSpy.and.returnValue(mockedPosition);
+        expect(ListFeatures.autoBullet.shouldHandleEvent(null, editor, false)).toBe(expectedResult);
+    }
+
+    it('AutoBullet detects the correct patterns', () => {
+        runListPatternTest('1.', true);
+        runListPatternTest('2.', true);
+        runListPatternTest('90.', true);
+        runListPatternTest('1>', true);
+        runListPatternTest('2>', true);
+        runListPatternTest('90>', true);
+        runListPatternTest('1)', true);
+        runListPatternTest('2)', true);
+        runListPatternTest('90)', true);
+        runListPatternTest('1-', true);
+        runListPatternTest('2-', true);
+        runListPatternTest('90-', true);
+        runListPatternTest('(1)', true);
+        runListPatternTest('(2)', true);
+        runListPatternTest('(90)', true);
+    });
+
+    it('AutoBullet ignores incorrect not valid patterns', () => {
+        runListPatternTest('1=', false);
+        runListPatternTest('1/', false);
+        runListPatternTest('1#', false);
+        runListPatternTest(' ', false);
+        runListPatternTest('', false);
+    });
+});


### PR DESCRIPTION
Autobullet should allow for additional patterns to trigger its behavior.

Current pattern:

"1."

New Patterns available:

"1-"
"1)"
"1>"
"(1)"

**Tests**
* Tested locally with demo deployment of roosterjs
* Unit tests added to cover new behavior
  
![listpatterns](https://user-images.githubusercontent.com/2343465/125561811-aa498200-ca16-4219-abe4-15402ec017b9.gif)
