### PR TITLE
Enable strict mode for event and clipboard

### DIFF
--- a/packages/roosterjs-editor-dom/lib/clipboard/extractClipboardEvent.ts
+++ b/packages/roosterjs-editor-dom/lib/clipboard/extractClipboardEvent.ts
@@ -28,7 +28,7 @@ export default function extractClipboardEvent(
 ) {
     const dataTransfer =
         event.clipboardData ||
-        (<WindowForIE>(<unknown>(<Node>event.target).ownerDocument.defaultView)).clipboardData;
+        (<WindowForIE>(<unknown>(<Node>event.target).ownerDocument?.defaultView)).clipboardData;
 
     if (dataTransfer.items) {
         event.preventDefault();

--- a/packages/roosterjs-editor-dom/lib/clipboard/extractClipboardItemsForIE.ts
+++ b/packages/roosterjs-editor-dom/lib/clipboard/extractClipboardItemsForIE.ts
@@ -21,7 +21,7 @@ import {
 export default function extractClipboardItemsForIE(
     dataTransfer: DataTransfer,
     callback: (data: ClipboardData) => void,
-    options: ExtractClipboardItemsForIEOptions
+    options?: ExtractClipboardItemsForIEOptions
 ) {
     const clipboardData: ClipboardData = {
         types: dataTransfer.types ? toArray(dataTransfer.types) : [],
@@ -33,7 +33,7 @@ export default function extractClipboardItemsForIE(
 
     for (let i = 0; i < (dataTransfer.files ? dataTransfer.files.length : 0); i++) {
         let file = dataTransfer.files.item(i);
-        if (file.type?.indexOf(ContentTypePrefix.Image) == 0) {
+        if (file?.type?.indexOf(ContentTypePrefix.Image) == 0) {
             clipboardData.image = file;
             break;
         }
@@ -55,9 +55,9 @@ export default function extractClipboardItemsForIE(
         div.contentEditable = 'true';
         div.innerHTML = '';
         div.focus();
-        div.ownerDocument.defaultView.setTimeout(() => {
+        div.ownerDocument?.defaultView?.setTimeout(() => {
             clipboardData.rawHtml = div.innerHTML;
-            options.removeTempDiv(div);
+            options.removeTempDiv?.(div);
             nextStep();
         }, 0);
     } else {

--- a/packages/roosterjs-editor-dom/lib/clipboard/tsconfig.child.json
+++ b/packages/roosterjs-editor-dom/lib/clipboard/tsconfig.child.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "strict": false
+        "strict": true
     },
     "extends": "../../../tsconfig.json",
     "include": ["./**/*.ts"],

--- a/packages/roosterjs-editor-dom/lib/event/isCharacterValue.ts
+++ b/packages/roosterjs-editor-dom/lib/event/isCharacterValue.ts
@@ -8,5 +8,5 @@ import isModifierKey from './isModifierKey';
  * @param event The keyboard event object
  */
 export default function isCharacterValue(event: KeyboardEvent): boolean {
-    return !isModifierKey(event) && event.key && event.key.length == 1;
+    return !isModifierKey(event) && !!event.key && event.key.length == 1;
 }

--- a/packages/roosterjs-editor-dom/lib/event/tsconfig.child.json
+++ b/packages/roosterjs-editor-dom/lib/event/tsconfig.child.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "strict": false
+        "strict": true
     },
     "extends": "../../../tsconfig.json",
     "include": ["./**/*.ts"],

--- a/packages/roosterjs-editor-types/lib/interface/ClipboardData.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ClipboardData.ts
@@ -19,7 +19,7 @@ export default interface ClipboardData {
      * When set to null, it means there's no HTML from clipboard event.
      * When set to undefined, it means there may be HTML in clipboard event, but fail to retrieve
      */
-    rawHtml: string;
+    rawHtml: string | null | undefined;
 
     /**
      * Link Preview information provided by Edge
@@ -29,7 +29,7 @@ export default interface ClipboardData {
     /**
      * Image file from clipboard event
      */
-    image: File;
+    image: File | null;
 
     /**
      * Html extracted from raw html string and remove content before and after fragment tag
@@ -44,7 +44,7 @@ export default interface ClipboardData {
     /**
      * BASE64 encoded data uri of the image if any
      */
-    imageDataUri?: string;
+    imageDataUri?: string | null;
 
     /**
      * Array of tag names of the first level child nodes


### PR DESCRIPTION
Enable strict mode for 
roosterjs-editor-dom/lib/event
roosterjs-editor-dom/lib/clipboard