### PR TITLE
Shadow DOM Entity step 0

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/TypeInContainerPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/TypeInContainerPlugin.ts
@@ -13,6 +13,7 @@ import {
  */
 export default class TypeInContainerPlugin implements EditorPlugin {
     private editor: IEditor;
+    private shouldAlwaysApplyDefaultFormat: boolean;
 
     /**
      * Get a friendly name of  this plugin
@@ -27,6 +28,9 @@ export default class TypeInContainerPlugin implements EditorPlugin {
      */
     initialize(editor: IEditor) {
         this.editor = editor;
+        this.shouldAlwaysApplyDefaultFormat = this.editor.isFeatureEnabled(
+            ExperimentalFeatures.AlwaysApplyDefaultFormat
+        );
     }
 
     /**
@@ -50,9 +54,6 @@ export default class TypeInContainerPlugin implements EditorPlugin {
             //
             // Only schedule when the range is not collapsed to catch this edge case.
             let range = this.editor.getSelectionRange();
-            let shouldAlwaysApplyDefaultFormat = this.editor.isFeatureEnabled(
-                ExperimentalFeatures.AlwaysApplyDefaultFormat
-            );
 
             if (
                 !range ||
@@ -60,7 +61,7 @@ export default class TypeInContainerPlugin implements EditorPlugin {
                     findClosestElementAncestor(
                         range.startContainer,
                         null /* root */,
-                        shouldAlwaysApplyDefaultFormat ? '[style]' : null /*selector*/
+                        this.shouldAlwaysApplyDefaultFormat ? '[style]' : null /*selector*/
                     )
                 )
             ) {

--- a/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
@@ -65,7 +65,6 @@ describe('Editor', () => {
             features: {},
         });
         expect(core.entity).toEqual({
-            clickingPoint: null,
             knownEntityElements: [],
         });
         expect(core.lifecycle.customData).toEqual({});
@@ -168,7 +167,6 @@ describe('Editor', () => {
             features: {},
         });
         expect(core.entity).toEqual({
-            clickingPoint: null,
             knownEntityElements: [],
         });
         expect(core.lifecycle.customData).toEqual({});

--- a/packages/roosterjs-editor-types/lib/corePluginState/EntityPluginState.ts
+++ b/packages/roosterjs-editor-types/lib/corePluginState/EntityPluginState.ts
@@ -3,9 +3,10 @@
  */
 export default interface EntityPluginState {
     /**
+     * @deprecated
      * Last clicking point when mouse down event happens
      */
-    clickingPoint: { pageX: number; pageY: number };
+    clickingPoint?: { pageX: number; pageY: number };
 
     /**
      * All known entity elements


### PR DESCRIPTION
Step 0: Some refactors in Entity plugin to remove unnecessary code.
- stop using "clickingPoint" since we already have "isClicking" property in MouseUpEvent
- do not prevent default when mouse down since that can break some scenarios
- handle BeforeSetContentEvent to clean up known entities
- use new API createElement() for workaroundSelectionIssueForIE()
- fix related test cases
- other minor refactors