### PR TITLE
Fix setHtmlWithSelectionPath with DOMPurify

### DIFF
--- a/demo/scripts/utils/trustedHTMLHandler.ts
+++ b/demo/scripts/utils/trustedHTMLHandler.ts
@@ -2,9 +2,7 @@ import * as DOMPurify from 'dompurify';
 
 const policy = !!window.trustedTypes
     ? window.trustedTypes.createPolicy('sanitizeHtml', {
-          createHTML: (input: string) => {
-              return DOMPurify.sanitize(input);
-          }, //
+          createHTML: (input: string) => DOMPurify.sanitize(input),
       })
     : null;
 

--- a/demo/scripts/utils/trustedHTMLHandler.ts
+++ b/demo/scripts/utils/trustedHTMLHandler.ts
@@ -2,7 +2,9 @@ import * as DOMPurify from 'dompurify';
 
 const policy = !!window.trustedTypes
     ? window.trustedTypes.createPolicy('sanitizeHtml', {
-          createHTML: (input: string) => DOMPurify.sanitize(input), //
+          createHTML: (input: string) => {
+              return DOMPurify.sanitize(input);
+          }, //
       })
     : null;
 

--- a/packages/roosterjs-editor-dom/lib/selection/setHtmlWithSelectionPath.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/setHtmlWithSelectionPath.ts
@@ -1,6 +1,8 @@
 import createRange from './createRange';
 import { NodeType, SelectionPath, TrustedHTMLHandler } from 'roosterjs-editor-types';
 
+const LastCommentRegex = /<!--([^-]+)-->$/;
+
 /**
  * Restore inner Html of a root element from given html string. If the string contains selection path,
  * remove the selection path and return a range represented by the path
@@ -13,22 +15,41 @@ export default function setHtmlWithSelectionPath(
     html: string,
     trustedHTMLHandler?: TrustedHTMLHandler
 ): Range {
-    html = html || '';
-    rootNode.innerHTML = trustedHTMLHandler?.(html) || html;
-    let path: SelectionPath = null;
-    let pathComment = rootNode.lastChild;
+    if (!rootNode) {
+        return null;
+    }
 
-    try {
-        path =
-            pathComment &&
-            pathComment.nodeType == NodeType.Comment &&
-            (JSON.parse(pathComment.nodeValue) as SelectionPath);
-        if (path && path.end && path.end.length > 0 && path.start && path.start.length > 0) {
-            rootNode.removeChild(pathComment);
-        } else {
-            path = null;
-        }
-    } catch {}
+    html = html || '';
+    const lastComment = LastCommentRegex.exec(html);
+    rootNode.innerHTML = trustedHTMLHandler?.(html) || html;
+    const path = getSelectionPath(rootNode, lastComment?.[1]);
 
     return path && createRange(rootNode, path.start, path.end);
+}
+
+function getSelectionPath(root: HTMLElement, alternativeComment: string): SelectionPath {
+    let pathCommentValue: string = '';
+    let pathCommentNode: Node = null;
+    let path: SelectionPath = null;
+    if (root.lastChild?.nodeType == NodeType.Comment) {
+        pathCommentNode = root.lastChild;
+        pathCommentValue = pathCommentNode.nodeValue;
+    } else {
+        pathCommentValue = alternativeComment;
+    }
+
+    if (pathCommentValue) {
+        try {
+            path = JSON.parse(pathCommentValue) as SelectionPath;
+            if (path && path.start?.length > 0 && path.end?.length > 0) {
+                if (pathCommentNode) {
+                    root.removeChild(pathCommentNode);
+                }
+            } else {
+                path = null;
+            }
+        } catch {}
+    }
+
+    return path;
 }

--- a/packages/roosterjs-editor-dom/test/selections/setHtmlWithSelectionPathTest.ts
+++ b/packages/roosterjs-editor-dom/test/selections/setHtmlWithSelectionPathTest.ts
@@ -1,0 +1,100 @@
+import setHtmlWithSelectionPath from '../../lib/selection/setHtmlWithSelectionPath';
+
+describe('setHtmlWithSelectionPath', () => {
+    it('null element', () => {
+        const result = setHtmlWithSelectionPath(null, null);
+        expect(result).toBeNull();
+    });
+
+    it('null html', () => {
+        const node = document.createElement('span');
+        node.innerText = 'test';
+        const result = setHtmlWithSelectionPath(node, null);
+        expect(node.innerHTML).toBe('');
+        expect(result).toBeNull();
+    });
+
+    it('html without selection path', () => {
+        const node = document.createElement('span');
+        node.innerText = 'test';
+        const result = setHtmlWithSelectionPath(node, 'test2');
+        expect(node.innerHTML).toBe('test2');
+        expect(result).toBeNull();
+    });
+
+    it('html with invalid selection path', () => {
+        const node = document.createElement('span');
+        node.innerText = 'test';
+        const result = setHtmlWithSelectionPath(node, 'test2<!--test-->');
+        expect(node.innerHTML).toBe('test2<!--test-->');
+        expect(result).toBeNull();
+    });
+
+    it('html with invalid selection path 2', () => {
+        const node = document.createElement('span');
+        node.innerText = 'test';
+        const result = setHtmlWithSelectionPath(node, 'test2<!--{}-->');
+        expect(node.innerHTML).toBe('test2<!--{}-->');
+        expect(result).toBeNull();
+    });
+
+    function removeComment(html: string) {
+        return html.replace(/<--.*-->/g, '');
+    }
+
+    function runTest(
+        html: string,
+        expected: (
+            root: Node
+        ) => {
+            startContainer: Node;
+            startOffset: number;
+            endContainer: Node;
+            endOffset: number;
+        }
+    ) {
+        const div = document.createElement('div');
+
+        let range1 = setHtmlWithSelectionPath(div, html);
+        let result1 = expected(div);
+        expect(range1.startContainer).toBe(result1.startContainer);
+        expect(range1.startOffset).toBe(result1.startOffset);
+        expect(range1.endContainer).toBe(result1.endContainer);
+        expect(range1.endOffset).toBe(result1.endOffset);
+
+        html = removeComment(html);
+        let range2 = setHtmlWithSelectionPath(div, html, removeComment);
+        let result2 = expected(div);
+        expect(range2.startContainer).toBe(result2.startContainer);
+        expect(range2.startOffset).toBe(result2.startOffset);
+        expect(range2.endContainer).toBe(result2.endContainer);
+        expect(range2.endOffset).toBe(result2.endOffset);
+    }
+
+    it('Single node', () => {
+        runTest('<div>test</div><!--{"start":[0,0,2],"end":[0,0,2]}-->', root => ({
+            startContainer: root.firstChild.firstChild,
+            startOffset: 2,
+            endContainer: root.firstChild.firstChild,
+            endOffset: 2,
+        }));
+    });
+
+    it('Single node with selection', () => {
+        runTest('<div>test</div><!--{"start":[0,0,1],"end":[0,0,3]}-->', root => ({
+            startContainer: root.firstChild.firstChild,
+            startOffset: 1,
+            endContainer: root.firstChild.firstChild,
+            endOffset: 3,
+        }));
+    });
+
+    it('Multiple nodes with selection', () => {
+        runTest('<div>test</div><div>test2</div><!--{"start":[0,0,2],"end":[1,0,2]}-->', root => ({
+            startContainer: root.firstChild.firstChild,
+            startOffset: 2,
+            endContainer: root.lastChild.firstChild,
+            endOffset: 2,
+        }));
+    });
+});


### PR DESCRIPTION
With DOMPurify, comment will be removed when sanitize html, so that selection path won't work since it is based on HTML commment. To fix it, let's add a fallback logic in setHtmlWithSelectionPath in case comment is removed.

Related test added.