### PR TITLE
Support "inherit" color for dark mode color transform

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
@@ -91,7 +91,8 @@ function transformToDarkMode(element: HTMLElement, getDarkColor: (color: string)
         if (
             !element.dataset[names[ColorAttributeEnum.CssDataSet]] &&
             !element.dataset[names[ColorAttributeEnum.HtmlDataSet]] &&
-            (styleColor || attrColor)
+            (styleColor || attrColor) &&
+            styleColor != 'inherit' // For inherit style, no need to change it and let it keep inherit from parent element
         ) {
             const newColor = getDarkColor(computedValues[index] || styleColor || attrColor);
             element.style.setProperty(names[ColorAttributeEnum.CssColor], newColor, 'important');

--- a/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
@@ -200,4 +200,15 @@ describe('transformColor Light to dark', () => {
             '<div style="color: white; background-color: black;" data-ogsc="red" data-ogsb="green"></div>'
         );
     });
+
+    it('single element with inherit color', () => {
+        const core = createEditorCore(div, { inDarkMode: true, getDarkColor });
+        const element = document.createElement('div');
+        element.style.color = 'inherit';
+        element.style.backgroundColor = 'inherit';
+        transformColor(core, element, true, null, ColorTransformDirection.LightToDark);
+        expect(element.outerHTML).toBe(
+            '<div style="color: inherit; background-color: inherit;"></div>'
+        );
+    });
 });


### PR DESCRIPTION
When color style is "inherit", color transform function will incorrectly calculate its color for dark mode. So we can skip calculating them and let them keep "inherit" parent element's color.