### PR TITLE
Fix image Overflowing the editor wrapper

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -12,6 +12,18 @@ import ImageHtmlOptions from './types/ImageHtmlOptions';
 import Rotator, { getRotateHTML, ROTATE_GAP, ROTATE_SIZE } from './imageEditors/Rotator';
 import { ImageEditElementClass } from './types/ImageEditElementClass';
 import { insertEntity } from 'roosterjs-editor-api';
+import {
+    arrayPush,
+    Browser,
+    createElement,
+    getComputedStyle,
+    getEntityFromElement,
+    getEntitySelector,
+    matchesSelector,
+    safeInstanceOf,
+    toArray,
+    wrap,
+} from 'roosterjs-editor-dom';
 import Resizer, {
     doubleCheckResize,
     getSideResizeHTML,
@@ -33,17 +45,6 @@ import {
     CreateElementData,
     KnownCreateElementDataIndex,
 } from 'roosterjs-editor-types';
-import {
-    Browser,
-    getEntitySelector,
-    getEntityFromElement,
-    matchesSelector,
-    safeInstanceOf,
-    toArray,
-    wrap,
-    arrayPush,
-    createElement,
-} from 'roosterjs-editor-dom';
 
 const SHIFT_KEYCODE = 16;
 const CTRL_KEYCODE = 17;
@@ -396,6 +397,7 @@ export default class ImageEdit implements EditorPlugin {
             img.style.position = '';
             img.style.maxWidth = '100%';
             img.style.margin = null;
+            img.style.textAlign = null;
 
             parent.insertBefore(img, wrapper);
             parent.removeChild(wrapper);
@@ -447,6 +449,10 @@ export default class ImageEdit implements EditorPlugin {
             wrapper.style.height = getPx(visibleHeight);
             wrapper.style.margin = `${marginVertical}px ${marginHorizontal}px`;
             wrapper.style.transform = `rotate(${angleRad}rad)`;
+
+            // Update the text-alignment to avoid the image to overflow if the parent element have align center or right
+            // or if the direction is Right To Left
+            wrapper.style.textAlign = isRtl(wrapper.parentNode) ? 'right' : 'left';
 
             // Update size of the image
             this.image.style.width = getPx(originalWidth);
@@ -578,4 +584,10 @@ function getPx(value: number): string {
 
 function getEditElements(wrapper: HTMLElement, elementClass: ImageEditElementClass): HTMLElement[] {
     return toArray(wrapper.querySelectorAll('.' + elementClass)) as HTMLElement[];
+}
+
+function isRtl(element: Node): boolean {
+    return safeInstanceOf(element, 'HTMLElement')
+        ? getComputedStyle(element, 'direction') == 'rtl'
+        : false;
 }


### PR DESCRIPTION
When selecting photo and the text align was center or right, the image was overflowing the Image Edit Wrapper. Also when debugging I found another behavior when the RTL was enabled causing the overflow when the text align was center or left.

Previous behavior:
![image](https://user-images.githubusercontent.com/8291124/130300152-6e9db075-7f03-461f-82a7-61ea64e473ab.png)

After code changes
![ImageOverflowingFix](https://user-images.githubusercontent.com/8291124/130300113-cb0678e7-78ed-4d75-8db1-ef6c13f0e73e.gif)

