### PR TITLE
8.15.0 Fix table resize bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "8.14.1",
+    "version": "8.15.0",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "8.14.0",
+    "version": "8.14.1",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-dom/lib/utils/changeElementTag.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/changeElementTag.ts
@@ -26,6 +26,13 @@ export default function changeElementTag(element: HTMLElement, newTag: string): 
         return null;
     }
 
+    const origianlTag = getTagOfNode(element);
+
+    if (origianlTag == newTag.toUpperCase()) {
+        // Already in the target tag, no need to change
+        return element;
+    }
+
     let newElement = element.ownerDocument.createElement(newTag);
 
     for (let i = 0; i < element.attributes.length; i++) {
@@ -35,7 +42,7 @@ export default function changeElementTag(element: HTMLElement, newTag: string): 
 
     moveChildNodes(newElement, element);
 
-    if (getTagOfNode(element) == 'P' || getTagOfNode(newElement) == 'P') {
+    if (origianlTag == 'P' || getTagOfNode(newElement) == 'P') {
         [newElement.style.marginTop, newElement.style.marginBottom] = getComputedStyles(element, [
             'margin-top',
             'margin-bottom',

--- a/packages/roosterjs-editor-dom/test/utils/changeElementTagTest.ts
+++ b/packages/roosterjs-editor-dom/test/utils/changeElementTagTest.ts
@@ -45,4 +45,10 @@ describe('changeElementTag()', () => {
             '<p style="margin: 0 2px 2px 0"></p>'
         );
     });
+
+    it('changeElementTag to same tag', () => {
+        const node = document.createElement('div');
+        const newNode = changeElementTag(node, 'div');
+        expect(newNode).toBe(node);
+    });
 });


### PR DESCRIPTION
Due to a conflict with table format feature, table cell is not working now. Fix it by preserving the same node when changeElementTag to the same tag name