### PR TITLE
Add A PoC for SelectionRangeEx

### DIFF
--- a/packages/roosterjs-editor-api/lib/utils/applyInlineStyle.ts
+++ b/packages/roosterjs-editor-api/lib/utils/applyInlineStyle.ts
@@ -1,4 +1,4 @@
-import { applyTextStyle, ContentTraverser, getTagOfNode } from 'roosterjs-editor-dom';
+import { applyTextStyle, getTagOfNode } from 'roosterjs-editor-dom';
 import {
     ChangeSource,
     IEditor,
@@ -59,10 +59,7 @@ export default function applyInlineStyle(
             let lastNode: Node;
             const selectionRange = editor.getSelectionRangeEx();
             selectionRange.ranges.forEach(range => {
-                const contentTraverser = ContentTraverser.createSelectionTraverser(
-                    range.commonAncestorContainer,
-                    range
-                );
+                const contentTraverser = editor.getSelectionTraverser(range);
                 let inlineElement = contentTraverser && contentTraverser.currentInlineElement;
                 while (inlineElement) {
                     let nextInlineElement = contentTraverser.getNextInlineElement();

--- a/packages/roosterjs-editor-api/lib/utils/applyInlineStyle.ts
+++ b/packages/roosterjs-editor-api/lib/utils/applyInlineStyle.ts
@@ -57,8 +57,7 @@ export default function applyInlineStyle(
         editor.addUndoSnapshot(() => {
             let firstNode: Node;
             let lastNode: Node;
-            const selectionRange = editor.getSelectionRangeEx();
-            selectionRange.ranges.forEach(range => {
+            srEx.ranges.forEach(range => {
                 const contentTraverser = editor.getSelectionTraverser(range);
                 let inlineElement = contentTraverser && contentTraverser.currentInlineElement;
                 while (inlineElement) {

--- a/packages/roosterjs-editor-api/lib/utils/multipleSelectionRangesWrap.ts
+++ b/packages/roosterjs-editor-api/lib/utils/multipleSelectionRangesWrap.ts
@@ -1,0 +1,28 @@
+import { ChangeSource, IEditor, SelectionRangeEx } from 'roosterjs-editor-types';
+
+/**
+ * Wrap to add a undo snapshot before applying format, if there are more than one range.
+ * Otherwise, for each range an undosnapshot would be added.
+ * @param editor editor instance
+ * @param selectionRange selection ranges
+ * @param callback callback to use on all the ranges
+ * @param changeSource Optional parameter to add to the parent undoSnapshot
+ */
+export function multipleSelectionRangesWrap(
+    editor: IEditor,
+    selectionRange: SelectionRangeEx,
+    callback: (range: Range) => void,
+    changeSource?: ChangeSource
+) {
+    if (selectionRange.ranges.length > 1) {
+        editor.addUndoSnapshot(() => forEachRange(selectionRange, callback), changeSource);
+    } else {
+        forEachRange(selectionRange, callback);
+    }
+}
+
+function forEachRange(selectionRange: SelectionRangeEx, callback: (range: Range) => void): void {
+    selectionRange.ranges.forEach(range => {
+        callback(range);
+    });
+}

--- a/packages/roosterjs-editor-api/lib/utils/multipleSelectionRangesWrap.ts
+++ b/packages/roosterjs-editor-api/lib/utils/multipleSelectionRangesWrap.ts
@@ -1,6 +1,7 @@
 import { ChangeSource, IEditor, SelectionRangeEx } from 'roosterjs-editor-types';
 
 /**
+ * @internal
  * Wrap to add a undo snapshot before applying format, if there are more than one range.
  * Otherwise, for each range an undosnapshot would be added.
  * @param editor editor instance

--- a/packages/roosterjs-editor-core/lib/coreApi/coreApiMap.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/coreApiMap.ts
@@ -7,6 +7,7 @@ import { focus } from './focus';
 import { getContent } from './getContent';
 import { getPendableFormatState } from './getPendableFormatState';
 import { getSelectionRange } from './getSelectionRange';
+import { getSelectionRangeEx } from './getSelectionRangeEx';
 import { getStyleBasedFormatState } from './getStyleBasedFormatState';
 import { hasFocus } from './hasFocus';
 import { insertNode } from './insertNode';
@@ -38,4 +39,5 @@ export const coreApiMap: CoreApiMap = {
     switchShadowEdit,
     transformColor,
     triggerEvent,
+    getSelectionRangeEx,
 };

--- a/packages/roosterjs-editor-core/lib/coreApi/getSelectionRangeEx.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getSelectionRangeEx.ts
@@ -58,7 +58,10 @@ export const getSelectionRangeEx: GetSelectionRangeEx = (
 
             let selection = core.contentDiv.ownerDocument.defaultView?.getSelection();
             if (!result && selection && selection.rangeCount > 0) {
-                return createNormalSelectionEx(getRangesFromSelection(selection, core.contentDiv));
+                let range = selection.getRangeAt(0);
+                if (contains(core.contentDiv, range)) {
+                    return createNormalSelectionEx([range]);
+                }
             }
         }
 
@@ -67,18 +70,6 @@ export const getSelectionRangeEx: GetSelectionRangeEx = (
         }
     }
 };
-
-function getRangesFromSelection(selection: Selection, contentDiv: HTMLDivElement): Range[] {
-    const result: Range[] = [];
-    for (let index = 0; index < selection.rangeCount; index++) {
-        let range = selection.getRangeAt(index);
-        if (contains(contentDiv, range)) {
-            result.push(range);
-        }
-    }
-
-    return result.length > 0 ? result : null;
-}
 
 function createNormalSelectionEx(ranges: Range[]): SelectionRangeEx {
     return new NormalSelectionRange(ranges);

--- a/packages/roosterjs-editor-core/lib/coreApi/getSelectionRangeEx.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getSelectionRangeEx.ts
@@ -1,0 +1,92 @@
+import {
+    EditorCore,
+    GetSelectionRangeEx,
+    SelectionRangeEx,
+    TableSelectionPluginState,
+} from 'roosterjs-editor-types';
+import {
+    contains,
+    createRange,
+    findClosestElementAncestor,
+    NormalSelectionRange,
+    safeInstanceOf,
+    TableSelectionRange,
+} from 'roosterjs-editor-dom';
+
+/**
+ * @internal
+ * Get current or cached selection range
+ * @param core The EditorCore object
+ * @param tryGetFromCache Set to true to retrieve the selection range from cache if editor doesn't own the focus now
+ * @returns A Range object of the selection range
+ */
+export const getSelectionRangeEx: GetSelectionRangeEx = (
+    core: EditorCore,
+    tryGetFromCache: boolean
+) => {
+    let result: SelectionRangeEx = null;
+
+    const tSelection = core.tableSelection;
+    if (core.lifecycle.shadowEditFragment) {
+        const shadowRange =
+            core.lifecycle.shadowEditSelectionPath &&
+            createRange(
+                core.contentDiv,
+                core.lifecycle.shadowEditSelectionPath.start,
+                core.lifecycle.shadowEditSelectionPath.end
+            );
+        if (shadowRange.collapsed) {
+            const table = findClosestElementAncestor(
+                shadowRange.startContainer,
+                core.contentDiv,
+                'table'
+            ) as HTMLTableElement;
+            if (tSelection.vSelection && safeInstanceOf(table, 'HTMLTableElement')) {
+                return createTableSelectionEx(table, tSelection);
+            }
+        }
+
+        return createNormalSelectionEx([shadowRange]);
+    } else {
+        if (!tryGetFromCache || core.api.hasFocus(core)) {
+            if (
+                tSelection.vSelection &&
+                safeInstanceOf(tSelection.firstTarget, 'HTMLTableCellElement')
+            ) {
+                return createTableSelectionEx(tSelection.firstTarget, tSelection);
+            }
+
+            let selection = core.contentDiv.ownerDocument.defaultView?.getSelection();
+            if (!result && selection && selection.rangeCount > 0) {
+                return createNormalSelectionEx(getRangesFromSelection(selection, core.contentDiv));
+            }
+        }
+
+        if (!result && tryGetFromCache) {
+            return createNormalSelectionEx([core.domEvent.selectionRange]);
+        }
+    }
+};
+
+function getRangesFromSelection(selection: Selection, contentDiv: HTMLDivElement): Range[] {
+    const result: Range[] = [];
+    for (let index = 0; index < selection.rangeCount; index++) {
+        let range = selection.getRangeAt(index);
+        if (contains(contentDiv, range)) {
+            result.push(range);
+        }
+    }
+
+    return result.length > 0 ? result : null;
+}
+
+function createNormalSelectionEx(ranges: Range[]): SelectionRangeEx {
+    return new NormalSelectionRange(ranges);
+}
+
+function createTableSelectionEx(
+    element: HTMLTableElement | HTMLTableCellElement,
+    state: TableSelectionPluginState
+): SelectionRangeEx {
+    return new TableSelectionRange(element, state.startRange, state.endRange);
+}

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -33,6 +33,7 @@ import {
     Region,
     RegionType,
     SelectionPath,
+    SelectionRangeEx,
     StyleBasedFormatState,
     TableSelectionPluginState,
     TrustedHTMLHandler,
@@ -355,6 +356,17 @@ export default class Editor implements IEditor {
     }
 
     /**
+     * Get current selection range from Editor.
+     * It does a live pull on the selection, if nothing retrieved, return whatever we have in cache.
+     * @param tryGetFromCache Set to true to retrieve the selection range from cache if editor doesn't own the focus now.
+     * Default value is true
+     * @returns current selection range, or null if editor never got focus before
+     */
+    public getSelectionRangeEx(tryGetFromCache: boolean = true): SelectionRangeEx {
+        return this.core.api.getSelectionRangeEx(this.core, tryGetFromCache);
+    }
+
+    /**
      * Get current selection in a serializable format
      * It does a live pull on the selection, if nothing retrieved, return whatever we have in cache.
      * @returns current selection path, or null if editor never got focus before
@@ -648,7 +660,7 @@ export default class Editor implements IEditor {
      * Get a content traverser for current selection
      */
     public getSelectionTraverser(): IContentTraverser {
-        let range = this.getSelectionRange();
+        const range = this.getSelectionRange();
         return (
             range &&
             ContentTraverser.createSelectionTraverser(

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -362,8 +362,8 @@ export default class Editor implements IEditor {
      * Default value is true
      * @returns current selection range, or null if editor never got focus before
      */
-    public getSelectionRangeEx(tryGetFromCache: boolean = true): SelectionRangeEx {
-        return this.core.api.getSelectionRangeEx(this.core, tryGetFromCache);
+    public getSelectionRangeEx(): SelectionRangeEx {
+        return this.core.api.getSelectionRangeEx(this.core);
     }
 
     /**
@@ -661,13 +661,7 @@ export default class Editor implements IEditor {
      */
     public getSelectionTraverser(range?: Range): IContentTraverser {
         range = range ?? this.getSelectionRange();
-        return (
-            range &&
-            ContentTraverser.createSelectionTraverser(
-                this.core.contentDiv,
-                this.getSelectionRange()
-            )
-        );
+        return range && ContentTraverser.createSelectionTraverser(this.core.contentDiv, range);
     }
 
     /**

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -659,8 +659,8 @@ export default class Editor implements IEditor {
     /**
      * Get a content traverser for current selection
      */
-    public getSelectionTraverser(): IContentTraverser {
-        const range = this.getSelectionRange();
+    public getSelectionTraverser(range?: Range): IContentTraverser {
+        range = range ?? this.getSelectionRange();
         return (
             range &&
             ContentTraverser.createSelectionTraverser(

--- a/packages/roosterjs-editor-core/test/coreApi/getSelectionRangeExTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/getSelectionRangeExTest.ts
@@ -1,0 +1,75 @@
+import createEditorCore from './createMockEditorCore';
+import { getSelectionRangeEx } from '../../lib/coreApi/getSelectionRangeEx';
+import { selectNode } from '../TestHelper';
+
+describe('getSelectionRangeEx', () => {
+    let div: HTMLDivElement;
+    beforeEach(() => {
+        div = document.createElement('div');
+        document.body.appendChild(div);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(div);
+        div = null;
+    });
+
+    it('do not use cache, focus is in editor', () => {
+        const core = createEditorCore(div, {});
+        div.contentEditable = 'true';
+        div.innerHTML = '<div>test</div>';
+        selectNode(div.firstChild);
+
+        const selectionEx = getSelectionRangeEx(core);
+        selectionEx.ranges.forEach(range => {
+            expect(range.startContainer).toBe(div);
+            expect(range.endContainer).toBe(div);
+            expect(range.startOffset).toBe(0);
+            expect(range.endOffset).toBe(1);
+        });
+    });
+
+    it('use cache, focus is not in editor', () => {
+        const core = createEditorCore(div, {});
+        const cachedRange = document.createRange();
+        core.domEvent = {
+            selectionRange: cachedRange,
+            isInIME: false,
+            scrollContainer: null,
+            stopPrintableKeyboardEventPropagation: false,
+            contextMenuProviders: [],
+        };
+        const input = document.createElement('input');
+        document.body.appendChild(input);
+        input.focus();
+
+        const selectionEx = getSelectionRangeEx(core);
+        selectionEx.ranges.forEach(range => {
+            expect(range.startContainer).toBe(div);
+            expect(range.endContainer).toBe(div);
+            expect(range.startOffset).toBe(0);
+            expect(range.endOffset).toBe(1);
+        });
+        document.body.removeChild(input);
+    });
+
+    it('use cache, focus is in editor', () => {
+        const core = createEditorCore(div, {});
+        div.contentEditable = 'true';
+        div.innerHTML =
+            '<div><table cellspacing="0" cellpadding="1" style="border-collapse: collapse;" class="_tableSelected"><tbody><tr><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171); background-color: rgba(198, 198, 198, 0.7);" scope="" data-original-background-color="" class="_tableCellSelected"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171); background-color: rgba(198, 198, 198, 0.7);" scope="" data-original-background-color="" class="_tableCellSelected"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);" scope=""><br></td></tr><tr><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171); background-color: rgba(198, 198, 198, 0.7);" scope="" data-original-background-color="" class="_tableCellSelected"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171); background-color: rgba(198, 198, 198, 0.7);" data-original-background-color="" class="_tableCellSelected"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr><tr><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171); background-color: rgba(198, 198, 198, 0.7);" scope="" data-original-background-color="" class="_tableCellSelected"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171); background-color: rgba(198, 198, 198, 0.7);" data-original-background-color="" class="_tableCellSelected"><br></td><td style="width: 120px; border-width: 1px; border-style: solid; border-color: rgb(171, 171, 171);"><br></td></tr></tbody></table><br></div>';
+        selectNode(div.firstChild);
+
+        const selectionEx = getSelectionRangeEx(core);
+        expect(selectionEx.ranges.length).toBe(3);
+        let cont = 1;
+        selectionEx.ranges.forEach(range => {
+            const tr = div.querySelector(`tr:nth-child(${cont})`);
+            expect(range.startContainer).toBe(tr);
+            expect(range.endContainer).toBe(tr);
+            expect(range.startOffset).toBe(0);
+            expect(range.endOffset).toBe(1);
+            cont++;
+        });
+    });
+});

--- a/packages/roosterjs-editor-core/test/coreApi/getSelectionRangeExTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/getSelectionRangeExTest.ts
@@ -29,31 +29,7 @@ describe('getSelectionRangeEx', () => {
         });
     });
 
-    it('use cache, focus is not in editor', () => {
-        const core = createEditorCore(div, {});
-        const cachedRange = document.createRange();
-        core.domEvent = {
-            selectionRange: cachedRange,
-            isInIME: false,
-            scrollContainer: null,
-            stopPrintableKeyboardEventPropagation: false,
-            contextMenuProviders: [],
-        };
-        const input = document.createElement('input');
-        document.body.appendChild(input);
-        input.focus();
-
-        const selectionEx = getSelectionRangeEx(core);
-        selectionEx.ranges.forEach(range => {
-            expect(range.startContainer).toBe(div);
-            expect(range.endContainer).toBe(div);
-            expect(range.startOffset).toBe(0);
-            expect(range.endOffset).toBe(1);
-        });
-        document.body.removeChild(input);
-    });
-
-    it('use cache, focus is in editor', () => {
+    it('table selection', () => {
         const core = createEditorCore(div, {});
         div.contentEditable = 'true';
         div.innerHTML =
@@ -68,7 +44,7 @@ describe('getSelectionRangeEx', () => {
             expect(range.startContainer).toBe(tr);
             expect(range.endContainer).toBe(tr);
             expect(range.startOffset).toBe(0);
-            expect(range.endOffset).toBe(1);
+            expect(range.endOffset).toBe(2);
             cont++;
         });
     });

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -71,6 +71,8 @@ export { default as getSelectionRangeInRegion } from './region/getSelectionRange
 export { default as mergeBlocksInRegion } from './region/mergeBlocksInRegion';
 
 export { default as Position } from './selection/Position';
+export { default as NormalSelectionRange } from './selection/NormalSelectionRange';
+export { default as TableSelectionRange } from './selection/TableSelectionRange';
 export { default as createRange } from './selection/createRange';
 export { default as getPositionRect } from './selection/getPositionRect';
 export { default as isPositionAtBeginningOf } from './selection/isPositionAtBeginningOf';

--- a/packages/roosterjs-editor-dom/lib/selection/NormalSelectionRange.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/NormalSelectionRange.ts
@@ -1,0 +1,15 @@
+import { INormalSelectionRange, SelectionRangeTypes } from 'roosterjs-editor-types';
+
+export default class NormalSelectionRange implements INormalSelectionRange {
+    constructor(ranges: Range[]) {
+        this.ranges = ranges;
+    }
+
+    type: SelectionRangeTypes.Normal;
+
+    ranges: Range[];
+
+    isCollapsed = () => {
+        return this.ranges.length == 1 && this.ranges[0].collapsed;
+    };
+}

--- a/packages/roosterjs-editor-dom/lib/selection/NormalSelectionRange.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/NormalSelectionRange.ts
@@ -7,12 +7,14 @@ export default class NormalSelectionRange implements INormalSelectionRange {
     constructor(ranges: Range[]) {
         this.ranges = ranges;
         this.type = SelectionRangeTypes.Normal;
+
+        this.areAllCollapsed =
+            this.ranges.filter(range => range.collapsed).length == this.ranges.length;
     }
 
-    type: SelectionRangeTypes.Normal;
-    ranges: Range[];
+    readonly type: SelectionRangeTypes.Normal;
 
-    isCollapsed = () => {
-        return this.ranges[0].collapsed;
-    };
+    readonly ranges: Range[];
+
+    readonly areAllCollapsed: boolean;
 }

--- a/packages/roosterjs-editor-dom/lib/selection/NormalSelectionRange.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/NormalSelectionRange.ts
@@ -1,5 +1,8 @@
 import { INormalSelectionRange, SelectionRangeTypes } from 'roosterjs-editor-types';
 
+/**
+ * Normal selection Range used in the getSelectedRangeEx editor Api
+ */
 export default class NormalSelectionRange implements INormalSelectionRange {
     constructor(ranges: Range[]) {
         this.ranges = ranges;

--- a/packages/roosterjs-editor-dom/lib/selection/NormalSelectionRange.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/NormalSelectionRange.ts
@@ -6,13 +6,13 @@ import { INormalSelectionRange, SelectionRangeTypes } from 'roosterjs-editor-typ
 export default class NormalSelectionRange implements INormalSelectionRange {
     constructor(ranges: Range[]) {
         this.ranges = ranges;
+        this.type = SelectionRangeTypes.Normal;
     }
 
     type: SelectionRangeTypes.Normal;
-
     ranges: Range[];
 
     isCollapsed = () => {
-        return this.ranges.length == 1 && this.ranges[0].collapsed;
+        return this.ranges[0].collapsed;
     };
 }

--- a/packages/roosterjs-editor-dom/lib/selection/TableSelectionRange.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/TableSelectionRange.ts
@@ -1,0 +1,24 @@
+import { ITableSelectionRange, SelectionRangeTypes } from 'roosterjs-editor-types';
+import { VTable } from '..';
+
+export default class TableSelectionRange implements ITableSelectionRange {
+    constructor(
+        tableElement: HTMLTableElement | HTMLTableCellElement,
+        startRange: number[],
+        endRange: number[]
+    ) {
+        this.vTable = new VTable(tableElement);
+        this.vTable.startRange = startRange;
+        this.vTable.endRange = endRange;
+
+        this.ranges = this.vTable.getSelectedRanges();
+    }
+    vTable: VTable;
+    type: SelectionRangeTypes.VSelection;
+
+    ranges: Range[];
+
+    isCollapsed = () => {
+        return this.ranges.length == 1 && this.ranges[0].collapsed;
+    };
+}

--- a/packages/roosterjs-editor-dom/lib/selection/TableSelectionRange.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/TableSelectionRange.ts
@@ -15,7 +15,9 @@ export default class TableSelectionRange implements ITableSelectionRange {
         this.vTable.endRange = endRange;
 
         this.ranges = this.vTable.getSelectedRanges();
+        this.type = SelectionRangeTypes.VSelection;
     }
+
     vTable: VTable;
     type: SelectionRangeTypes.VSelection;
 

--- a/packages/roosterjs-editor-dom/lib/selection/TableSelectionRange.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/TableSelectionRange.ts
@@ -5,25 +5,20 @@ import { ITableSelectionRange, SelectionRangeTypes } from 'roosterjs-editor-type
  * Can create a object with an array of ranges depending on a vTable range provided.
  */
 export default class TableSelectionRange implements ITableSelectionRange {
-    constructor(
-        tableElement: HTMLTableElement | HTMLTableCellElement,
-        startRange: number[],
-        endRange: number[]
-    ) {
-        this.vTable = new VTable(tableElement);
-        this.vTable.startRange = startRange;
-        this.vTable.endRange = endRange;
+    constructor(vTable: VTable) {
+        this.vTable = vTable;
 
         this.ranges = this.vTable.getSelectedRanges();
-        this.type = SelectionRangeTypes.VSelection;
+
+        this.areAllCollapsed =
+            this.ranges.filter(range => range.collapsed).length == this.ranges.length;
     }
 
-    vTable: VTable;
-    type: SelectionRangeTypes.VSelection;
+    readonly type: SelectionRangeTypes.TableSelection;
 
-    ranges: Range[];
+    readonly vTable: VTable;
 
-    isCollapsed = () => {
-        return this.ranges.length == 1 && this.ranges[0].collapsed;
-    };
+    readonly ranges: Range[];
+
+    readonly areAllCollapsed: boolean;
 }

--- a/packages/roosterjs-editor-dom/lib/selection/TableSelectionRange.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/TableSelectionRange.ts
@@ -1,6 +1,9 @@
+import VTable from '../table/VTable';
 import { ITableSelectionRange, SelectionRangeTypes } from 'roosterjs-editor-types';
-import { VTable } from '..';
-
+/**
+ * Table selection Range used in the getSelectedRangeEx editor Api
+ * Can create a object with an array of ranges depending on a vTable range provided.
+ */
 export default class TableSelectionRange implements ITableSelectionRange {
     constructor(
         tableElement: HTMLTableElement | HTMLTableCellElement,

--- a/packages/roosterjs-editor-dom/lib/table/VTable.ts
+++ b/packages/roosterjs-editor-dom/lib/table/VTable.ts
@@ -1184,6 +1184,6 @@ function getOriginalColor(colorString: string) {
  * Retrieve the color to be applied when a cell is selected
  * @returns color to be applied when a cell is selected
  */
-export function getHighlightColor() {
+function getHighlightColor() {
     return `rgba(198,198,198, ${TableMetadata.SELECTION_COLOR_OPACITY})`;
 }

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -136,6 +136,7 @@ export {
     Focus,
     GetContent,
     GetSelectionRange,
+    GetSelectionRangeEx,
     GetStyleBasedFormatState,
     GetPendableFormatState,
     HasFocus,
@@ -167,6 +168,13 @@ export { default as PickerPluginOptions } from './interface/PickerPluginOptions'
 export { default as VCell } from './interface/VCell';
 export { default as ImageEditOptions } from './interface/ImageEditOptions';
 export { default as CreateElementData } from './interface/CreateElementData';
+export {
+    ISelectionRangeEx,
+    INormalSelectionRange,
+    ITableSelectionRange,
+    SelectionRangeEx,
+    SelectionRangeTypes,
+} from './interface/SelectionRangeEx';
 
 // Core Plugin State
 export { default as DOMEventPluginState } from './corePluginState/DOMEventPluginState';

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -166,6 +166,7 @@ export { default as UndoSnapshotsService } from './interface/UndoSnapshotsServic
 export { default as PickerDataProvider } from './interface/PickerDataProvider';
 export { default as PickerPluginOptions } from './interface/PickerPluginOptions';
 export { default as VCell } from './interface/VCell';
+export { default as IVTable } from './interface/IVTable';
 export { default as ImageEditOptions } from './interface/ImageEditOptions';
 export { default as CreateElementData } from './interface/CreateElementData';
 export {

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -9,6 +9,7 @@ import { InsertOption } from './InsertOption';
 import { PendableFormatState, StyleBasedFormatState } from './FormatState';
 import { PluginEvent } from '../event/PluginEvent';
 import { PluginState } from './CorePlugins';
+import { SelectionRangeEx } from './SelectionRangeEx';
 import { TrustedHTMLHandler } from '../type/TrustedHTMLHandler';
 
 /**
@@ -113,6 +114,14 @@ export type GetContent = (core: EditorCore, mode: GetContentMode) => string;
  * @returns A Range object of the selection range
  */
 export type GetSelectionRange = (core: EditorCore, tryGetFromCache: boolean) => Range;
+
+/**
+ * Get current or cached selection range
+ * @param core The EditorCore object
+ * @param tryGetFromCache Set to true to retrieve the selection range from cache if editor doesn't own the focus now
+ * @returns A Range object of the selection range
+ */
+export type GetSelectionRangeEx = (core: EditorCore, tryGetFromCache: boolean) => SelectionRangeEx;
 
 /**
  * Get style based format state from current selection, including font name/size and colors
@@ -271,6 +280,14 @@ export interface CoreApiMap {
      * @returns A Range object of the selection range
      */
     getSelectionRange: GetSelectionRange;
+
+    /**
+     * Get current or cached selection range
+     * @param core The EditorCore object
+     * @param tryGetFromCache Set to true to retrieve the selection range from cache if editor doesn't own the focus now
+     * @returns A Range object of the selection range
+     */
+    getSelectionRangeEx: GetSelectionRangeEx;
 
     /**
      * Get style based format state from current selection, including font name/size and colors

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -116,12 +116,11 @@ export type GetContent = (core: EditorCore, mode: GetContentMode) => string;
 export type GetSelectionRange = (core: EditorCore, tryGetFromCache: boolean) => Range;
 
 /**
- * Get current or cached selection range
+ * Get current selection range
  * @param core The EditorCore object
- * @param tryGetFromCache Set to true to retrieve the selection range from cache if editor doesn't own the focus now
  * @returns A Range object of the selection range
  */
-export type GetSelectionRangeEx = (core: EditorCore, tryGetFromCache: boolean) => SelectionRangeEx;
+export type GetSelectionRangeEx = (core: EditorCore) => SelectionRangeEx;
 
 /**
  * Get style based format state from current selection, including font name/size and colors

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -216,12 +216,10 @@ export default interface IEditor {
 
     /**
      * Get current selection range from Editor.
-     * It does a live pull on the selection, if nothing retrieved, return whatever we have in cache.
-     * @param tryGetFromCache Set to true to retrieve the selection range from cache if editor doesn't own the focus now.
-     * Default value is true
+     * It does a live pull on the selection.
      * @returns current selection range, or null if editor never got focus before
      */
-    getSelectionRangeEx(tryGetFromCache?: boolean): SelectionRangeEx;
+    getSelectionRangeEx(): SelectionRangeEx;
 
     /**
      * Get current selection in a serializable format

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -21,6 +21,7 @@ import { PluginKeyboardEvent } from '../event/PluginDomEvent';
 import { PositionType } from '../enum/PositionType';
 import { QueryScope } from '../enum/QueryScope';
 import { RegionType } from '../enum/RegionType';
+import { SelectionRangeEx } from './SelectionRangeEx';
 import { TrustedHTMLHandler } from '../type/TrustedHTMLHandler';
 
 /**
@@ -212,6 +213,15 @@ export default interface IEditor {
      * @returns current selection range, or null if editor never got focus before
      */
     getSelectionRange(tryGetFromCache?: boolean): Range;
+
+    /**
+     * Get current selection range from Editor.
+     * It does a live pull on the selection, if nothing retrieved, return whatever we have in cache.
+     * @param tryGetFromCache Set to true to retrieve the selection range from cache if editor doesn't own the focus now.
+     * Default value is true
+     * @returns current selection range, or null if editor never got focus before
+     */
+    getSelectionRangeEx(tryGetFromCache?: boolean): SelectionRangeEx;
 
     /**
      * Get current selection in a serializable format

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -462,7 +462,7 @@ export default interface IEditor {
     /**
      * Get a content traverser for current selection
      */
-    getSelectionTraverser(): IContentTraverser;
+    getSelectionTraverser(range?: Range): IContentTraverser;
 
     /**
      * Get a content traverser for current block element start from specified position

--- a/packages/roosterjs-editor-types/lib/interface/IVTable.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IVTable.ts
@@ -1,0 +1,176 @@
+import ModeIndependentColor from './ModeIndependentColor';
+import TableFormat from './TableFormat';
+import VCell from './VCell';
+import { TableOperation } from '../enum/TableOperation';
+
+/**
+ * A virtual table class, represent an HTML table, by expand all merged cells to each separated cells
+ */
+export default interface IVTable {
+    /**
+     * The HTML table object
+     */
+    table: HTMLTableElement;
+
+    /**
+     * Virtual cells
+     */
+    cells: VCell[][];
+
+    /**
+     * Current row index
+     */
+    row: number;
+
+    /**
+     * Current column index
+     */
+    col: number;
+
+    /**
+     * Start of the  Selection Range
+     */
+    startRange: number[];
+
+    /**
+     * End of the  Selection Range
+     */
+    endRange: number[];
+
+    /**
+     * Write the virtual table back to DOM tree to represent the change of VTable
+     */
+    writeBack(): void;
+
+    /**
+     * Apply the given table format to this virtual table
+     * @param format Table format to apply
+     */
+    applyFormat(format: Partial<TableFormat>): void;
+
+    /**
+     * Edit table with given operation.
+     * @param operation Table operation
+     */
+    edit(operation: TableOperation): void;
+
+    /**
+     * Loop each cell of current column and invoke a callback function
+     * @param callback The callback function to invoke
+     */
+    forEachCellOfCurrentColumn(callback: (cell: VCell, row: VCell[], i: number) => any): void;
+
+    /**
+     * Loop each table cell and get all the cells that share the same border from one side
+     * The result is an array of table cell elements
+     * @param borderPos The position of the border
+     * @param getLeftCells Get left-hand-side or right-hand-side cells of the border
+     *
+     * Example, consider having a 3 by 4 table as below with merged and split cells
+     *
+     *     | 1 | 4 | 7 | 8 |
+     *     |   5   |   9   |
+     *     |   3   |   10  |
+     *
+     *  input => borderPos: the 3rd border, getLeftCells: true
+     *  output => [4, 5, 3]
+     *
+     *  input => borderPos: the 3rd border, getLeftCells: false
+     *  output => [7, 9, 10]
+     *
+     *  input => borderPos: the 2nd border, getLeftCells: true
+     *  output => [1]
+     *
+     *  input => borderPos: the 2nd border, getLeftCells: false
+     *  output => [4]
+     */
+    getCellsWithBorder(borderPos: number, getLeftCells: boolean): HTMLTableCellElement[];
+
+    /**
+     * Loop each cell of current row and invoke a callback function
+     * @param callback The callback function to invoke
+     */
+    forEachCellOfCurrentRow(callback: (cell: VCell, i: number) => any): void;
+
+    /**
+     * Get a table cell using its row and column index. This function will always return an object
+     * even if the given indexes don't exist in table.
+     * @param row The row index
+     * @param col The column index
+     */
+    getCell(row: number, col: number): VCell;
+
+    /**
+     * Get current HTML table cell object. If the current table cell is a virtual expanded cell, return its root cell
+     */
+    getCurrentTd(): HTMLTableCellElement;
+
+    /**
+     * Highlights a range of cells, used in the TableSelection Plugin
+     */
+    highlight(): void;
+
+    /**
+     * Sets the range of selection and highlights
+     * @param start represents the start of the range type of array [x, y]
+     * @param end  represents the end of the range type of array [x, y]
+     */
+    highlightSelection(start: number[], end: number[]): void;
+
+    /**
+     * Highlights all the cells in the table.
+     */
+    highlightAll(): void;
+
+    /**
+     * Removes the selection of all the tables
+     */
+    deSelectAll(): void;
+
+    /**
+     * Executes an action to all the cells within the selection range.
+     * @param callback action to apply on each selected cell
+     * @returns the amount of cells modified
+     */
+    forEachSelectedCell(callback: (cell: VCell) => void): number;
+
+    /**
+     * Execute an action on all the cells
+     * @param callback action to apply on all the cells.
+     */
+    forEachCell(callback: (cell: VCell, x?: number, y?: number) => void): void;
+
+    /**
+     * Remove the cells outside of the selection.
+     * @param outsideOfSelection whether to remove the cells outside or inside of the selection
+     */
+    removeCellsBySelection(outsideOfSelection: boolean): void;
+
+    /**
+     * Gets the coordinates of a cell
+     * @param cellInput The cell the function is going to retrieve the coordinate
+     * @returns an array[2] => [x,y]
+     */
+    getCellCoordinates(cellInput: Node): number[];
+
+    /**
+     * Get the TableCell in a provided coordinate
+     * @param row
+     * @param col
+     */
+    getTd(row: number, col: number): HTMLTableCellElement;
+
+    /**
+     * Sets the background color
+     * @param backgroundColor color
+     * @param isInDarkMode whether is in darkmode
+     */
+    setBackgroundColor(backgroundColor: string | ModeIndependentColor, isInDarkMode: boolean): void;
+
+    /**
+     * Transforms the selected cells to Ranges.
+     * For Each Row a Range with selected cells, a Range is going to be returned.
+     * @returns
+     */
+    getSelectedRanges(): Range[];
+}

--- a/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
+++ b/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
@@ -58,9 +58,15 @@ export interface ISelectionRangeEx {
     ranges: Range[];
 }
 
+/**
+ * Types of Selection Ranges that the SelectionRangeEx can return
+ */
 export const enum SelectionRangeTypes {
     Normal,
     VSelection,
 }
 
+/**
+ * Types of ranges used in editor api getSelectionRangeEx
+ */
 export type SelectionRangeEx = INormalSelectionRange | ITableSelectionRange;

--- a/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
+++ b/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
@@ -1,69 +1,50 @@
+import IVTable from './IVTable';
+
 /**
  * Represents the selection made inside of a table.
  */
-export interface ITableSelectionRange extends ISelectionRangeEx {
-    /**
-     * Selection Type definition
-     */
-    type: SelectionRangeTypes.VSelection;
-
-    /**
-     * Whether the selection is collapsed
-     */
-    isCollapsed: () => boolean;
-
-    /**
-     * Ranges
-     */
-    ranges: Range[];
+export interface ITableSelectionRange
+    extends ISelectionRangeEx<SelectionRangeTypes.TableSelection> {
+    vTable: IVTable;
 }
 
 /**
  * Represents normal selection
  */
-export interface INormalSelectionRange extends ISelectionRangeEx {
-    /**
-     * Selection Type definition
-     */
-    type: SelectionRangeTypes.Normal;
-
-    /**
-     * Whether the selection is collapsed
-     */
-    isCollapsed: () => boolean;
-
-    /**
-     * Ranges
-     */
-    ranges: Range[];
-}
+export interface INormalSelectionRange extends ISelectionRangeEx<SelectionRangeTypes.Normal> {}
 
 /**
  * Represents normal selection
  */
-export interface ISelectionRangeEx {
+export interface ISelectionRangeEx<T> {
     /**
      * Selection Type definition
      */
-    type: SelectionRangeTypes;
-
-    /**
-     * Whether the selection is collapsed
-     */
-    isCollapsed: () => boolean;
+    type: T;
 
     /**
      * Ranges
      */
     ranges: Range[];
+
+    /**
+     * Whether all the ranges are collapsed
+     */
+    areAllCollapsed: boolean;
 }
 
 /**
  * Types of Selection Ranges that the SelectionRangeEx can return
  */
-export enum SelectionRangeTypes {
+export const enum SelectionRangeTypes {
+    /**
+     * Normal selection range provided by browser.
+     */
     Normal,
-    VSelection,
+    /**
+     * Selection made inside of a single table.
+     */
+    TableSelection,
 }
 
 /**

--- a/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
+++ b/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
@@ -1,0 +1,66 @@
+/**
+ * Represents the selection made inside of a table.
+ */
+export interface ITableSelectionRange extends ISelectionRangeEx {
+    /**
+     * Selection Type definition
+     */
+    type: SelectionRangeTypes.VSelection;
+
+    /**
+     * Whether the selection is collapsed
+     */
+    isCollapsed: () => boolean;
+
+    /**
+     * Ranges
+     */
+    ranges: Range[];
+}
+
+/**
+ * Represents normal selection
+ */
+export interface INormalSelectionRange extends ISelectionRangeEx {
+    /**
+     * Selection Type definition
+     */
+    type: SelectionRangeTypes.Normal;
+
+    /**
+     * Whether the selection is collapsed
+     */
+    isCollapsed: () => boolean;
+
+    /**
+     * Ranges
+     */
+    ranges: Range[];
+}
+
+/**
+ * Represents normal selection
+ */
+export interface ISelectionRangeEx {
+    /**
+     * Selection Type definition
+     */
+    type: SelectionRangeTypes;
+
+    /**
+     * Whether the selection is collapsed
+     */
+    isCollapsed: () => boolean;
+
+    /**
+     * Ranges
+     */
+    ranges: Range[];
+}
+
+export const enum SelectionRangeTypes {
+    Normal,
+    VSelection,
+}
+
+export type SelectionRangeEx = INormalSelectionRange | ITableSelectionRange;

--- a/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
+++ b/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
@@ -61,7 +61,7 @@ export interface ISelectionRangeEx {
 /**
  * Types of Selection Ranges that the SelectionRangeEx can return
  */
-export const enum SelectionRangeTypes {
+export enum SelectionRangeTypes {
     Normal,
     VSelection,
 }


### PR DESCRIPTION
Add a Editor APi for getSelectionRangeEx, so we can use this api to use different type of ranges.

At the moment, only have 2 types of selections Normal, using the selection of the window, and Table selection.

Also added an example with the inlineStyle to apply the formating to the changes independently of the type of selection range returned from  getSelectionRangeEx.