### PR TITLE
Fix for scroll issue in the table resize plugin

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -61,7 +61,8 @@ export default class TableResize implements EditorPlugin {
         }
 
         this.ensureTableRects();
-        const { pageX: x, pageY: y } = e;
+        const x = e.pageX - window.scrollX;
+        const y = e.pageY - window.scrollY;
         let currentTable: HTMLTableElement | null = null;
 
         for (let i = this.tableRectMap.length - 1; i >= 0; i--) {

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -61,8 +61,10 @@ export default class TableResize implements EditorPlugin {
         }
 
         this.ensureTableRects();
-        const x = e.pageX - window.scrollX;
-        const y = e.pageY - window.scrollY;
+
+        const editorWindow = this.editor.getDocument().defaultView;
+        const x = e.pageX - editorWindow.scrollX;
+        const y = e.pageY - editorWindow.scrollY;
         let currentTable: HTMLTableElement | null = null;
 
         for (let i = this.tableRectMap.length - 1; i >= 0; i--) {


### PR DESCRIPTION
If the editor is in a scrollable container and you start scrolling the TableResize plugin breaks.

The error can be reproduced by adding min-height to the .mainPane container on the demo page and setting it to a value at which the scrollbar appears. If you then add a table and scroll down a bit the resize function is broken.
The reason seems to be that in the onMouseMove event the cursor coordinates are directly compared with the table rect coordinates. But the cursor coordinates are the absolute position on the page and the table rect coordinates are relative to the browser window. So subtracting the scroll position from the cursor coordinates should fix the issue.

I was able to reproduce the issue and also test the fix in Firefox, Chrome und Edge.