### PR TITLE
Fix bug in createElement for popout

### DIFF
--- a/packages/roosterjs-editor-dom/lib/utils/createElement.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/createElement.ts
@@ -1,3 +1,4 @@
+import safeInstanceOf from './safeInstanceOf';
 import { Browser } from './Browser';
 import { CreateElementData, KnownCreateElementDataIndex } from 'roosterjs-editor-types';
 
@@ -73,7 +74,7 @@ export default function createElement(
         result.className = className;
     }
 
-    if (dataset && result instanceof HTMLElement) {
+    if (dataset && safeInstanceOf(result, 'HTMLElement')) {
         Object.keys(dataset).forEach(datasetName => {
             result.dataset[datasetName] = dataset[datasetName];
         });


### PR DESCRIPTION
There is a misused "instanceof" in createElement function which can't work correctly in popout window. We need to replace it with safeInstanceOf()