### PR TITLE
Fix Narrator not announcing on delete at the last char

### DIFF
--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -53,6 +53,7 @@ export { default as adjustInsertPosition } from './utils/adjustInsertPosition';
 export { default as createElement, KnownCreateElementData } from './utils/createElement';
 export { default as moveChildNodes } from './utils/moveChildNodes';
 export { default as setListItemStyle } from './utils/setListItemStyle';
+export { default as narratorMessage } from './utils/narratorMessage';
 
 export { default as VTable } from './table/VTable';
 export { default as VList } from './list/VList';

--- a/packages/roosterjs-editor-dom/lib/utils/narratorMessage.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/narratorMessage.ts
@@ -1,0 +1,54 @@
+import { ContentPosition, IEditor } from 'roosterjs-editor-types';
+
+const MESSAGE_CONTAINER_ID = 'roosterjs_NarratorMessage';
+let MESSAGE_JOB: number;
+/**
+ * Makes the narrator announce a message
+ * @param file The file to read
+ * @param message Message to announce
+ * @param priority priority (non mandatory): "polite" (by default) or "assertive"
+ */
+export default function narratorMessage(
+    editor: IEditor,
+    message: string,
+    priority: 'polite' | 'assertive' = 'polite'
+) {
+    const editorDocument = editor.getDocument() || document;
+    const currentWindow = editorDocument.defaultView || window;
+
+    currentWindow.clearTimeout(MESSAGE_JOB);
+
+    const el = document.createElement('div');
+    const id = 'roosterjs-make-a-screen-reader-talk-' + Date.now();
+    const containerId = MESSAGE_CONTAINER_ID + Date.now();
+    el.setAttribute('id', id);
+    el.setAttribute('aria-live', priority);
+    el.classList.add('sr-only');
+    el.style.position = '';
+
+    let container = editorDocument.getElementById(containerId);
+
+    if (!container) {
+        container = editorDocument.createElement('DIV');
+        container.id = containerId;
+        container.style.zIndex = '-1';
+        editor.insertNode(container, {
+            updateCursor: false,
+            insertOnNewLine: false,
+            replaceSelection: false,
+            position: ContentPosition.Outside,
+        });
+    }
+
+    container.appendChild(el);
+
+    MESSAGE_JOB = currentWindow.setTimeout(function () {
+        editorDocument.getElementById(id).textContent = message;
+    }, 200);
+
+    currentWindow.setTimeout(function () {
+        const element = editorDocument.getElementById(id);
+        element?.parentNode.removeChild(element);
+        container?.parentNode?.removeChild(container);
+    }, 1000);
+}

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/textFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/textFeatures.ts
@@ -1,0 +1,38 @@
+import { narratorMessage } from 'roosterjs-editor-dom';
+import {
+    BuildInEditFeature,
+    Keys,
+    PluginKeyboardEvent,
+    TextFeatureSettings,
+} from 'roosterjs-editor-types';
+
+/**
+ * A content edit feature to trigger the last character that is going to be removed.
+ */
+const TextSpeechOnBackspace: BuildInEditFeature<PluginKeyboardEvent> = {
+    keys: [Keys.BACKSPACE],
+    shouldHandleEvent: (event, editor) => {
+        const range = editor.getSelectionRange();
+        const text = range.commonAncestorContainer.textContent;
+        return (
+            range.collapsed &&
+            range.commonAncestorContainer.nodeType == Node.TEXT_NODE &&
+            text.length - 1 <= range.endOffset
+        );
+    },
+    handleEvent: (event, editor) => {
+        const range = editor.getSelectionRange();
+        const text = range.commonAncestorContainer.textContent;
+        const msg = text.substring(range.endOffset - 1, range.endOffset);
+        narratorMessage(editor, msg, 'assertive');
+    },
+};
+/**
+ * @internal
+ */
+export const TextFeatures: Record<
+    keyof TextFeatureSettings,
+    BuildInEditFeature<PluginKeyboardEvent>
+> = {
+    textSpeechOnBackspace: TextSpeechOnBackspace,
+};

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/getAllFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/getAllFeatures.ts
@@ -7,6 +7,7 @@ import { QuoteFeatures } from './features/quoteFeatures';
 import { ShortcutFeatures } from './features/shortcutFeatures';
 import { StructuredNodeFeatures } from './features/structuredNodeFeatures';
 import { TableFeatures } from './features/tableFeatures';
+import { TextFeatures } from './features/textFeatures';
 import {
     BuildInEditFeature,
     ContentEditFeatureSettings,
@@ -23,6 +24,7 @@ const allFeatures = {
     ...CursorFeatures,
     ...MarkdownFeatures,
     ...EntityFeatures,
+    ...TextFeatures,
 };
 
 /**

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -158,6 +158,7 @@ export {
     ShortcutFeatureSettings,
     StructuredNodeFeatureSettings,
     TableFeatureSettings,
+    TextFeatureSettings,
 } from './interface/ContentEditFeatureSettings';
 export { default as CustomReplacement } from './interface/CustomReplacement';
 export { default as UndoSnapshotsService } from './interface/UndoSnapshotsService';

--- a/packages/roosterjs-editor-types/lib/interface/ContentEditFeatureSettings.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ContentEditFeatureSettings.ts
@@ -202,6 +202,33 @@ export interface TableFeatureSettings {
 }
 
 /**
+ * Settings for table features
+ */
+export interface TableFeatureSettings {
+    /**
+     * When press TAB or SHIFT+TAB key in table cell, jump to next/previous table cell
+     * @default true
+     */
+    tabInTable: boolean;
+
+    /**
+     * When press Up or Down in table cell, jump to the table cell above/below
+     * @default true for Chrome and safari, false for other browsers since they already have correct behavior
+     */
+    upDownInTable: boolean;
+}
+
+/**
+ * Settings for text features
+ */
+export interface TextFeatureSettings {
+    /**
+     * When press backspace to delete a character with backspace
+     */
+    textSpeechOnBackspace: boolean;
+}
+
+/**
  * A list to specify whether each of the listed content edit features is enabled
  */
 export default interface ContentEditFeatureSettings
@@ -213,4 +240,5 @@ export default interface ContentEditFeatureSettings
         ShortcutFeatureSettings,
         CursorFeatureSettings,
         MarkdownFeatureSettings,
-        EntityFeatureSettings {}
+        EntityFeatureSettings,
+        TableFeatureSettings {}


### PR DESCRIPTION
Issue:
The Narrator is not announcing the deleted charater when on the last element.

Before the change: (Notice how the narrator is not announcing the deleted charater)
![Sppech on deleting B4](https://user-images.githubusercontent.com/8291124/145310816-f7e51d10-0648-4528-ab58-5ef5c62316e3.gif)

After
![Sppech on deleting after](https://user-images.githubusercontent.com/8291124/145310822-326b9059-e449-4f33-98ef-97bb6b0964fb.gif)

Code Changes:

Added a function to announce the deleted charater, only when is at the end of the line.
Also a new content edit feature to announce the message to the narrator.


This seems to be a browser issue. I tried to repro the behavior and I was able to repro an a bare HTML Div contenteditable.

