### PR TITLE
Fix #632

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ node_js:
     - 10
 before_install:
     - yarn
-#install:
-#    - npm run build:ci
+install:
+    - npm run build:ci
 script:
     - xvfb-run npm run test:coverage
     - xvfb-run npm run test:chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: node_js
 sudo: required
 addons:
-    - chrome: latest
-    - firefox: latest
+    chrome: stable
+    #firefox: latest
 node_js:
     - 10
 before_install:
     - yarn
-install:
-    - npm run build:ci
+#install:
+#    - npm run build:ci
 script:
-    - xvfb-run npm run test:coverage
+    #    - xvfb-run npm run test:coverage
     - xvfb-run npm run test:chrome
 cache:
     yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 sudo: required
 addons:
-    firefox: latest
+    - firefox: latest
+    - chrome: latest
 node_js:
     - 10
 before_install:
@@ -11,11 +12,6 @@ install:
 script:
     - xvfb-run npm run test:coverage
     - xvfb-run npm run test:chrome
-    # puppeteer-firefox does not run in travis because it depends on a
-    # libstdc++6  that is not available in travis.
-    # See https://github.com/GoogleChrome/puppeteer/pull/3657
-    # Temporarily disable instrumentation test since it is not stable
-    # - xvfb-run npm run instrumentation:chrome
 cache:
     yarn: true
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 sudo: required
 addons:
     chrome: stable
-    #firefox: latest
+    firefox: latest
 node_js:
     - 10
 before_install:
@@ -10,7 +10,7 @@ before_install:
 #install:
 #    - npm run build:ci
 script:
-    #    - xvfb-run npm run test:coverage
+    - xvfb-run npm run test:coverage
     - xvfb-run npm run test:chrome
 cache:
     yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
     - npm run build:ci
 script:
     - xvfb-run npm run test:coverage
+    - xvfb-run npm run test:chrome
     # puppeteer-firefox does not run in travis because it depends on a
     # libstdc++6  that is not available in travis.
     # See https://github.com/GoogleChrome/puppeteer/pull/3657

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 sudo: required
 addons:
-    - firefox: latest
     - chrome: latest
+    - firefox: latest
 node_js:
     - 10
 before_install:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,6 +10,7 @@ module.exports = function (config) {
         'karma-phantomjs-launcher',
         'karma-jasmine',
         'karma-sourcemap-loader',
+        'karma-verbose-reporter',
     ];
 
     if (runCoverage) {
@@ -45,11 +46,12 @@ module.exports = function (config) {
             browser: browser,
         },
         browsers: [browser],
-        customLaunchers: {
-            Chrome: {
-                flags: ['--disable-gpu'],
-            },
-        },
+        // customLaunchers: {
+        //     Chrome: {
+
+        //         flags: ['--disable-gpu'],
+        //     },
+        // },
         files: ['karma.tests.js'],
         frameworks: ['jasmine'],
         preprocessors: {
@@ -91,6 +93,8 @@ module.exports = function (config) {
             reports: ['html', 'lcovonly', 'text-summary'],
             dir: './dist/deploy/coverage',
         };
+    } else {
+        settings.reporters = ['verbose'];
     }
 
     config.set(settings);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,7 +49,12 @@ module.exports = function (config) {
         customLaunchers: {
             ChromeCustomize: {
                 base: 'Chrome',
-                flags: ['--disable-gpu', '--disable-dev-shm-usage', '--no-sandbox'],
+                flags: [
+                    '--disable-gpu',
+                    '--disable-dev-shm-usage',
+                    '--no-sandbox',
+                    '--disable-seccomp-filter-sandbox',
+                ],
             },
         },
         files: ['karma.tests.js'],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,6 @@ module.exports = function (config) {
         'karma-phantomjs-launcher',
         'karma-jasmine',
         'karma-sourcemap-loader',
-        'karma-verbose-reporter',
     ];
 
     if (runCoverage) {
@@ -18,6 +17,7 @@ module.exports = function (config) {
     }
 
     const browser = runChrome ? 'Chrome' : 'Firefox';
+    const launcher = runChrome ? ['ChromeCustomize'] : ['Firefox'];
 
     const rules = runCoverage
         ? [
@@ -45,13 +45,13 @@ module.exports = function (config) {
             clearContext: false,
             browser: browser,
         },
-        browsers: [browser],
-        // customLaunchers: {
-        //     Chrome: {
-
-        //         flags: ['--disable-gpu'],
-        //     },
-        // },
+        browsers: launcher,
+        customLaunchers: {
+            ChromeCustomize: {
+                base: 'Chrome',
+                flags: ['--disable-gpu'],
+            },
+        },
         files: ['karma.tests.js'],
         frameworks: ['jasmine'],
         preprocessors: {
@@ -93,8 +93,6 @@ module.exports = function (config) {
             reports: ['html', 'lcovonly', 'text-summary'],
             dir: './dist/deploy/coverage',
         };
-    } else {
-        settings.reporters = ['verbose'];
     }
 
     config.set(settings);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -45,6 +45,11 @@ module.exports = function (config) {
             browser: browser,
         },
         browsers: [browser],
+        customLaunchers: {
+            Chrome: {
+                flags: ['--disable-gpu'],
+            },
+        },
         files: ['karma.tests.js'],
         frameworks: ['jasmine'],
         preprocessors: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,7 @@ module.exports = function (config) {
     }
 
     const browser = runChrome ? 'Chrome' : 'Firefox';
-    const launcher = runChrome ? ['ChromeCustomize'] : ['Firefox'];
+    const launcher = runChrome ? ['Chrome'] : ['Firefox'];
 
     const rules = runCoverage
         ? [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,7 +49,7 @@ module.exports = function (config) {
         customLaunchers: {
             ChromeCustomize: {
                 base: 'Chrome',
-                flags: ['--disable-gpu', '--disable-dev-shm-usage'],
+                flags: ['--disable-gpu', '--disable-dev-shm-usage', '--no-sandbox'],
             },
         },
         files: ['karma.tests.js'],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,17 +46,6 @@ module.exports = function (config) {
             browser: browser,
         },
         browsers: launcher,
-        customLaunchers: {
-            ChromeCustomize: {
-                base: 'Chrome',
-                flags: [
-                    '--disable-gpu',
-                    '--disable-dev-shm-usage',
-                    '--no-sandbox',
-                    '--disable-seccomp-filter-sandbox',
-                ],
-            },
-        },
         files: ['karma.tests.js'],
         frameworks: ['jasmine'],
         preprocessors: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,11 +1,12 @@
 const argv = require('minimist')(process.argv.slice(2));
 const components = argv.components !== true && argv.components;
 const runCoverage = typeof argv.coverage !== 'undefined';
+const runChrome = typeof argv.chrome !== 'undefined';
 
 module.exports = function (config) {
     const plugins = [
         'karma-webpack',
-        'karma-firefox-launcher',
+        runChrome ? 'karma-chrome-launcher' : 'karma-firefox-launcher',
         'karma-phantomjs-launcher',
         'karma-jasmine',
         'karma-sourcemap-loader',
@@ -14,6 +15,8 @@ module.exports = function (config) {
     if (runCoverage) {
         plugins.push('karma-coverage-istanbul-reporter');
     }
+
+    const browser = runChrome ? 'Chrome' : 'Firefox';
 
     const rules = runCoverage
         ? [
@@ -39,8 +42,9 @@ module.exports = function (config) {
         client: {
             components: components,
             clearContext: false,
+            browser: browser,
         },
-        browsers: ['Firefox'],
+        browsers: [browser],
         files: ['karma.tests.js'],
         frameworks: ['jasmine'],
         preprocessors: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,7 +49,7 @@ module.exports = function (config) {
         customLaunchers: {
             ChromeCustomize: {
                 base: 'Chrome',
-                flags: ['--disable-gpu'],
+                flags: ['--disable-gpu', '--disable-dev-shm-usage'],
             },
         },
         files: ['karma.tests.js'],

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "build:ci": "node tools/build.js clean checkdep normalize tslint buildcommonjs buildamd dts pack packprod builddemo builddoc",
         "start": "node tools/start.js",
         "test": "karma start",
+        "test:chrome": "karma start --chrome",
         "test:debug": "karma start --no-single-run",
         "test:coverage": "karma start --coverage",
         "publish": "node tools/build.js clean normalize tslint buildcommonjs buildamd dts pack packprod builddemo publish"
@@ -40,6 +41,7 @@
         "karma": "5.0.4",
         "karma-coverage-istanbul-reporter": "3.0.3",
         "karma-firefox-launcher": "1.3.0",
+        "karma-chrome-launcher": "3.1.0",
         "karma-jasmine": "3.1.1",
         "karma-phantomjs-launcher": "1.0.4",
         "karma-sourcemap-loader": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "karma-jasmine": "3.1.1",
         "karma-phantomjs-launcher": "1.0.4",
         "karma-sourcemap-loader": "0.3.7",
-        "karma-verbose-reporter": "^0.0.6",
         "karma-webpack": "4.0.2",
         "prettier": "2.0.5",
         "pretty-quick": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "karma-jasmine": "3.1.1",
         "karma-phantomjs-launcher": "1.0.4",
         "karma-sourcemap-loader": "0.3.7",
+        "karma-verbose-reporter": "^0.0.6",
         "karma-webpack": "4.0.2",
         "prettier": "2.0.5",
         "pretty-quick": "^2.0.1",

--- a/packages/roosterjs-editor-api/test/format/changeCapitalizationTest.ts
+++ b/packages/roosterjs-editor-api/test/format/changeCapitalizationTest.ts
@@ -30,7 +30,7 @@ describe('changeCapitalization()', () => {
     }
 
     // Basic functionality tests
-    it('UPPERCASE', () => {
+    TestHelper.itFirefoxOnly('UPPERCASE', () => {
         runTest(
             '<div id="divToTest">text</div>',
             '<div id="divToTest"><span>TEXT</span></div>',
@@ -38,7 +38,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('lowercase', () => {
+    TestHelper.itFirefoxOnly('lowercase', () => {
         runTest(
             '<div id="divToTest">TEXT</div>',
             '<div id="divToTest"><span>text</span></div>',
@@ -46,7 +46,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('Capitalize Each Word', () => {
+    TestHelper.itFirefoxOnly('Capitalize Each Word', () => {
         runTest(
             '<div id="divToTest">text</div>',
             '<div id="divToTest"><span>Text</span></div>',
@@ -54,7 +54,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('Capitalize Each Word from lowercase', () => {
+    TestHelper.itFirefoxOnly('Capitalize Each Word from lowercase', () => {
         runTest(
             '<div id="divToTest">first second third</div>',
             '<div id="divToTest"><span>First Second Third</span></div>',
@@ -62,7 +62,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('Capitalize Each Word from UPPERCASE', () => {
+    TestHelper.itFirefoxOnly('Capitalize Each Word from UPPERCASE', () => {
         runTest(
             '<div id="divToTest">FIRST SECOND THIRD</div>',
             '<div id="divToTest"><span>First Second Third</span></div>',
@@ -70,7 +70,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('Sentence case from UPPERCASE', () => {
+    TestHelper.itFirefoxOnly('Sentence case from UPPERCASE', () => {
         runTest(
             '<div id="divToTest">WHAT IS IT? PLEASE. I NEED TO KNOW! ANOTHER SENTENCE.</div>',
             '<div id="divToTest"><span>What is it? Please. I need to know! Another sentence.</span></div>',
@@ -78,7 +78,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('Sentence case does not capitalize URLS', () => {
+    TestHelper.itFirefoxOnly('Sentence case does not capitalize URLS', () => {
         runTest(
             '<div id="divToTest">example: www.contoso.com is not capitalized but. aww is.</div>',
             '<div id="divToTest"><span>Example: www.contoso.com is not capitalized but. Aww is.</span></div>',
@@ -87,15 +87,18 @@ describe('changeCapitalization()', () => {
     });
 
     // Style and markup tests
-    it('styled content will retain styling after changing capitalization', () => {
-        runTest(
-            '<div id="divToTest" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><b>Text</b></div>',
-            '<div id="divToTest" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><span><b>TEXT</b></span></div>',
-            Capitalization.Uppercase
-        );
-    });
+    TestHelper.itFirefoxOnly(
+        'styled content will retain styling after changing capitalization',
+        () => {
+            runTest(
+                '<div id="divToTest" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><b>Text</b></div>',
+                '<div id="divToTest" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><span><b>TEXT</b></span></div>',
+                Capitalization.Uppercase
+            );
+        }
+    );
 
-    it('will retain list format when changing capitalization', () => {
+    TestHelper.itFirefoxOnly('will retain list format when changing capitalization', () => {
         runTest(
             '<div id="divToTest"><ul><li><span>coffee</span></li><li><span>tea<span></li></ul></div>',
             '<div id="divToTest"><ul><li><span>COFFEE</span></li><li><span>TEA</span><span><span></span></span></li></ul></div>',
@@ -103,7 +106,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('Multi line is respected', () => {
+    TestHelper.itFirefoxOnly('Multi line is respected', () => {
         runTest(
             '<div id="divToTest">This is<br>a test</div>',
             '<div id="divToTest"><span>THIS IS</span><br><span>A TEST</span></div>',
@@ -111,7 +114,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('Hyperlink is not affected', () => {
+    TestHelper.itFirefoxOnly('Hyperlink is not affected', () => {
         runTest(
             '<div id="divToTest">This is a <a href="http://contoso.com" title="http://contoso.com">test</a></div>',
             '<div id="divToTest"><span>THIS IS A </span><a href="http://contoso.com" title="http://contoso.com"><span>TEST</span></a></div>',
@@ -119,7 +122,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('<IMG> is not affected', () => {
+    TestHelper.itFirefoxOnly('<IMG> is not affected', () => {
         runTest(
             '<div id="divToTest"><img src="test" width="100%">see the image above</div>',
             '<div id="divToTest"><img src="test" width="100%"><span>See The Image Above</span></div>',
@@ -128,15 +131,18 @@ describe('changeCapitalization()', () => {
     });
 
     // Internationalization tests
-    it('works without a language passed when the character mapping is clear', () => {
-        runTest(
-            '<div id="divToTest">ılık ısırgan ışık</div>',
-            '<div id="divToTest"><span>ILIK ISIRGAN IŞIK</span></div>',
-            Capitalization.Uppercase
-        );
-    });
+    TestHelper.itFirefoxOnly(
+        'works without a language passed when the character mapping is clear',
+        () => {
+            runTest(
+                '<div id="divToTest">ılık ısırgan ışık</div>',
+                '<div id="divToTest"><span>ILIK ISIRGAN IŞIK</span></div>',
+                Capitalization.Uppercase
+            );
+        }
+    );
 
-    it('works with an invalid string passed for language', () => {
+    TestHelper.itFirefoxOnly('works with an invalid string passed for language', () => {
         runTest(
             '<div id="divToTest">first second third</div>',
             '<div id="divToTest"><span>First Second Third</span></div>',
@@ -145,16 +151,19 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('does not affect uncased languages even when a cased language is passed', () => {
-        runTest(
-            '<div id="divToTest">לשון הקודש</div>',
-            '<div id="divToTest"><span>לשון הקודש</span></div>',
-            Capitalization.Uppercase,
-            'es'
-        );
-    });
+    TestHelper.itFirefoxOnly(
+        'does not affect uncased languages even when a cased language is passed',
+        () => {
+            runTest(
+                '<div id="divToTest">לשון הקודש</div>',
+                '<div id="divToTest"><span>לשון הקודש</span></div>',
+                Capitalization.Uppercase,
+                'es'
+            );
+        }
+    );
 
-    it('Turkish undotted lowercase undotted to uppercase I', () => {
+    TestHelper.itFirefoxOnly('Turkish undotted lowercase undotted to uppercase I', () => {
         runTest(
             '<div id="divToTest">ılık ısırgan ışık</div>',
             '<div id="divToTest"><span>ILIK ISIRGAN IŞIK</span></div>',
@@ -163,7 +172,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('Turkish undotted uppercase dotted to lowercase ı', () => {
+    TestHelper.itFirefoxOnly('Turkish undotted uppercase dotted to lowercase ı', () => {
         runTest(
             '<div id="divToTest">ILIK ISIRGAN IŞIK</div>',
             '<div id="divToTest"><span>ılık ısırgan ışık</span></div>',
@@ -172,7 +181,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('Greek Σ to lowercase: σ OR ς if terminating a word', () => {
+    TestHelper.itFirefoxOnly('Greek Σ to lowercase: σ OR ς if terminating a word', () => {
         runTest(
             '<div id="divToTest">Σ IS A GREEK LETTER AND APPEARS IN ΟΔΥΣΣΕΥΣ.</div>',
             '<div id="divToTest"><span>σ is a greek letter and appears in οδυσσευς.</span></div>',
@@ -181,7 +190,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('German ß to uppercase', () => {
+    TestHelper.itFirefoxOnly('German ß to uppercase', () => {
         runTest(
             '<div id="divToTest">grüßen</div>',
             '<div id="divToTest"><span>GRÜSSEN</span></div>',
@@ -190,7 +199,7 @@ describe('changeCapitalization()', () => {
         );
     });
 
-    it('Spanish special characters', () => {
+    TestHelper.itFirefoxOnly('Spanish special characters', () => {
         runTest(
             '<div id="divToTest">A sus órdenes señora</div>',
             '<div id="divToTest"><span>A SUS ÓRDENES SEÑORA</span></div>',

--- a/packages/roosterjs-editor-api/test/format/clearBlockFormatTest.ts
+++ b/packages/roosterjs-editor-api/test/format/clearBlockFormatTest.ts
@@ -26,7 +26,7 @@ describe('clearBlockFormat()', () => {
         runTest('', '');
     });
 
-    it('Empty DIV', () => {
+    TestHelper.itFirefoxOnly('Empty DIV', () => {
         runTest('<div></div><!--{"start":[0],"end":[0]}-->', '');
     });
 

--- a/packages/roosterjs-editor-api/test/format/clearFormatTest.ts
+++ b/packages/roosterjs-editor-api/test/format/clearFormatTest.ts
@@ -29,7 +29,7 @@ describe('clearFormat()', () => {
         expect(document.execCommand).toHaveBeenCalledWith('removeFormat', false, null);
     });
 
-    it('removes the existing formats', () => {
+    TestHelper.itFirefoxOnly('removes the existing formats', () => {
         // Arrange
         editor.setContent(originalContent);
         TestHelper.selectNode(document.getElementById('text'));
@@ -51,7 +51,7 @@ describe('clearFormat()', () => {
         expect(spy).toHaveBeenCalledTimes(1);
     });
 
-    it('removes the existing inline formats, text with hyperlink', () => {
+    TestHelper.itFirefoxOnly('removes the existing inline formats, text with hyperlink', () => {
         // Arrange
         let contentWithHyperlink =
             '<div id="text"><span style="font-size: 20pt; color: rgb(237, 92, 87); font-family: &quot;Courier New&quot;;">This is a </span><a href="http://microsoft.com"><span style="font-size: 20pt; color: rgb(237, 92, 87); font-family: &quot;Courier New&quot;;">link</span></a><span style="font-size: 20pt; color: rgb(237, 92, 87); font-family: &quot;Courier New&quot;;">.</span></div>';
@@ -67,7 +67,7 @@ describe('clearFormat()', () => {
         );
     });
 
-    it('removes the existing inline formats, hyperlink', () => {
+    TestHelper.itFirefoxOnly('removes the existing inline formats, hyperlink', () => {
         // Arrange
         let contentWithHyperlink =
             '<div id="text"><a href="http://microsoft.com"><span style="font-family: arial; font-size: 72pt; color: rgb(179, 106, 226);">link</span></a></div>';
@@ -83,37 +83,43 @@ describe('clearFormat()', () => {
         );
     });
 
-    it('removes the existing inline formats, text starting with a Hyperlink', () => {
-        // Arrange
-        let contentWithHyperlink =
-            '<div id="text" style="font-family: &quot;Times New Roman&quot;; font-size: 12pt; color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);"><a href="http://microsoft.com"><span style="font-size: 36pt; color: rgb(12, 100, 192); background-color: rgb(255, 0, 0); font-family: Tahoma;">hello</span></a><span style="font-size: 36pt; color: rgb(12, 100, 192); background-color: rgb(255, 0, 0); font-family: Tahoma;"> World!</span></div>';
-        editor.setContent(contentWithHyperlink);
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'removes the existing inline formats, text starting with a Hyperlink',
+        () => {
+            // Arrange
+            let contentWithHyperlink =
+                '<div id="text" style="font-family: &quot;Times New Roman&quot;; font-size: 12pt; color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);"><a href="http://microsoft.com"><span style="font-size: 36pt; color: rgb(12, 100, 192); background-color: rgb(255, 0, 0); font-family: Tahoma;">hello</span></a><span style="font-size: 36pt; color: rgb(12, 100, 192); background-color: rgb(255, 0, 0); font-family: Tahoma;"> World!</span></div>';
+            editor.setContent(contentWithHyperlink);
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        clearFormat(editor);
+            // Act
+            clearFormat(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(
-            '<div id="text" style=""><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">hello</span></a><span style="font-family: arial; font-size: 12pt; color: black;"> World!</span></div>'
-        );
-    });
+            // Assert
+            expect(editor.getContent()).toBe(
+                '<div id="text" style=""><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">hello</span></a><span style="font-family: arial; font-size: 12pt; color: black;"> World!</span></div>'
+            );
+        }
+    );
 
-    it('removes the existing inline formats, text with a Hyperlink at the end', () => {
-        // Arrange
-        let contentWithHyperlink =
-            '<span  id="text" style="font-size: 48px; background-color: rgb(255, 0, 0);">This is a test text with <a href="http://microsoft.com">Hyperlink.</a></span>';
-        editor.setContent(contentWithHyperlink);
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'removes the existing inline formats, text with a Hyperlink at the end',
+        () => {
+            // Arrange
+            let contentWithHyperlink =
+                '<span  id="text" style="font-size: 48px; background-color: rgb(255, 0, 0);">This is a test text with <a href="http://microsoft.com">Hyperlink.</a></span>';
+            editor.setContent(contentWithHyperlink);
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        clearFormat(editor);
+            // Act
+            clearFormat(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(
-            '<span style="font-family: arial; font-size: 12pt; color: black;">This is a test text with </span><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">Hyperlink.</span></a>'
-        );
-    });
+            // Assert
+            expect(editor.getContent()).toBe(
+                '<span style="font-family: arial; font-size: 12pt; color: black;">This is a test text with </span><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">Hyperlink.</span></a>'
+            );
+        }
+    );
 });
 
 describe('clearAutodetectFormat tests', () => {
@@ -132,23 +138,26 @@ describe('clearAutodetectFormat tests', () => {
         doc.getSelection().removeAllRanges();
     });
 
-    it('removes all text and structure format when selecting all the document', () => {
-        const expectedFormat =
-            '<div></div><div>Text in Arial font-family<o:p>&nbsp;</o:p><br></div><div>Text in paragraph<o:p>&nbsp;</o:p></div><div>Header middle text 1&nbsp;&nbsp; <o:p>&nbsp;</o:p></div><div>item 1<o:p>&nbsp;</o:p></div><div>Item 2<o:p>&nbsp;</o:p></div><div>Sdasd<o:p>&nbsp;</o:p></div><div>asdasd<o:p>&nbsp;</o:p></div><div>kjjkjk<o:p>&nbsp;</o:p></div><div><br></div>';
-        editor.setContent(ALL_CONTENT_TEST);
+    TestHelper.itFirefoxOnly(
+        'removes all text and structure format when selecting all the document',
+        () => {
+            const expectedFormat =
+                '<div></div><div>Text in Arial font-family<o:p>&nbsp;</o:p><br></div><div>Text in paragraph<o:p>&nbsp;</o:p></div><div>Header middle text 1&nbsp;&nbsp; <o:p>&nbsp;</o:p></div><div>item 1<o:p>&nbsp;</o:p></div><div>Item 2<o:p>&nbsp;</o:p></div><div>Sdasd<o:p>&nbsp;</o:p></div><div>asdasd<o:p>&nbsp;</o:p></div><div>kjjkjk<o:p>&nbsp;</o:p></div><div><br></div>';
+            editor.setContent(ALL_CONTENT_TEST);
 
-        let start = doc.getElementById('start');
-        let end = doc.getElementById('end');
-        let range = new Range();
-        range.setStart(start, 0);
-        range.setEnd(end, 0);
-        doc.getSelection().addRange(range);
+            let start = doc.getElementById('start');
+            let end = doc.getElementById('end');
+            let range = new Range();
+            range.setStart(start, 0);
+            range.setEnd(end, 0);
+            doc.getSelection().addRange(range);
 
-        clearFormat(editor, ClearFormatMode.AutoDetect);
-        expect(editor.getContent()).toBe(expectedFormat);
-    });
+            clearFormat(editor, ClearFormatMode.AutoDetect);
+            expect(editor.getContent()).toBe(expectedFormat);
+        }
+    );
 
-    it('removes format of partial inline element', () => {
+    TestHelper.itFirefoxOnly('removes format of partial inline element', () => {
         const originalText =
             '<h1 id="testHeader" style="margin-right:0in;margin-left:0in;font-size:24pt;font-family:&quot;Times New Roman&quot;, serif"><span style="font-size: 24pt; font-family: Arial, sans-serif;">Header middle text 1</span></h1>';
         const expectedFormat =
@@ -168,44 +177,50 @@ describe('clearAutodetectFormat tests', () => {
         expect(header.innerHTML).toBe(expectedFormat);
     });
 
-    it('removes all the block format and structure if all block children are selected', () => {
-        const originalText =
-            '<h1 id="testHeader" style="margin-right:0in;margin-left:0in;font-size:24pt;font-family:&quot;Times New Roman&quot;, serif"><span style="font-size: 24pt; font-family: Arial, sans-serif;">Header middle text 1</span></h1>';
-        const expectedFormat = '<div>Header middle text 1</div>';
-        editor.setContent(originalText);
+    TestHelper.itFirefoxOnly(
+        'removes all the block format and structure if all block children are selected',
+        () => {
+            const originalText =
+                '<h1 id="testHeader" style="margin-right:0in;margin-left:0in;font-size:24pt;font-family:&quot;Times New Roman&quot;, serif"><span style="font-size: 24pt; font-family: Arial, sans-serif;">Header middle text 1</span></h1>';
+            const expectedFormat = '<div>Header middle text 1</div>';
+            editor.setContent(originalText);
 
-        const header = doc.getElementById('testHeader');
-        let range = new Range();
-        range.setStart(header, 0);
-        range.setEnd(header, 1);
-        doc.getSelection().addRange(range);
+            const header = doc.getElementById('testHeader');
+            let range = new Range();
+            range.setStart(header, 0);
+            range.setEnd(header, 1);
+            doc.getSelection().addRange(range);
 
-        clearFormat(editor, ClearFormatMode.AutoDetect);
+            clearFormat(editor, ClearFormatMode.AutoDetect);
 
-        expect(editor.getContent()).toBe(expectedFormat);
-    });
+            expect(editor.getContent()).toBe(expectedFormat);
+        }
+    );
 
-    it('removes structure and text format when selecting multiple blocks', () => {
-        const originalContent =
-            '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif" id="testP"><span style="font-size:13.5pt;color:black">Text in paragraph<o:p>&nbsp;</o:p></span></p><h1 style="background-color:rgb(255, 255, 255);margin-right:0in;margin-left:0in;font-size:24pt;font-family:&quot;Times New Roman&quot;, serif" id="testHeader"><span style="font-family:Arial, sans-serif;color:black">Header middle text 1<span>&nbsp;</span></span></h1><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
-        const expectedFormat =
-            '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div>Text in paragraph<o:p>&nbsp;</o:p></div><div>Header middle text 1&nbsp;</div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
-        editor.setContent(originalContent);
+    TestHelper.itFirefoxOnly(
+        'removes structure and text format when selecting multiple blocks',
+        () => {
+            const originalContent =
+                '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif" id="testP"><span style="font-size:13.5pt;color:black">Text in paragraph<o:p>&nbsp;</o:p></span></p><h1 style="background-color:rgb(255, 255, 255);margin-right:0in;margin-left:0in;font-size:24pt;font-family:&quot;Times New Roman&quot;, serif" id="testHeader"><span style="font-family:Arial, sans-serif;color:black">Header middle text 1<span>&nbsp;</span></span></h1><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
+            const expectedFormat =
+                '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div>Text in paragraph<o:p>&nbsp;</o:p></div><div>Header middle text 1&nbsp;</div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
+            editor.setContent(originalContent);
 
-        const paragraph = doc.getElementById('testP');
-        const header = doc.getElementById('testHeader');
+            const paragraph = doc.getElementById('testP');
+            const header = doc.getElementById('testHeader');
 
-        let range = new Range();
-        range.setStart(paragraph, 0);
-        range.setEnd(header, 1);
-        doc.getSelection().addRange(range);
+            let range = new Range();
+            range.setStart(paragraph, 0);
+            range.setEnd(header, 1);
+            doc.getSelection().addRange(range);
 
-        clearFormat(editor, ClearFormatMode.AutoDetect);
+            clearFormat(editor, ClearFormatMode.AutoDetect);
 
-        expect(editor.getContent()).toBe(expectedFormat);
-    });
+            expect(editor.getContent()).toBe(expectedFormat);
+        }
+    );
 
-    it('removes format of partial selected element inside a LI', () => {
+    TestHelper.itFirefoxOnly('removes format of partial selected element inside a LI', () => {
         const originalContent =
             '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul type="disc" style="margin-bottom:0in"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">item 1</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Item 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
         const expectedFormat =
@@ -225,27 +240,30 @@ describe('clearAutodetectFormat tests', () => {
         expect(editor.getContent()).toBe(expectedFormat);
     });
 
-    it('removes format and structure of LI element when all the children are selected', () => {
-        const originalContent =
-            '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul type="disc" style="margin-bottom:0in"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">item 2 with more text</span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Item 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
-        const expectedFormat =
-            '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul style="margin-bottom:0in" type="disc"> </ul><div>item 2 with more text</div><ul style="margin-bottom:0in" type="disc"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Item 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
-        editor.setContent(originalContent);
+    TestHelper.itFirefoxOnly(
+        'removes format and structure of LI element when all the children are selected',
+        () => {
+            const originalContent =
+                '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul type="disc" style="margin-bottom:0in"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">item 2 with more text</span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Item 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
+            const expectedFormat =
+                '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul style="margin-bottom:0in" type="disc"> </ul><div>item 2 with more text</div><ul style="margin-bottom:0in" type="disc"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Item 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
+            editor.setContent(originalContent);
 
-        const ul = doc.getElementsByTagName('ul')[0];
-        const li = ul.children[0];
+            const ul = doc.getElementsByTagName('ul')[0];
+            const li = ul.children[0];
 
-        const range = new Range();
-        range.setStart(li, 0);
-        range.setEnd(li, li.children.length);
-        doc.getSelection().addRange(range);
+            const range = new Range();
+            range.setStart(li, 0);
+            range.setEnd(li, li.children.length);
+            doc.getSelection().addRange(range);
 
-        clearFormat(editor, ClearFormatMode.AutoDetect);
+            clearFormat(editor, ClearFormatMode.AutoDetect);
 
-        expect(editor.getContent()).toBe(expectedFormat);
-    });
+            expect(editor.getContent()).toBe(expectedFormat);
+        }
+    );
 
-    it('removes text format when selecting a cell of a table', () => {
+    TestHelper.itFirefoxOnly('removes text format when selecting a cell of a table', () => {
         editor.setContent(TABLE_TEST);
         const expectedFormat =
             '<div style="width:95.75pt;padding:0in 5.4pt 0in 5.4pt"> </div><div>asdfadf<o:p>&nbsp;</o:p></div><div style="width:95.75pt;padding:0in 5.4pt 0in 5.4pt"> </div>';

--- a/packages/roosterjs-editor-api/test/format/toggleBlockQuoteTest.ts
+++ b/packages/roosterjs-editor-api/test/format/toggleBlockQuoteTest.ts
@@ -26,7 +26,7 @@ describe('toggleBlockQuote', () => {
         runTest('<!--{"start":[0],"end":[0]}-->', '<blockquote><div><br></div></blockquote>');
     });
 
-    it('Empty DIV', () => {
+    TestHelper.itFirefoxOnly('Empty DIV', () => {
         runTest(
             '<div></div><!--{"start":[0],"end":[0]}-->',
             '<blockquote><div><br></div></blockquote>'

--- a/packages/roosterjs-editor-api/test/format/toggleBoldTest.ts
+++ b/packages/roosterjs-editor-api/test/format/toggleBoldTest.ts
@@ -26,59 +26,71 @@ describe('toggleBold()', () => {
         expect(document.execCommand).toHaveBeenCalledWith('bold', false, null);
     });
 
-    it('if select an unbold string and then toggle bold, the string will wrap with <b></b>', () => {
-        // Arrange
-        editor.setContent(originalContent);
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'if select an unbold string and then toggle bold, the string will wrap with <b></b>',
+        () => {
+            // Arrange
+            editor.setContent(originalContent);
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        toggleBold(editor);
+            // Act
+            toggleBold(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><b>text</b></div>'
-        );
-    });
+            // Assert
+            expect(editor.getContent()).toBe(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><b>text</b></div>'
+            );
+        }
+    );
 
-    it('if select an unbold string and then toggle bold, only the selected string will wrap with <b></b>', () => {
-        // Arrange
-        editor.setContent(originalContent);
-        TestHelper.selectText(document.getElementById('text').firstChild, 0, 3);
+    TestHelper.itFirefoxOnly(
+        'if select an unbold string and then toggle bold, only the selected string will wrap with <b></b>',
+        () => {
+            // Arrange
+            editor.setContent(originalContent);
+            TestHelper.selectText(document.getElementById('text').firstChild, 0, 3);
 
-        // Act
-        toggleBold(editor);
+            // Act
+            toggleBold(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><b>tex</b>t</div>'
-        );
-    });
+            // Assert
+            expect(editor.getContent()).toBe(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><b>tex</b>t</div>'
+            );
+        }
+    );
 
-    it('if select a bold string and then toggle bold, the string will be unbold', () => {
-        // Arrange
-        editor.setContent(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><b>text</b></div>'
-        );
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'if select a bold string and then toggle bold, the string will be unbold',
+        () => {
+            // Arrange
+            editor.setContent(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><b>text</b></div>'
+            );
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        toggleBold(editor);
+            // Act
+            toggleBold(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(originalContent);
-    });
+            // Assert
+            expect(editor.getContent()).toBe(originalContent);
+        }
+    );
 
-    it('if select a string with font-weight set as bold and then toggle bold, the font-weight style will be removed', () => {
-        // Arrange
-        editor.setContent(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);font-weight:bold">text</div>'
-        );
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'if select a string with font-weight set as bold and then toggle bold, the font-weight style will be removed',
+        () => {
+            // Arrange
+            editor.setContent(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);font-weight:bold">text</div>'
+            );
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        toggleBold(editor);
+            // Act
+            toggleBold(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(originalContent);
-    });
+            // Assert
+            expect(editor.getContent()).toBe(originalContent);
+        }
+    );
 });

--- a/packages/roosterjs-editor-api/test/format/toggleItalicTest.ts
+++ b/packages/roosterjs-editor-api/test/format/toggleItalicTest.ts
@@ -26,59 +26,71 @@ describe('toggleItalic()', () => {
         expect(document.execCommand).toHaveBeenCalledWith('italic', false, null);
     });
 
-    it('if select an unItalic string and then toggle italic, the string will wrap with <i></i>', () => {
-        // Arrange
-        editor.setContent(originalContent);
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'if select an unItalic string and then toggle italic, the string will wrap with <i></i>',
+        () => {
+            // Arrange
+            editor.setContent(originalContent);
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        toggleItalic(editor);
+            // Act
+            toggleItalic(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><i>text</i></div>'
-        );
-    });
+            // Assert
+            expect(editor.getContent()).toBe(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><i>text</i></div>'
+            );
+        }
+    );
 
-    it('if select an unItalic string and then toggle italic, only the selected string will wrap with <i></i>', () => {
-        // Arrange
-        editor.setContent(originalContent);
-        TestHelper.selectText(document.getElementById('text').firstChild, 0, 3);
+    TestHelper.itFirefoxOnly(
+        'if select an unItalic string and then toggle italic, only the selected string will wrap with <i></i>',
+        () => {
+            // Arrange
+            editor.setContent(originalContent);
+            TestHelper.selectText(document.getElementById('text').firstChild, 0, 3);
 
-        // Act
-        toggleItalic(editor);
+            // Act
+            toggleItalic(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><i>tex</i>t</div>'
-        );
-    });
+            // Assert
+            expect(editor.getContent()).toBe(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><i>tex</i>t</div>'
+            );
+        }
+    );
 
-    it('if select an italic string and then toggle italic, the string will be unItalic', () => {
-        // Arrange
-        editor.setContent(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><i>text</i></div>'
-        );
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'if select an italic string and then toggle italic, the string will be unItalic',
+        () => {
+            // Arrange
+            editor.setContent(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><i>text</i></div>'
+            );
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        toggleItalic(editor);
+            // Act
+            toggleItalic(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(originalContent);
-    });
+            // Assert
+            expect(editor.getContent()).toBe(originalContent);
+        }
+    );
 
-    it('if select a string with font-style set as italic and then toggle italic, the font-style style will be removed', () => {
-        // Arrange
-        editor.setContent(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);font-style: italic;">text</div>'
-        );
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'if select a string with font-style set as italic and then toggle italic, the font-style style will be removed',
+        () => {
+            // Arrange
+            editor.setContent(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);font-style: italic;">text</div>'
+            );
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        toggleItalic(editor);
+            // Act
+            toggleItalic(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(originalContent);
-    });
+            // Assert
+            expect(editor.getContent()).toBe(originalContent);
+        }
+    );
 });

--- a/packages/roosterjs-editor-api/test/format/toggleUnderlineTest.ts
+++ b/packages/roosterjs-editor-api/test/format/toggleUnderlineTest.ts
@@ -26,59 +26,71 @@ describe('toggleUnderline()', () => {
         expect(document.execCommand).toHaveBeenCalledWith('underline', false, null);
     });
 
-    it('if select a normal string and then toggle underline, the string will wrap with <u></u>', () => {
-        // Arrange
-        editor.setContent(originalContent);
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'if select a normal string and then toggle underline, the string will wrap with <u></u>',
+        () => {
+            // Arrange
+            editor.setContent(originalContent);
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        toggleUnderline(editor);
+            // Act
+            toggleUnderline(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><u>text</u></div>'
-        );
-    });
+            // Assert
+            expect(editor.getContent()).toBe(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><u>text</u></div>'
+            );
+        }
+    );
 
-    it('if select a normal string and then toggle underline, only the selected string will wrap with <u></u>', () => {
-        // Arrange
-        editor.setContent(originalContent);
-        TestHelper.selectText(document.getElementById('text').firstChild, 0, 3);
+    TestHelper.itFirefoxOnly(
+        'if select a normal string and then toggle underline, only the selected string will wrap with <u></u>',
+        () => {
+            // Arrange
+            editor.setContent(originalContent);
+            TestHelper.selectText(document.getElementById('text').firstChild, 0, 3);
 
-        // Act
-        toggleUnderline(editor);
+            // Act
+            toggleUnderline(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><u>tex</u>t</div>'
-        );
-    });
+            // Assert
+            expect(editor.getContent()).toBe(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><u>tex</u>t</div>'
+            );
+        }
+    );
 
-    it('if select an underline string and then toggle underline, the string will be normal', () => {
-        // Arrange
-        editor.setContent(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><u>text</u></div>'
-        );
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'if select an underline string and then toggle underline, the string will be normal',
+        () => {
+            // Arrange
+            editor.setContent(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0);"><u>text</u></div>'
+            );
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        toggleUnderline(editor);
+            // Act
+            toggleUnderline(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(originalContent);
-    });
+            // Assert
+            expect(editor.getContent()).toBe(originalContent);
+        }
+    );
 
-    it('if select a string with text-decoration set as underline and then toggle underline, the text-decoration style will be removed', () => {
-        // Arrange
-        editor.setContent(
-            '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0); text-decoration: underline;">text</div>'
-        );
-        TestHelper.selectNode(document.getElementById('text'));
+    TestHelper.itFirefoxOnly(
+        'if select a string with text-decoration set as underline and then toggle underline, the text-decoration style will be removed',
+        () => {
+            // Arrange
+            editor.setContent(
+                '<div id="text" style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(0, 0, 0); text-decoration: underline;">text</div>'
+            );
+            TestHelper.selectNode(document.getElementById('text'));
 
-        // Act
-        toggleUnderline(editor);
+            // Act
+            toggleUnderline(editor);
 
-        // Assert
-        expect(editor.getContent()).toBe(originalContent);
-    });
+            // Assert
+            expect(editor.getContent()).toBe(originalContent);
+        }
+    );
 });

--- a/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
@@ -2,6 +2,7 @@ import * as dom from 'roosterjs-editor-dom';
 import createEditorCore from './createMockEditorCore';
 import { ClipboardData, PluginEventType } from 'roosterjs-editor-types';
 import { createPasteFragment } from '../../lib/coreApi/createPasteFragment';
+import { itFirefoxOnly } from '../TestHelper';
 
 describe('createPasteFragment', () => {
     let div: HTMLDivElement;
@@ -210,7 +211,7 @@ describe('createPasteFragment', () => {
         expect(html).toBe('This is a test<div>this is line 2</div>this is line 3');
     });
 
-    it('image input, html output', () => {
+    itFirefoxOnly('image input, html output', () => {
         const triggerEvent = jasmine.createSpy();
         const core = createEditorCore(div, {
             coreApiOverride: {

--- a/packages/roosterjs-editor-core/test/coreApi/getSelectionRangeTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/getSelectionRangeTest.ts
@@ -61,6 +61,7 @@ describe('getSelectionRange', () => {
         const core = createEditorCore(div, {});
         div.contentEditable = 'true';
         div.innerHTML = '<div>test</div>';
+        div.focus();
         selectNode(div.firstChild);
 
         const range = getSelectionRange(core, true);

--- a/packages/roosterjs-editor-core/test/coreApi/hasFocusTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/hasFocusTest.ts
@@ -43,6 +43,7 @@ describe('hasFocus', () => {
 
         let span = core.contentDiv.querySelector('span');
         core.api.selectRange(core, createRange(span.firstChild, 1));
+        core.api.focus(core);
         expect(hasFocus(core)).toBe(true);
     });
 });

--- a/packages/roosterjs-editor-core/test/coreApi/insertNodeTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/insertNodeTest.ts
@@ -2,7 +2,7 @@ import createEditorCore from './createMockEditorCore';
 import { ContentPosition } from 'roosterjs-editor-types';
 import { getSelectionRange } from '../../lib/coreApi/getSelectionRange';
 import { insertNode } from '../../lib/coreApi/insertNode';
-import { selectNode } from '../TestHelper';
+import { itFirefoxOnly, selectNode } from '../TestHelper';
 
 describe('insertNode', () => {
     let div: HTMLDivElement;
@@ -190,26 +190,29 @@ describe('insertNode', () => {
         expect(div.innerHTML).toBe('<div id="div2"></div><div id="div3"></div>');
     });
 
-    it('insert at selection with focus, no replace, no new line, no update cursor', () => {
-        const core = createEditorCore(div, {});
-        const node = document.createElement('span');
-        node.id = 'span1';
-        div.contentEditable = 'true';
-        div.innerHTML = '<div id="div2"></div><div id="div3"></div>';
-        selectNode(document.getElementById('div2'));
-        insertNode(core, node, {
-            position: ContentPosition.SelectionStart,
-            insertOnNewLine: false,
-            updateCursor: false,
-            replaceSelection: false,
-        });
+    itFirefoxOnly(
+        'insert at selection with focus, no replace, no new line, no update cursor',
+        () => {
+            const core = createEditorCore(div, {});
+            const node = document.createElement('span');
+            node.id = 'span1';
+            div.contentEditable = 'true';
+            div.innerHTML = '<div id="div2"></div><div id="div3"></div>';
+            selectNode(document.getElementById('div2'));
+            insertNode(core, node, {
+                position: ContentPosition.SelectionStart,
+                insertOnNewLine: false,
+                updateCursor: false,
+                replaceSelection: false,
+            });
 
-        expect(div.innerHTML).toBe(
-            '<span id="span1"></span><div id="div2"></div><div id="div3"></div>'
-        );
-    });
+            expect(div.innerHTML).toBe(
+                '<span id="span1"></span><div id="div2"></div><div id="div3"></div>'
+            );
+        }
+    );
 
-    it('insert at selection with focus, replace, no new line, no update cursor', () => {
+    itFirefoxOnly('insert at selection with focus, replace, no new line, no update cursor', () => {
         const core = createEditorCore(div, {});
         const node = document.createElement('span');
         node.id = 'span1';
@@ -226,45 +229,51 @@ describe('insertNode', () => {
         expect(div.innerHTML).toBe('<span id="span1"></span><div id="div3"></div>');
     });
 
-    it('insert at selection with focus, no replace, new line and no element block, no update cursor', () => {
-        const core = createEditorCore(div, {});
-        const node = document.createElement('span');
-        node.id = 'span1';
-        div.contentEditable = 'true';
-        div.innerHTML = '<span id="span2"></span><br><span id="span3"></span>';
-        selectNode(document.getElementById('span2'));
-        insertNode(core, node, {
-            position: ContentPosition.SelectionStart,
-            insertOnNewLine: true,
-            updateCursor: false,
-            replaceSelection: false,
-        });
+    itFirefoxOnly(
+        'insert at selection with focus, no replace, new line and no element block, no update cursor',
+        () => {
+            const core = createEditorCore(div, {});
+            const node = document.createElement('span');
+            node.id = 'span1';
+            div.contentEditable = 'true';
+            div.innerHTML = '<span id="span2"></span><br><span id="span3"></span>';
+            selectNode(document.getElementById('span2'));
+            insertNode(core, node, {
+                position: ContentPosition.SelectionStart,
+                insertOnNewLine: true,
+                updateCursor: false,
+                replaceSelection: false,
+            });
 
-        expect(div.innerHTML).toBe(
-            '<span id="span2"></span><br><span id="span1"></span><span id="span3"></span>'
-        );
-    });
+            expect(div.innerHTML).toBe(
+                '<span id="span2"></span><br><span id="span1"></span><span id="span3"></span>'
+            );
+        }
+    );
 
-    it('insert at selection with focus, no replace, new line with parent block, no update cursor', () => {
-        const core = createEditorCore(div, {});
-        const node = document.createElement('span');
-        node.id = 'span1';
-        div.contentEditable = 'true';
-        div.innerHTML = '<div><span id="span2"></span><span id="span3"></span></div>';
-        selectNode(document.getElementById('span2'));
-        insertNode(core, node, {
-            position: ContentPosition.SelectionStart,
-            insertOnNewLine: true,
-            updateCursor: false,
-            replaceSelection: false,
-        });
+    itFirefoxOnly(
+        'insert at selection with focus, no replace, new line with parent block, no update cursor',
+        () => {
+            const core = createEditorCore(div, {});
+            const node = document.createElement('span');
+            node.id = 'span1';
+            div.contentEditable = 'true';
+            div.innerHTML = '<div><span id="span2"></span><span id="span3"></span></div>';
+            selectNode(document.getElementById('span2'));
+            insertNode(core, node, {
+                position: ContentPosition.SelectionStart,
+                insertOnNewLine: true,
+                updateCursor: false,
+                replaceSelection: false,
+            });
 
-        expect(div.innerHTML).toBe(
-            '<div><span id="span2"></span><span id="span3"></span></div><span id="span1"></span>'
-        );
-    });
+            expect(div.innerHTML).toBe(
+                '<div><span id="span2"></span><span id="span3"></span></div><span id="span1"></span>'
+            );
+        }
+    );
 
-    it('insert at selection with focus, no replace, no new line, update cursor', () => {
+    itFirefoxOnly('insert at selection with focus, no replace, no new line, update cursor', () => {
         const core = createEditorCore(div, {});
         const node = document.createElement('span');
         node.id = 'span1';

--- a/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
@@ -1,6 +1,7 @@
 import createEditorCore from './createMockEditorCore';
 import { ColorTransformDirection } from 'roosterjs-editor-types';
 import { getDarkColor } from 'roosterjs-color-utils';
+import { itFirefoxOnly } from '../TestHelper';
 import { transformColor } from '../../lib/coreApi/transformColor';
 
 describe('transformColor Dark to light', () => {
@@ -181,7 +182,7 @@ describe('transformColor Light to dark', () => {
         );
     });
 
-    it('single element with color and background color, has transform function', () => {
+    itFirefoxOnly('single element with color and background color, has transform function', () => {
         const core = createEditorCore(div, {
             inDarkMode: true,
             onExternalContentTransform: element => {

--- a/packages/roosterjs-editor-core/test/editor/EditorTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/EditorTest.ts
@@ -117,7 +117,7 @@ describe('Editor insertContent()', () => {
         expect(editor.getContent()).toBe('<div id="text">texthello</div>');
     });
 
-    it('insert selection, replace selection', () => {
+    TestHelper.itFirefoxOnly('insert selection, replace selection', () => {
         // Arrange
         TestHelper.selectNode(document.getElementById('text'));
 
@@ -133,7 +133,7 @@ describe('Editor insertContent()', () => {
         expect(editor.getContent()).toBe('hello');
     });
 
-    it('insert selection, not replace selection', () => {
+    TestHelper.itFirefoxOnly('insert selection, not replace selection', () => {
         // Arrange
         TestHelper.selectNode(document.getElementById('text'));
 
@@ -241,7 +241,7 @@ describe('Editor insertNode()', () => {
         expect(editor.getContent()).toBe('<div id="text">text<div id="testNode">abc</div></div>');
     });
 
-    it('insert selection, replace selection', () => {
+    TestHelper.itFirefoxOnly('insert selection, replace selection', () => {
         // Arrange
         TestHelper.selectNode(document.getElementById('text'));
 
@@ -257,7 +257,7 @@ describe('Editor insertNode()', () => {
         expect(editor.getContent()).toBe('<div id="testNode">abc</div>');
     });
 
-    it('insert selection, not replace selection', () => {
+    TestHelper.itFirefoxOnly('insert selection, not replace selection', () => {
         // Arrange
         TestHelper.selectNode(document.getElementById('text'));
 

--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
@@ -329,5 +329,5 @@ const policy = trustedTypes?.createPolicy('roosterjsUnsafeConvertHTML', {
 });
 
 const unsafeConvertToTrustedHTML = policy
-    ? (html: string) => policy.createHTML(html)
+    ? (html: string) => policy.createHTML(html || '')
     : (html: string) => html;

--- a/packages/roosterjs-editor-dom/test/DomTestHelper.ts
+++ b/packages/roosterjs-editor-dom/test/DomTestHelper.ts
@@ -102,3 +102,14 @@ export function htmlToDom(html: string): Node[] {
 
     return [].slice.call(element.childNodes);
 }
+
+declare var __karma__: any;
+
+export function itFirefoxOnly(
+    expectation: string,
+    assertion?: jasmine.ImplementationCallback,
+    timeout?: number
+) {
+    const func = __karma__.config.browser == 'Chrome' ? xit : it;
+    return func(expectation, assertion, timeout);
+}

--- a/packages/roosterjs-editor-dom/test/list/VListChainTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/VListChainTest.ts
@@ -1,6 +1,7 @@
 import getBlockElementAtNode from '../../lib/blockElements/getBlockElementAtNode';
 import VListChain from '../../lib/list/VListChain';
 import VListItem from '../../lib/list/VListItem';
+import { itFirefoxOnly } from '../DomTestHelper';
 import { ListType, PositionType } from 'roosterjs-editor-types';
 import { Position } from 'roosterjs-editor-dom';
 
@@ -67,42 +68,42 @@ describe('createListChains', () => {
         );
     });
 
-    it('Two continuously lists', () => {
+    itFirefoxOnly('Two continuously lists', () => {
         runTest(
             '<ol><li>item1</li><li>item2</li></ol><div>test</div><ol start="3"><li>item3</li></ol>',
             `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><li>item2</li></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}0" start="3"><li>item3</li></ol>`
         );
     });
 
-    it('Two list chains', () => {
+    itFirefoxOnly('Two list chains', () => {
         runTest(
             '<ol><li>item1</li><li>item2</li><li>item3</li></ol><div>test</div><ol><li>itemA</li><li>itemB</li></ol><ol start="4"><li>item4</li></ol><div>test</div><ol start="3"><li>itemC</li></ol>',
             `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><li>item2</li><li>item3</li></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}1"><li>itemA</li><li>itemB</li></ol><ol data-listchain="${CHAIN_NAME_PREFIX}0" start="4"><li>item4</li></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}1" start="3"><li>itemC</li></ol>`
         );
     });
 
-    it('Unordered list in a chain', () => {
+    itFirefoxOnly('Unordered list in a chain', () => {
         runTest(
             '<ol><li>item1</li><li>item2</li></ol><div>test</div><ul><li>test</li></ul><div>test</div><ol start="3"><li>item3</li></ol>',
             `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><li>item2</li></ol><div>test</div><ul><li>test</li></ul><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}0" start="3"><li>item3</li></ol>`
         );
     });
 
-    it('Nested list', () => {
+    itFirefoxOnly('Nested list', () => {
         runTest(
             '<ol><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div>test</div><ol start="2"><li>item2</li></ol>',
             `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}0" start="2"><li>item2</li></ol>`
         );
     });
 
-    it('Nested list for separated lists', () => {
+    itFirefoxOnly('Nested list for separated lists', () => {
         runTest(
             '<ol><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div>test</div><ol start="3"><li>item2</li></ol>',
             `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div>test</div><ol data-listchain="${CHAIN_NAME_PREFIX}1" start="3"><li>item2</li></ol>`
         );
     });
 
-    it('Current node', () => {
+    itFirefoxOnly('Current node', () => {
         runTest(
             `<ol><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div id="${CurrentNode}">test</div><ol start="2"><li>item2</li></ol>`,
             `<ol data-listchain="${CHAIN_NAME_PREFIX}0"><li>item1</li><ol><li>item1.1</li><li>item1.2</li></ol></ol><div id="${CurrentNode}">test</div><ol data-listchain="${CHAIN_NAME_PREFIX}0" data-listchainafter="true" start="2"><li>item2</li></ol>`
@@ -252,7 +253,7 @@ describe('VListChain.createVListAtNode', () => {
         );
     });
 
-    it('Single list', () => {
+    itFirefoxOnly('Single list', () => {
         runTest(
             `<ol><li>item</li></ol><div id="${CurrentNode}">test</div>`,
             2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,6 +3470,13 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+karma-chrome-launcher@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz#805a586799a4d05f4e54f72a204979f3f3066738"
+  integrity sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==
+  dependencies:
+    which "^1.2.1"
+
 karma-coverage-istanbul-reporter@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/karma-coverage-istanbul-reporter/-/karma-coverage-istanbul-reporter-3.0.3.tgz#f3b5303553aadc8e681d40d360dfdc19bc7e9fe9"
@@ -6558,7 +6565,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@1, which@^1.2.10, which@^1.2.14, which@^1.2.9, which@^1.3.1:
+which@1, which@^1.2.1, which@^1.2.10, which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,11 +1330,6 @@ color@3.1.3:
     color-convert "^1.9.1"
     color-string "^1.5.4"
 
-colors@>=1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
-
 colors@^1.1.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
@@ -3521,13 +3516,6 @@ karma-sourcemap-loader@0.3.7:
   integrity sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=
   dependencies:
     graceful-fs "^4.1.2"
-
-karma-verbose-reporter@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/karma-verbose-reporter/-/karma-verbose-reporter-0.0.6.tgz#5909052451c607f02ac77c763791a2fe1251260c"
-  integrity sha1-WQkFJFHGB/Aqx3x2N5Gi/hJRJgw=
-  dependencies:
-    colors ">=1.0"
 
 karma-webpack@4.0.2:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,6 +1330,11 @@ color@3.1.3:
     color-convert "^1.9.1"
     color-string "^1.5.4"
 
+colors@>=1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
 colors@^1.1.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
@@ -3516,6 +3521,13 @@ karma-sourcemap-loader@0.3.7:
   integrity sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=
   dependencies:
     graceful-fs "^4.1.2"
+
+karma-verbose-reporter@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/karma-verbose-reporter/-/karma-verbose-reporter-0.0.6.tgz#5909052451c607f02ac77c763791a2fe1251260c"
+  integrity sha1-WQkFJFHGB/Aqx3x2N5Gi/hJRJgw=
+  dependencies:
+    colors ">=1.0"
 
 karma-webpack@4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Fix #632 
Add a null check in HtmlSanitizer to make sure we pass a valid string to trustedType policy.

The original regression can be caught by test case, however we only run test case for Firefox, but the regression happens in Chrome only. So I also try to re-enable test case for Chrome. Due to the browser differences, some HTML comparison will be failed in Chrome since they will still run in Firefox. So I skipped those cases, and we can fix them for Chrome later.