### PR TITLE
Support "trusted-types dompurify"

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,7 +11,10 @@
                 bottom: 10px;
             }
         </style>
-        <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';" />
+        <meta
+            http-equiv="Content-Security-Policy"
+            content="require-trusted-types-for 'script'; trusted-types dompurify;"
+        />
     </head>
     <body>
         <div id="mainPane"></div>

--- a/demo/scripts/controls/sidePane/apiPlayground/sanitizer/SanitizerPane.tsx
+++ b/demo/scripts/controls/sidePane/apiPlayground/sanitizer/SanitizerPane.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import ApiPaneProps from '../ApiPaneProps';
 import { HtmlSanitizer } from 'roosterjs-editor-dom';
+import { trustedHTMLHandler } from '../../../../utils/trustedHTMLHandler';
 
 const styles = require('./SanitizerPane.scss');
 
@@ -29,10 +30,27 @@ export default class SanitizerPane extends React.Component<ApiPaneProps, {}> {
     }
 
     private inline = () => {
-        this.result.current.value = this.sanitizer.exec(this.source.current.value, true);
+        const doc = this.getDOMDocument();
+
+        if (doc?.body) {
+            this.sanitizer.convertGlobalCssToInlineCss(doc);
+            this.result.current.value = doc.body.innerHTML;
+        }
     };
 
     private sanitize = () => {
-        this.result.current.value = HtmlSanitizer.sanitizeHtml(this.source.current.value);
+        const doc = this.getDOMDocument();
+
+        if (doc?.body) {
+            this.sanitizer.sanitize(doc.body.firstChild);
+            this.result.current.value = doc.body.innerHTML;
+        }
     };
+
+    private getDOMDocument(): Document {
+        const parser = new DOMParser();
+        const html = trustedHTMLHandler(this.source.current.value) || '';
+        const doc = parser.parseFromString(html, 'text/html');
+        return doc;
+    }
 }

--- a/demo/scripts/utils/trustedHTMLHandler.ts
+++ b/demo/scripts/utils/trustedHTMLHandler.ts
@@ -1,18 +1,11 @@
 import * as DOMPurify from 'dompurify';
 
-const policy = !!window.trustedTypes
-    ? window.trustedTypes.createPolicy('sanitizeHtml', {
-          createHTML: (input: string) =>
-              DOMPurify.sanitize(input, {
-                  ADD_TAGS: ['head', 'meta'],
-                  ADD_ATTR: ['name', 'content'],
-                  WHOLE_DOCUMENT: true,
-              }),
-      })
-    : null;
-
-const trustedHTMLHandler = policy
-    ? (input: string) => <string>(<any>policy.createHTML(input))
-    : (input: string) => input;
-
-export { trustedHTMLHandler };
+export function trustedHTMLHandler(html: string): string {
+    const result = DOMPurify.sanitize(html, {
+        ADD_TAGS: ['head', 'meta'],
+        ADD_ATTR: ['name', 'content'],
+        WHOLE_DOCUMENT: true,
+        RETURN_TRUSTED_TYPE: true,
+    });
+    return <string>(<any>result);
+}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
                 bottom: 10px;
             }
         </style>
-        <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';" />
+        <meta
+            http-equiv="Content-Security-Policy"
+            content="require-trusted-types-for 'script'; trusted-types dompurify;"
+        />
     </head>
     <body>
         <div id="mainPane"></div>

--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
@@ -32,6 +32,7 @@ import {
  */
 export default class HtmlSanitizer {
     /**
+     * @deprecated Use new HtmlSanitizer().convertGlobalCssToInlineCss() instead
      * Convert global CSS to inline CSS if any
      * @param html HTML source
      * @param additionalStyleNodes (Optional) additional HTML STYLE elements used as global CSS
@@ -44,6 +45,7 @@ export default class HtmlSanitizer {
     }
 
     /**
+     * @deprecated Use new HtmlSanitizer().sanitize() instead
      * Sanitize HTML string, remove any unused HTML node/attribute/CSS.
      * @param html HTML source string
      * @param options Options used for this sanitizing process
@@ -91,6 +93,7 @@ export default class HtmlSanitizer {
     }
 
     /**
+     * @deprecated Use HtmlSanitizer.convertGlobalCssToInlineCss() and HtmlSanitizer.sanitize() instead
      * Sanitize HTML string
      * This function will do the following work:
      * 1. Convert global CSS into inline CSS
@@ -102,7 +105,7 @@ export default class HtmlSanitizer {
      */
     exec(html: string, convertCssOnly?: boolean, currentStyles?: StringMap): string {
         const parser = new DOMParser();
-        const doc = parser.parseFromString(unsafeConvertToTrustedHTML(html) || '', 'text/html');
+        const doc = parser.parseFromString(html || '', 'text/html');
 
         if (doc && doc.body && doc.body.firstChild) {
             this.convertGlobalCssToInlineCss(doc);
@@ -320,14 +323,3 @@ export default class HtmlSanitizer {
         return calculatedClasses.length > 0 ? calculatedClasses.join(' ') : null;
     }
 }
-
-const trustedTypes = (<any>window).trustedTypes;
-const policy = trustedTypes?.createPolicy('roosterjsUnsafeConvertHTML', {
-    // This is unsafe. However, we only use this function for HtmlSanitizer which we will
-    // sanitize HTML tree by our own code. So we just directly return the HTML string here.
-    createHTML: (html: string) => html,
-});
-
-const unsafeConvertToTrustedHTML = policy
-    ? (html: string) => policy.createHTML(html || '')
-    : (html: string) => html;

--- a/packages/roosterjs-editor-types/lib/interface/SanitizeHtmlOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/SanitizeHtmlOptions.ts
@@ -2,6 +2,7 @@ import HtmlSanitizerOptions from './HtmlSanitizerOptions';
 import { StringMap } from '../type/htmlSanitizerCallbackTypes';
 
 /**
+ * @deprecated
  * Options for sanitizeHtml function
  */
 export default interface SanitizeHtmlOptions extends HtmlSanitizerOptions {


### PR DESCRIPTION
Most of our code already support this security level. The only places are:
1. In HtmlSanitizer.ts, we create sanitizer function with our own code. We can remove the code and mark the related functions as deprecated since we are actually not using them at alll.
2. In trustedHTMLHandler.ts in demo site, we can directly use DOMPurify.sanitize() and no need to create a new security policy. This is for demo site only and no impact to production code.
