### PR TITLE
8.6.1 Fix #592

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "8.6.0",
+    "version": "8.6.1",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/commonConverter/convertPastedContentForLI.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/commonConverter/convertPastedContentForLI.ts
@@ -16,20 +16,32 @@ export default function convertPastedContentForLI(fragment: DocumentFragment) {
     // So always assume it is UL here, and later user can change it.
     if (isPureLiNode(fragment)) {
         wrap(toArray(fragment.childNodes), 'UL');
-    } else if (isPureLiNode(fragment.firstChild)) {
+    } else if (
+        safeInstanceOf(fragment.firstChild, 'HTMLElement') &&
+        isPureLiNode(fragment.firstChild)
+    ) {
         changeElementTag(fragment.firstChild as HTMLElement, 'UL');
     }
 }
 
-function isPureLiNode(node: Node) {
-    return (
-        node &&
-        !node.nextSibling &&
-        ['OL', 'UL', 'MENU'].indexOf(getTagOfNode(node)) < 0 &&
-        toArray(node.childNodes).every(
-            childNode =>
-                (safeInstanceOf(childNode, 'Text') && !childNode.nodeValue?.trim()) ||
-                getTagOfNode(childNode) == 'LI'
-        )
-    );
+function isPureLiNode(node: ParentNode & Node) {
+    if (node && !node.nextSibling && ['OL', 'UL', 'MENU'].indexOf(getTagOfNode(node)) < 0) {
+        let hasLi = false;
+        if (
+            toArray(node.childNodes).every(childNode => {
+                if (safeInstanceOf(childNode, 'Text') && !childNode.nodeValue?.trim()) {
+                    return true;
+                } else if (getTagOfNode(childNode) == 'LI') {
+                    hasLi = true;
+                    return true;
+                } else {
+                    return false;
+                }
+            }) &&
+            hasLi
+        ) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/packages/roosterjs-editor-plugins/test/paste/convertPastedContentForLITest.ts
+++ b/packages/roosterjs-editor-plugins/test/paste/convertPastedContentForLITest.ts
@@ -1,0 +1,91 @@
+import convertPastedContentForLI from '../../lib/plugins/Paste/commonConverter/convertPastedContentForLI';
+import { fromHtml } from 'roosterjs-editor-dom';
+
+describe('convertPastedContentForLi', () => {
+    function runTest(source: string, expected: string) {
+        const nodes = fromHtml(source, document);
+        const fragment = document.createDocumentFragment();
+        nodes.forEach(node => fragment.appendChild(node));
+
+        convertPastedContentForLI(fragment);
+
+        const div = document.createElement('div');
+        div.appendChild(fragment);
+        expect(div.innerHTML).toBe(expected);
+    }
+
+    it('Empty input', () => {
+        runTest('', '');
+    });
+
+    it('Single text node', () => {
+        runTest('test', 'test');
+    });
+
+    it('Empty DIV', () => {
+        runTest('<div></div>', '<div></div>');
+    });
+
+    it('Single DIV', () => {
+        runTest('<div>test</div>', '<div>test</div>');
+    });
+
+    it('Single DIV with nested elements', () => {
+        runTest('<div><span>test</span></div>', '<div><span>test</span></div>');
+    });
+
+    it('Single DIV with child LI', () => {
+        runTest('<div><li>1</li><li>2</li></div>', '<ul><li>1</li><li>2</li></ul>');
+    });
+
+    it('Single DIV with deeper child LI', () => {
+        runTest(
+            '<div><div><li>1</li></div><li>2</li></div>',
+            '<div><div><li>1</li></div><li>2</li></div>'
+        );
+    });
+
+    it('Single DIV with text and LI', () => {
+        runTest('<div>test<li>1</li></div>', '<div>test<li>1</li></div>');
+    });
+
+    it('Single DIV with empty text and LI', () => {
+        runTest('<div> <li>1</li> \n </div>', '<ul> <li>1</li> \n </ul>');
+    });
+
+    it('Single LI', () => {
+        runTest('<li>1</li>', '<ul><li>1</li></ul>');
+    });
+
+    it('Single LI and text', () => {
+        runTest('<li>1</li>test', '<li>1</li>test');
+    });
+
+    it('Single LI and empty text', () => {
+        runTest(' <li>1</li> \n ', '<ul> <li>1</li> \n </ul>');
+    });
+
+    it('Multiple LI', () => {
+        runTest('<li>1</li><li>2</li>', '<ul><li>1</li><li>2</li></ul>');
+    });
+
+    it('Multiple LI and text', () => {
+        runTest('<li>1</li>test<li>2</li>', '<li>1</li>test<li>2</li>');
+    });
+
+    it('Multiple LI and empty text', () => {
+        runTest(' <li>1</li> \n <li>2</li> ', '<ul> <li>1</li> \n <li>2</li> </ul>');
+    });
+
+    it('UL and LI', () => {
+        runTest('<ul><li>test</li></ul>', '<ul><li>test</li></ul>');
+    });
+
+    it('OL and LI', () => {
+        runTest('<ol><li>test</li></ol>', '<ol><li>test</li></ol>');
+    });
+
+    it('Single IMG', () => {
+        runTest('<img>', '<img>');
+    });
+});


### PR DESCRIPTION
There is a regression in 8.5.0 when paste a single element without any child node. It will always change the element tag to UL since it can pass the check if all child nodes are LI.

Fix it by checking there must be at least one LI child node. Related test case added.