### PR TITLE
new api to rotate resize handles

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -12,6 +12,7 @@ import ImageHtmlOptions from './types/ImageHtmlOptions';
 import Rotator, { getRotateHTML, ROTATE_GAP, ROTATE_SIZE } from './imageEditors/Rotator';
 import { ImageEditElementClass } from './types/ImageEditElementClass';
 import { insertEntity } from 'roosterjs-editor-api';
+import { resizeHandlesRotator } from './api/resizeHandlesRotator';
 import Resizer, {
     doubleCheckResize,
     getSideResizeHTML,
@@ -362,14 +363,12 @@ export default class ImageEdit implements EditorPlugin {
                 }
             }
         );
-
         htmlData.forEach(data => {
             const element = createElement(data, this.image.ownerDocument);
             if (element) {
                 wrapper.appendChild(element);
             }
         });
-
         return wrapper;
     }
 
@@ -414,6 +413,7 @@ export default class ImageEdit implements EditorPlugin {
             const cropOverlays = getEditElements(wrapper, ImageEditElementClass.CropOverlay);
             const rotateCenter = getEditElements(wrapper, ImageEditElementClass.RotateCenter)[0];
             const rotateHandle = getEditElements(wrapper, ImageEditElementClass.RotateHandle)[0];
+            const resizeHandles = getEditElements(wrapper, ImageEditElementClass.ResizeHandle);
 
             // Cropping and resizing will show different UI, so check if it is cropping here first
             const isCropping = cropContainers.length == 1 && cropOverlays.length == 4;
@@ -499,6 +499,7 @@ export default class ImageEdit implements EditorPlugin {
                             ? Number.MAX_SAFE_INTEGER
                             : (distance[1] + heightPx / 2 + marginVertical) / cosAngle -
                               heightPx / 2;
+
                     const rotateGap = Math.max(Math.min(ROTATE_GAP, adjustedDistance), 0);
                     const rotateTop = Math.max(
                         Math.min(ROTATE_SIZE, adjustedDistance - rotateGap),
@@ -507,6 +508,7 @@ export default class ImageEdit implements EditorPlugin {
                     rotateCenter.style.top = getPx(-rotateGap);
                     rotateCenter.style.height = getPx(rotateGap);
                     rotateHandle.style.top = getPx(-rotateTop);
+                    resizeHandlesRotator(resizeHandles, angleRad);
                 }
             }
         }
@@ -528,7 +530,6 @@ export default class ImageEdit implements EditorPlugin {
             elementClass,
         };
         const wrapper = this.getImageWrapper(this.image);
-
         return wrapper
             ? getEditElements(wrapper, elementClass).map(
                   element =>

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/api/resizeHandlesRotator.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/api/resizeHandlesRotator.ts
@@ -1,0 +1,122 @@
+const Rotation30to60DegreesHandlesSequence = [
+    'w-resize',
+    'n-resize',
+    's-resize',
+    'e-resize',
+    'nw-resize',
+    'sw-resize',
+    'ne-resize',
+    'se-resize',
+];
+
+const Rotation60to120DegreesHandlesSequence = [
+    'nw-resize',
+    'ne-resize',
+    'sw-resize',
+    'se-resize',
+    'n-resize',
+    'w-resize',
+    'e-resize',
+    's-resize',
+];
+
+const Rotation120to150DegreesHandlesSequence = [
+    'n-resize',
+    'e-resize',
+    'w-resize',
+    's-resize',
+    'ne-resize',
+    'nw-resize',
+    'se-resize',
+    'sw-resize',
+];
+
+const Rotation150to210DegreesHandlesSequence = [
+    'ne-resize',
+    'se-resize',
+    'nw-resize',
+    'sw-resize',
+    'e-resize',
+    'n-resize',
+    's-resize',
+    'w-resize',
+];
+
+const Rotation210to240DegreesHandlesSequence = [
+    'e-resize',
+    's-resize',
+    'n-resize',
+    'w-resize',
+    'se-resize',
+    'ne-resize',
+    'sw-resize',
+    'nw-resize',
+];
+
+const Rotation240to300DegreeshandlesSequence = [
+    'se-resize',
+    'sw-resize',
+    'ne-resize',
+    'nw-resize',
+    's-resize',
+    'e-resize',
+    'w-resize',
+    'n-resize',
+];
+
+const Rotation300to330DegreesHandlesSequence = [
+    's-resize',
+    'w-resize',
+    'e-resize',
+    'n-resize',
+    'sw-resize',
+    'se-resize',
+    'nw-resize',
+    'ne-resize',
+];
+
+const Rotation330to30DegreesHandlesSequence = [
+    'sw-resize',
+    'nw-resize',
+    'se-resize',
+    'ne-resize',
+    'w-resize',
+    's-resize',
+    'n-resize',
+    'e-resize',
+];
+
+const PI = Math.PI;
+
+function rotateResizeHandles(angleRad: number, index: number): string {
+    switch (true) {
+        case angleRad >= PI / 6 && angleRad <= PI / 3:
+            return Rotation30to60DegreesHandlesSequence[index];
+        case angleRad > PI / 3 && angleRad <= (2 * PI) / 3:
+            return Rotation60to120DegreesHandlesSequence[index];
+        case angleRad > (2 * PI) / 3 && angleRad <= (5 * PI) / 6:
+            return Rotation120to150DegreesHandlesSequence[index];
+        case angleRad > (5 * PI) / 6 && angleRad <= (7 * PI) / 6:
+            return Rotation150to210DegreesHandlesSequence[index];
+        case angleRad < -(2 * PI) / 3 && angleRad >= -(5 * PI) / 6:
+            return Rotation210to240DegreesHandlesSequence[index];
+        case angleRad < -PI / 3 && angleRad >= -(2 * PI) / 3:
+            return Rotation240to300DegreeshandlesSequence[index];
+        case angleRad <= -PI / 6 && angleRad >= -PI / 3:
+            return Rotation300to330DegreesHandlesSequence[index];
+        default:
+            return Rotation330to30DegreesHandlesSequence[index];
+    }
+}
+
+/**
+ * Rotation the resizer handles according to the image position.
+ * @param resizeHandles The resizer handles.
+ * @param angleRad The angle that the image was rotated.
+ */
+export function resizeHandlesRotator(resizerHandles: HTMLElement[], angleRad: number) {
+    resizerHandles.map(handles => {
+        const index = resizerHandles.indexOf(handles);
+        handles.style.cursor = rotateResizeHandles(angleRad, index);
+    });
+}


### PR DESCRIPTION
New api to rotate the resize handles when the image is rotated. 

![rotateHandles](https://user-images.githubusercontent.com/87443959/130516303-e904399b-7fa5-42a9-ae5d-afa740fc8b02.gif)
