### PR TITLE
8.11.2 Fix a bug for Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "8.11.1",
+    "version": "8.11.2",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-core/lib/corePlugins/LifecyclePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/LifecyclePlugin.ts
@@ -74,9 +74,11 @@ export default class LifecyclePlugin implements PluginWithState<LifecyclePluginS
             this.initializer = () => {
                 contentDiv.contentEditable = 'true';
                 contentDiv.style.userSelect = 'text';
+                contentDiv.style.webkitUserSelect = 'text';
             };
             this.disposer = () => {
                 contentDiv.style.userSelect = '';
+                contentDiv.style.webkitUserSelect = '';
                 contentDiv.removeAttribute(CONTENT_EDITABLE_ATTRIBUTE_NAME);
             };
         }


### PR DESCRIPTION
In 8.11.1 there is a change to remove webkitUserSelect style when init. This causes sometimes use can't type in the editor in Safari. So let's add it back