### PR TITLE
Fix #704

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -354,7 +354,7 @@ export default class ImageEdit implements EditorPlugin {
         wrapper.style.display = Browser.isSafari ? 'inline-block' : 'inline-flex';
 
         // Cache current src so that we can compare it after edit see if src is changed
-        this.lastSrc = this.image.src;
+        this.lastSrc = this.image.getAttribute('src');
 
         // Set image src to original src to help show editing UI, also it will be used when regenerate image dataURL after editing
         this.image.src = this.editInfo.src;

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/api/resizeByPercentage.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/api/resizeByPercentage.ts
@@ -25,7 +25,7 @@ export default function resizeByPercentage(
     if (!isResizedTo(image, percentage)) {
         loadImage(image, editInfo.src, () => {
             if (!editor.isDisposed() && editor.contains(image)) {
-                const lastSrc = image.src;
+                const lastSrc = image.getAttribute('src');
                 const { width, height } = getTargetSizeByPercentage(editInfo, percentage);
                 editInfo.widthPx = Math.max(width, minWidth);
                 editInfo.heightPx = Math.max(height, minHeight);

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/editInfo.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/editInfo.ts
@@ -41,7 +41,7 @@ export function getEditInfoFromImage(image: HTMLImageElement): ImageEditInfo {
 
 function getInitialEditInfo(image: HTMLImageElement): ImageEditInfo {
     return {
-        src: image.src,
+        src: image.getAttribute('src'),
         widthPx: image.clientWidth,
         heightPx: image.clientHeight,
         naturalWidth: image.naturalWidth,

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/editInfo.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/editInfo.ts
@@ -41,7 +41,7 @@ export function getEditInfoFromImage(image: HTMLImageElement): ImageEditInfo {
 
 function getInitialEditInfo(image: HTMLImageElement): ImageEditInfo {
     return {
-        src: image.getAttribute('src'),
+        src: image.getAttribute('src') || '',
         widthPx: image.clientWidth,
         heightPx: image.clientHeight,
         naturalWidth: image.naturalWidth,


### PR DESCRIPTION
Use image.getAttribute('src') instead of image.src to avoid browser translate relative path to absolute path