### PR TITLE
Fix a conflict issue between list features and entity plugin

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/EntityPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/EntityPlugin.ts
@@ -188,14 +188,6 @@ export default class EntityPlugin implements PluginWithState<EntityPluginState> 
     }
 
     private handleKeyDownEvent(event: KeyboardEvent) {
-        // Workaround an issue for Chrome that when Delete or Backsapce, shadow DOM may be lost in editor
-        if (
-            (Browser.isChrome || Browser.isSafari) &&
-            (event.which == Keys.BACKSPACE || event.which == Keys.DELETE)
-        ) {
-            this.workaroundShadowDOMIssueForChrome();
-        }
-
         if (
             isCharacterValue(event) ||
             event.which == Keys.BACKSPACE ||
@@ -417,30 +409,6 @@ export default class EntityPlugin implements PluginWithState<EntityPluginState> 
     private isEntityKnown(wrapper: HTMLElement) {
         return this.state.knownEntityElements.indexOf(wrapper) >= 0;
     }
-
-    private workaroundShadowDOMIssueForChrome = () => {
-        const cache: Record<string, HTMLElement> = {};
-        this.cacheShadowEntities(cache);
-        this.editor.runAsync(() => {
-            Object.keys(cache).forEach(id => {
-                const entity = getEntityFromElement(cache[id]);
-                const newWrapper = this.editor.queryElements(
-                    getEntitySelector(entity.type, entity.id)
-                )[0];
-
-                if (newWrapper != entity.wrapper) {
-                    this.triggerEvent(entity.wrapper, EntityOperation.RemoveShadowRoot);
-                    this.setIsEntityKnown(entity.wrapper, false /*isKnown*/);
-
-                    if (newWrapper) {
-                        moveChildNodes(newWrapper, entity.wrapper);
-                        this.createShadowRoot(newWrapper, entity.wrapper.shadowRoot);
-                        this.setIsEntityKnown(newWrapper, true /*isKnown*/);
-                    }
-                }
-            });
-        });
-    };
 }
 
 /**

--- a/packages/roosterjs-editor-core/lib/corePlugins/EntityPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/EntityPlugin.ts
@@ -81,15 +81,6 @@ export default class EntityPlugin implements PluginWithState<EntityPluginState> 
      */
     initialize(editor: IEditor) {
         this.editor = editor;
-
-        // Workaround an issue for Chrome that when Delete or Backsapce, shadow DOM may be lost in editor
-        if (Browser.isChrome || Browser.isSafari) {
-            this.editor.addContentEditFeature({
-                keys: [Keys.BACKSPACE, Keys.DELETE],
-                shouldHandleEvent: () => true,
-                handleEvent: this.workaroundShadowDOMIssueForChrome,
-            });
-        }
     }
 
     /**
@@ -197,6 +188,14 @@ export default class EntityPlugin implements PluginWithState<EntityPluginState> 
     }
 
     private handleKeyDownEvent(event: KeyboardEvent) {
+        // Workaround an issue for Chrome that when Delete or Backsapce, shadow DOM may be lost in editor
+        if (
+            (Browser.isChrome || Browser.isSafari) &&
+            (event.which == Keys.BACKSPACE || event.which == Keys.DELETE)
+        ) {
+            this.workaroundShadowDOMIssueForChrome();
+        }
+
         if (
             isCharacterValue(event) ||
             event.which == Keys.BACKSPACE ||

--- a/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
@@ -1,9 +1,7 @@
 import * as dom from 'roosterjs-editor-dom';
 import EntityPlugin from '../../lib/corePlugins/EntityPlugin';
-import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
 import {
     ChangeSource,
-    ContentEditFeature,
     EntityClasses,
     EntityOperation,
     EntityOperationEvent,
@@ -405,43 +403,6 @@ describe('Shadow DOM Entity', () => {
             },
         };
         expect(plugin.willHandleEventExclusively(event)).toBeTrue();
-    });
-
-    itChromeOnly('Workaround Chrome issue', () => {
-        let feature: ContentEditFeature;
-        let wrapper = document.createElement('span');
-        const plugin = new EntityPlugin();
-        const runAsync = jasmine.createSpy('runAsync').and.callFake((callback: Function) => {
-            wrapper = wrapper.cloneNode(true) as HTMLElement;
-            callback();
-        });
-
-        wrapper.innerHTML = 'test';
-        dom.commitEntity(wrapper, 'TEST', false, 'TEST');
-        wrapper.attachShadow({ mode: 'open' });
-        const editor: IEditor = <any>{
-            getDocument: () => document,
-            addContentEditFeature: (f: ContentEditFeature) => {
-                feature = f;
-            },
-            queryElements: () => {
-                return [wrapper];
-            },
-            runAsync,
-            triggerPluginEvent: () => {},
-        };
-
-        plugin.initialize(editor);
-
-        expect(feature).toBeDefined();
-        expect(feature.keys).toEqual([Keys.BACKSPACE, Keys.DELETE]);
-        expect(feature.shouldHandleEvent(<any>{}, editor, false /*ctrlOrMeta*/)).toBeTrue();
-
-        feature.handleEvent(<any>{}, editor);
-
-        expect(runAsync).toHaveBeenCalled();
-        expect(wrapper.innerHTML).toBe('test');
-        expect(wrapper.shadowRoot).toBeTruthy();
     });
 
     it('Cache shadow entity before set content', () => {


### PR DESCRIPTION
In my previous change I added a new ContentEditFeature in EntityPlugin to workaround some issue with ShadowDomEntity. However, this feature is conflict with another ContentEditFeature - MergeInNewLine in listfeatures.ts.

As a short term fix, I temporarily removed this workaround code. For long term, we need to reconsider the design of ContentEditFeature to better handle conflict.