### PR TITLE
Dark and undo step 1: Improve color transformation

### DIFF
--- a/packages/roosterjs-editor-api/lib/table/editTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/editTable.ts
@@ -9,13 +9,12 @@ import { VTable } from 'roosterjs-editor-dom';
 export default function editTable(editor: IEditor, operation: TableOperation) {
     let td = editor.getElementAtCursor('TD,TH') as HTMLTableCellElement;
     if (td) {
-        editor.addUndoSnapshot((start, end) => {
+        editor.addUndoSnapshot(() => {
             let vtable = new VTable(td);
             vtable.edit(operation);
             vtable.writeBack();
 
-            //Adding replaceNode to transform color when the theme is switched to dark.
-            editor.replaceNode(vtable.table, vtable.table, true /**transformColorForDarkMode*/);
+            editor.transformToDarkColor(vtable.table);
             editor.focus();
             let cellToSelect = calculateCellToSelect(operation, vtable.row, vtable.col);
             editor.select(

--- a/packages/roosterjs-editor-api/lib/table/formatTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/formatTable.ts
@@ -19,9 +19,7 @@ export default function formatTable(
             vtable.applyFormat(format);
             vtable.writeBack();
 
-            //Adding replaceNode to transform color when the theme is switched to dark.
-            editor.replaceNode(vtable.table, vtable.table, true /**transformColorForDarkMode*/);
-
+            editor.transformToDarkColor(vtable.table);
             editor.focus();
             editor.select(start, end);
         }, ChangeSource.Format);

--- a/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
@@ -1,4 +1,4 @@
-import { arrayPush, getComputedStyles, safeInstanceOf, toArray } from 'roosterjs-editor-dom';
+import { arrayPush, safeInstanceOf, toArray } from 'roosterjs-editor-dom';
 import {
     ColorTransformDirection,
     DarkModeDatasetNames,
@@ -36,73 +36,91 @@ const ColorAttributeName: { [key in ColorAttributeEnum]: string }[] = [
  * @param includeSelf True to transform the root node as well, otherwise false
  * @param callback The callback function to invoke before do color transformation
  * @param direction To specify the transform direction, light to dark, or dark to light
+ * @param forceTransform By default this function will only work when editor core is in dark mode.
+ * Pass true to this value to force do color transformation even editor core is in light mode
  */
 export const transformColor: TransformColor = (
     core: EditorCore,
     rootNode: Node,
     includeSelf: boolean,
     callback: () => void,
-    direction: ColorTransformDirection
+    direction: ColorTransformDirection,
+    forceTransform?: boolean
 ) => {
-    const elementsToTransform = core.lifecycle.isDarkMode ? getAll(rootNode, includeSelf) : [];
-    const transformFunction =
-        direction == ColorTransformDirection.DarkToLight
-            ? transformToLightMode
-            : core.lifecycle.onExternalContentTransform ||
-              ((element: HTMLElement) => transformToDarkMode(element, core.lifecycle.getDarkColor));
+    const elements =
+        forceTransform || core.lifecycle.isDarkMode ? getAll(rootNode, includeSelf) : [];
 
     callback?.();
 
-    elementsToTransform.forEach(
-        element => element?.dataset && element.style && transformFunction(element)
-    );
+    if (direction == ColorTransformDirection.DarkToLight) {
+        transformToLightMode(elements);
+    } else if (core.lifecycle.onExternalContentTransform) {
+        elements.forEach(element => core.lifecycle.onExternalContentTransform(element));
+    } else {
+        transformToDarkMode(elements, core.lifecycle.getDarkColor);
+    }
 };
 
-function transformToLightMode(element: HTMLElement) {
-    ColorAttributeName.forEach(names => {
-        // Reset color styles based on the content of the ogsc/ogsb data element.
-        // If those data properties are empty or do not exist, set them anyway to clear the content.
-        element.style.setProperty(
-            names[ColorAttributeEnum.CssColor],
-            getValueOrDefault(element.dataset[names[ColorAttributeEnum.CssDataSet]], '')
-        );
-        delete element.dataset[names[ColorAttributeEnum.CssDataSet]];
+function transformToLightMode(elements: HTMLElement[]) {
+    elements.forEach(element => {
+        ColorAttributeName.forEach(names => {
+            // Reset color styles based on the content of the ogsc/ogsb data element.
+            // If those data properties are empty or do not exist, set them anyway to clear the content.
+            element.style.setProperty(
+                names[ColorAttributeEnum.CssColor],
+                getValueOrDefault(element.dataset[names[ColorAttributeEnum.CssDataSet]], '')
+            );
+            delete element.dataset[names[ColorAttributeEnum.CssDataSet]];
 
-        // Some elements might have set attribute colors. We need to reset these as well.
-        const value = element.dataset[names[ColorAttributeEnum.HtmlDataSet]];
+            // Some elements might have set attribute colors. We need to reset these as well.
+            const value = element.dataset[names[ColorAttributeEnum.HtmlDataSet]];
 
-        if (getValueOrDefault(value, null)) {
-            element.setAttribute(names[ColorAttributeEnum.HtmlColor], value);
-        } else {
-            element.removeAttribute(names[ColorAttributeEnum.HtmlColor]);
-        }
+            if (getValueOrDefault(value, null)) {
+                element.setAttribute(names[ColorAttributeEnum.HtmlColor], value);
+            } else {
+                element.removeAttribute(names[ColorAttributeEnum.HtmlColor]);
+            }
 
-        delete element.dataset[names[ColorAttributeEnum.HtmlDataSet]];
+            delete element.dataset[names[ColorAttributeEnum.HtmlDataSet]];
+        });
     });
 }
 
-function transformToDarkMode(element: HTMLElement, getDarkColor: (color: string) => string) {
-    const computedValues = getComputedStyles(element, ['color', 'background-color']);
+function transformToDarkMode(elements: HTMLElement[], getDarkColor: (color: string) => string) {
+    ColorAttributeName.forEach(names => {
+        elements
+            .map(element => {
+                const styleColor = element.style.getPropertyValue(
+                    names[ColorAttributeEnum.CssColor]
+                );
+                const attrColor = element.getAttribute(names[ColorAttributeEnum.HtmlColor]);
 
-    ColorAttributeName.forEach((names, index) => {
-        const styleColor = element.style.getPropertyValue(names[ColorAttributeEnum.CssColor]);
-        const attrColor = element.getAttribute(names[ColorAttributeEnum.HtmlColor]);
+                return !element.dataset[names[ColorAttributeEnum.CssDataSet]] &&
+                    !element.dataset[names[ColorAttributeEnum.HtmlDataSet]] &&
+                    (styleColor || attrColor) &&
+                    styleColor != 'inherit' // For inherit style, no need to change it and let it keep inherit from parent element
+                    ? {
+                          element,
+                          styleColor,
+                          attrColor,
+                          newColor: getDarkColor(styleColor || attrColor),
+                      }
+                    : null;
+            })
+            .filter(x => !!x)
+            .forEach(({ element, styleColor, attrColor, newColor }) => {
+                element.style.setProperty(
+                    names[ColorAttributeEnum.CssColor],
+                    newColor,
+                    'important'
+                );
+                element.dataset[names[ColorAttributeEnum.CssDataSet]] = styleColor || '';
 
-        if (
-            !element.dataset[names[ColorAttributeEnum.CssDataSet]] &&
-            !element.dataset[names[ColorAttributeEnum.HtmlDataSet]] &&
-            (styleColor || attrColor) &&
-            styleColor != 'inherit' // For inherit style, no need to change it and let it keep inherit from parent element
-        ) {
-            const newColor = getDarkColor(computedValues[index] || styleColor || attrColor);
-            element.style.setProperty(names[ColorAttributeEnum.CssColor], newColor, 'important');
-            element.dataset[names[ColorAttributeEnum.CssDataSet]] = styleColor || '';
-
-            if (attrColor) {
-                element.setAttribute(names[ColorAttributeEnum.HtmlColor], newColor);
-                element.dataset[names[ColorAttributeEnum.HtmlDataSet]] = attrColor;
-            }
-        }
+                if (attrColor) {
+                    element.setAttribute(names[ColorAttributeEnum.HtmlColor], newColor);
+                    element.dataset[names[ColorAttributeEnum.HtmlDataSet]] = attrColor;
+                }
+            });
     });
 }
 
@@ -124,5 +142,13 @@ function getAll(rootNode: Node, includeSelf: boolean): HTMLElement[] {
         arrayPush(result, toArray(allChildren));
     }
 
-    return result;
+    return result.filter(isHTMLElement);
+}
+
+// This is not a strict check, we just need to make sure this element has style so that we can set style to it
+// We don't use safeInstanceOf() here since this function will be called very frequently when extract html content
+// in dark mode, so we need to make sure this check is fast enough
+function isHTMLElement(element: Element): element is HTMLElement {
+    const htmlElement = <HTMLElement>element;
+    return !!htmlElement.style && !!htmlElement.dataset;
 }

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -814,16 +814,24 @@ export default class Editor implements IEditor {
      * @param nextDarkMode The next status of dark mode. True if the editor should be in dark mode, false if not.
      */
     public setDarkModeState(nextDarkMode?: boolean) {
-        if (this.isDarkMode() == nextDarkMode) {
+        if (this.isDarkMode() == !!nextDarkMode) {
             return;
         }
 
-        const currentContent = this.getContent(GetContentMode.CleanHTML);
+        this.core.api.transformColor(
+            this.core,
+            this.core.contentDiv,
+            false /*includeSelf*/,
+            null /*callback*/,
+            nextDarkMode
+                ? ColorTransformDirection.LightToDark
+                : ColorTransformDirection.DarkToLight,
+            true /*forceTransform*/
+        );
 
         this.triggerContentChangedEvent(
             nextDarkMode ? ChangeSource.SwitchToDarkMode : ChangeSource.SwitchToLightMode
         );
-        this.setContent(currentContent);
     }
 
     /**
@@ -832,6 +840,20 @@ export default class Editor implements IEditor {
      */
     public isDarkMode(): boolean {
         return this.core.lifecycle.isDarkMode;
+    }
+
+    /**
+     * Transform the given node and all its child nodes to dark mode color if editor is in dark mode
+     * @param node The node to transform
+     */
+    public transformToDarkColor(node: Node) {
+        this.core.api.transformColor(
+            this.core,
+            node,
+            true /*includeSelf*/,
+            null /*callback*/,
+            ColorTransformDirection.LightToDark
+        );
     }
 
     /**

--- a/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
@@ -30,6 +30,14 @@ describe('transformColor Dark to light', () => {
         expect(element.outerHTML).toBe('<div data-ogsc="#123456"></div>');
     });
 
+    it('light mode still need to transform when force transform', () => {
+        const core = createEditorCore(div, { inDarkMode: false });
+        const element = document.createElement('div');
+        element.dataset.ogsc = '#123456';
+        transformColor(core, element, true, null, ColorTransformDirection.DarkToLight, true);
+        expect(element.outerHTML).toBe('<div style="color: rgb(18, 52, 86);"></div>');
+    });
+
     it('callback must be called', () => {
         const core = createEditorCore(div, { inDarkMode: false });
         const callback = jasmine.createSpy('callback');
@@ -162,6 +170,16 @@ describe('transformColor Light to dark', () => {
         element.style.color = 'rgb(18, 52, 86)';
         transformColor(core, element, true, null, ColorTransformDirection.LightToDark);
         expect(element.outerHTML).toBe('<div style="color: rgb(18, 52, 86);"></div>');
+    });
+
+    it('light mode still need to transform when force transform', () => {
+        const core = createEditorCore(div, { inDarkMode: false });
+        const element = document.createElement('div');
+        element.style.color = 'rgb(18, 52, 86)';
+        transformColor(core, element, true, null, ColorTransformDirection.LightToDark, true);
+        expect(element.outerHTML).toBe(
+            '<div style="color: rgb(18, 52, 86) !important;" data-ogsc="rgb(18, 52, 86)"></div>'
+        );
     });
 
     it('single element, no transform function', () => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -242,7 +242,8 @@ export default class TableEditor {
         this.editor.addUndoSnapshot();
     }
 
-    private onInserted = () => {
+    private onInserted = (table: HTMLTableElement) => {
+        this.editor.transformToDarkColor(table);
         this.disposeTableResizer();
         this.onFinishEditing();
     };

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
@@ -16,7 +16,7 @@ export default function createTableInserter(
     td: HTMLTableCellElement,
     isRTL: boolean,
     isHorizontal: boolean,
-    onInsert: () => void
+    onInsert: (table: HTMLTableElement) => void
 ): TableEditFeature {
     const table = editor.getElementAtCursor('table', td);
     const tdRect = normalizeRect(td.getBoundingClientRect());
@@ -65,7 +65,7 @@ class TableInsertHandler implements Disposable {
         private td: HTMLTableCellElement,
         private isHorizontal: boolean,
         private editor: IEditor,
-        private onInsert: () => void
+        private onInsert: (table: HTMLTableElement) => void
     ) {
         this.div.addEventListener('click', this.insertTd);
     }
@@ -88,10 +88,8 @@ class TableInsertHandler implements Disposable {
 
         vtable.edit(this.isHorizontal ? TableOperation.InsertBelow : TableOperation.InsertRight);
         vtable.writeBack();
-        //Adding replaceNode to transform color when the theme is switched to dark.
-        this.editor.replaceNode(vtable.table, vtable.table, true /**transformColorForDarkMode*/);
 
-        this.onInsert();
+        this.onInsert(vtable.table);
     };
 }
 

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -213,13 +213,16 @@ export type SwitchShadowEdit = (core: EditorCore, isOn: boolean) => void;
  * @param includeSelf True to transform the root node as well, otherwise false
  * @param callback The callback function to invoke before do color transformation
  * @param direction To specify the transform direction, light to dark, or dark to light
+ * @param forceTransform By default this function will only work when editor core is in dark mode.
+ * Pass true to this value to force do color transformation even editor core is in light mode
  */
 export type TransformColor = (
     core: EditorCore,
     rootNode: Node,
     includeSelf: boolean,
     callback: () => void,
-    direction: ColorTransformDirection
+    direction: ColorTransformDirection,
+    forceTransform?: boolean
 ) => void;
 
 /**
@@ -386,6 +389,8 @@ export interface CoreApiMap {
      * @param includeSelf True to transform the root node as well, otherwise false
      * @param callback The callback function to invoke before do color transformation
      * @param direction To specify the transform direction, light to dark, or dark to light
+     * @param forceTransform By default this function will only work when editor core is in dark mode.
+     * Pass true to this value to force do color transformation even editor core is in light mode
      */
     transformColor: TransformColor;
 

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -548,6 +548,12 @@ export default interface IEditor {
     isDarkMode(): boolean;
 
     /**
+     * Transform the given node and all its child nodes to dark mode color if editor is in dark mode
+     * @param node The node to transform
+     */
+    transformToDarkColor(node: Node): void;
+
+    /**
      * Make the editor in "Shadow Edit" mode.
      * In Shadow Edit mode, all format change will finally be ignored.
      * This can be used for building a live preview feature for format button, to allow user


### PR DESCRIPTION
1. To fix #838 , read colors at once when do color transform, then write back together for all elements
2. To fix #835 , add new API IEditor.transformToDarkColor() to allow trigger color transformation outside editor
3. Fix existing usage of editor.replaceNode() with transformToDarkColor.