### PR TITLE
Fix Cut failed on Android since we collapse selection range before deleteSelectedContent #797

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
@@ -99,7 +99,7 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
             });
 
             this.editor.runAsync(editor => {
-                this.cleanUpAndRestoreSelection(tempDiv, originalRange);
+                this.cleanUpAndRestoreSelection(tempDiv, originalRange, !isCut /* isCopy */);
 
                 if (isCut) {
                     editor.addUndoSnapshot(() => {
@@ -128,7 +128,7 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
                     return this.getTempDiv();
                 },
                 removeTempDiv: div => {
-                    this.cleanUpAndRestoreSelection(div, range);
+                    this.cleanUpAndRestoreSelection(div, range, false /* isCopy */);
                 },
             }
         );
@@ -162,8 +162,8 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
         return div;
     }
 
-    private cleanUpAndRestoreSelection(tempDiv: HTMLDivElement, range: Range) {
-        if (Browser.isAndroid) {
+    private cleanUpAndRestoreSelection(tempDiv: HTMLDivElement, range: Range, isCopy: boolean) {
+        if (isCopy && Browser.isAndroid) {
             range.collapse();
         }
 


### PR DESCRIPTION
Cut operation is no longer working on Android. Its behavior becomes the same as copy. Selected range will not be deleted, even though it will still be coped to clipboard.

For more details: #797

Before:
![797 b](https://user-images.githubusercontent.com/8291124/157273361-4b3673eb-0bef-4242-a248-7802ae57c235.gif)

After:
![797 a](https://user-images.githubusercontent.com/8291124/157273391-6e3bd3a7-dcce-4849-a37f-ca6faa367ecd.gif)

