### PR TITLE
test font-picker

### DIFF
--- a/packages/roosterjs-editor-dom/lib/utils/getComputedStyles.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/getComputedStyles.ts
@@ -23,7 +23,6 @@ export default function getComputedStyles(
                 let value = styles.getPropertyValue(style) || '';
                 value = style != 'font-family' ? value.toLowerCase() : value;
                 value = style == 'font-size' ? px2Pt(value) : value;
-                console.log(value);
                 result.push(value);
             }
         }


### PR DESCRIPTION
Remove lowerCase for font-family. 
Bugfix for: https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/119857/