### PR TITLE
Update package.json to include the repository 

### DIFF
--- a/packages/roosterjs-color-utils/package.json
+++ b/packages/roosterjs-color-utils/package.json
@@ -5,6 +5,11 @@
         "color": "^3.0.0",
         "roosterjs-editor-types": ""
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/roosterjs.git",
+        "directory": "packages/roosterjs-color-utils"
+    },
     "main": "./lib/index.ts",
     "version": "1.0.0"
 }

--- a/packages/roosterjs-editor-api/package.json
+++ b/packages/roosterjs-editor-api/package.json
@@ -5,5 +5,10 @@
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": ""
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/roosterjs.git",
+        "directory": "packages/roosterjs-editor-api"
+    },
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-core/package.json
+++ b/packages/roosterjs-editor-core/package.json
@@ -5,5 +5,10 @@
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": ""
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/roosterjs.git",
+        "directory": "packages/roosterjs-editor-core"
+    },
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-dom/package.json
+++ b/packages/roosterjs-editor-dom/package.json
@@ -4,5 +4,10 @@
     "dependencies": {
         "roosterjs-editor-types": ""
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/roosterjs.git",
+        "directory": "packages/roosterjs-editor-dom"
+    },
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-plugins/package.json
+++ b/packages/roosterjs-editor-plugins/package.json
@@ -6,5 +6,10 @@
         "roosterjs-editor-dom": "",
         "roosterjs-editor-api": ""
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/roosterjs.git",
+        "directory": "packages/roosterjs-editor-plugins"
+    },
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-types/package.json
+++ b/packages/roosterjs-editor-types/package.json
@@ -4,5 +4,10 @@
     "dependencies": {
         "@types/dom-inputevent": "^1.0.3"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/roosterjs.git",
+        "directory": "packages/roosterjs-editor-types"
+    },
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs/package.json
+++ b/packages/roosterjs/package.json
@@ -9,5 +9,10 @@
         "roosterjs-editor-plugins": "",
         "roosterjs-color-utils": ""
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/roosterjs.git",
+        "directory": "packages/roosterjs"
+    },
     "main": "./lib/index.ts"
 }


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your repositories, please comment on this PR. We will see replies to this pull request.

Published NPM packages with repository information:
* roosterjs-editor-types
* roosterjs-editor-plugins
* roosterjs-editor-dom
* roosterjs-editor-core
* roosterjs-editor-api
* roosterjs-color-utils
* roosterjs