### PR TITLE
Fix bug in shadowEditTableSelection

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreApi/getSelectionRangeEx.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getSelectionRangeEx.ts
@@ -17,7 +17,7 @@ export const getSelectionRangeEx: GetSelectionRangeEx = (core: EditorCore) => {
     if (core.lifecycle.shadowEditFragment) {
         const { shadowEditTableSelectionPath, shadowEditSelectionPath } = core.lifecycle;
 
-        if (shadowEditTableSelectionPath) {
+        if (shadowEditTableSelectionPath?.length > 0) {
             const ranges = core.lifecycle.shadowEditTableSelectionPath.map(path =>
                 createRange(core.contentDiv, path.start, path.end)
             );
@@ -33,17 +33,17 @@ export const getSelectionRangeEx: GetSelectionRangeEx = (core: EditorCore) => {
                 ) as HTMLTableElement,
                 coordinates: null,
             };
+        } else {
+            const shadowRange =
+                shadowEditSelectionPath &&
+                createRange(
+                    core.contentDiv,
+                    shadowEditSelectionPath.start,
+                    shadowEditSelectionPath.end
+                );
+
+            return createNormalSelectionEx([shadowRange]);
         }
-
-        const shadowRange =
-            shadowEditSelectionPath &&
-            createRange(
-                core.contentDiv,
-                shadowEditSelectionPath.start,
-                shadowEditSelectionPath.end
-            );
-
-        return createNormalSelectionEx([shadowRange]);
     } else {
         if (core.api.hasFocus(core)) {
             if (core.domEvent.tableSelectionRange) {
@@ -61,7 +61,9 @@ export const getSelectionRangeEx: GetSelectionRangeEx = (core: EditorCore) => {
 
         return (
             core.domEvent.tableSelectionRange ??
-            createNormalSelectionEx([core.domEvent.selectionRange])
+            createNormalSelectionEx(
+                core.domEvent.selectionRange ? [core.domEvent.selectionRange] : []
+            )
         );
     }
 };

--- a/packages/roosterjs-editor-core/lib/coreApi/getSelectionRangeEx.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getSelectionRangeEx.ts
@@ -42,7 +42,7 @@ export const getSelectionRangeEx: GetSelectionRangeEx = (core: EditorCore) => {
                     shadowEditSelectionPath.end
                 );
 
-            return createNormalSelectionEx([shadowRange]);
+            return createNormalSelectionEx(shadowRange ? [shadowRange] : []);
         }
     } else {
         if (core.api.hasFocus(core)) {

--- a/packages/roosterjs-editor-core/test/coreApi/getSelectionRangeExTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/getSelectionRangeExTest.ts
@@ -21,7 +21,7 @@ describe('getSelectionRangeEx', () => {
         document.body.appendChild(input);
         input.focus();
         const selection = getSelectionRangeEx(core);
-        expect(selection.ranges[0]).toBeNull();
+        expect(selection.ranges.length).toBe(0);
         document.body.removeChild(input);
     });
 


### PR DESCRIPTION
When editor hasn't got focus, there is no range. So when we call getSelectionRangeEx(), we should return empty array but not an array with null element.