### PR TITLE
bump roosterJS version to 8.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "8.10.1",
+    "version": "8.11.0",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",


### PR DESCRIPTION
1. [Fix 665](https://github.com/microsoft/roosterjs/pull/665)
2. [Upgarde TypeScript to 4.4.4](https://github.com/microsoft/roosterjs/pull/666)
3. [Remove "reference export" from doc of roosterjs package](https://github.com/microsoft/roosterjs/pull/667)