### PR TITLE
Support TrustedType step 2: Remove usage of innerHTML

### DIFF
--- a/demo/scripts/controls/MainPane.tsx
+++ b/demo/scripts/controls/MainPane.tsx
@@ -132,14 +132,7 @@ class MainPane extends MainPaneBase {
 
         let styles = document.getElementsByTagName('STYLE');
         for (let i = 0; i < styles.length; i++) {
-            let newStyle = win.document.createElement('STYLE') as HTMLStyleElement;
-            let sheet = (styles[i] as HTMLStyleElement).sheet as CSSStyleSheet;
-            let cssText = '';
-            for (let j = 0; j < sheet.cssRules.length; j++) {
-                cssText += sheet.cssRules[j].cssText;
-            }
-            newStyle.innerHTML = cssText;
-            win.document.head.appendChild(newStyle);
+            win.document.head.appendChild(styles[i].cloneNode(true));
         }
 
         this.setState({

--- a/demo/scripts/controls/samplepicker/SampleColorPickerPluginDataProvider.tsx
+++ b/demo/scripts/controls/samplepicker/SampleColorPickerPluginDataProvider.tsx
@@ -120,7 +120,7 @@ export default class SampleColorPickerPluginDataProvider implements PickerDataPr
 
     private insertColor = (color: string) => {
         const span = this.editor.getDocument().createElement('span');
-        span.innerHTML = '⬤';
+        span.innerText = '⬤';
         span.style.color = color;
         this.insertNodeCallback(span);
     };

--- a/packages/roosterjs-editor-api/lib/format/toggleHeader.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleHeader.ts
@@ -1,5 +1,5 @@
 import { ChangeSource, DocumentCommand, IEditor, QueryScope } from 'roosterjs-editor-types';
-import { HtmlSanitizer } from 'roosterjs-editor-dom';
+import { HtmlSanitizer, moveChildNodes } from 'roosterjs-editor-dom';
 
 /**
  * Toggle header at selection
@@ -21,10 +21,8 @@ export default function toggleHeader(editor: IEditor, level: number) {
                 wrapped = true;
             }
 
-            let div = editor.getDocument().createElement('div');
-            while (header.firstChild) {
-                div.appendChild(header.firstChild);
-            }
+            const div = editor.getDocument().createElement('div');
+            moveChildNodes(div, header);
             editor.replaceNode(header, div);
         });
 

--- a/packages/roosterjs-editor-core/lib/coreApi/createPasteFragment.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/createPasteFragment.ts
@@ -7,6 +7,7 @@ import {
     HtmlSanitizer,
     toArray,
     wrap,
+    moveChildNodes,
 } from 'roosterjs-editor-dom';
 import {
     BeforePasteEvent,
@@ -98,9 +99,7 @@ export const createPasteFragment: CreatePasteFragment = (
             processStyles(doc.body, style => style.parentNode?.removeChild(style));
         }
 
-        while (doc.body.firstChild) {
-            fragment.appendChild(doc.body.firstChild);
-        }
+        moveChildNodes(fragment, doc.body);
 
         if (applyCurrentStyle && position) {
             const format = getCurrentFormat(core, position.node);

--- a/packages/roosterjs-editor-core/lib/coreApi/switchShadowEdit.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/switchShadowEdit.ts
@@ -1,4 +1,4 @@
-import { createRange, getSelectionPath } from 'roosterjs-editor-dom';
+import { createRange, getSelectionPath, moveChildNodes } from 'roosterjs-editor-dom';
 import { EditorCore, PluginEventType, SwitchShadowEdit } from 'roosterjs-editor-types';
 
 /**
@@ -15,10 +15,7 @@ export const switchShadowEdit: SwitchShadowEdit = (core: EditorCore, isOn: boole
             shadowEditSelectionPath = range && getSelectionPath(contentDiv, range);
             shadowEditFragment = core.contentDiv.ownerDocument.createDocumentFragment();
 
-            while (contentDiv.firstChild) {
-                shadowEditFragment.appendChild(contentDiv.firstChild);
-            }
-
+            moveChildNodes(shadowEditFragment, contentDiv);
             shadowEditFragment.normalize();
             core.api.triggerEvent(
                 core,
@@ -34,7 +31,7 @@ export const switchShadowEdit: SwitchShadowEdit = (core: EditorCore, isOn: boole
             lifecycle.shadowEditSelectionPath = shadowEditSelectionPath;
         }
 
-        contentDiv.innerHTML = '';
+        moveChildNodes(contentDiv);
         contentDiv.appendChild(lifecycle.shadowEditFragment.cloneNode(true /*deep*/));
     } else {
         lifecycle.shadowEditFragment = null;
@@ -49,7 +46,7 @@ export const switchShadowEdit: SwitchShadowEdit = (core: EditorCore, isOn: boole
                 false /*broadcast*/
             );
 
-            contentDiv.innerHTML = '';
+            moveChildNodes(contentDiv);
             contentDiv.appendChild(shadowEditFragment);
             core.api.focus(core);
 

--- a/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
@@ -3,6 +3,7 @@ import {
     createElement,
     extractClipboardEvent,
     setHtmlWithSelectionPath,
+    moveChildNodes,
 } from 'roosterjs-editor-dom';
 import {
     ChangeSource,
@@ -159,6 +160,6 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
         tempDiv.style.backgroundColor = '';
         tempDiv.style.color = '';
         tempDiv.style.display = 'none';
-        tempDiv.innerHTML = '';
+        moveChildNodes(tempDiv);
     }
 }

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -50,6 +50,7 @@ export { default as getInnerHTML } from './utils/getInnerHTML';
 export { default as setColor } from './utils/setColor';
 export { default as matchesSelector } from './utils/matchesSelector';
 export { default as createElement, KnownCreateElementData } from './utils/createElement';
+export { default as moveChildNodes } from './utils/moveChildNodes';
 
 export { default as VTable } from './table/VTable';
 export { default as VList } from './list/VList';

--- a/packages/roosterjs-editor-dom/lib/list/VListItem.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VListItem.ts
@@ -2,6 +2,7 @@ import contains from '../utils/contains';
 import getListTypeFromNode from './getListTypeFromNode';
 import getTagOfNode from '../utils/getTagOfNode';
 import isBlockElement from '../utils/isBlockElement';
+import moveChildNodes from '../utils/moveChildNodes';
 import safeInstanceOf from '../utils/safeInstanceOf';
 import toArray from '../utils/toArray';
 import unwrap from '../utils/unwrap';
@@ -233,9 +234,7 @@ function createListElement(
             (<HTMLOListElement>result).removeAttribute('id');
         } else {
             // Remove all child nodes, they will be added back later when write back other items
-            while (originalRoot.firstChild) {
-                originalRoot.removeChild(originalRoot.firstChild);
-            }
+            moveChildNodes(originalRoot);
             result = originalRoot;
         }
     } else {

--- a/packages/roosterjs-editor-dom/lib/selection/getPositionRect.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/getPositionRect.ts
@@ -1,3 +1,4 @@
+import createElement from '../utils/createElement';
 import createRange from './createRange';
 import normalizeRect from '../utils/normalizeRect';
 import { NodePosition, NodeType, Rect } from 'roosterjs-editor-types';
@@ -30,9 +31,10 @@ export default function getPositionRect(position: NodePosition): Rect {
 
     // 3) if node is text node, try inserting a SPAN and get the rect of SPAN for others
     if (position.node.nodeType == NodeType.Text) {
-        const document = position.node.ownerDocument;
-        let span = document.createElement('SPAN');
-        span.innerHTML = '\u200b';
+        const span = createElement(
+            { tag: 'span', children: ['\u200b'] },
+            position.node.ownerDocument
+        );
         range = createRange(position);
         range.insertNode(span);
         rect = span.getBoundingClientRect && normalizeRect(span.getBoundingClientRect());

--- a/packages/roosterjs-editor-dom/lib/table/VTable.ts
+++ b/packages/roosterjs-editor-dom/lib/table/VTable.ts
@@ -1,3 +1,4 @@
+import moveChildNodes from '../utils/moveChildNodes';
 import normalizeRect from '../utils/normalizeRect';
 import safeInstanceOf from '../utils/safeInstanceOf';
 import toArray from '../utils/toArray';
@@ -78,7 +79,7 @@ export default class VTable {
      */
     writeBack() {
         if (this.cells) {
-            moveChildren(this.table);
+            moveChildNodes(this.table);
             this.cells.forEach((row, r) => {
                 let tr = cloneNode(this.trs[r % 2] || this.trs[0]);
                 this.table.appendChild(tr);
@@ -214,7 +215,11 @@ export default class VTable {
                         let aboveCell = rowIndex < this.row ? cell : currentCell;
                         let belowCell = rowIndex < this.row ? currentCell : cell;
                         if (aboveCell.td.colSpan == belowCell.td.colSpan) {
-                            moveChildren(belowCell.td, aboveCell.td);
+                            moveChildNodes(
+                                aboveCell.td,
+                                belowCell.td,
+                                true /*keepExistingChildren*/
+                            );
                             belowCell.td = null;
                             belowCell.spanAbove = true;
                         }
@@ -236,7 +241,11 @@ export default class VTable {
                         let leftCell = colIndex < this.col ? cell : currentCell;
                         let rightCell = colIndex < this.col ? currentCell : cell;
                         if (leftCell.td.rowSpan == rightCell.td.rowSpan) {
-                            moveChildren(rightCell.td, leftCell.td);
+                            moveChildNodes(
+                                leftCell.td,
+                                rightCell.td,
+                                true /*keepExistingChildren*/
+                            );
                             rightCell.td = null;
                             rightCell.spanLeft = true;
                         }
@@ -527,19 +536,4 @@ function cloneNode<T extends Node>(node: T): T {
         }
     }
     return newNode;
-}
-
-/**
- * Move all children from one node to another
- * @param fromNode The source node to move children from
- * @param toNode Target node. If not passed, children nodes of source node will be removed
- */
-function moveChildren(fromNode: Node, toNode?: Node) {
-    while (fromNode.firstChild) {
-        if (toNode) {
-            toNode.appendChild(fromNode.firstChild);
-        } else {
-            fromNode.removeChild(fromNode.firstChild);
-        }
-    }
 }

--- a/packages/roosterjs-editor-dom/lib/utils/changeElementTag.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/changeElementTag.ts
@@ -1,5 +1,6 @@
 import getComputedStyles from './getComputedStyles';
 import getTagOfNode from './getTagOfNode';
+import moveChildNodes from './moveChildNodes';
 
 /**
  * Change tag of an HTML Element to a new one, and replace it from DOM tree
@@ -32,9 +33,7 @@ export default function changeElementTag(element: HTMLElement, newTag: string): 
         newElement.setAttribute(attr.name, attr.value);
     }
 
-    while (element.firstChild) {
-        newElement.appendChild(element.firstChild);
-    }
+    moveChildNodes(newElement, element);
 
     if (getTagOfNode(element) == 'P' || getTagOfNode(newElement) == 'P') {
         [newElement.style.marginTop, newElement.style.marginBottom] = getComputedStyles(element, [

--- a/packages/roosterjs-editor-dom/lib/utils/moveChildNodes.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/moveChildNodes.ts
@@ -1,0 +1,23 @@
+/**
+ * Replace all child nodes of the given target node to the child nodes of source node.
+ * @param target Target node, all child nodes of this node will be removed if keepExistingChildren is not set to true
+ * @param source (Optional) source node, all child nodes of this node will be move to target node
+ * @param keepExistingChildren (Optional) When set to true, all existing child nodes of target will be kept
+ */
+export default function moveChildNodes(
+    target: Node,
+    source?: Node,
+    keepExistingChildren?: boolean
+) {
+    if (!target) {
+        return;
+    }
+
+    while (!keepExistingChildren && target.firstChild) {
+        target.removeChild(target.firstChild);
+    }
+
+    while (source?.firstChild) {
+        target.appendChild(source.firstChild);
+    }
+}

--- a/packages/roosterjs-editor-dom/test/utils/moveChildNodesTest.ts
+++ b/packages/roosterjs-editor-dom/test/utils/moveChildNodesTest.ts
@@ -1,0 +1,55 @@
+import fromHtml from '../../lib/utils/fromHtml';
+import moveChildNodes from '../../lib/utils/moveChildNodes';
+
+describe('moveChildNodes', () => {
+    function runTest(
+        targetHtml: string,
+        sourceHtml: string,
+        keepExisting: boolean,
+        expectedTargetHtml: string
+    ) {
+        const source = sourceHtml ? (fromHtml(sourceHtml, document)[0] as HTMLElement) : null;
+        const target = targetHtml ? (fromHtml(targetHtml, document)[0] as HTMLElement) : null;
+
+        moveChildNodes(target, source, keepExisting);
+
+        const targetResult = target ? target.outerHTML : '';
+
+        expect(targetResult).toBe(expectedTargetHtml);
+    }
+
+    it('null input', () => {
+        runTest(null, null, true, '');
+        runTest(null, null, false, '');
+    });
+
+    it('null target input', () => {
+        runTest(null, '<div><span>test</span></div>', true, '');
+        runTest(null, '<div><span>test</span></div>', false, '');
+    });
+
+    it('null source input', () => {
+        runTest('<div><span>test</span></div>', null, true, '<div><span>test</span></div>');
+        runTest('<div><span>test</span></div>', null, false, '<div></div>');
+    });
+
+    it('null source input', () => {
+        runTest('<div><span>test</span></div>', null, true, '<div><span>test</span></div>');
+        runTest('<div><span>test</span></div>', null, false, '<div></div>');
+    });
+
+    it('regular case', () => {
+        runTest(
+            '<div><span>test1</span><span>test2</span></div>',
+            '<div><span>test3</span><span>test4</span></div>',
+            false,
+            '<div><span>test3</span><span>test4</span></div>'
+        );
+        runTest(
+            '<div><span>test1</span><span>test2</span></div>',
+            '<div><span>test3</span><span>test4</span></div>',
+            true,
+            '<div><span>test1</span><span>test2</span><span>test3</span><span>test4</span></div>'
+        );
+    });
+});

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/excelConverter/convertPastedContentFromExcel.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/excelConverter/convertPastedContentFromExcel.ts
@@ -1,5 +1,5 @@
 import { BeforePasteEvent } from 'roosterjs-editor-types';
-import { chainSanitizerCallback } from 'roosterjs-editor-dom';
+import { chainSanitizerCallback, moveChildNodes } from 'roosterjs-editor-dom';
 
 const LAST_TD_END_REGEX = /<\/\s*td\s*>((?!<\/\s*tr\s*>)[\s\S])*$/i;
 const LAST_TR_END_REGEX = /<\/\s*tr\s*>((?!<\/\s*table\s*>)[\s\S])*$/i;
@@ -18,12 +18,7 @@ export default function convertPastedContentFromExcel(event: BeforePasteEvent) {
 
     if (clipboardData.html != html) {
         const doc = new DOMParser().parseFromString(html, 'text/html');
-        while (fragment.firstChild) {
-            fragment.removeChild(fragment.firstChild);
-        }
-        while (doc?.body?.firstChild) {
-            fragment.appendChild(doc.body.firstChild);
-        }
+        moveChildNodes(fragment, doc?.body);
     }
 
     chainSanitizerCallback(sanitizingOption.elementCallbacks, 'TD', element => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/pptConverter/convertPastedContentFromPowerPoint.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/pptConverter/convertPastedContentFromPowerPoint.ts
@@ -1,11 +1,12 @@
 import { BeforePasteEvent } from 'roosterjs-editor-types';
+import { moveChildNodes } from 'roosterjs-editor-dom';
 
 /**
  * @internal
  * Convert pasted content from PowerPoint
  * @param event The BeforePaste event
  */
-export default function convertPastedContentFromExcel(event: BeforePasteEvent) {
+export default function convertPastedContentFromPowerPoint(event: BeforePasteEvent) {
     const { fragment, clipboardData } = event;
 
     if (clipboardData.html && !clipboardData.text && clipboardData.image) {
@@ -13,11 +14,6 @@ export default function convertPastedContentFromExcel(event: BeforePasteEvent) {
         // We always prefer HTML if any.
         const doc = new DOMParser().parseFromString(clipboardData.html, 'text/html');
 
-        while (fragment.firstChild) {
-            fragment.removeChild(fragment.firstChild);
-        }
-        while (doc?.body?.firstChild) {
-            fragment.appendChild(doc.body.firstChild);
-        }
+        moveChildNodes(fragment, doc?.body);
     }
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/convertPastedContentFromWord.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/convertPastedContentFromWord.ts
@@ -1,5 +1,5 @@
 import { BeforePasteEvent } from 'roosterjs-editor-types';
-import { chainSanitizerCallback } from 'roosterjs-editor-dom';
+import { chainSanitizerCallback, moveChildNodes } from 'roosterjs-editor-dom';
 import { createWordConverter } from './wordConverter';
 import { createWordConverterArguments } from './WordConverterArguments';
 import { processNodeConvert, processNodesDiscovery } from './converterUtils';
@@ -13,7 +13,8 @@ export default function convertPastedContentFromWord(event: BeforePasteEvent) {
 
     // Preserve <o:p> when its innerHTML is "&nbsp;" to avoid dropping an empty line
     chainSanitizerCallback(sanitizingOption.elementCallbacks, 'O:P', element => {
-        element.innerHTML = '&nbsp;';
+        moveChildNodes(element);
+        element.appendChild(element.ownerDocument.createTextNode('\u00A0')); // &nbsp;
         return true;
     });
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/converterUtils.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/converterUtils.ts
@@ -4,7 +4,7 @@ import WordConverter from './wordConverter';
 import WordConverterArguments from './WordConverterArguments';
 import { createLevelLists } from './LevelLists';
 import { getObject, setObject } from './WordCustomData';
-import { getStyles, getTagOfNode } from 'roosterjs-editor-dom';
+import { getStyles, getTagOfNode, moveChildNodes } from 'roosterjs-editor-dom';
 import { NodeType } from 'roosterjs-editor-types';
 
 /** Word list metadata style name */
@@ -130,9 +130,7 @@ export function processNodesDiscovery(wordConverter: WordConverter): boolean {
                 // Add 2 line breaks and move all the nodes to the last item
                 last.appendChild(last.ownerDocument.createElement('br'));
                 last.appendChild(last.ownerDocument.createElement('br'));
-                while (node.firstChild != null) {
-                    last.appendChild(node.firstChild);
-                }
+                moveChildNodes(last, node, true /*keepExistingChildren*/);
 
                 // Remove the item that we don't need anymore
                 node.parentNode.removeChild(node);
@@ -170,9 +168,7 @@ export function processNodeConvert(wordConverter: WordConverter): boolean {
 
                 // Create a new list item and transfer the children
                 let li = node.ownerDocument.createElement('LI');
-                while (node.firstChild) {
-                    li.appendChild(node.firstChild);
-                }
+                moveChildNodes(li, node);
 
                 // Append the list item into the list
                 list.appendChild(li);
@@ -254,9 +250,7 @@ function convertListIfNeeded(
             UNIQUE_LIST_ID_CUSTOM_DATA,
             getObject(wordConverter.wordCustomData, list, UNIQUE_LIST_ID_CUSTOM_DATA)
         );
-        while (list.firstChild) {
-            newList.appendChild(list.firstChild);
-        }
+        moveChildNodes(newList, list);
         list.parentNode.insertBefore(newList, list);
         list.parentNode.removeChild(list);
         list = newList;


### PR DESCRIPTION
In this change I remove most of the places where we assign value to innerHTML.

I also add a new util moveChildNodes() to help move child nodes from one node to another, this also helps remove innerHTML usage.