### PR TITLE
Support TrustedType step 1: Replace fromHtml with createElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Rooster provides DOM level APIs (in `roosterjs-editor-dom`), core APIs (in `roos
 
 `roosterjs-editor-dom` provides several levels of DOM operations:
 
--   Perform basic DOM operations such as `fromHtml()`, `wrap()`, `unwrap()`, ...
+-   Perform basic DOM operations such as `wrap()`, `unwrap()`, ...
 -   Wrap a given DOM node with `InlineElement` or `BlockElement` and perform
     operations with DOM Walker API.
 -   Perform DOM operations on a given scope using scopers.

--- a/packages/roosterjs-editor-api/lib/format/setIndentation.ts
+++ b/packages/roosterjs-editor-api/lib/format/setIndentation.ts
@@ -1,5 +1,11 @@
 import blockFormat from '../utils/blockFormat';
-import { BlockElement, IEditor, Indentation, RegionBase } from 'roosterjs-editor-types';
+import {
+    BlockElement,
+    IEditor,
+    Indentation,
+    KnownCreateElementDataIndex,
+    RegionBase,
+} from 'roosterjs-editor-types';
 import {
     collapseNodesInRegion,
     createVListFromRegion,
@@ -12,8 +18,6 @@ import {
     unwrap,
     wrap,
 } from 'roosterjs-editor-dom';
-
-const BlockWrapper = '<blockquote style="margin-top:0;margin-bottom:0"></blockquote>';
 
 /**
  * Set indentation at selection
@@ -52,7 +56,7 @@ export default function setIndentation(editor: IEditor, indentation: Indentation
 
 function indent(region: RegionBase, blocks: BlockElement[]) {
     const nodes = collapseNodesInRegion(region, blocks);
-    wrap(nodes, BlockWrapper);
+    wrap(nodes, KnownCreateElementDataIndex.BlockquoteWrapper);
 }
 
 function outdent(region: RegionBase, blocks: BlockElement[]) {

--- a/packages/roosterjs-editor-core/lib/coreApi/ensureTypeInContainer.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/ensureTypeInContainer.ts
@@ -2,14 +2,14 @@ import {
     ContentPosition,
     EditorCore,
     EnsureTypeInContainer,
+    KnownCreateElementDataIndex,
     NodePosition,
     PositionType,
 } from 'roosterjs-editor-types';
 import {
     applyFormat,
-    Browser,
+    createElement,
     createRange,
-    fromHtml,
     getBlockElementAtNode,
     isNodeEmpty,
     Position,
@@ -44,10 +44,10 @@ export const ensureTypeInContainer: EnsureTypeInContainer = (
         // Only reason we don't get the selection block is that we have an empty content div
         // which can happen when users removes everything (i.e. select all and DEL, or backspace from very end to begin)
         // The fix is to add a DIV wrapping, apply default format and move cursor over
-        formatNode = fromHtml(
-            Browser.isEdge ? '<div><span><br></span></div>' : '<div><br></div>',
+        formatNode = createElement(
+            KnownCreateElementDataIndex.EmptyLine,
             core.contentDiv.ownerDocument
-        )[0] as HTMLElement;
+        ) as HTMLElement;
         core.api.insertNode(core, formatNode, {
             position: ContentPosition.End,
             updateCursor: false,

--- a/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
@@ -1,7 +1,7 @@
 import {
     addRangeToSelection,
+    createElement,
     extractClipboardEvent,
-    fromHtml,
     setHtmlWithSelectionPath,
 } from 'roosterjs-editor-dom';
 import {
@@ -14,10 +14,8 @@ import {
     PluginEventType,
     ExperimentalFeatures,
     PluginWithState,
+    KnownCreateElementDataIndex,
 } from 'roosterjs-editor-types';
-
-const CONTAINER_HTML =
-    '<div contenteditable style="width: 1px; height: 1px; overflow: hidden; position: fixed; top: 0; left; 0; -webkit-user-select: text"></div>';
 
 /**
  * @internal
@@ -132,10 +130,10 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
         const div = this.editor.getCustomData(
             'CopyPasteTempDiv',
             () => {
-                const tempDiv = fromHtml(
-                    CONTAINER_HTML,
+                const tempDiv = createElement(
+                    KnownCreateElementDataIndex.CopyPasteTempDiv,
                     this.editor.getDocument()
-                )[0] as HTMLDivElement;
+                ) as HTMLDivElement;
                 this.editor.insertNode(tempDiv, {
                     position: ContentPosition.Outside,
                 });

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -49,6 +49,7 @@ export { default as readFile } from './utils/readFile';
 export { default as getInnerHTML } from './utils/getInnerHTML';
 export { default as setColor } from './utils/setColor';
 export { default as matchesSelector } from './utils/matchesSelector';
+export { default as createElement, KnownCreateElementData } from './utils/createElement';
 
 export { default as VTable } from './table/VTable';
 export { default as VList } from './list/VList';

--- a/packages/roosterjs-editor-dom/lib/list/VListItem.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VListItem.ts
@@ -6,7 +6,7 @@ import safeInstanceOf from '../utils/safeInstanceOf';
 import toArray from '../utils/toArray';
 import unwrap from '../utils/unwrap';
 import wrap from '../utils/wrap';
-import { ListType } from 'roosterjs-editor-types';
+import { KnownCreateElementDataIndex, ListType } from 'roosterjs-editor-types';
 
 const orderListStyles = [null, 'lower-alpha', 'lower-roman'];
 
@@ -39,7 +39,7 @@ export default class VListItem {
 
         this.node = safeInstanceOf(node, 'HTMLLIElement')
             ? node
-            : (wrap(node, '<li style="display:block"></li>') as HTMLLIElement);
+            : (wrap(node, KnownCreateElementDataIndex.BlockListItem) as HTMLLIElement);
         const display = this.node.style.display;
 
         this.dummy = display != 'list-item' && display != '';

--- a/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
+++ b/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
@@ -1,4 +1,4 @@
-import fromHtml from '../utils/fromHtml';
+import createElement from '../utils/createElement';
 import getRootListNode from './getRootListNode';
 import getSelectedBlockElementsInRegion from '../region/getSelectedBlockElementsInRegion';
 import isNodeInRegion from '../region/isNodeInRegion';
@@ -10,7 +10,7 @@ import VList from './VList';
 import wrap from '../utils/wrap';
 import { getLeafSibling } from '../utils/getLeafSibling';
 import { isListElement } from './getListTypeFromNode';
-import { ListType, Region } from 'roosterjs-editor-types';
+import { KnownCreateElementDataIndex, ListType, Region } from 'roosterjs-editor-types';
 import { PositionType } from 'roosterjs-editor-types';
 
 const ListSelector = 'ol,ul';
@@ -62,7 +62,10 @@ export default function createVListFromRegion(
         });
 
         if (nodes.length == 0 && !region.rootNode.firstChild) {
-            const newNode = fromHtml('<div><br></div>', region.rootNode.ownerDocument)[0];
+            const newNode = createElement(
+                KnownCreateElementDataIndex.EmptyLine,
+                region.rootNode.ownerDocument
+            );
             region.rootNode.appendChild(newNode);
             nodes.push(newNode);
             region.fullSelectionStart = new Position(newNode, PositionType.Begin);

--- a/packages/roosterjs-editor-dom/lib/region/getSelectedBlockElementsInRegion.ts
+++ b/packages/roosterjs-editor-dom/lib/region/getSelectedBlockElementsInRegion.ts
@@ -1,9 +1,9 @@
 import ContentTraverser from '../contentTraverser/ContentTraverser';
-import fromHtml from '../utils/fromHtml';
+import createElement from '../utils/createElement';
 import getBlockElementAtNode from '../blockElements/getBlockElementAtNode';
 import getSelectionRangeInRegion from './getSelectionRangeInRegion';
 import shouldSkipNode from '../utils/shouldSkipNode';
-import { BlockElement, RegionBase } from 'roosterjs-editor-types';
+import { BlockElement, KnownCreateElementDataIndex, RegionBase } from 'roosterjs-editor-types';
 
 /**
  * Get all block elements covered by the selection under this region
@@ -45,7 +45,10 @@ export default function getSelectedBlockElementsInRegion(
     }
 
     if (blocks.length == 0 && regionBase && !regionBase.rootNode.firstChild && createBlockIfEmpty) {
-        const newNode = fromHtml('<div><br></div>', regionBase.rootNode.ownerDocument)[0];
+        const newNode = createElement(
+            KnownCreateElementDataIndex.EmptyLine,
+            regionBase.rootNode.ownerDocument
+        );
         regionBase.rootNode.appendChild(newNode);
         blocks.push(getBlockElementAtNode(regionBase.rootNode, newNode));
     }

--- a/packages/roosterjs-editor-dom/lib/utils/createElement.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/createElement.ts
@@ -1,0 +1,99 @@
+import { Browser } from './Browser';
+import { CreateElementData, KnownCreateElementDataIndex } from 'roosterjs-editor-types';
+
+export const KnownCreateElementData: Record<KnownCreateElementDataIndex, CreateElementData> = {
+    [KnownCreateElementDataIndex.None]: null,
+
+    // Edge can sometimes lose current format when Enter to new line.
+    // So here we add an extra SPAN for Edge to workaround this bug
+    [KnownCreateElementDataIndex.EmptyLine]: Browser.isEdge
+        ? { tag: 'div', children: [{ tag: 'span', children: [{ tag: 'br' }] }] }
+        : { tag: 'div', children: [{ tag: 'br' }] },
+    [KnownCreateElementDataIndex.BlockquoteWrapper]: {
+        tag: 'blockquote',
+        style: 'margin-top:0;margin-bottom:0',
+    },
+    [KnownCreateElementDataIndex.CopyPasteTempDiv]: {
+        tag: 'div',
+        style:
+            'width: 1px; height: 1px; overflow: hidden; position: fixed; top: 0; left; 0; -webkit-user-select: text',
+        attributes: {
+            contenteditable: 'true',
+        },
+    },
+    [KnownCreateElementDataIndex.BlockListItem]: { tag: 'li', style: 'display:block' },
+    [KnownCreateElementDataIndex.ContextMenuWrapper]: {
+        tag: 'div',
+        style: 'position: fixed; width: 0; height: 0',
+    },
+    [KnownCreateElementDataIndex.ImageEditWrapper]: {
+        tag: 'div',
+        style: 'width:100%;height:100%;position:relative;overflow:hidden',
+    },
+    [KnownCreateElementDataIndex.TableHorizontalResizer]: {
+        tag: 'div',
+        style: 'position: fixed; cursor: row-resize; user-select: none',
+    },
+    [KnownCreateElementDataIndex.TableVerticalResizer]: {
+        tag: 'div',
+        style: 'position: fixed; cursor: col-resize; user-select: none',
+    },
+    [KnownCreateElementDataIndex.TableResizerLTR]: {
+        tag: 'div',
+        style: 'position: fixed; cursor: nw-resize; user-select: none; border: 1px solid #808080',
+    },
+    [KnownCreateElementDataIndex.TableResizerRTL]: {
+        tag: 'div',
+        style: 'position: fixed; cursor: ne-resize; user-select: none; border: 1px solid #808080',
+    },
+};
+
+export default function createElement(
+    elementData: CreateElementData | KnownCreateElementDataIndex,
+    document: Document
+): Element {
+    if (typeof elementData == 'number') {
+        elementData = KnownCreateElementData[elementData];
+    }
+
+    if (!elementData || !elementData.tag) {
+        return null;
+    }
+
+    const { tag, namespace, className, style, dataset, attributes, children } = elementData;
+    const result = namespace
+        ? document.createElementNS(namespace, tag)
+        : document.createElement(tag);
+
+    if (style) {
+        result.setAttribute('style', style);
+    }
+
+    if (className) {
+        result.className = className;
+    }
+
+    if (dataset && result instanceof HTMLElement) {
+        Object.keys(dataset).forEach(datasetName => {
+            result.dataset[datasetName] = dataset[datasetName];
+        });
+    }
+
+    if (attributes) {
+        Object.keys(attributes).forEach(attrName => {
+            result.setAttribute(attrName, attributes[attrName]);
+        });
+    }
+
+    if (children) {
+        children.forEach(child => {
+            if (typeof child === 'string') {
+                result.appendChild(document.createTextNode(child));
+            } else if (child) {
+                result.appendChild(createElement(child, document));
+            }
+        });
+    }
+
+    return result;
+}

--- a/packages/roosterjs-editor-dom/lib/utils/fromHtml.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/fromHtml.ts
@@ -1,6 +1,7 @@
 import toArray from './toArray';
 
 /**
+ * @deprecated
  * Creates an HTML node array from html
  * @param html the html string to create HTML elements from
  * @param ownerDocument Owner document of the result HTML elements

--- a/packages/roosterjs-editor-dom/lib/utils/wrap.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/wrap.ts
@@ -1,5 +1,7 @@
 import fromHtml from './fromHtml';
 import safeInstanceOf from '../utils/safeInstanceOf';
+import { createElement } from 'roosterjs-editor-dom';
+import { CreateElementData, KnownCreateElementDataIndex } from 'roosterjs-editor-types';
 
 /**
  * Wrap all the node with html and return the wrapped node, and put the wrapper node under the parent of the first node
@@ -13,6 +15,7 @@ export default function wrap<T extends keyof HTMLElementTagNameMap>(
 ): HTMLElementTagNameMap[T];
 
 /**
+ * @deprecated
  * Wrap all the node with html and return the wrapped node, and put the wrapper node under the parent of the first node
  * @param nodes The node or node array to wrap
  * @param wrapper The wrapper HTML string, default value is DIV
@@ -28,18 +31,34 @@ export default function wrap(nodes: Node | Node[], wrapper?: string): HTMLElemen
  */
 export default function wrap(nodes: Node | Node[], wrapper?: HTMLElement): HTMLElement;
 
-export default function wrap(nodes: Node | Node[], wrapper?: string | HTMLElement): HTMLElement {
+export default function wrap(
+    nodes: Node | Node[],
+    wrapper?: CreateElementData | KnownCreateElementDataIndex
+): HTMLElement;
+
+export default function wrap(
+    nodes: Node | Node[],
+    wrapper?: string | HTMLElement | CreateElementData | KnownCreateElementDataIndex
+): HTMLElement {
     nodes = !nodes ? [] : safeInstanceOf(nodes, 'Node') ? [nodes] : nodes;
     if (nodes.length == 0 || !nodes[0]) {
         return null;
     }
 
+    if (!wrapper) {
+        wrapper = 'div';
+    }
+
     if (!safeInstanceOf(wrapper, 'HTMLElement')) {
         let document = nodes[0].ownerDocument;
-        wrapper = wrapper || 'div';
-        wrapper = /^\w+$/.test(wrapper)
-            ? document.createElement(wrapper)
-            : (fromHtml(wrapper, document)[0] as HTMLElement);
+
+        if (typeof wrapper === 'string') {
+            wrapper = /^\w+$/.test(wrapper)
+                ? document.createElement(wrapper)
+                : (fromHtml(wrapper, document)[0] as HTMLElement); // This will be removed in next major release
+        } else {
+            wrapper = createElement(wrapper, document) as HTMLElement;
+        }
     }
 
     let parentNode = nodes[0].parentNode;

--- a/packages/roosterjs-editor-dom/test/utils/createElementTest.ts
+++ b/packages/roosterjs-editor-dom/test/utils/createElementTest.ts
@@ -1,0 +1,74 @@
+import createElement from '../../lib/utils/createElement';
+import { CreateElementData, KnownCreateElementDataIndex } from 'roosterjs-editor-types';
+
+describe('createElement', () => {
+    function runTest(input: CreateElementData | KnownCreateElementDataIndex, output: string) {
+        const result = createElement(input, document);
+        const html = result ? result.outerHTML : null;
+        expect(html).toBe(output);
+    }
+
+    it('null', () => {
+        runTest(null, null);
+    });
+
+    it('create by index', () => {
+        runTest(KnownCreateElementDataIndex.EmptyLine, '<div><br></div>');
+    });
+
+    it('create by tag', () => {
+        runTest({ tag: 'div' }, '<div></div>');
+    });
+
+    it('create by tag and namespace', () => {
+        runTest({ tag: 'svg', namespace: 'http://www.w3.org/2000/svg' }, '<svg></svg>');
+    });
+    it('create by tag and class', () => {
+        runTest({ tag: 'div', className: 'test' }, '<div class="test"></div>');
+    });
+    it('create by tag and style', () => {
+        runTest(
+            { tag: 'div', style: 'position: absolute' },
+            '<div style="position: absolute"></div>'
+        );
+    });
+    it('create by tag and dataset', () => {
+        runTest({ tag: 'div', dataset: null }, '<div></div>');
+        runTest({ tag: 'div', dataset: {} }, '<div></div>');
+        runTest({ tag: 'div', dataset: { x: '1', y: '2' } }, '<div data-x="1" data-y="2"></div>');
+    });
+    it('create by tag and attributes', () => {
+        runTest({ tag: 'div', attributes: null }, '<div></div>');
+        runTest({ tag: 'div', attributes: {} }, '<div></div>');
+        runTest(
+            { tag: 'div', attributes: { contenteditable: 'true', align: 'left' } },
+            '<div contenteditable="true" align="left"></div>'
+        );
+    });
+
+    it('create by tag and everthing', () => {
+        runTest(
+            {
+                tag: 'div',
+                className: 'test1',
+                style: 'position:absolute',
+                dataset: { x: '1' },
+                attributes: { contenteditable: 'true' },
+            },
+            '<div style="position:absolute" class="test1" data-x="1" contenteditable="true"></div>'
+        );
+    });
+    it('create by tag and children', () => {
+        runTest({ tag: 'div', children: null }, '<div></div>');
+        runTest({ tag: 'div', children: [] }, '<div></div>');
+        runTest({ tag: 'div', children: ['text'] }, '<div>text</div>');
+        runTest(
+            { tag: 'div', children: [{ tag: 'span' }, 'text', { tag: 'span' }] },
+            '<div><span></span>text<span></span></div>'
+        );
+        runTest(
+            { tag: 'div', children: [null, 'text', { tag: 'span' }, ''] },
+            '<div>text<span></span></div>'
+        );
+    });
+});

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/structuredNodeFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/structuredNodeFeatures.ts
@@ -2,22 +2,19 @@ import {
     BuildInEditFeature,
     IEditor,
     Keys,
+    KnownCreateElementDataIndex,
     PluginKeyboardEvent,
     PositionType,
     StructuredNodeFeatureSettings,
 } from 'roosterjs-editor-types';
 import {
-    Browser,
     cacheGetEventData,
-    fromHtml,
     isPositionAtBeginningOf,
     Position,
     getTagOfNode,
+    createElement,
 } from 'roosterjs-editor-dom';
 
-// Edge can sometimes lose current format when Enter to new line.
-// So here we add an extra SPAN for Edge to workaround this bug
-const NEWLINE_HTML = Browser.isEdge ? '<div><span><br></span></div>' : '<div><br></div>';
 const CHILD_PARENT_TAG_MAP: { [childTag: string]: string } = {
     TD: 'TABLE',
     TH: 'TABLE',
@@ -35,7 +32,10 @@ const InsertLineBeforeStructuredNodeFeature: BuildInEditFeature<PluginKeyboardEv
     shouldHandleEvent: cacheGetStructuredElement,
     handleEvent: (event, editor) => {
         let element = cacheGetStructuredElement(event, editor);
-        let div = fromHtml(NEWLINE_HTML, editor.getDocument())[0] as HTMLElement;
+        let div = createElement(
+            KnownCreateElementDataIndex.EmptyLine,
+            editor.getDocument()
+        ) as HTMLElement;
         editor.addUndoSnapshot(() => {
             element.parentNode.insertBefore(div, element);
             // Select the new line when we are in table. This is the same behavior with Word

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContextMenu/ContextMenu.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContextMenu/ContextMenu.ts
@@ -1,13 +1,12 @@
-import { fromHtml } from 'roosterjs-editor-dom';
+import { createElement } from 'roosterjs-editor-dom';
 import {
     ContentPosition,
     EditorPlugin,
     IEditor,
+    KnownCreateElementDataIndex,
     PluginEvent,
     PluginEventType,
 } from 'roosterjs-editor-types';
-
-const CONTAINER_HTML = '<div style="position: fixed; width: 0; height: 0"></div>';
 
 export interface ContextMenuOptions<T> {
     render: (container: HTMLElement, items: (T | null)[], onDismiss: () => void) => void;
@@ -81,7 +80,10 @@ export default class ContextMenu<T> implements EditorPlugin {
 
     private initContainer(x: number, y: number) {
         if (!this.container) {
-            this.container = fromHtml(CONTAINER_HTML, this.editor.getDocument())[0] as HTMLElement;
+            this.container = createElement(
+                KnownCreateElementDataIndex.ContextMenuWrapper,
+                this.editor.getDocument()
+            ) as HTMLElement;
             this.editor.insertNode(this.container, {
                 position: ContentPosition.Outside,
             });

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
@@ -2,6 +2,7 @@ import DragAndDropContext, { X, Y } from '../types/DragAndDropContext';
 import DragAndDropHandler from '../../../pluginUtils/DragAndDropHandler';
 import ImageEditInfo, { ResizeInfo } from '../types/ImageEditInfo';
 import ImageHtmlOptions from '../types/ImageHtmlOptions';
+import { CreateElementData } from 'roosterjs-editor-types';
 import { ImageEditElementClass } from '../types/ImageEditElementClass';
 
 const RESIZE_HANDLE_SIZE = 7;
@@ -110,39 +111,60 @@ export function doubleCheckResize(
  * @internal
  * Get HTML for resize handles at the corners
  */
-export function getCornerResizeHTML({ borderColor: resizeBorderColor }: ImageHtmlOptions): string {
-    return Xs.map(x =>
-        Ys.map(y =>
-            (x == '') == (y == '') ? getResizeHandleHTML(x, y, resizeBorderColor) : ''
-        ).join('')
-    ).join('');
+export function getCornerResizeHTML({
+    borderColor: resizeBorderColor,
+}: ImageHtmlOptions): CreateElementData[] {
+    const result: CreateElementData[] = [];
+    Xs.forEach(x =>
+        Ys.forEach(y =>
+            result.push(
+                (x == '') == (y == '') ? getResizeHandleHTML(x, y, resizeBorderColor) : null
+            )
+        )
+    );
+    return result;
 }
 
 /**
  * @internal
  * Get HTML for resize handles on the sides
  */
-export function getSideResizeHTML({ borderColor: resizeBorderColor }: ImageHtmlOptions): string {
-    return Xs.map(x =>
-        Ys.map(y =>
-            (x == '') != (y == '') ? getResizeHandleHTML(x, y, resizeBorderColor) : ''
-        ).join('')
-    ).join('');
+export function getSideResizeHTML({
+    borderColor: resizeBorderColor,
+}: ImageHtmlOptions): CreateElementData[] {
+    const result: CreateElementData[] = [];
+    Xs.forEach(x =>
+        Ys.forEach(y =>
+            result.push(
+                (x == '') != (y == '') ? getResizeHandleHTML(x, y, resizeBorderColor) : null
+            )
+        )
+    );
+    return result;
 }
 
-function getResizeHandleHTML(x: X, y: Y, borderColor: string): string {
+function getResizeHandleHTML(x: X, y: Y, borderColor: string): CreateElementData {
     const leftOrRight = x == 'w' ? 'left' : 'right';
     const topOrBottom = y == 'n' ? 'top' : 'bottom';
     const leftOrRightValue = x == '' ? '50%' : '0px';
     const topOrBottomValue = y == '' ? '50%' : '0px';
     const direction = y + x;
-    const context = `data-x="${x}" data-y="${y}"`;
 
     return x == '' && y == ''
-        ? `<div style="position:absolute;left:0;right:0;top:0;bottom:0;border:solid 1px ${borderColor};pointer-events:none;"></div>`
-        : `
-    <div style="position:absolute;${leftOrRight}:${leftOrRightValue};${topOrBottom}:${topOrBottomValue}">
-        <div class="${ImageEditElementClass.ResizeHandle}" ${context} style="position:relative;width:${RESIZE_HANDLE_SIZE}px;height:${RESIZE_HANDLE_SIZE}px;background-color: ${borderColor};cursor:${direction}-resize;${topOrBottom}:-${RESIZE_HANDLE_MARGIN}px;${leftOrRight}:-${RESIZE_HANDLE_MARGIN}px">
-        </div>
-    </div>`;
+        ? {
+              tag: 'div',
+              style: `position:absolute;left:0;right:0;top:0;bottom:0;border:solid 1px ${borderColor};pointer-events:none`,
+          }
+        : {
+              tag: 'div',
+              style: `position:absolute;${leftOrRight}:${leftOrRightValue};${topOrBottom}:${topOrBottomValue}`,
+              children: [
+                  {
+                      tag: 'div',
+                      style: `position:relative;width:${RESIZE_HANDLE_SIZE}px;height:${RESIZE_HANDLE_SIZE}px;background-color: ${borderColor};cursor:${direction}-resize;${topOrBottom}:-${RESIZE_HANDLE_MARGIN}px;${leftOrRight}:-${RESIZE_HANDLE_MARGIN}px`,
+                      className: ImageEditElementClass.ResizeHandle,
+                      dataset: { x, y },
+                  },
+              ],
+          };
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
@@ -1,6 +1,7 @@
 import DragAndDropContext from '../types/DragAndDropContext';
 import DragAndDropHandler from '../../../pluginUtils/DragAndDropHandler';
 import ImageHtmlOptions from '../types/ImageHtmlOptions';
+import { CreateElementData } from 'roosterjs-editor-types';
 import { ImageEditElementClass } from '../types/ImageEditElementClass';
 import { RotateInfo } from '../types/ImageEditInfo';
 
@@ -56,26 +57,50 @@ export default Rotator;
  */
 export function getRotateHTML({
     borderColor,
-    rotateIconHTML: rotateHandleHTML,
     rotateHandleBackColor,
-}: ImageHtmlOptions): string {
+}: ImageHtmlOptions): CreateElementData[] {
     const handleLeft = ROTATE_SIZE / 2;
-    return `
-        <div class="${
-            ImageEditElementClass.RotateCenter
-        }" style="position:absolute;left:50%;width:1px;background-color:${borderColor}">
-            <div class="${
-                ImageEditElementClass.RotateHandle
-            }" style="position:absolute;background-color:${rotateHandleBackColor};border:solid 1px ${borderColor};border-radius:50%;width:${ROTATE_SIZE}px;height:${ROTATE_SIZE}px;left:-${handleLeft}px;cursor:move">
-                ${rotateHandleHTML || getRotateIconHTML(borderColor)}
-            </div>
-        </div>`;
+    return [
+        {
+            tag: 'div',
+            className: ImageEditElementClass.RotateCenter,
+            style: `position:absolute;left:50%;width:1px;background-color:${borderColor}`,
+            children: [
+                {
+                    tag: 'div',
+                    className: ImageEditElementClass.RotateHandle,
+                    style: `position:absolute;background-color:${rotateHandleBackColor};border:solid 1px ${borderColor};border-radius:50%;width:${ROTATE_SIZE}px;height:${ROTATE_SIZE}px;left:-${handleLeft}px;cursor:move`,
+                    children: [getRotateIconHTML(borderColor)],
+                },
+            ],
+        },
+    ];
 }
 
-function getRotateIconHTML(borderColor: string): string {
-    return `
-        <svg style="width:16px;height:16px;margin: ${ROTATE_ICON_MARGIN}px ${ROTATE_ICON_MARGIN}px">
-            <path d="M 10.5,10.0 A 3.8,3.8 0 1 1 6.7,6.3" transform="matrix(1.1 1.1 -1.1 1.1 11.6 -10.8)" fill-opacity="0" stroke-width="1" stroke="${borderColor}" />
-            <path d="M12.0 3.648l.884-.884.53 2.298-2.298-.53z" stroke="${borderColor}" />
-        </svg>`;
+function getRotateIconHTML(borderColor: string): CreateElementData {
+    return {
+        tag: 'svg',
+        namespace: 'http://www.w3.org/2000/svg',
+        style: `width:16px;height:16px;margin: ${ROTATE_ICON_MARGIN}px ${ROTATE_ICON_MARGIN}px`,
+        children: [
+            {
+                tag: 'path',
+                namespace: 'http://www.w3.org/2000/svg',
+                attributes: {
+                    d: 'M 10.5,10.0 A 3.8,3.8 0 1 1 6.7,6.3',
+                    transform: 'matrix(1.1 1.1 -1.1 1.1 11.6 -10.8)',
+                    ['fill-opacity']: '0',
+                    stroke: borderColor,
+                },
+            },
+            {
+                tag: 'path',
+                namespace: 'http://www.w3.org/2000/svg',
+                attributes: {
+                    d: 'M12.0 3.648l.884-.884.53 2.298-2.298-.53z',
+                    stroke: borderColor,
+                },
+            },
+        ],
+    };
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/types/ImageHtmlOptions.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/types/ImageHtmlOptions.ts
@@ -9,6 +9,7 @@ export default interface ImageHtmlOptions {
     borderColor: string;
 
     /**
+     * @deprecated
      * HTML string for rotate handle icon.
      * If not passed, a default SVG icon will be used
      */

--- a/packages/roosterjs-editor-types/lib/enum/KnownCreateElementDataIndex.ts
+++ b/packages/roosterjs-editor-types/lib/enum/KnownCreateElementDataIndex.ts
@@ -1,0 +1,47 @@
+/**
+ * Index of known CreateElementData used by createElement function
+ */
+export const enum KnownCreateElementDataIndex {
+    /**
+     * Set a none value to help createElement funciton ignore falsy value
+     */
+    None = 0,
+
+    /**
+     * An empty line without format
+     */
+    EmptyLine = 1,
+
+    /**
+     * Wrapper for blockquote
+     */
+    BlockquoteWrapper = 2,
+
+    /**
+     * Temp DIV for copy/paste
+     */
+    CopyPasteTempDiv = 3,
+
+    /**
+     * ListItem with block style
+     */
+    BlockListItem = 4,
+
+    /**
+     * Wrapper element for context menu
+     */
+    ContextMenuWrapper = 5,
+
+    /**
+     * Wrapper element for image edit
+     */
+    ImageEditWrapper = 6,
+
+    /**
+     * Table resizers
+     */
+    TableHorizontalResizer = 7,
+    TableVerticalResizer = 8,
+    TableResizerLTR = 9,
+    TableResizerRTL = 10,
+}

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -28,6 +28,8 @@ export { RegionType } from './enum/RegionType';
 export { TableOperation } from './enum/TableOperation';
 export { ImageEditOperation } from './enum/ImageEditOperation';
 export { ClearFormatMode } from './enum/ClearFormatMode';
+export { KnownCreateElementDataIndex } from './enum/KnownCreateElementDataIndex';
+
 // Event
 export { default as BeforeCutCopyEvent } from './event/BeforeCutCopyEvent';
 export { default as BasePluginEvent } from './event/BasePluginEvent';
@@ -160,6 +162,7 @@ export { default as PickerDataProvider } from './interface/PickerDataProvider';
 export { default as PickerPluginOptions } from './interface/PickerPluginOptions';
 export { default as VCell } from './interface/VCell';
 export { default as ImageEditOptions } from './interface/ImageEditOptions';
+export { default as CreateElementData } from './interface/CreateElementData';
 
 // Core Plugin State
 export { default as DOMEventPluginState } from './corePluginState/DOMEventPluginState';

--- a/packages/roosterjs-editor-types/lib/interface/CreateElementData.ts
+++ b/packages/roosterjs-editor-types/lib/interface/CreateElementData.ts
@@ -1,0 +1,40 @@
+/**
+ * An interface represents the data for creating element used by createElemnet()
+ */
+export default interface CreateElementData {
+    /**
+     * Tag name of this element.
+     * It can be just a tag, or in format "namespace:tag"
+     */
+    tag: string;
+
+    /**
+     * Namespace of this tag
+     */
+    namespace?: string;
+
+    /**
+     * CSS class name
+     */
+    className?: string;
+
+    /**
+     * CSS style
+     */
+    style?: string;
+
+    /**
+     * Dataset of this element
+     */
+    dataset?: Record<string, string>;
+
+    /**
+     * Additional attributes of this element
+     */
+    attributes?: Record<string, string>;
+
+    /**
+     * Child nodes of this element, can be another CreateElementData, or a string which represents a text node
+     */
+    children?: (CreateElementData | string)[];
+}

--- a/packages/roosterjs-editor-types/lib/interface/ImageEditOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ImageEditOptions.ts
@@ -41,6 +41,7 @@ export default interface ImageEditOptions {
     imageSelector?: string;
 
     /**
+     * @deprecated
      * HTML for the rotate icon
      * @default A predefined SVG icon
      */


### PR DESCRIPTION
innerHTML is widely used in roosterjs. To support TrustedType, we need to avoid assigning value to innerHTML.

This is the first step, since function fromHtml() is based on innerHTML, we deprecate it, and replace with a new function createElement()