### PR TITLE
Change Node version in Github actions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,6 +12,11 @@ jobs:
               with:
                   persist-credentials: false
 
+            - name: Set Node Version
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 'v14.18.2'
+
             - name: Install dependencies
               run: npm install
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,9 @@ jobs:
                   persist-credentials: false
 
             - name: Install dependencies
+              run: npm --version
+
+            - name: Install dependencies
               run: npm install
 
             - name: Install Chrome

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,11 @@ jobs:
               with:
                   persist-credentials: false
 
+            - name: Set Node Version
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 'v14.18.2'
+
             - name: Install dependencies
               run: npm install
 
@@ -35,12 +40,6 @@ jobs:
                   node-version: 'v14.18.2'
 
             - name: Install dependencies
-              run: npm --version
-
-            - name: Install dependencies
-              run: node --version
-
-            - name: Install dependencies
               run: npm install
 
             - name: Install Chrome
@@ -57,6 +56,11 @@ jobs:
               uses: actions/checkout@v2.3.1
               with:
                   persist-credentials: false
+
+            - name: Set Node Version
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 'v14.18.2'
 
             - name: Install dependencies
               run: npm install

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,6 +29,11 @@ jobs:
               with:
                   persist-credentials: false
 
+            - name: Set Node Version
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 'v14.18.2'
+
             - name: Install dependencies
               run: npm --version
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,6 +33,9 @@ jobs:
               run: npm --version
 
             - name: Install dependencies
+              run: node --version
+
+            - name: Install dependencies
               run: npm install
 
             - name: Install Chrome


### PR DESCRIPTION
It seems like the default version of node in github actions is not working fine when building.

The latest npm version that the github actions is 8.1.0 which is stricter with the dependencies.
Lowering the node version to 14.18.2 and the npm version to 6.14.15 works fine.
