### PR TITLE
fix paste SVG issue

### DIFF
--- a/packages/roosterjs-editor-dom/lib/clipboard/extractClipboardItems.ts
+++ b/packages/roosterjs-editor-dom/lib/clipboard/extractClipboardItems.ts
@@ -63,7 +63,7 @@ export default function extractClipboardItems(
         (items || []).map(item => {
             const type = item.type;
 
-            if (type.indexOf(ContentTypePrefix.Image) == 0 && !data.image) {
+            if (type.indexOf(ContentTypePrefix.Image) == 0 && !data.image && item.kind == 'file') {
                 data.types.push(type);
                 data.image = item.getAsFile();
                 return new Promise<void>(resolve => {

--- a/packages/roosterjs-editor-dom/test/clipboard/extractClipboardItemsTest.ts
+++ b/packages/roosterjs-editor-dom/test/clipboard/extractClipboardItemsTest.ts
@@ -218,4 +218,16 @@ describe('extractClipboardItems', () => {
             linkPreview: linkPreview,
         });
     });
+
+    it('input with svg text', async () => {
+        const svg = '<svg>test</svg>';
+        const clipboardData = await extractClipboardItems([createStringItem('image/svg+xml', svg)]);
+        expect(clipboardData).toEqual({
+            types: [],
+            text: '',
+            image: null,
+            rawHtml: null,
+            customValues: {},
+        });
+    });
 });


### PR DESCRIPTION
When paste an image with image/svg+xml content type, our code try to get the content blob as file but it is actually string. 
Let's ignore those images for now by checking the clipboard item kind property.