### PR TITLE
Bump version to 8.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "8.17.0",
+    "version": "8.18.0",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages-ui/roosterjs-react/package.json
+++ b/packages-ui/roosterjs-react/package.json
@@ -14,6 +14,5 @@
         "react-dom": ">=16.0.0",
         "@fluentui/react": ">=8.0.0"
     },
-    "main": "./lib/index.ts",
-    "version": "0.0.0"
+    "main": "./lib/index.ts"
 }


### PR DESCRIPTION
- Bump roosterjs to 8.18.0
- Start to publish roosterjs-react