### PR TITLE
Remove "reference  export" from doc of roosterjs package

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
         "tslint-eslint-rules": "5.4.0",
         "tslint-microsoft-contrib": "6.2.0",
         "typedoc": "0.21.0",
-        "typedoc-plugin-remove-references": "0.0.5",
         "typedoc-plugin-external-module-map": "1.2.1",
         "typescript": "4.4.4",
         "webpack": "4.43.0",

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -57,6 +57,7 @@
         "readme": "../reference.md",
         "name": "RoosterJs API Reference",
         "excludeExternals": true,
+        "exclude": "**/*.d.ts",
         "excludePrivate": true,
         "includeVersion": true,
         "external-modulemap": ".*\\/(roosterjs[a-zA-Z0-9\\-]*)\\/lib\\/"

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -52,7 +52,7 @@
             "roosterjs-color-utils/lib/index.ts",
             "roosterjs/lib/index.ts"
         ],
-        "plugin": ["typedoc-plugin-remove-references", "typedoc-plugin-external-module-map"],
+        "plugin": ["typedoc-plugin-external-module-map"],
         "out": "../dist/deploy/docs",
         "readme": "../reference.md",
         "name": "RoosterJs API Reference",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6342,11 +6342,6 @@ typedoc-plugin-external-module-map@1.2.1:
   resolved "https://registry.yarnpkg.com/typedoc-plugin-external-module-map/-/typedoc-plugin-external-module-map-1.2.1.tgz#32669a6b81e57962d2dae80d7a6ef8f5d0be65dd"
   integrity sha512-ha+he4JFhCufF6wnpMpeH2XwsMgnYR6IrRUBCiMbZoYoudn6zICX7NA40pMjA35A6afxWNhKZU19pXnvysPK7A==
 
-typedoc-plugin-remove-references@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-remove-references/-/typedoc-plugin-remove-references-0.0.5.tgz#08b129d2697e50208c807e06c3662fd2fc86a925"
-  integrity sha512-DSZ7kM/Y90CgZUKt8MiDsoi4fvrJyleHydj3ncGyqDqMdhuMes2E/4I6mSmXBrVdTjYhVH6BeoOFSbj2pQ821g==
-
 typedoc@0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.21.0.tgz#d35dd69b1566032cd893f4f6f21f37156f5f78d2"


### PR DESCRIPTION
With my previous PR (#666), roosterjs package document shows a lot of exports that are actually exported from other packages. This can be fixed by adding an "exclude" param in the typedoc param list.

Also remove an unnecessary plugin of typedoc.

Before:

![image](https://user-images.githubusercontent.com/23065085/137848532-a50c71cb-9b78-45db-92c7-86e48cf687c7.png)

After: 

![image](https://user-images.githubusercontent.com/23065085/137848564-cbe6fe88-8d0e-4125-a550-22a8e4a27621.png)
