### PR TITLE
Shadow DOM entity

### DIFF
--- a/demo/scripts/controls/editor/EntityHydratingPlugin.ts
+++ b/demo/scripts/controls/editor/EntityHydratingPlugin.ts
@@ -1,0 +1,43 @@
+import { moveChildNodes, safeInstanceOf } from 'roosterjs-editor-dom';
+import { trustedHTMLHandler } from '../../utils/trustedHTMLHandler';
+import {
+    EditorPlugin,
+    PluginEvent,
+    PluginEventType,
+    EntityOperation,
+    IEditor,
+} from 'roosterjs-editor-types';
+
+export default class EntityHydratingPlugin implements EditorPlugin {
+    private editor: IEditor;
+
+    getName() {
+        return 'EntityHydrating';
+    }
+
+    initialize(editor: IEditor) {
+        this.editor = editor;
+    }
+
+    dispose() {
+        this.editor = null;
+    }
+
+    onPluginEvent(event: PluginEvent) {
+        if (
+            event.eventType == PluginEventType.EntityOperation &&
+            event.operation == EntityOperation.NewEntity &&
+            event.contentForShadowEntity &&
+            !event.contentForShadowEntity.firstChild
+        ) {
+            const child = event.entity.wrapper.firstChild;
+            const hydratedHtml = safeInstanceOf(child, 'HTMLElement') && child.dataset.hydratedHtml;
+
+            if (hydratedHtml) {
+                const div = this.editor.getDocument().createElement('div');
+                div.innerHTML = trustedHTMLHandler(hydratedHtml);
+                moveChildNodes(event.contentForShadowEntity, div);
+            }
+        }
+    }
+}

--- a/demo/scripts/controls/plugins.ts
+++ b/demo/scripts/controls/plugins.ts
@@ -1,5 +1,6 @@
 import ApiPlaygroundPlugin from './sidePane/apiPlayground/ApiPlaygroundPlugin';
 import EditorOptionsPlugin from './sidePane/editorOptions/EditorOptionsPlugin';
+import EntityHydratingPlugin from './editor/EntityHydratingPlugin';
 import EventViewPlugin from './sidePane/eventViewer/EventViewPlugin';
 import FormatStatePlugin from './sidePane/formatState/FormatStatePlugin';
 import MainPaneBase from './MainPaneBase';
@@ -16,6 +17,7 @@ export default interface Plugins {
     eventView: EventViewPlugin;
     api: ApiPlaygroundPlugin;
     bridge: Bridge;
+    entityHydrating: EntityHydratingPlugin;
 }
 
 let plugins: Plugins = null;
@@ -30,6 +32,7 @@ export function getPlugins(): Plugins {
             eventView: new EventViewPlugin(),
             api: new ApiPlaygroundPlugin(),
             bridge: new Bridge(),
+            entityHydrating: new EntityHydratingPlugin(),
         };
     }
     return plugins;
@@ -44,6 +47,7 @@ export function getAllPluginArray(includeSidePanePlugins: boolean): EditorPlugin
         includeSidePanePlugins && allPlugins.eventView,
         includeSidePanePlugins && allPlugins.api,
         includeSidePanePlugins && allPlugins.snapshot,
+        allPlugins.entityHydrating,
         allPlugins.bridge,
     ];
 }

--- a/demo/scripts/controls/sidePane/apiPlayground/insertEntity/InsertEntityPane.tsx
+++ b/demo/scripts/controls/sidePane/apiPlayground/insertEntity/InsertEntityPane.tsx
@@ -1,15 +1,9 @@
 import * as React from 'react';
 import ApiPaneProps from '../ApiPaneProps';
-import { ApiPlaygroundReactComponent } from '../apiEntries';
-import { Entity, EntityOperation, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
+import { Entity } from 'roosterjs-editor-types';
+import { getEntityFromElement, getEntitySelector } from 'roosterjs-editor-dom';
 import { insertEntity } from 'roosterjs-editor-api';
 import { trustedHTMLHandler } from '../../../../utils/trustedHTMLHandler';
-import {
-    getEntityFromElement,
-    getEntitySelector,
-    moveChildNodes,
-    safeInstanceOf,
-} from 'roosterjs-editor-dom';
 
 const styles = require('./InsertEntityPane.scss');
 
@@ -17,8 +11,7 @@ interface InsertEntityPaneState {
     entities: Entity[];
 }
 
-export default class InsertEntityPane extends React.Component<ApiPaneProps, InsertEntityPaneState>
-    implements ApiPlaygroundReactComponent {
+export default class InsertEntityPane extends React.Component<ApiPaneProps, InsertEntityPaneState> {
     private entityType = React.createRef<HTMLInputElement>();
     private html = React.createRef<HTMLTextAreaElement>();
     private hydratedHtml = React.createRef<HTMLTextAreaElement>();
@@ -75,24 +68,6 @@ export default class InsertEntityPane extends React.Component<ApiPaneProps, Inse
                 </div>
             </>
         );
-    }
-
-    onPluginEvent(event: PluginEvent) {
-        if (
-            event.eventType == PluginEventType.EntityOperation &&
-            event.operation == EntityOperation.NewEntity &&
-            event.contentForShadowEntity &&
-            !event.contentForShadowEntity.firstChild
-        ) {
-            const child = event.entity.wrapper.firstChild;
-            const hydratedHtml = safeInstanceOf(child, 'HTMLElement') && child.dataset.hydratedHtml;
-
-            if (hydratedHtml) {
-                const div = this.props.getEditor().getDocument().createElement('div');
-                div.innerHTML = trustedHTMLHandler(hydratedHtml);
-                moveChildNodes(event.contentForShadowEntity, div);
-            }
-        }
     }
 
     private insertEntity = () => {

--- a/demo/scripts/controls/sidePane/eventViewer/EventViewPane.tsx
+++ b/demo/scripts/controls/sidePane/eventViewer/EventViewPane.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { getTagOfNode, HtmlSanitizer, readFile, safeInstanceOf } from 'roosterjs-editor-dom';
-import { PendableFormatState, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import { SidePaneElementProps } from '../SidePaneElement';
+import {
+    EntityOperation,
+    PendableFormatState,
+    PluginEvent,
+    PluginEventType,
+} from 'roosterjs-editor-types';
 
 const styles = require('./EventViewPane.scss');
 
@@ -16,7 +21,7 @@ export interface EventViewPaneState {
     currentIndex: number;
 }
 
-const EventTypeMap = {
+const EventTypeMap: { [key in PluginEventType]: string } = {
     [PluginEventType.BeforeDispose]: 'BeforeDispose',
     [PluginEventType.BeforePaste]: 'BeforePaste',
     [PluginEventType.CompositionEnd]: 'CompositionEnd',
@@ -38,6 +43,20 @@ const EventTypeMap = {
     [PluginEventType.LeavingShadowEdit]: 'LeavingShadowEdit',
     [PluginEventType.EditImage]: 'EditImage',
     [PluginEventType.BeforeSetContent]: 'BeforeSetContent',
+};
+
+const EntityOperationMap: { [key in EntityOperation]: string } = {
+    [EntityOperation.AddShadowRoot]: 'AddShadowRoot',
+    [EntityOperation.RemoveShadowRoot]: 'RemoveShadowRoot',
+    [EntityOperation.Click]: 'Click',
+    [EntityOperation.ContextMenu]: 'ContextMenu',
+    [EntityOperation.Escape]: 'Escape',
+    [EntityOperation.NewEntity]: 'NewEntity',
+    [EntityOperation.Overwrite]: 'Overwrite',
+    [EntityOperation.PartialOverwrite]: 'PartialOverwrite',
+    [EntityOperation.RemoveFromEnd]: 'RemoveFromEnd',
+    [EntityOperation.RemoveFromStart]: 'RemoveFromStart',
+    [EntityOperation.ReplaceTemporaryContent]: 'ReplaceTemporaryContent',
 };
 
 export default class EventViewPane extends React.Component<
@@ -198,7 +217,7 @@ export default class EventViewPane extends React.Component<
                 } = event;
                 return (
                     <span>
-                        Operation={operation} Type={type}; Id={id}
+                        Operation={EntityOperationMap[operation]} Type={type}; Id={id}
                     </span>
                 );
 

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -658,14 +658,19 @@ export default class Editor implements IEditor {
     /**
      * Run a callback function asynchronously
      * @param callback The callback function to run
+     * @returns a function to cancel this async run
      */
     public runAsync(callback: (editor: IEditor) => void) {
         let win = this.core.contentDiv.ownerDocument.defaultView || window;
-        win.requestAnimationFrame(() => {
+        const handle = win.requestAnimationFrame(() => {
             if (!this.isDisposed() && callback) {
                 callback(this);
             }
         });
+
+        return () => {
+            win.cancelAnimationFrame(handle);
+        };
     }
 
     /**

--- a/packages/roosterjs-editor-core/test/corePlugins/copyPastePluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/copyPastePluginTest.ts
@@ -134,7 +134,7 @@ describe('CopyPastePlugin copy', () => {
     });
 
     it('before copy', () => {
-        editor.runAsync = () => {};
+        editor.runAsync = () => null;
 
         const event = <Event>{};
         handler.copy(event);
@@ -151,7 +151,10 @@ describe('CopyPastePlugin copy', () => {
     });
 
     it('after copy', () => {
-        editor.runAsync = callback => callback(editor);
+        editor.runAsync = callback => {
+            callback(editor);
+            return null;
+        };
 
         const event = <Event>{};
         handler.copy(event);
@@ -161,7 +164,10 @@ describe('CopyPastePlugin copy', () => {
     });
 
     it('after cut with text content', () => {
-        editor.runAsync = callback => callback(editor);
+        editor.runAsync = callback => {
+            callback(editor);
+            return null;
+        };
         const contentDiv = document.createElement('div');
         contentDiv.innerHTML = 'This is a test';
 
@@ -192,7 +198,10 @@ describe('CopyPastePlugin copy', () => {
     });
 
     it('after cut with html content', () => {
-        editor.runAsync = callback => callback(editor);
+        editor.runAsync = callback => {
+            callback(editor);
+            return null;
+        };
         const contentDiv = document.createElement('div');
         contentDiv.innerHTML =
             '<ol><li>line1</li><li><div>line2</div><div>line3</div></li><li>line4</li></ol><div>line5</div>';

--- a/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
@@ -441,7 +441,7 @@ describe('Shadow DOM Entity', () => {
 
         expect(runAsync).toHaveBeenCalled();
         expect(wrapper.innerHTML).toBe('test');
-        expect(wrapper.shadowRoot).toBeFalsy();
+        expect(wrapper.shadowRoot).toBeTruthy();
     });
 
     it('Cache shadow entity before set content', () => {

--- a/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
@@ -452,8 +452,8 @@ describe('Shadow DOM Entity', () => {
             queryElements: () => [entity1, entity2],
             addContentEditFeature: () => {},
         };
-        const textNode = document.createTextNode('text');
         const state = plugin.getState();
+        const textNode = document.createTextNode('text');
 
         dom.commitEntity(entity1, 'ENTITY1', false, 'TEST1');
         dom.commitEntity(entity2, 'ENTITY2', false, 'TEST2');
@@ -471,8 +471,8 @@ describe('Shadow DOM Entity', () => {
         });
 
         expect(Object.keys(state.shadowEntityCache)).toEqual(['TEST2']);
-        expect(state.shadowEntityCache.TEST2.shadowDOM.firstChild).toBe(textNode);
-        expect(entity2.shadowRoot.firstChild).toBeNull();
+        expect(state.shadowEntityCache.TEST2).toBe(entity2);
+        expect(entity2.shadowRoot.firstChild).toBe(textNode);
     });
 
     it('ContentChange - Check removed shadow entity', () => {
@@ -527,6 +527,7 @@ describe('Shadow DOM Entity', () => {
             queryElements: () => [entity1],
             contains: (node: Node) => node == entity1,
             addContentEditFeature: () => {},
+            getDocument: () => document,
         };
 
         plugin.initialize(editor);
@@ -573,6 +574,7 @@ describe('Shadow DOM Entity', () => {
             triggerPluginEvent,
             contains: (node: Node) => node == entity1,
             addContentEditFeature: () => {},
+            getDocument: () => document,
         };
 
         plugin.initialize(editor);
@@ -615,6 +617,7 @@ describe('Shadow DOM Entity', () => {
                 newEntity = newNode;
             },
             addContentEditFeature: () => {},
+            getDocument: () => document,
         };
 
         plugin.initialize(editor);
@@ -750,6 +753,7 @@ describe('Shadow DOM Entity', () => {
             contains: (node: Node) =>
                 node == entity1 || node == entity2 || node == entity3 || node == entity4,
             addContentEditFeature: () => {},
+            getDocument: () => document,
         };
 
         dom.commitEntity(entity1, 'TEST', false, 'Test');

--- a/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
@@ -1,13 +1,17 @@
 import * as dom from 'roosterjs-editor-dom';
 import EntityPlugin from '../../lib/corePlugins/EntityPlugin';
+import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
 import {
     ChangeSource,
+    ContentEditFeature,
     EntityClasses,
     EntityOperation,
+    EntityOperationEvent,
     EntityPluginState,
     IEditor,
     Keys,
     PluginEventType,
+    PluginKeyboardEvent,
     QueryScope,
 } from 'roosterjs-editor-types';
 
@@ -22,7 +26,9 @@ describe('EntityPlugin', () => {
         plugin = new EntityPlugin();
         state = plugin.getState();
         editor = <IEditor>(<any>{
+            getDocument: () => document,
             getElementAtCursor: (selector: string, node: Node) => node,
+            addContentEditFeature: () => {},
             triggerPluginEvent,
         });
         plugin.initialize(editor);
@@ -37,6 +43,7 @@ describe('EntityPlugin', () => {
     it('init', () => {
         expect(state).toEqual({
             knownEntityElements: [],
+            shadowEntityCache: {},
         });
     });
 
@@ -88,24 +95,28 @@ describe('EntityPlugin', () => {
             operation: EntityOperation.Overwrite,
             entity: <any>entityReadonly,
             rawEvent,
+            contentForShadowEntity: undefined,
         });
         expect(triggerPluginEvent.calls.argsFor(1)[0]).toBe(PluginEventType.EntityOperation);
         expect(triggerPluginEvent.calls.argsFor(1)[1]).toEqual({
             operation: EntityOperation.Overwrite,
             entity: <any>entityOnSelection1,
             rawEvent,
+            contentForShadowEntity: undefined,
         });
         expect(triggerPluginEvent.calls.argsFor(2)[0]).toBe(PluginEventType.EntityOperation);
         expect(triggerPluginEvent.calls.argsFor(2)[1]).toEqual({
             operation: EntityOperation.PartialOverwrite,
             entity: <any>entityOnSelection2,
             rawEvent,
+            contentForShadowEntity: undefined,
         });
         expect(triggerPluginEvent.calls.argsFor(3)[0]).toBe(PluginEventType.EntityOperation);
         expect(triggerPluginEvent.calls.argsFor(3)[1]).toEqual({
             operation: EntityOperation.Overwrite,
             entity: <any>entityInSelection,
             rawEvent,
+            contentForShadowEntity: undefined,
         });
     }
 
@@ -131,6 +142,7 @@ describe('EntityPlugin', () => {
             operation: EntityOperation.Click,
             rawEvent,
             entity: <any>target,
+            contentForShadowEntity: undefined,
         });
     });
 
@@ -236,6 +248,7 @@ describe('EntityPlugin', () => {
                 isReadonly: true,
             },
             rawEvent: undefined,
+            contentForShadowEntity: undefined,
         });
 
         expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.EntityOperation, {
@@ -247,6 +260,7 @@ describe('EntityPlugin', () => {
                 isReadonly: false,
             },
             rawEvent: undefined,
+            contentForShadowEntity: undefined,
         });
     });
 
@@ -256,6 +270,7 @@ describe('EntityPlugin', () => {
         let node2: HTMLElement;
         let node3: HTMLElement;
         let containedNodes: Node[];
+        let fragment: DocumentFragment = document.createDocumentFragment();
 
         beforeEach(() => {
             node1 = document.createElement('div');
@@ -280,11 +295,12 @@ describe('EntityPlugin', () => {
             });
 
             editor.queryElements = <any>((selector: string, callback: (e: HTMLElement) => void) => {
-                containedNodes.forEach(callback);
+                containedNodes.forEach(callback || (() => {}));
                 return containedNodes;
             });
 
             spyOn(dom, 'commitEntity');
+            spyOn(document, 'createDocumentFragment').and.returnValue(fragment);
         });
 
         function verify(inStateNodes: HTMLElement[], commitedNodes: HTMLElement[]) {
@@ -301,6 +317,7 @@ describe('EntityPlugin', () => {
                         isReadonly: false,
                     },
                     rawEvent: undefined,
+                    contentForShadowEntity: fragment,
                 });
             });
         }
@@ -329,18 +346,13 @@ describe('EntityPlugin', () => {
             verify([node2, node3], [node3]);
         });
 
-        it('content changed event, reset known nodes', () => {
+        xit('content changed event, reset known nodes', () => {
             state.knownEntityElements = [node1, node2];
             containedNodes = [node2, node3];
 
             editor.queryElements = <any>((selector: string, callback: (e: HTMLElement) => void) => {
                 containedNodes.forEach(callback);
                 return containedNodes;
-            });
-
-            plugin.onPluginEvent({
-                eventType: PluginEventType.BeforeSetContent,
-                newContent: '',
             });
 
             expect(state.knownEntityElements).toEqual([]);
@@ -352,42 +364,408 @@ describe('EntityPlugin', () => {
 
             verify([node2, node3], [node2, node3]);
         });
-
         it('editor ready event', () => {
             state.knownEntityElements = [node1, node2];
             containedNodes = [node2, node3];
 
             plugin.onPluginEvent({
-                eventType: PluginEventType.BeforeSetContent,
-                newContent: '',
-            });
-
-            plugin.onPluginEvent({
                 eventType: PluginEventType.EditorReady,
             });
 
-            verify([node2, node3], [node2, node3]);
+            verify([node2, node3], [node3]);
         });
 
-        it('handle id duplication', () => {
+        xit('handle id duplication', () => {
             node3.id = node2.id;
             state.knownEntityElements = [node1, node2];
             containedNodes = [node2, node3];
 
             plugin.onPluginEvent({
-                eventType: PluginEventType.BeforeSetContent,
-                newContent: '',
-            });
-
-            plugin.onPluginEvent({
                 eventType: PluginEventType.EditorReady,
             });
 
-            verify([node2, node3], [node2, node3]);
+            node3.id = 'node2_1';
+            verify([node2, node3], [node3]);
 
-            expect(dom.commitEntity).toHaveBeenCalledTimes(2);
-            expect(dom.commitEntity).toHaveBeenCalledWith(node2, entityType, false, 'node2');
-            expect(dom.commitEntity).toHaveBeenCalledWith(node3, entityType, false, 'node2_1');
+            expect(dom.commitEntity).toHaveBeenCalledTimes(1);
+            expect(dom.commitEntity).toHaveBeenCalledWith(node2, entityType, false, 'node2_1');
         });
+    });
+});
+
+describe('Shadow DOM Entity', () => {
+    it('Key press event should be handled exclusively when focus to shadow DOM entity', () => {
+        const plugin = new EntityPlugin();
+        const event: PluginKeyboardEvent = {
+            eventType: PluginEventType.KeyPress,
+            rawEvent: <any>{
+                target: {
+                    shadowRoot: {},
+                },
+            },
+        };
+        expect(plugin.willHandleEventExclusively(event)).toBeTrue();
+    });
+
+    itChromeOnly('Workaround Chrome issue', () => {
+        let feature: ContentEditFeature;
+        let wrapper = document.createElement('span');
+        const plugin = new EntityPlugin();
+        const runAsync = jasmine.createSpy('runAsync').and.callFake((callback: Function) => {
+            wrapper = wrapper.cloneNode(true) as HTMLElement;
+            callback();
+        });
+
+        wrapper.innerHTML = 'test';
+        dom.commitEntity(wrapper, 'TEST', false, 'TEST');
+        wrapper.attachShadow({ mode: 'open' });
+        const editor: IEditor = <any>{
+            getDocument: () => document,
+            addContentEditFeature: (f: ContentEditFeature) => {
+                feature = f;
+            },
+            queryElements: () => {
+                return [wrapper];
+            },
+            runAsync,
+        };
+
+        plugin.initialize(editor);
+
+        expect(feature).toBeDefined();
+        expect(feature.keys).toEqual([Keys.BACKSPACE, Keys.DELETE]);
+        expect(feature.shouldHandleEvent(<any>{}, editor, false /*ctrlOrMeta*/)).toBeTrue();
+
+        feature.handleEvent(<any>{}, editor);
+
+        expect(runAsync).toHaveBeenCalled();
+        expect(wrapper.innerHTML).toBe('test');
+        expect(wrapper.shadowRoot).toBeFalsy();
+    });
+
+    it('Cache shadow entity before set content', () => {
+        const plugin = new EntityPlugin();
+        const entity1 = document.createElement('span');
+        const entity2 = document.createElement('span');
+        const editor: IEditor = <any>{
+            getDocument: () => document,
+            queryElements: () => [entity1, entity2],
+            addContentEditFeature: () => {},
+        };
+        const textNode = document.createTextNode('text');
+        const state = plugin.getState();
+
+        dom.commitEntity(entity1, 'ENTITY1', false, 'TEST1');
+        dom.commitEntity(entity2, 'ENTITY2', false, 'TEST2');
+        entity2.attachShadow({ mode: 'open' }).appendChild(textNode);
+
+        expect(state).toEqual({
+            knownEntityElements: [],
+            shadowEntityCache: {},
+        });
+
+        plugin.initialize(editor);
+        plugin.onPluginEvent({
+            eventType: PluginEventType.BeforeSetContent,
+            newContent: '',
+        });
+
+        expect(Object.keys(state.shadowEntityCache)).toEqual(['TEST2']);
+        expect(state.shadowEntityCache.TEST2.shadowDOM.firstChild).toBe(textNode);
+        expect(entity2.shadowRoot.firstChild).toBeNull();
+    });
+
+    it('ContentChange - Check removed shadow entity', () => {
+        const plugin = new EntityPlugin();
+        const state = plugin.getState();
+        const entity1 = document.createElement('span');
+        const triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        const editor: IEditor = <any>{
+            triggerPluginEvent,
+            queryElements: () => <HTMLElement[]>[],
+            contains: () => false,
+            addContentEditFeature: () => {},
+        };
+
+        state.knownEntityElements.push(entity1);
+        plugin.initialize(editor);
+        dom.commitEntity(entity1, 'TEST', false, 'TEST1');
+        entity1.attachShadow({ mode: 'open' });
+
+        plugin.onPluginEvent({
+            eventType: PluginEventType.ContentChanged,
+            source: '',
+        });
+
+        expect(state.knownEntityElements).toEqual([]);
+        expect(state.shadowEntityCache).toEqual({});
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.EntityOperation, {
+            operation: EntityOperation.RemoveShadowRoot,
+            rawEvent: undefined,
+            entity: dom.getEntityFromElement(entity1),
+            contentForShadowEntity: undefined,
+        });
+    });
+
+    it('ContentChange - hydrate new entity', () => {
+        const plugin = new EntityPlugin();
+        const state = plugin.getState();
+        const entity1 = document.createElement('span');
+        const textNode = document.createTextNode('test');
+        const triggerPluginEvent = jasmine
+            .createSpy('triggerPluginEvent')
+            .and.callFake((type: PluginEventType, param: EntityOperationEvent) => {
+                if (
+                    type == PluginEventType.EntityOperation &&
+                    param.operation == EntityOperation.NewEntity
+                ) {
+                    param.contentForShadowEntity.appendChild(textNode);
+                }
+            });
+        const editor: IEditor = <any>{
+            triggerPluginEvent,
+            queryElements: () => [entity1],
+            contains: (node: Node) => node == entity1,
+            addContentEditFeature: () => {},
+        };
+
+        plugin.initialize(editor);
+        dom.commitEntity(entity1, 'TEST', false, 'TEST1');
+
+        plugin.onPluginEvent({
+            eventType: PluginEventType.ContentChanged,
+            source: '',
+        });
+
+        expect(state.knownEntityElements).toEqual([entity1]);
+        expect(state.shadowEntityCache).toEqual({});
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.EntityOperation, {
+            operation: EntityOperation.NewEntity,
+            rawEvent: undefined,
+            entity: dom.getEntityFromElement(entity1),
+            contentForShadowEntity: document.createDocumentFragment(),
+        });
+        expect(entity1.shadowRoot.firstChild).toBe(textNode);
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.EntityOperation, {
+            operation: EntityOperation.AddShadowRoot,
+            rawEvent: undefined,
+            entity: dom.getEntityFromElement(entity1),
+            contentForShadowEntity: undefined,
+        });
+    });
+
+    it('ContentChange - hydrate new entity with known entity', () => {
+        const plugin = new EntityPlugin();
+        const state = plugin.getState();
+        const entity1 = document.createElement('span');
+        const textNode = document.createTextNode('test');
+        const triggerPluginEvent = jasmine
+            .createSpy('triggerPluginEvent')
+            .and.callFake((type: PluginEventType, param: EntityOperationEvent) => {
+                if (
+                    type == PluginEventType.EntityOperation &&
+                    param.operation == EntityOperation.NewEntity
+                ) {
+                    param.contentForShadowEntity.appendChild(textNode);
+                }
+            });
+        const editor: IEditor = <any>{
+            triggerPluginEvent,
+            contains: (node: Node) => node == entity1,
+            addContentEditFeature: () => {},
+        };
+
+        plugin.initialize(editor);
+        dom.commitEntity(entity1, 'TEST', false, 'TEST1');
+
+        plugin.onPluginEvent({
+            eventType: PluginEventType.ContentChanged,
+            source: ChangeSource.InsertEntity,
+            data: dom.getEntityFromElement(entity1),
+        });
+
+        expect(state.knownEntityElements).toEqual([entity1]);
+        expect(state.shadowEntityCache).toEqual({});
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.EntityOperation, {
+            operation: EntityOperation.NewEntity,
+            rawEvent: undefined,
+            entity: dom.getEntityFromElement(entity1),
+            contentForShadowEntity: document.createDocumentFragment(),
+        });
+        expect(entity1.shadowRoot.firstChild).toBe(textNode);
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.EntityOperation, {
+            operation: EntityOperation.AddShadowRoot,
+            rawEvent: undefined,
+            entity: dom.getEntityFromElement(entity1),
+            contentForShadowEntity: undefined,
+        });
+    });
+
+    it('ContentChange - dehydrate existing entity', () => {
+        const plugin = new EntityPlugin();
+        const state = plugin.getState();
+        const entity1 = document.createElement('span');
+        let newEntity: HTMLElement;
+        const triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        const editor: IEditor = <any>{
+            triggerPluginEvent,
+            queryElements: () => [entity1],
+            contains: (node: Node) => node == entity1,
+            replaceNode: (oldNode: HTMLElement, newNode: HTMLElement) => {
+                newEntity = newNode;
+            },
+            addContentEditFeature: () => {},
+        };
+
+        plugin.initialize(editor);
+        dom.commitEntity(entity1, 'TEST', false, 'TEST1');
+        entity1.attachShadow({ mode: 'open' });
+
+        plugin.onPluginEvent({
+            eventType: PluginEventType.ContentChanged,
+            source: '',
+        });
+
+        expect(state.knownEntityElements.length).toBe(1);
+        expect(state.knownEntityElements[0]).not.toBe(entity1);
+        expect(state.knownEntityElements[1]).not.toBe(newEntity);
+        expect(state.shadowEntityCache).toEqual({});
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.EntityOperation, {
+            operation: EntityOperation.NewEntity,
+            rawEvent: undefined,
+            entity: dom.getEntityFromElement(entity1),
+            contentForShadowEntity: document.createDocumentFragment(),
+        });
+        expect(newEntity.shadowRoot).toBe(null);
+    });
+
+    it('ContentChange - rehydrate existing entity with different content', () => {
+        const plugin = new EntityPlugin();
+        const state = plugin.getState();
+        const entity1 = document.createElement('span');
+        const entity2 = document.createElement('span');
+        const triggerPluginEvent = jasmine
+            .createSpy('triggerPluginEvent')
+            .and.callFake((type: PluginEventType, param: EntityOperationEvent) => {
+                if (
+                    type == PluginEventType.EntityOperation &&
+                    param.operation == EntityOperation.NewEntity
+                ) {
+                    dom.moveChildNodes(
+                        param.contentForShadowEntity,
+                        dom.createElement(
+                            {
+                                tag: 'span',
+                                children: ['test2'],
+                            },
+                            document
+                        )
+                    );
+                }
+            });
+        const editor: IEditor = <any>{
+            triggerPluginEvent,
+            queryElements: () => [entity1],
+            contains: (node: Node) => node == entity2,
+            getDocument: () => document,
+            addContentEditFeature: () => {},
+        };
+
+        plugin.initialize(editor);
+        dom.commitEntity(entity1, 'TEST', false, 'TEST1');
+        dom.commitEntity(entity2, 'TEST', false, 'TEST1');
+        entity1.attachShadow({ mode: 'open' }).appendChild(document.createTextNode('test'));
+        state.knownEntityElements.push(entity1);
+
+        plugin.onPluginEvent({
+            eventType: PluginEventType.BeforeSetContent,
+            newContent: '',
+        });
+
+        editor.queryElements = () => [entity2];
+        plugin.onPluginEvent({
+            eventType: PluginEventType.ContentChanged,
+            source: '',
+        });
+
+        expect(state.knownEntityElements.length).toBe(1);
+        expect(state.knownEntityElements[0]).toBe(entity2);
+        expect(state.shadowEntityCache).toEqual({});
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.EntityOperation, {
+            operation: EntityOperation.NewEntity,
+            rawEvent: undefined,
+            entity: dom.getEntityFromElement(entity2),
+            contentForShadowEntity: document.createDocumentFragment(),
+        });
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.EntityOperation, {
+            operation: EntityOperation.RemoveShadowRoot,
+            rawEvent: undefined,
+            entity: dom.getEntityFromElement(entity1),
+            contentForShadowEntity: undefined,
+        });
+    });
+
+    it('EntityOperation event', () => {
+        const plugin = new EntityPlugin();
+        const state = plugin.getState();
+        const entity1 = document.createElement('span');
+        const triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        const editor: IEditor = <any>{
+            triggerPluginEvent,
+            queryElements: () => <HTMLElement[]>[],
+            contains: () => false,
+            runAsync: (callback: Function) => callback(),
+            addContentEditFeature: () => {},
+        };
+
+        state.knownEntityElements.push(entity1);
+        dom.commitEntity(entity1, 'TEST', false, 'TEST1');
+        entity1.attachShadow({ mode: 'open' });
+        plugin.initialize(editor);
+        plugin.onPluginEvent({
+            eventType: PluginEventType.EntityOperation,
+            operation: EntityOperation.Overwrite,
+            entity: dom.getEntityFromElement(entity1),
+        });
+
+        expect(state.knownEntityElements).toEqual([]);
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.EntityOperation, {
+            operation: EntityOperation.RemoveShadowRoot,
+            entity: dom.getEntityFromElement(entity1),
+            rawEvent: undefined,
+            contentForShadowEntity: undefined,
+        });
+    });
+
+    it('Id management', () => {
+        const plugin = new EntityPlugin();
+        const entity1 = document.createElement('span');
+        const entity2 = document.createElement('span');
+        const entity3 = document.createElement('span');
+        const entity4 = document.createElement('span');
+        const state = plugin.getState();
+        const editor: IEditor = <any>{
+            triggerPluginEvent: jasmine.createSpy('triggerPluginEvent'),
+            queryElements: () => [entity1, entity2, entity3, entity4],
+            contains: (node: Node) =>
+                node == entity1 || node == entity2 || node == entity3 || node == entity4,
+            addContentEditFeature: () => {},
+        };
+
+        dom.commitEntity(entity1, 'TEST', false, 'Test');
+        dom.commitEntity(entity2, 'TEST', false, 'Test_2');
+        dom.commitEntity(entity3, 'TEST', false, 'Test');
+        dom.commitEntity(entity4, 'TEST', false, 'Test_2');
+        state.knownEntityElements.push(entity1);
+        plugin.initialize(editor);
+        plugin.onPluginEvent({
+            eventType: PluginEventType.ContentChanged,
+            source: '',
+        });
+
+        expect(dom.getEntityFromElement(entity1).id).toBe('Test');
+        expect(dom.getEntityFromElement(entity2).id).toBe('Test_2');
+        expect(dom.getEntityFromElement(entity3).id).toBe('Test_1');
+        expect(dom.getEntityFromElement(entity4).id).toBe('Test_3');
     });
 });

--- a/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
@@ -428,6 +428,7 @@ describe('Shadow DOM Entity', () => {
                 return [wrapper];
             },
             runAsync,
+            triggerPluginEvent: () => {},
         };
 
         plugin.initialize(editor);

--- a/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
@@ -1,6 +1,7 @@
 import Editor from '../../lib/editor/Editor';
 import { addUndoSnapshot } from '../../lib/coreApi/addUndoSnapshot';
 import { attachDomEvent } from '../../lib/coreApi/attachDomEvent';
+import { Browser } from 'roosterjs-editor-dom/lib';
 import { createPasteFragment } from '../../lib/coreApi/createPasteFragment';
 import { EditorCore } from 'roosterjs-editor-types';
 import { ensureTypeInContainer } from '../../lib/coreApi/ensureTypeInContainer';
@@ -61,11 +62,14 @@ describe('Editor', () => {
             stopPrintableKeyboardEventPropagation: true,
             contextMenuProviders: [],
         });
-        expect(core.edit).toEqual({
-            features: {},
-        });
+        if (!Browser.isChrome) {
+            expect(core.edit).toEqual({
+                features: {},
+            });
+        }
         expect(core.entity).toEqual({
             knownEntityElements: [],
+            shadowEntityCache: {},
         });
         expect(core.lifecycle.customData).toEqual({});
         expect(core.lifecycle.isDarkMode).toBeFalse();
@@ -163,11 +167,14 @@ describe('Editor', () => {
             stopPrintableKeyboardEventPropagation: false,
             contextMenuProviders: [],
         });
-        expect(core.edit).toEqual({
-            features: {},
-        });
+        if (!Browser.isChrome) {
+            expect(core.edit).toEqual({
+                features: {},
+            });
+        }
         expect(core.entity).toEqual({
             knownEntityElements: [],
+            shadowEntityCache: {},
         });
         expect(core.lifecycle.customData).toEqual({});
         expect(core.lifecycle.isDarkMode).toBeTrue();

--- a/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
@@ -65,7 +65,6 @@ describe('Editor', () => {
             features: {},
         });
         expect(core.entity).toEqual({
-            clickingPoint: null,
             knownEntityElements: [],
         });
         expect(core.lifecycle.customData).toEqual({});
@@ -168,7 +167,6 @@ describe('Editor', () => {
             features: {},
         });
         expect(core.entity).toEqual({
-            clickingPoint: null,
             knownEntityElements: [],
         });
         expect(core.lifecycle.customData).toEqual({});

--- a/packages/roosterjs-editor-dom/test/DomTestHelper.ts
+++ b/packages/roosterjs-editor-dom/test/DomTestHelper.ts
@@ -113,3 +113,12 @@ export function itFirefoxOnly(
     const func = __karma__.config.browser == 'Chrome' ? xit : it;
     return func(expectation, assertion, timeout);
 }
+
+export function itChromeOnly(
+    expectation: string,
+    assertion?: jasmine.ImplementationCallback,
+    timeout?: number
+) {
+    const func = __karma__.config.browser == 'Chrome' ? it : xit;
+    return func(expectation, assertion, timeout);
+}

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
@@ -150,6 +150,7 @@ function cacheGetNeighborEntityElement(
                 return null;
             }
 
+            range.commonAncestorContainer.normalize();
             const pos = Position.getEnd(range).normalize();
             const isAtBeginOrEnd = pos.offset == 0 || pos.isAtEnd;
             let entityNode: HTMLElement = null;

--- a/packages/roosterjs-editor-types/lib/corePluginState/EntityPluginState.ts
+++ b/packages/roosterjs-editor-types/lib/corePluginState/EntityPluginState.ts
@@ -1,4 +1,19 @@
 /**
+ * Represents an object of a cache item of a shadow DOM entity
+ */
+export interface ShadowEntityCache {
+    /**
+     * Entity wrapper element of the original entity
+     */
+    wrapper: HTMLElement;
+
+    /**
+     * The document fragment of hydrated entity content under shadow root
+     */
+    shadowDOM: DocumentFragment;
+}
+
+/**
  * The state object for EntityPlugin
  */
 export default interface EntityPluginState {
@@ -12,4 +27,11 @@ export default interface EntityPluginState {
      * All known entity elements
      */
     knownEntityElements: HTMLElement[];
+
+    /**
+     * Cache for the hydrated content of shadow DOM entity.
+     * When set content to replace the whole editor, we will cache the hydrated content
+     * before it is gone, then after that we can use the cached content to rehydrate entity
+     */
+    shadowEntityCache: Record<string, ShadowEntityCache>;
 }

--- a/packages/roosterjs-editor-types/lib/corePluginState/EntityPluginState.ts
+++ b/packages/roosterjs-editor-types/lib/corePluginState/EntityPluginState.ts
@@ -1,19 +1,4 @@
 /**
- * Represents an object of a cache item of a shadow DOM entity
- */
-export interface ShadowEntityCache {
-    /**
-     * Entity wrapper element of the original entity
-     */
-    wrapper: HTMLElement;
-
-    /**
-     * The document fragment of hydrated entity content under shadow root
-     */
-    shadowDOM: DocumentFragment;
-}
-
-/**
  * The state object for EntityPlugin
  */
 export default interface EntityPluginState {
@@ -33,5 +18,5 @@ export default interface EntityPluginState {
      * When set content to replace the whole editor, we will cache the hydrated content
      * before it is gone, then after that we can use the cached content to rehydrate entity
      */
-    shadowEntityCache: Record<string, ShadowEntityCache>;
+    shadowEntityCache: Record<string, HTMLElement>;
 }

--- a/packages/roosterjs-editor-types/lib/corePluginState/EntityPluginState.ts
+++ b/packages/roosterjs-editor-types/lib/corePluginState/EntityPluginState.ts
@@ -3,9 +3,10 @@
  */
 export default interface EntityPluginState {
     /**
+     * @deprecated
      * Last clicking point when mouse down event happens
      */
-    clickingPoint: { pageX: number; pageY: number };
+    clickingPoint?: { pageX: number; pageY: number };
 
     /**
      * All known entity elements

--- a/packages/roosterjs-editor-types/lib/enum/EntityOperation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/EntityOperation.ts
@@ -57,4 +57,16 @@ export const enum EntityOperation {
      * because it will always return false.
      */
     ReplaceTemporaryContent,
+
+    /**
+     * Notify plugins that editor has attached shadow root for an entity.
+     * Plugins can handle this event to do extra operations to the shadow root
+     */
+    AddShadowRoot,
+
+    /**
+     * Notify plugins that editor has removed the shadow root of an entity
+     * Plugins can handle this event to do any necessary clean up for shadow root
+     */
+    RemoveShadowRoot,
 }

--- a/packages/roosterjs-editor-types/lib/event/EntityOperationEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/EntityOperationEvent.ts
@@ -23,4 +23,17 @@ export default interface EntityOperationEvent
      * Optional raw event. Need to do null check before use its value
      */
     rawEvent?: Event;
+
+    /**
+     * A document fragment for entity based on Shadow DOM. This property is only available for NewEntity operation.
+     * Putting DOM nodes under this fragment will cause a shadow root to be attached to the entity wrapper
+     * with these DOM nodes under it.
+     *
+     * If there is already cached DOM nodes, they will also be put under this fragment.
+     * Plugin need to decide:
+     * 1. Apply the cache: do nothing and the DOM nodes will be appended as shadow DOM entity content
+     * 2. Discard the cache and use new content instead: clear the fragment and append new DOM nodes, then new DOM nodes will be used
+     * 3. Dehydrate this entity: clear the fragment, and leave it empty
+     */
+    contentForShadowEntity?: DocumentFragment;
 }

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -169,10 +169,7 @@ export { default as CreateElementData } from './interface/CreateElementData';
 // Core Plugin State
 export { default as DOMEventPluginState } from './corePluginState/DOMEventPluginState';
 export { default as EditPluginState } from './corePluginState/EditPluginState';
-export {
-    default as EntityPluginState,
-    ShadowEntityCache,
-} from './corePluginState/EntityPluginState';
+export { default as EntityPluginState } from './corePluginState/EntityPluginState';
 export { default as LifecyclePluginState } from './corePluginState/LifecyclePluginState';
 export { default as PendingFormatStatePluginState } from './corePluginState/PendingFormatStatePluginState';
 export { default as UndoPluginState } from './corePluginState/UndoPluginState';

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -169,7 +169,10 @@ export { default as CreateElementData } from './interface/CreateElementData';
 // Core Plugin State
 export { default as DOMEventPluginState } from './corePluginState/DOMEventPluginState';
 export { default as EditPluginState } from './corePluginState/EditPluginState';
-export { default as EntityPluginState } from './corePluginState/EntityPluginState';
+export {
+    default as EntityPluginState,
+    ShadowEntityCache,
+} from './corePluginState/EntityPluginState';
 export { default as LifecyclePluginState } from './corePluginState/LifecyclePluginState';
 export { default as PendingFormatStatePluginState } from './corePluginState/PendingFormatStatePluginState';
 export { default as UndoPluginState } from './corePluginState/UndoPluginState';

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -463,8 +463,9 @@ export default interface IEditor {
     /**
      * Run a callback function asynchronously
      * @param callback The callback function to run
+     * @returns a function to cancel this async run
      */
-    runAsync(callback: (editor: IEditor) => void): void;
+    runAsync(callback: (editor: IEditor) => void): () => void;
 
     /**
      * Set DOM attribute of editor content DIV


### PR DESCRIPTION
This is the change to introduce Shadow DOM entity. Shadow DOM entity is the new functionality of entity API. It allows hydrate an entity under a shadow DOM root, and benefit React Entity, undo snapshot, memory management.

The new API is fully compatible with existing API. Existing code based on Entity API can still work.

To use shadow DOM entity, just need to handle EntityOperation event (event.operation==EntityOperation.NewEntity), and put the hydrated content under event.contentForShadowEntity. Then Entity API will mount it and do memory management.

Two new EntityOperation enum values are added:
- AddShadowRoot triggers when a new shadowRoot is added into entity
- RemoveShadowRoot triggers when an existing shadowRoot is removed