### PR TITLE
Fix the EntityId Regex

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/EntityPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/EntityPlugin.ts
@@ -23,7 +23,7 @@ import {
     QueryScope,
 } from 'roosterjs-editor-types';
 
-const ENTITY_ID_REGEX = /_\d{1,8}$/;
+const ENTITY_ID_REGEX = /_(\d{1,8})$/;
 
 const ENTITY_CSS_REGEX = '^' + EntityClasses.ENTITY_INFO_NAME + '$';
 const ENTITY_ID_CSS_REGEX = '^' + EntityClasses.ENTITY_ID_PREFIX;


### PR DESCRIPTION
We use a Regex to match existing Entity Id. However the regex misses a ( ) to capture the id number. We need to fix it.