### PR TITLE
Dark and undo step 4: Switch UndoPlugin to use Snapshot and ContentMetadata

### DIFF
--- a/demo/scripts/utils/trustedHTMLHandler.ts
+++ b/demo/scripts/utils/trustedHTMLHandler.ts
@@ -2,7 +2,7 @@ import * as DOMPurify from 'dompurify';
 
 export function trustedHTMLHandler(html: string): string {
     const result = DOMPurify.sanitize(html, {
-        ADD_TAGS: ['head', 'meta'],
+        ADD_TAGS: ['head', 'meta', '#comment'],
         ADD_ATTR: ['name', 'content'],
         WHOLE_DOCUMENT: true,
         RETURN_TRUSTED_TYPE: true,

--- a/packages/roosterjs-editor-api/lib/table/editTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/editTable.ts
@@ -9,13 +9,12 @@ import { VTable } from 'roosterjs-editor-dom';
 export default function editTable(editor: IEditor, operation: TableOperation) {
     let td = editor.getElementAtCursor('TD,TH') as HTMLTableCellElement;
     if (td) {
-        editor.addUndoSnapshot((start, end) => {
+        editor.addUndoSnapshot(() => {
             let vtable = new VTable(td);
             vtable.edit(operation);
             vtable.writeBack();
 
-            //Adding replaceNode to transform color when the theme is switched to dark.
-            editor.replaceNode(vtable.table, vtable.table, true /**transformColorForDarkMode*/);
+            editor.transformToDarkColor(vtable.table);
             editor.focus();
             let cellToSelect = calculateCellToSelect(operation, vtable.row, vtable.col);
             editor.select(

--- a/packages/roosterjs-editor-api/lib/table/formatTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/formatTable.ts
@@ -19,9 +19,7 @@ export default function formatTable(
             vtable.applyFormat(format);
             vtable.writeBack();
 
-            //Adding replaceNode to transform color when the theme is switched to dark.
-            editor.replaceNode(vtable.table, vtable.table, true /**transformColorForDarkMode*/);
-
+            editor.transformToDarkColor(vtable.table);
             editor.focus();
             editor.select(start, end);
         }, ChangeSource.Format);

--- a/packages/roosterjs-editor-core/lib/coreApi/restoreUndoSnapshot.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/restoreUndoSnapshot.ts
@@ -18,10 +18,15 @@ export const restoreUndoSnapshot: RestoreUndoSnapshot = (core: EditorCore, step:
 
     const snapshot = core.undo.snapshotsService.move(step);
 
-    if (snapshot != null) {
+    if (snapshot && snapshot.html != null) {
         try {
             core.undo.isRestoring = true;
-            core.api.setContent(core, snapshot, true /*triggerContentChangedEvent*/);
+            core.api.setContent(
+                core,
+                snapshot.html,
+                true /*triggerContentChangedEvent*/,
+                snapshot.metadata
+            );
         } finally {
             core.undo.isRestoring = false;
         }

--- a/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
@@ -1,4 +1,4 @@
-import { arrayPush, getComputedStyles, safeInstanceOf, toArray } from 'roosterjs-editor-dom';
+import { arrayPush, safeInstanceOf, toArray } from 'roosterjs-editor-dom';
 import {
     ColorTransformDirection,
     DarkModeDatasetNames,
@@ -36,73 +36,91 @@ const ColorAttributeName: { [key in ColorAttributeEnum]: string }[] = [
  * @param includeSelf True to transform the root node as well, otherwise false
  * @param callback The callback function to invoke before do color transformation
  * @param direction To specify the transform direction, light to dark, or dark to light
+ * @param forceTransform By default this function will only work when editor core is in dark mode.
+ * Pass true to this value to force do color transformation even editor core is in light mode
  */
 export const transformColor: TransformColor = (
     core: EditorCore,
     rootNode: Node,
     includeSelf: boolean,
     callback: () => void,
-    direction: ColorTransformDirection
+    direction: ColorTransformDirection,
+    forceTransform?: boolean
 ) => {
-    const elementsToTransform = core.lifecycle.isDarkMode ? getAll(rootNode, includeSelf) : [];
-    const transformFunction =
-        direction == ColorTransformDirection.DarkToLight
-            ? transformToLightMode
-            : core.lifecycle.onExternalContentTransform ||
-              ((element: HTMLElement) => transformToDarkMode(element, core.lifecycle.getDarkColor));
+    const elements =
+        forceTransform || core.lifecycle.isDarkMode ? getAll(rootNode, includeSelf) : [];
 
     callback?.();
 
-    elementsToTransform.forEach(
-        element => element?.dataset && element.style && transformFunction(element)
-    );
+    if (direction == ColorTransformDirection.DarkToLight) {
+        transformToLightMode(elements);
+    } else if (core.lifecycle.onExternalContentTransform) {
+        elements.forEach(element => core.lifecycle.onExternalContentTransform(element));
+    } else {
+        transformToDarkMode(elements, core.lifecycle.getDarkColor);
+    }
 };
 
-function transformToLightMode(element: HTMLElement) {
-    ColorAttributeName.forEach(names => {
-        // Reset color styles based on the content of the ogsc/ogsb data element.
-        // If those data properties are empty or do not exist, set them anyway to clear the content.
-        element.style.setProperty(
-            names[ColorAttributeEnum.CssColor],
-            getValueOrDefault(element.dataset[names[ColorAttributeEnum.CssDataSet]], '')
-        );
-        delete element.dataset[names[ColorAttributeEnum.CssDataSet]];
+function transformToLightMode(elements: HTMLElement[]) {
+    elements.forEach(element => {
+        ColorAttributeName.forEach(names => {
+            // Reset color styles based on the content of the ogsc/ogsb data element.
+            // If those data properties are empty or do not exist, set them anyway to clear the content.
+            element.style.setProperty(
+                names[ColorAttributeEnum.CssColor],
+                getValueOrDefault(element.dataset[names[ColorAttributeEnum.CssDataSet]], '')
+            );
+            delete element.dataset[names[ColorAttributeEnum.CssDataSet]];
 
-        // Some elements might have set attribute colors. We need to reset these as well.
-        const value = element.dataset[names[ColorAttributeEnum.HtmlDataSet]];
+            // Some elements might have set attribute colors. We need to reset these as well.
+            const value = element.dataset[names[ColorAttributeEnum.HtmlDataSet]];
 
-        if (getValueOrDefault(value, null)) {
-            element.setAttribute(names[ColorAttributeEnum.HtmlColor], value);
-        } else {
-            element.removeAttribute(names[ColorAttributeEnum.HtmlColor]);
-        }
+            if (getValueOrDefault(value, null)) {
+                element.setAttribute(names[ColorAttributeEnum.HtmlColor], value);
+            } else {
+                element.removeAttribute(names[ColorAttributeEnum.HtmlColor]);
+            }
 
-        delete element.dataset[names[ColorAttributeEnum.HtmlDataSet]];
+            delete element.dataset[names[ColorAttributeEnum.HtmlDataSet]];
+        });
     });
 }
 
-function transformToDarkMode(element: HTMLElement, getDarkColor: (color: string) => string) {
-    const computedValues = getComputedStyles(element, ['color', 'background-color']);
+function transformToDarkMode(elements: HTMLElement[], getDarkColor: (color: string) => string) {
+    ColorAttributeName.forEach(names => {
+        elements
+            .map(element => {
+                const styleColor = element.style.getPropertyValue(
+                    names[ColorAttributeEnum.CssColor]
+                );
+                const attrColor = element.getAttribute(names[ColorAttributeEnum.HtmlColor]);
 
-    ColorAttributeName.forEach((names, index) => {
-        const styleColor = element.style.getPropertyValue(names[ColorAttributeEnum.CssColor]);
-        const attrColor = element.getAttribute(names[ColorAttributeEnum.HtmlColor]);
+                return !element.dataset[names[ColorAttributeEnum.CssDataSet]] &&
+                    !element.dataset[names[ColorAttributeEnum.HtmlDataSet]] &&
+                    (styleColor || attrColor) &&
+                    styleColor != 'inherit' // For inherit style, no need to change it and let it keep inherit from parent element
+                    ? {
+                          element,
+                          styleColor,
+                          attrColor,
+                          newColor: getDarkColor(styleColor || attrColor),
+                      }
+                    : null;
+            })
+            .filter(x => !!x)
+            .forEach(({ element, styleColor, attrColor, newColor }) => {
+                element.style.setProperty(
+                    names[ColorAttributeEnum.CssColor],
+                    newColor,
+                    'important'
+                );
+                element.dataset[names[ColorAttributeEnum.CssDataSet]] = styleColor || '';
 
-        if (
-            !element.dataset[names[ColorAttributeEnum.CssDataSet]] &&
-            !element.dataset[names[ColorAttributeEnum.HtmlDataSet]] &&
-            (styleColor || attrColor) &&
-            styleColor != 'inherit' // For inherit style, no need to change it and let it keep inherit from parent element
-        ) {
-            const newColor = getDarkColor(computedValues[index] || styleColor || attrColor);
-            element.style.setProperty(names[ColorAttributeEnum.CssColor], newColor, 'important');
-            element.dataset[names[ColorAttributeEnum.CssDataSet]] = styleColor || '';
-
-            if (attrColor) {
-                element.setAttribute(names[ColorAttributeEnum.HtmlColor], newColor);
-                element.dataset[names[ColorAttributeEnum.HtmlDataSet]] = attrColor;
-            }
-        }
+                if (attrColor) {
+                    element.setAttribute(names[ColorAttributeEnum.HtmlColor], newColor);
+                    element.dataset[names[ColorAttributeEnum.HtmlDataSet]] = attrColor;
+                }
+            });
     });
 }
 
@@ -124,5 +142,13 @@ function getAll(rootNode: Node, includeSelf: boolean): HTMLElement[] {
         arrayPush(result, toArray(allChildren));
     }
 
-    return result;
+    return result.filter(isHTMLElement);
+}
+
+// This is not a strict check, we just need to make sure this element has style so that we can set style to it
+// We don't use safeInstanceOf() here since this function will be called very frequently when extract html content
+// in dark mode, so we need to make sure this check is fast enough
+function isHTMLElement(element: Element): element is HTMLElement {
+    const htmlElement = <HTMLElement>element;
+    return !!htmlElement.style && !!htmlElement.dataset;
 }

--- a/packages/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts
@@ -1,0 +1,144 @@
+import { getTagOfNode, moveChildNodes, toArray } from 'roosterjs-editor-dom';
+import {
+    EditorPlugin,
+    IEditor,
+    PluginEvent,
+    PluginEventType,
+    SelectionRangeTypes,
+} from 'roosterjs-editor-types';
+
+/**
+ * @internal
+ * NormalizeTable plugin makes sure each table in editor has TBODY/THEAD/TFOOT tag around TR tags
+ *
+ * When we retrieve HTML content using innerHTML, browser will always add TBODY around TR nodes if there is not.
+ * This causes some issue when we restore the HTML content with selection path since the selection path is
+ * deeply coupled with DOM structure. So we need to always make sure there is already TBODY tag whenever
+ * new table is inserted, to make sure the selection path we created is correct.
+ */
+export default class NormalizeTablePlugin implements EditorPlugin {
+    private editor: IEditor;
+
+    /**
+     * Get a friendly name of this plugin
+     */
+    getName() {
+        return 'NormalizeTable';
+    }
+
+    /**
+     * The first method that editor will call to a plugin when editor is initializing.
+     * It will pass in the editor instance, plugin should take this chance to save the
+     * editor reference so that it can call to any editor method or format API later.
+     * @param editor The editor object
+     */
+    initialize(editor: IEditor) {
+        this.editor = editor;
+    }
+
+    /**
+     * The last method that editor will call to a plugin before it is disposed.
+     * Plugin can take this chance to clear the reference to editor. After this method is
+     * called, plugin should not call to any editor method since it will result in error.
+     */
+    dispose() {
+        this.editor = null;
+    }
+
+    /**
+     * Core method for a plugin. Once an event happens in editor, editor will call this
+     * method of each plugin to handle the event as long as the event is not handled
+     * exclusively by another plugin.
+     * @param event The event to handle:
+     */
+    onPluginEvent(event: PluginEvent) {
+        switch (event.eventType) {
+            case PluginEventType.EditorReady:
+            case PluginEventType.ContentChanged:
+                this.normalizeTables(this.editor.queryElements('table'));
+                break;
+
+            case PluginEventType.BeforePaste:
+                this.normalizeTables(toArray(event.fragment.querySelectorAll('table')));
+                break;
+
+            case PluginEventType.MouseDown:
+                this.normalizeTableFromEvent(event.rawEvent);
+                break;
+
+            case PluginEventType.KeyDown:
+                if (event.rawEvent.shiftKey) {
+                    this.normalizeTableFromEvent(event.rawEvent);
+                }
+                break;
+        }
+    }
+
+    private normalizeTableFromEvent(event: KeyboardEvent | MouseEvent) {
+        const table = this.editor.getElementAtCursor(
+            'table',
+            event.target as Node
+        ) as HTMLTableElement;
+
+        if (table) {
+            this.normalizeTables([table]);
+        }
+    }
+
+    private normalizeTables(tables: HTMLTableElement[]) {
+        if (tables.length > 0) {
+            const rangeEx = this.editor.getSelectionRangeEx();
+            const { startContainer, endContainer, startOffset, endOffset } =
+                (rangeEx?.type == SelectionRangeTypes.Normal && rangeEx.ranges[0]) || {};
+
+            const isChanged = normalizeTables(tables);
+
+            if (isChanged) {
+                if (startContainer && endContainer) {
+                    this.editor.select(startContainer, startOffset, endContainer, endOffset);
+                } else if (rangeEx?.type == SelectionRangeTypes.TableSelection) {
+                    this.editor.select(rangeEx.table, rangeEx.coordinates);
+                }
+            }
+        }
+    }
+}
+
+function normalizeTables(tables: HTMLTableElement[]) {
+    let isDOMChanged = false;
+    tables.forEach(table => {
+        let tbody: HTMLTableSectionElement | null = null;
+
+        for (let child = table.firstChild; child; child = child.nextSibling) {
+            const tag = getTagOfNode(child);
+            switch (tag) {
+                case 'TR':
+                    if (!tbody) {
+                        tbody = table.ownerDocument.createElement('tbody');
+                        table.insertBefore(tbody, child);
+                    }
+
+                    tbody.appendChild(child);
+                    child = tbody;
+                    isDOMChanged = true;
+
+                    break;
+                case 'TBODY':
+                    if (tbody) {
+                        moveChildNodes(tbody, child, true /*keepExistingChildren*/);
+                        child.parentNode.removeChild(child);
+                        child = tbody;
+                        isDOMChanged = true;
+                    } else {
+                        tbody = child as HTMLTableSectionElement;
+                    }
+                    break;
+                default:
+                    tbody = null;
+                    break;
+            }
+        }
+    });
+
+    return isDOMChanged;
+}

--- a/packages/roosterjs-editor-core/lib/corePlugins/createCorePlugins.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/createCorePlugins.ts
@@ -4,6 +4,7 @@ import EditPlugin from './EditPlugin';
 import EntityPlugin from './EntityPlugin';
 import LifecyclePlugin from './LifecyclePlugin';
 import MouseUpPlugin from './MouseUpPlugin';
+import NormalizeTablePlugin from './NormalizeTablePlugin';
 import PendingFormatStatePlugin from './PendingFormatStatePlugin';
 import TypeInContainerPlugin from './TypeInContainerPlugin';
 import UndoPlugin from './UndoPlugin';
@@ -40,6 +41,7 @@ export default function createCorePlugins(
         mouseUp: map.mouseUp || new MouseUpPlugin(),
         copyPaste: map.copyPaste || new CopyPastePlugin(options),
         entity: map.entity || new EntityPlugin(),
+        normalizeTable: map.normalizeTable || new NormalizeTablePlugin(),
         lifecycle: map.lifecycle || new LifecyclePlugin(options, contentDiv),
     };
 }

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -814,16 +814,24 @@ export default class Editor implements IEditor {
      * @param nextDarkMode The next status of dark mode. True if the editor should be in dark mode, false if not.
      */
     public setDarkModeState(nextDarkMode?: boolean) {
-        if (this.isDarkMode() == nextDarkMode) {
+        if (this.isDarkMode() == !!nextDarkMode) {
             return;
         }
 
-        const currentContent = this.getContent(GetContentMode.CleanHTML);
+        this.core.api.transformColor(
+            this.core,
+            this.core.contentDiv,
+            false /*includeSelf*/,
+            null /*callback*/,
+            nextDarkMode
+                ? ColorTransformDirection.LightToDark
+                : ColorTransformDirection.DarkToLight,
+            true /*forceTransform*/
+        );
 
         this.triggerContentChangedEvent(
             nextDarkMode ? ChangeSource.SwitchToDarkMode : ChangeSource.SwitchToLightMode
         );
-        this.setContent(currentContent);
     }
 
     /**
@@ -832,6 +840,20 @@ export default class Editor implements IEditor {
      */
     public isDarkMode(): boolean {
         return this.core.lifecycle.isDarkMode;
+    }
+
+    /**
+     * Transform the given node and all its child nodes to dark mode color if editor is in dark mode
+     * @param node The node to transform
+     */
+    public transformToDarkColor(node: Node) {
+        this.core.api.transformColor(
+            this.core,
+            node,
+            true /*includeSelf*/,
+            null /*callback*/,
+            ColorTransformDirection.LightToDark
+        );
     }
 
     /**

--- a/packages/roosterjs-editor-core/test/coreApi/restoreUndoSnapshotTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/restoreUndoSnapshotTest.ts
@@ -1,0 +1,70 @@
+import createEditorCore from './createMockEditorCore';
+import { restoreUndoSnapshot } from '../../lib/coreApi/restoreUndoSnapshot';
+
+describe('restoreUndoSnapshot', () => {
+    let div: HTMLDivElement;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+        document.body.appendChild(div);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(div);
+        div = null;
+    });
+
+    it('Restore snapshot with -1', () => {
+        const addUndoSnapshot = jasmine.createSpy('addUndoSnapshot');
+        const setContent = jasmine.createSpy('setContent');
+        const html = 'test';
+        const metadata = {};
+        const move = jasmine.createSpy('move').and.returnValue(<any>{
+            html,
+            metadata,
+        });
+
+        const core = createEditorCore(div, {
+            coreApiOverride: {
+                addUndoSnapshot,
+                setContent,
+            },
+        });
+        core.undo.hasNewContent = true;
+        core.undo.snapshotsService.move = move;
+
+        restoreUndoSnapshot(core, -1);
+
+        expect(addUndoSnapshot).toHaveBeenCalledWith(core, null, null, false);
+        expect(move).toHaveBeenCalledWith(-1);
+        expect(setContent).toHaveBeenCalledWith(core, html, true, metadata);
+        expect(core.undo.isRestoring).toBeFalse();
+    });
+
+    it('Restore snapshot with 1', () => {
+        const addUndoSnapshot = jasmine.createSpy('addUndoSnapshot');
+        const setContent = jasmine.createSpy('setContent');
+        const html = 'test';
+        const metadata = {};
+        const move = jasmine.createSpy('move').and.returnValue(<any>{
+            html,
+            metadata,
+        });
+
+        const core = createEditorCore(div, {
+            coreApiOverride: {
+                addUndoSnapshot,
+                setContent,
+            },
+        });
+        core.undo.hasNewContent = true;
+        core.undo.snapshotsService.move = move;
+
+        restoreUndoSnapshot(core, 1);
+
+        expect(addUndoSnapshot).not.toHaveBeenCalled();
+        expect(move).toHaveBeenCalledWith(1);
+        expect(setContent).toHaveBeenCalledWith(core, html, true, metadata);
+        expect(core.undo.isRestoring).toBeFalse();
+    });
+});

--- a/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
@@ -30,6 +30,14 @@ describe('transformColor Dark to light', () => {
         expect(element.outerHTML).toBe('<div data-ogsc="#123456"></div>');
     });
 
+    it('light mode still need to transform when force transform', () => {
+        const core = createEditorCore(div, { inDarkMode: false });
+        const element = document.createElement('div');
+        element.dataset.ogsc = '#123456';
+        transformColor(core, element, true, null, ColorTransformDirection.DarkToLight, true);
+        expect(element.outerHTML).toBe('<div style="color: rgb(18, 52, 86);"></div>');
+    });
+
     it('callback must be called', () => {
         const core = createEditorCore(div, { inDarkMode: false });
         const callback = jasmine.createSpy('callback');
@@ -162,6 +170,16 @@ describe('transformColor Light to dark', () => {
         element.style.color = 'rgb(18, 52, 86)';
         transformColor(core, element, true, null, ColorTransformDirection.LightToDark);
         expect(element.outerHTML).toBe('<div style="color: rgb(18, 52, 86);"></div>');
+    });
+
+    it('light mode still need to transform when force transform', () => {
+        const core = createEditorCore(div, { inDarkMode: false });
+        const element = document.createElement('div');
+        element.style.color = 'rgb(18, 52, 86)';
+        transformColor(core, element, true, null, ColorTransformDirection.LightToDark, true);
+        expect(element.outerHTML).toBe(
+            '<div style="color: rgb(18, 52, 86) !important;" data-ogsc="rgb(18, 52, 86)"></div>'
+        );
     });
 
     it('single element, no transform function', () => {

--- a/packages/roosterjs-editor-core/test/corePlugins/normalizeTablePluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/normalizeTablePluginTest.ts
@@ -1,0 +1,263 @@
+import NormalizeTablePlugin from '../../lib/corePlugins/NormalizeTablePlugin';
+import { createElement } from 'roosterjs-editor-dom';
+import {
+    IEditor,
+    PluginEventType,
+    SelectionRangeTypes,
+    CreateElementData,
+} from 'roosterjs-editor-types';
+
+describe('NormalizeTablePlugin', () => {
+    let plugin: NormalizeTablePlugin;
+    let editor: IEditor;
+    let getSelectionRangeEx: jasmine.Spy;
+
+    beforeEach(() => {
+        getSelectionRangeEx = jasmine.createSpy('getSelectionRangeEx');
+        editor = <IEditor>(<any>{
+            getSelectionRangeEx,
+        });
+
+        plugin = new NormalizeTablePlugin();
+        plugin.initialize(editor);
+    });
+
+    afterEach(() => {
+        plugin.dispose();
+        plugin = null;
+        editor = null;
+    });
+
+    it('No table 1', () => {
+        editor.queryElements = () => <any>[];
+
+        plugin.onPluginEvent({
+            eventType: PluginEventType.EditorReady,
+        });
+        plugin.onPluginEvent({
+            eventType: PluginEventType.ContentChanged,
+            source: '',
+        });
+
+        expect(getSelectionRangeEx).not.toHaveBeenCalled();
+    });
+
+    it('No table 2', () => {
+        editor.getElementAtCursor = () => <any>null;
+
+        plugin.onPluginEvent(<any>{
+            eventType: PluginEventType.BeforePaste,
+            fragment: document.createDocumentFragment(),
+        });
+        plugin.onPluginEvent(<any>{
+            eventType: PluginEventType.MouseDown,
+            rawEvent: {},
+        });
+        plugin.onPluginEvent(<any>{
+            eventType: PluginEventType.KeyDown,
+            rawEvent: {},
+        });
+        expect(getSelectionRangeEx).not.toHaveBeenCalled();
+    });
+
+    it('Only query for keyboard event when SHIFT is pressed', () => {
+        const getElementAtCursor = jasmine.createSpy('getElementAtCursor');
+        editor.getElementAtCursor = getElementAtCursor;
+
+        plugin.onPluginEvent(<any>{
+            eventType: PluginEventType.KeyDown,
+            rawEvent: {
+                shiftKey: false,
+            },
+        });
+
+        expect(getElementAtCursor).not.toHaveBeenCalled();
+
+        plugin.onPluginEvent(<any>{
+            eventType: PluginEventType.KeyDown,
+            rawEvent: {
+                shiftKey: true,
+            },
+        });
+
+        expect(getElementAtCursor).toHaveBeenCalled();
+    });
+
+    function runTest(input: CreateElementData, expected: string) {
+        const table = createElement(input, document);
+
+        editor.queryElements = () => [table];
+        plugin.onPluginEvent({
+            eventType: PluginEventType.EditorReady,
+        });
+
+        expect(table.outerHTML).toBe(expected);
+    }
+
+    function createTr(text: string): CreateElementData {
+        return {
+            tag: 'tr',
+            children: [
+                {
+                    tag: 'td',
+                    children: [text],
+                },
+            ],
+        };
+    }
+
+    function createTableSection(tag: string, ...texts: string[]): CreateElementData {
+        return {
+            tag,
+            children: texts.map(createTr),
+        };
+    }
+
+    function createTable(...args: CreateElementData[]): CreateElementData {
+        return {
+            tag: 'table',
+            children: args,
+        };
+    }
+
+    it('Table already has THEAD/TBODY/TFOOT', () => {
+        const html =
+            '<table><thead><tr><td>test1</td></tr></thead><tbody><tr><td>test2</td></tr><tr><td>test3</td></tr></tbody><tfoot><tr><td>test4</td></tr></tfoot></table>';
+        runTest(
+            createTable(
+                createTableSection('thead', 'test1'),
+                createTableSection('tbody', 'test2', 'test3'),
+                createTableSection('tfoot', 'test4')
+            ),
+            html
+        );
+    });
+
+    it('Table only has TR', () => {
+        runTest(
+            createTable(createTr('test1'), createTr('test2')),
+            '<table><tbody><tr><td>test1</td></tr><tr><td>test2</td></tr></tbody></table>'
+        );
+    });
+
+    it('Table has TR and TBODY 1', () => {
+        runTest(
+            createTable(createTr('test1'), createTableSection('tbody', 'test2')),
+            '<table><tbody><tr><td>test1</td></tr><tr><td>test2</td></tr></tbody></table>'
+        );
+    });
+
+    it('Table has TR and TBODY 2', () => {
+        runTest(
+            createTable(createTableSection('tbody', 'test1'), createTr('test2')),
+            '<table><tbody><tr><td>test1</td></tr><tr><td>test2</td></tr></tbody></table>'
+        );
+    });
+
+    it('Table has TR and TBODY and TR', () => {
+        runTest(
+            createTable(createTr('test1'), createTableSection('tbody', 'test2'), createTr('test3')),
+            '<table><tbody><tr><td>test1</td></tr><tr><td>test2</td></tr><tr><td>test3</td></tr></tbody></table>'
+        );
+    });
+
+    it('Table has THEAD and TR and TFOOT', () => {
+        runTest(
+            createTable(
+                createTableSection('thead', 'test1'),
+                createTr('test2'),
+                createTr('test3'),
+                createTableSection('tfoot', 'test4')
+            ),
+            '<table><thead><tr><td>test1</td></tr></thead><tbody><tr><td>test2</td></tr><tr><td>test3</td></tr></tbody><tfoot><tr><td>test4</td></tr></tfoot></table>'
+        );
+    });
+
+    it('Table has THEAD and TR and TBODY and TR and TFOOT', () => {
+        runTest(
+            createTable(
+                createTableSection('thead', 'test1'),
+                createTr('test2'),
+                createTableSection('tbody', 'test3'),
+                createTr('test4'),
+                createTableSection('tfoot', 'test5')
+            ),
+            '<table>' +
+                '<thead><tr><td>test1</td></tr></thead>' +
+                '<tbody><tr><td>test2</td></tr><tr><td>test3</td></tr><tr><td>test4</td></tr></tbody>' +
+                '<tfoot><tr><td>test5</td></tr></tfoot>' +
+                '</table>'
+        );
+    });
+
+    it('Table has THEAD and TBODY and TR and TBODY and TFOOT', () => {
+        runTest(
+            createTable(
+                createTableSection('thead', 'test1'),
+                createTableSection('tbody', 'test2'),
+                createTr('test3'),
+                createTableSection('tbody', 'test4'),
+                createTableSection('tfoot', 'test5')
+            ),
+            '<table>' +
+                '<thead><tr><td>test1</td></tr></thead>' +
+                '<tbody><tr><td>test2</td></tr><tr><td>test3</td></tr><tr><td>test4</td></tr></tbody>' +
+                '<tfoot><tr><td>test5</td></tr></tfoot>' +
+                '</table>'
+        );
+    });
+
+    it('Restore selection after normalization', () => {
+        const table = createElement(createTable(createTr('test1')), document);
+        const startContainer = {};
+        const endContainer = {};
+        const startOffset = 1;
+        const endOffset = 2;
+        const select = jasmine.createSpy('select');
+
+        editor.queryElements = () => [table];
+        editor.select = select;
+
+        getSelectionRangeEx.and.returnValue(<any>{
+            type: SelectionRangeTypes.Normal,
+            ranges: [
+                {
+                    startContainer,
+                    endContainer,
+                    startOffset,
+                    endOffset,
+                },
+            ],
+        });
+        plugin.onPluginEvent({
+            eventType: PluginEventType.EditorReady,
+        });
+
+        expect(table.outerHTML).toBe('<table><tbody><tr><td>test1</td></tr></tbody></table>');
+        expect(select).toHaveBeenCalledWith(startContainer, startOffset, endContainer, endOffset);
+    });
+
+    it('Restore table selection after normalization', () => {
+        const table = createElement(createTable(createTr('test1')), document);
+        const coordinates = {
+            firstCell: { x: 1, y: 2 },
+            lastCell: { x: 3, y: 4 },
+        };
+        const select = jasmine.createSpy('select');
+
+        editor.queryElements = () => [table];
+        editor.select = select;
+
+        getSelectionRangeEx.and.returnValue(<any>{
+            type: SelectionRangeTypes.TableSelection,
+            table,
+            coordinates,
+        });
+        plugin.onPluginEvent({
+            eventType: PluginEventType.EditorReady,
+        });
+
+        expect(table.outerHTML).toBe('<table><tbody><tr><td>test1</td></tr></tbody></table>');
+        expect(select).toHaveBeenCalledWith(table, coordinates);
+    });
+});

--- a/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
@@ -52,6 +52,7 @@ describe('Editor', () => {
             'MouseUp',
             'CopyPaste',
             'Entity',
+            'NormalizeTable',
             'Lifecycle',
         ]);
 
@@ -158,6 +159,7 @@ describe('Editor', () => {
             'test mouse up',
             'CopyPaste',
             'Entity',
+            'NormalizeTable',
             'Lifecycle',
         ]);
 

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -77,9 +77,12 @@ export {
 } from './selection/setHtmlWithSelectionPath';
 export { default as addRangeToSelection } from './selection/addRangeToSelection';
 
-export { default as addSnapshot } from './snapshots/addSnapshot';
+export { default as addSnapshot, addSnapshotV2 } from './snapshots/addSnapshot';
 export { default as canMoveCurrentSnapshot } from './snapshots/canMoveCurrentSnapshot';
-export { default as clearProceedingSnapshots } from './snapshots/clearProceedingSnapshots';
+export {
+    default as clearProceedingSnapshots,
+    clearProceedingSnapshotsV2,
+} from './snapshots/clearProceedingSnapshots';
 export {
     default as moveCurrentSnapshot,
     moveCurrentSnapsnot,

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -71,7 +71,10 @@ export { default as getPositionRect } from './selection/getPositionRect';
 export { default as isPositionAtBeginningOf } from './selection/isPositionAtBeginningOf';
 export { default as getSelectionPath } from './selection/getSelectionPath';
 export { default as getHtmlWithSelectionPath } from './selection/getHtmlWithSelectionPath';
-export { default as setHtmlWithSelectionPath } from './selection/setHtmlWithSelectionPath';
+export {
+    default as setHtmlWithSelectionPath,
+    setHtmlWithMetadata,
+} from './selection/setHtmlWithSelectionPath';
 export { default as addRangeToSelection } from './selection/addRangeToSelection';
 
 export { default as addSnapshot } from './snapshots/addSnapshot';

--- a/packages/roosterjs-editor-dom/lib/selection/getHtmlWithSelectionPath.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/getHtmlWithSelectionPath.ts
@@ -1,7 +1,5 @@
 import getInnerHTML from '../utils/getInnerHTML';
 import getSelectionPath from './getSelectionPath';
-import getTagOfNode from '../utils/getTagOfNode';
-import queryElements from '../utils/queryElements';
 
 /**
  * Get inner Html of a root node with a selection path which can be used for restore selection.
@@ -16,36 +14,6 @@ export default function getHtmlWithSelectionPath(
 ): string {
     if (!rootNode) {
         return '';
-    }
-
-    const { startContainer, endContainer, startOffset, endOffset } = range || {};
-    let isDOMChanged = false;
-
-    queryElements(rootNode, 'table', table => {
-        let tbody: HTMLTableSectionElement | null = null;
-
-        for (let child = table.firstChild; child; child = child.nextSibling) {
-            if (getTagOfNode(child) == 'TR') {
-                if (!tbody) {
-                    tbody = table.ownerDocument.createElement('tbody');
-                    table.insertBefore(tbody, child);
-                }
-
-                tbody.appendChild(child);
-                child = tbody;
-
-                isDOMChanged = true;
-            } else {
-                tbody = null;
-            }
-        }
-    });
-
-    if (range && isDOMChanged) {
-        try {
-            range.setStart(startContainer, startOffset);
-            range.setEnd(endContainer, endOffset);
-        } catch {}
     }
 
     const content = getInnerHTML(rootNode);

--- a/packages/roosterjs-editor-dom/lib/snapshots/addSnapshot.ts
+++ b/packages/roosterjs-editor-dom/lib/snapshots/addSnapshot.ts
@@ -1,29 +1,57 @@
 import clearProceedingSnapshots from './clearProceedingSnapshots';
-import { Snapshots } from 'roosterjs-editor-types';
+import { Snapshot, Snapshots } from 'roosterjs-editor-types';
 
 /**
  * Add a new snapshot to the given snapshots data structure
  * @param snapshots The snapshots data structure to add new snapshot into
- * @param snapshot The snapshot to add
+ * @param html The snapshot HTML to add
  * @param isAutoCompleteSnapshot Whether this is a snapshot before auto complete action
  */
 export default function addSnapshot(
-    snapshots: Snapshots,
-    snapshot: string,
+    snapshots: Snapshots<string>,
+    html: string,
     isAutoCompleteSnapshot: boolean
+): void;
+
+/**
+ * Add a new snapshot to the given snapshots data structure
+ * @param snapshots The snapshots data structure to add new snapshot into
+ * @param snapshot The generic snapshot object to add
+ * @param isAutoCompleteSnapshot Whether this is a snapshot before auto complete action
+ * @param getLength A callback function to calculate length of the snapshot
+ * @param isSame A callback function to check if the given snapshots are the same
+ */
+export default function addSnapshot<T>(
+    snapshots: Snapshots<T>,
+    snapshot: T,
+    isAutoCompleteSnapshot: boolean,
+    getLength: (snapshot: T) => number,
+    isSame: (snapshot1: T, snapshot2: T) => boolean
+): void;
+
+export default function addSnapshot<T>(
+    snapshots: Snapshots<T>,
+    snapshot: T,
+    isAutoCompleteSnapshot: boolean,
+    getLength?: (snapshot: T) => number,
+    compare?: (snapshot1: T, snapshot2: T) => boolean
 ) {
-    if (snapshots.currentIndex < 0 || snapshot != snapshots.snapshots[snapshots.currentIndex]) {
-        clearProceedingSnapshots(snapshots);
+    getLength = getLength || (str => (<string>(<any>str))?.length || 0);
+    compare = compare || defaultCompare;
+
+    const currentSnapshot = snapshots.snapshots[snapshots.currentIndex];
+    if (snapshots.currentIndex < 0 || !currentSnapshot || !compare(snapshot, currentSnapshot)) {
+        clearProceedingSnapshots(snapshots, getLength);
         snapshots.snapshots.push(snapshot);
         snapshots.currentIndex++;
-        snapshots.totalSize += snapshot.length;
+        snapshots.totalSize += getLength(snapshot);
 
         let removeCount = 0;
         while (
             removeCount < snapshots.snapshots.length &&
             snapshots.totalSize > snapshots.maxSize
         ) {
-            snapshots.totalSize -= snapshots.snapshots[removeCount].length;
+            snapshots.totalSize -= getLength(snapshots.snapshots[removeCount]);
             removeCount++;
         }
 
@@ -37,4 +65,32 @@ export default function addSnapshot(
             snapshots.autoCompleteIndex = snapshots.currentIndex;
         }
     }
+}
+
+/**
+ * Add a new snapshot to the given snapshots data structure
+ * @param snapshots The snapshots data structure to add new snapshot into
+ * @param snapshot The snapshot object to add
+ * @param isAutoCompleteSnapshot Whether this is a snapshot before auto complete action
+ */
+export function addSnapshotV2(
+    snapshots: Snapshots<Snapshot>,
+    snapshot: Snapshot,
+    isAutoCompleteSnapshot: boolean
+) {
+    addSnapshot(
+        snapshots,
+        snapshot,
+        isAutoCompleteSnapshot,
+        s => s.html?.length || 0,
+        compareSnapshots
+    );
+}
+
+function compareSnapshots(s1: Snapshot, s2: Snapshot) {
+    return s1.html == s2.html;
+}
+
+function defaultCompare<T>(s1: T, s2: T) {
+    return s1 == s2;
 }

--- a/packages/roosterjs-editor-dom/lib/snapshots/canMoveCurrentSnapshot.ts
+++ b/packages/roosterjs-editor-dom/lib/snapshots/canMoveCurrentSnapshot.ts
@@ -6,7 +6,10 @@ import { Snapshots } from 'roosterjs-editor-types';
  * @param step The step to check, can be positive, negative or 0
  * @returns True if can move current snapshot with the given step, otherwise false
  */
-export default function canMoveCurrentSnapshot(snapshots: Snapshots, step: number): boolean {
+export default function canMoveCurrentSnapshot<T = string>(
+    snapshots: Snapshots<T>,
+    step: number
+): boolean {
     let newIndex = snapshots.currentIndex + step;
     return newIndex >= 0 && newIndex < snapshots.snapshots.length;
 }

--- a/packages/roosterjs-editor-dom/lib/snapshots/canUndoAutoComplete.ts
+++ b/packages/roosterjs-editor-dom/lib/snapshots/canUndoAutoComplete.ts
@@ -3,7 +3,7 @@ import { Snapshots } from 'roosterjs-editor-types';
 /**
  * Whether there is a snapshot added before auto complete and it can be undone now
  */
-export default function canUndoAutoComplete(snapshots: Snapshots): boolean {
+export default function canUndoAutoComplete<T = string>(snapshots: Snapshots<T>): boolean {
     return (
         snapshots.autoCompleteIndex >= 0 &&
         snapshots.currentIndex - snapshots.autoCompleteIndex == 1

--- a/packages/roosterjs-editor-dom/lib/snapshots/clearProceedingSnapshots.ts
+++ b/packages/roosterjs-editor-dom/lib/snapshots/clearProceedingSnapshots.ts
@@ -1,18 +1,45 @@
 import canMoveCurrentSnapshot from './canMoveCurrentSnapshot';
-import { Snapshots } from 'roosterjs-editor-types';
+import { Snapshot, Snapshots } from 'roosterjs-editor-types';
 
 /**
  * Clear all snapshots after the current one
  * @param snapshots The snapshots data structure to clear
  */
-export default function clearProceedingSnapshots(snapshots: Snapshots) {
+export default function clearProceedingSnapshots(snapshots: Snapshots<string>): void;
+
+/**
+ * Clear all snapshots after the current one
+ * @param snapshots The snapshots data structure to clear
+ */
+export default function clearProceedingSnapshots<T>(
+    snapshots: Snapshots<T>,
+    getLength: (snapshot: T) => number
+): void;
+
+/**
+ * Clear all snapshots after the current one
+ * @param snapshots The snapshots data structure to clear
+ */
+export default function clearProceedingSnapshots<T>(
+    snapshots: Snapshots<T>,
+    getLength?: (snapshot: T) => number
+) {
+    getLength = getLength || (str => (<string>(<any>str))?.length || 0);
     if (canMoveCurrentSnapshot(snapshots, 1)) {
         let removedSize = 0;
         for (let i = snapshots.currentIndex + 1; i < snapshots.snapshots.length; i++) {
-            removedSize += snapshots.snapshots[i].length;
+            removedSize += getLength(snapshots.snapshots[i]);
         }
         snapshots.snapshots.splice(snapshots.currentIndex + 1);
         snapshots.totalSize -= removedSize;
         snapshots.autoCompleteIndex = -1;
     }
+}
+
+/**
+ * Clear all snapshots after the current one
+ * @param snapshots The snapshots data structure to clear
+ */
+export function clearProceedingSnapshotsV2(snapshots: Snapshots<Snapshot>) {
+    clearProceedingSnapshots(snapshots, s => s.html?.length || 0);
 }

--- a/packages/roosterjs-editor-dom/lib/snapshots/createSnapshots.ts
+++ b/packages/roosterjs-editor-dom/lib/snapshots/createSnapshots.ts
@@ -4,7 +4,7 @@ import { Snapshots } from 'roosterjs-editor-types';
  * Create initial snapshots
  * @param maxSize max size of all snapshots
  */
-export default function createSnapshots(maxSize: number): Snapshots {
+export default function createSnapshots<T = string>(maxSize: number): Snapshots<T> {
     return {
         snapshots: [],
         totalSize: 0,

--- a/packages/roosterjs-editor-dom/lib/snapshots/moveCurrentSnapshot.ts
+++ b/packages/roosterjs-editor-dom/lib/snapshots/moveCurrentSnapshot.ts
@@ -7,7 +7,10 @@ import { Snapshots } from 'roosterjs-editor-types';
  * @param step The step to move
  * @returns If can move with the given step, returns the snapshot after move, otherwise null
  */
-export default function moveCurrentSnapshot(snapshots: Snapshots, step: number): string | null {
+export default function moveCurrentSnapshot<T = string>(
+    snapshots: Snapshots<T>,
+    step: number
+): T | null {
     if (canMoveCurrentSnapshot(snapshots, step)) {
         snapshots.currentIndex += step;
         snapshots.autoCompleteIndex = -1;

--- a/packages/roosterjs-editor-dom/test/selections/getHtmlWithSelectionPathTest.ts
+++ b/packages/roosterjs-editor-dom/test/selections/getHtmlWithSelectionPathTest.ts
@@ -22,30 +22,4 @@ describe('getHtmlWithSelectionPath', () => {
             'test1<div>text 2<span>test3</span>test 4</div>test 5<!--{"start":[1,0,2],"end":[2,3]}-->'
         );
     });
-
-    it('TABLE content', () => {
-        const div = document.createElement('div');
-        const range = document.createRange();
-        const table = document.createElement('table');
-
-        div.appendChild(document.createTextNode('test1'));
-        div.appendChild(table);
-        div.appendChild(document.createTextNode('test2'));
-
-        const tr = document.createElement('tr');
-        table.appendChild(tr);
-
-        const td = document.createElement('td');
-        tr.appendChild(td);
-
-        const text = document.createTextNode('test');
-        td.appendChild(text);
-
-        range.setStart(text, 2);
-        range.setEnd(text, 3);
-        const html = getHtmlWithSelectionPath(div, range);
-        expect(html).toBe(
-            'test1<table><tbody><tr><td>test</td></tr></tbody></table>test2<!--{"start":[1,0,0,0,0,2],"end":[1,0,0,0,0,3]}-->'
-        );
-    });
 });

--- a/packages/roosterjs-editor-dom/test/selections/setHtmlWithMetadataTest.ts
+++ b/packages/roosterjs-editor-dom/test/selections/setHtmlWithMetadataTest.ts
@@ -1,0 +1,254 @@
+import { SelectionRangeTypes } from 'roosterjs-editor-types';
+import { setHtmlWithMetadata } from '../../lib/selection/setHtmlWithSelectionPath';
+
+describe('setHtmlWithMetadata', () => {
+    let div: HTMLDivElement;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+    });
+
+    it('pure HTML', () => {
+        const html = '<div>test</div>';
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+
+    it('HTML with empty comment', () => {
+        const html = '<div>test</div><!---->';
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+
+    it('HTML with comment', () => {
+        const html = '<div>test</div><!--test-->';
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+
+    it('HTML with comment and invalid JSON', () => {
+        const html = '<div>test</div><!--{"a":b, "c":}-->';
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+
+    it('HTML with half selection path', () => {
+        const html = '<div>test</div><!--{"start":[]}-->';
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+
+    it('HTML with full selection path', () => {
+        const pureHtml = '<div>test</div>';
+        const comment = { start: <any[]>[], end: <any[]>[] };
+        const html = metadataToString(pureHtml, comment);
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(pureHtml);
+        expect(metadata).toEqual({
+            start: [],
+            end: [],
+            type: SelectionRangeTypes.Normal,
+            isDarkMode: false,
+        });
+    });
+
+    it('HTML with full normal content metadata', () => {
+        const pureHtml = '<div>test</div>';
+        const comment = <any>{
+            start: [1],
+            end: [2],
+            isDarkMode: true,
+            type: SelectionRangeTypes.Normal,
+        };
+        const html = metadataToString(pureHtml, comment);
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(pureHtml);
+        expect(metadata).toEqual(comment);
+    });
+
+    it('HTML with full normal content metadata but wrong type', () => {
+        const pureHtml = '<div>test</div>';
+        const comment = <any>{
+            start: [1],
+            end: [2],
+            isDarkMode: true,
+            type: SelectionRangeTypes.TableSelection,
+        };
+        const html = metadataToString(pureHtml, comment);
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+
+    it('HTML with full table selection metadata', () => {
+        const pureHtml = '<div>test</div>';
+        const comment = <any>{
+            type: SelectionRangeTypes.TableSelection,
+            isDarkMode: true,
+            tableId: 'table',
+            firstCell: {
+                x: 1,
+                y: 2,
+            },
+            lastCell: {
+                x: 3,
+                y: 4,
+            },
+        };
+        const html = metadataToString(pureHtml, comment);
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(pureHtml);
+        expect(metadata).toEqual(comment);
+    });
+
+    it('HTML with full table selection metadata but wrong type', () => {
+        const pureHtml = '<div>test</div>';
+        const comment = <any>{
+            type: SelectionRangeTypes.Normal,
+            isDarkMode: true,
+            tableId: 'table',
+            firstCell: {
+                x: 1,
+                y: 2,
+            },
+            lastCell: {
+                x: 3,
+                y: 4,
+            },
+        };
+        const html = metadataToString(pureHtml, comment);
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+
+    it('HTML with incomplete table selection metadata 1', () => {
+        const pureHtml = '<div>test</div>';
+        const comment = <any>{
+            type: SelectionRangeTypes.TableSelection,
+            tableId: 'table',
+            firstCell: {
+                x: 1,
+                y: 2,
+            },
+            lastCell: {
+                x: 3,
+                y: 4,
+            },
+        };
+        const html = metadataToString(pureHtml, comment);
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(pureHtml);
+        expect(metadata).toEqual({
+            type: SelectionRangeTypes.TableSelection,
+            tableId: 'table',
+            firstCell: {
+                x: 1,
+                y: 2,
+            },
+            lastCell: {
+                x: 3,
+                y: 4,
+            },
+            isDarkMode: false,
+        });
+    });
+
+    it('HTML with incomplete table selection metadata 2', () => {
+        const pureHtml = '<div>test</div>';
+        const comment = <any>{
+            type: SelectionRangeTypes.TableSelection,
+            firstCell: {
+                x: 1,
+                y: 2,
+            },
+            lastCell: {
+                x: 3,
+                y: 4,
+            },
+        };
+        const html = metadataToString(pureHtml, comment);
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+
+    it('HTML with incomplete table selection metadata 3', () => {
+        const pureHtml = '<div>test</div>';
+        const comment = <any>{
+            type: SelectionRangeTypes.TableSelection,
+            tableId: 'table',
+            firstCell: {
+                y: 2,
+            },
+            lastCell: {
+                x: 3,
+                y: 4,
+            },
+        };
+        const html = metadataToString(pureHtml, comment);
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+
+    it('HTML with incomplete table selection metadata 4', () => {
+        const pureHtml = '<div>test</div>';
+        const comment = <any>{
+            type: SelectionRangeTypes.TableSelection,
+            tableId: 'table',
+            firstCell: {
+                x: 1,
+                y: 2,
+            },
+        };
+        const html = metadataToString(pureHtml, comment);
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+
+    it('HTML with incomplete table selection metadata 5', () => {
+        const pureHtml = '<div>test</div>';
+        const comment = <any>{
+            type: SelectionRangeTypes.TableSelection,
+            tableId: 'table',
+            firstCell: {
+                x: 'test',
+                y: 2,
+            },
+            lastCell: {
+                x: 3,
+                y: 4,
+            },
+        };
+        const html = metadataToString(pureHtml, comment);
+        const metadata = setHtmlWithMetadata(div, html);
+
+        expect(div.innerHTML).toBe(html);
+        expect(metadata).toBeUndefined();
+    });
+});
+
+function metadataToString(html: string, metadata: object): string {
+    return html + (metadata ? `<!--${JSON.stringify(metadata)}-->` : '');
+}

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -135,6 +135,14 @@ export default class TableCellSelection implements EditorPlugin {
                         this.handleScrollEvent();
                     }
                     break;
+                case PluginEventType.BeforeSetContent:
+                    if (this.tableRange) {
+                        this.tableRange = null;
+                        this.firstTable = null;
+                        this.tableSelection = false;
+                        this.editor.select(null);
+                    }
+                    break;
             }
         }
     }

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -242,7 +242,8 @@ export default class TableEditor {
         this.editor.addUndoSnapshot();
     }
 
-    private onInserted = () => {
+    private onInserted = (table: HTMLTableElement) => {
+        this.editor.transformToDarkColor(table);
         this.disposeTableResizer();
         this.onFinishEditing();
     };

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
@@ -16,7 +16,7 @@ export default function createTableInserter(
     td: HTMLTableCellElement,
     isRTL: boolean,
     isHorizontal: boolean,
-    onInsert: () => void
+    onInsert: (table: HTMLTableElement) => void
 ): TableEditFeature {
     const table = editor.getElementAtCursor('table', td);
     const tdRect = normalizeRect(td.getBoundingClientRect());
@@ -65,7 +65,7 @@ class TableInsertHandler implements Disposable {
         private td: HTMLTableCellElement,
         private isHorizontal: boolean,
         private editor: IEditor,
-        private onInsert: () => void
+        private onInsert: (table: HTMLTableElement) => void
     ) {
         this.div.addEventListener('click', this.insertTd);
     }
@@ -88,10 +88,8 @@ class TableInsertHandler implements Disposable {
 
         vtable.edit(this.isHorizontal ? TableOperation.InsertBelow : TableOperation.InsertRight);
         vtable.writeBack();
-        //Adding replaceNode to transform color when the theme is switched to dark.
-        this.editor.replaceNode(vtable.table, vtable.table, true /**transformColorForDarkMode*/);
 
-        this.onInsert();
+        this.onInsert(vtable.table);
     };
 }
 

--- a/packages/roosterjs-editor-types/lib/corePluginState/UndoPluginState.ts
+++ b/packages/roosterjs-editor-types/lib/corePluginState/UndoPluginState.ts
@@ -1,4 +1,5 @@
 import NodePosition from '../interface/NodePosition';
+import Snapshot from '../interface/Snapshot';
 import UndoSnapshotsService from '../interface/UndoSnapshotsService';
 
 /**
@@ -8,7 +9,7 @@ export default interface UndoPluginState {
     /**
      * Snapshot service for undo, it helps handle snapshot add, remove and retrieve
      */
-    snapshotsService: UndoSnapshotsService;
+    snapshotsService: UndoSnapshotsService<Snapshot>;
 
     /**
      * Whether restoring of undo snapshot is in progress.

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -105,6 +105,13 @@ export { default as Region } from './interface/Region';
 export { default as RegionBase } from './interface/RegionBase';
 export { default as SelectionPath } from './interface/SelectionPath';
 export { default as Snapshots } from './interface/Snapshots';
+export {
+    ContentMetadataBase,
+    NormalContentMetadata,
+    TableContentMetadata,
+    ContentMetadata,
+} from './interface/ContentMetadata';
+export { default as Snapshot } from './interface/Snapshot';
 export { default as TableFormat } from './interface/TableFormat';
 export { default as TableSelection } from './interface/TableSelection';
 export { default as Coordinates } from './interface/Coordinates';

--- a/packages/roosterjs-editor-types/lib/interface/ContentMetadata.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ContentMetadata.ts
@@ -1,0 +1,45 @@
+import SelectionPath from './SelectionPath';
+import TableSelection from './TableSelection';
+import { SelectionRangeTypes } from './SelectionRangeEx';
+
+/**
+ * Common part of NormalContentMetadata and TableContentMetadata
+ */
+export interface ContentMetadataBase<T extends SelectionRangeTypes> {
+    isDarkMode: boolean;
+    type: T;
+}
+
+/**
+ * A content metadata is a data structure storing information other than HTML content,
+ * such as dark mode info, selection info, ...
+ *
+ * NormalContentMetadata is content metadata for normal selection with a start and end selection path.
+ *
+ * When do any change to this type, also need to fix function isUndoMetadata to make sure
+ * the check is correct
+ */
+export interface NormalContentMetadata
+    extends SelectionPath,
+        ContentMetadataBase<SelectionRangeTypes.Normal> {}
+
+/**
+ * A content metadata is a data structure storing information other than HTML content,
+ * such as dark mode info, selection info, ...
+ *
+ * TableContentMetadata is content metadata for table selection with table id and start and end coordinates
+ *
+ * When do any change to this type, also need to fix function isUndoMetadata to make sure
+ * the check is correct
+ */
+export interface TableContentMetadata
+    extends TableSelection,
+        ContentMetadataBase<SelectionRangeTypes.TableSelection> {
+    tableId: string;
+}
+
+/**
+ * A content metadata is a data structure storing information other than HTML content,
+ * such as dark mode info, selection info, ...
+ */
+export type ContentMetadata = NormalContentMetadata | TableContentMetadata;

--- a/packages/roosterjs-editor-types/lib/interface/CorePlugins.ts
+++ b/packages/roosterjs-editor-types/lib/interface/CorePlugins.ts
@@ -61,6 +61,11 @@ export default interface CorePlugins {
     readonly entity: PluginWithState<EntityPluginState>;
 
     /**
+     * NormalizeTable plugin makes sure each table in editor has TBODY/THEAD/TFOOT tag around TR tags
+     */
+    readonly normalizeTable: EditorPlugin;
+
+    /**
      * Lifecycle plugin handles editor initialization and disposing
      */
     readonly lifecycle: PluginWithState<LifecyclePluginState>;

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -4,6 +4,7 @@ import NodePosition from './NodePosition';
 import TableSelection from './TableSelection';
 import { ChangeSource } from '../enum/ChangeSource';
 import { ColorTransformDirection } from '../enum/ColorTransformDirection';
+import { ContentMetadata } from './ContentMetadata';
 import { DOMEventHandler } from '../type/domEventHandler';
 import { GetContentMode } from '../enum/GetContentMode';
 import { InsertOption } from './InsertOption';
@@ -196,7 +197,8 @@ export type SelectRange = (core: EditorCore, range: Range, skipSameRange?: boole
 export type SetContent = (
     core: EditorCore,
     content: string,
-    triggerContentChangedEvent: boolean
+    triggerContentChangedEvent: boolean,
+    metadata?: ContentMetadata
 ) => void;
 
 /**

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -213,13 +213,16 @@ export type SwitchShadowEdit = (core: EditorCore, isOn: boolean) => void;
  * @param includeSelf True to transform the root node as well, otherwise false
  * @param callback The callback function to invoke before do color transformation
  * @param direction To specify the transform direction, light to dark, or dark to light
+ * @param forceTransform By default this function will only work when editor core is in dark mode.
+ * Pass true to this value to force do color transformation even editor core is in light mode
  */
 export type TransformColor = (
     core: EditorCore,
     rootNode: Node,
     includeSelf: boolean,
     callback: () => void,
-    direction: ColorTransformDirection
+    direction: ColorTransformDirection,
+    forceTransform?: boolean
 ) => void;
 
 /**
@@ -386,6 +389,8 @@ export interface CoreApiMap {
      * @param includeSelf True to transform the root node as well, otherwise false
      * @param callback The callback function to invoke before do color transformation
      * @param direction To specify the transform direction, light to dark, or dark to light
+     * @param forceTransform By default this function will only work when editor core is in dark mode.
+     * Pass true to this value to force do color transformation even editor core is in light mode
      */
     transformColor: TransformColor;
 

--- a/packages/roosterjs-editor-types/lib/interface/EditorOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorOptions.ts
@@ -1,6 +1,7 @@
 import CorePlugins from './CorePlugins';
 import DefaultFormat from './DefaultFormat';
 import EditorPlugin from './EditorPlugin';
+import Snapshot from './Snapshot';
 import UndoSnapshotsService from './UndoSnapshotsService';
 import { CoreApiMap } from './EditorCore';
 import { ExperimentalFeatures } from '../enum/ExperimentalFeatures';
@@ -27,9 +28,16 @@ export default interface EditorOptions {
     defaultFormat?: DefaultFormat;
 
     /**
+     * @deprecated Use undoMetadataSnapshotService instead
      * Undo snapshot service. Use this parameter to customize the undo snapshot service.
      */
-    undoSnapshotService?: UndoSnapshotsService;
+    undoSnapshotService?: UndoSnapshotsService<string>;
+
+    /**
+     * Undo snapshot service based on content metadata. Use this parameter to customize the undo snapshot service.
+     * When this property is set, value of undoSnapshotService will be ignored.
+     */
+    undoMetadataSnapshotService?: UndoSnapshotsService<Snapshot>;
 
     /**
      * Initial HTML content

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -548,6 +548,12 @@ export default interface IEditor {
     isDarkMode(): boolean;
 
     /**
+     * Transform the given node and all its child nodes to dark mode color if editor is in dark mode
+     * @param node The node to transform
+     */
+    transformToDarkColor(node: Node): void;
+
+    /**
      * Make the editor in "Shadow Edit" mode.
      * In Shadow Edit mode, all format change will finally be ignored.
      * This can be used for building a live preview feature for format button, to allow user

--- a/packages/roosterjs-editor-types/lib/interface/Snapshot.ts
+++ b/packages/roosterjs-editor-types/lib/interface/Snapshot.ts
@@ -1,0 +1,16 @@
+import { ContentMetadata } from './ContentMetadata';
+
+/**
+ * A serializable snapshot of editor content, including the html content and metadata
+ */
+export default interface Snapshot {
+    /**
+     * HTML content string
+     */
+    html: string;
+
+    /**
+     * Metadata of the editor content state
+     */
+    metadata: ContentMetadata | null;
+}

--- a/packages/roosterjs-editor-types/lib/interface/Snapshots.ts
+++ b/packages/roosterjs-editor-types/lib/interface/Snapshots.ts
@@ -1,11 +1,11 @@
 /**
  * Represents a data structure of snapshots, this is usually used for undo snapshots
  */
-export default interface Snapshots {
+export default interface Snapshots<T = string> {
     /**
      * The snapshot array
      */
-    snapshots: string[];
+    snapshots: T[];
 
     /**
      * Size of all snapshots

--- a/packages/roosterjs-editor-types/lib/interface/UndoSnapshotsService.ts
+++ b/packages/roosterjs-editor-types/lib/interface/UndoSnapshotsService.ts
@@ -1,7 +1,7 @@
 /**
  * Represent an interface to provide functionalities for Undo Snapshots
  */
-export default interface UndoSnapshotsService {
+export default interface UndoSnapshotsService<T = string> {
     /**
      * Check whether can move current undo snapshot with the given step
      * @param step The step to check, can be positive, negative or 0
@@ -14,13 +14,13 @@ export default interface UndoSnapshotsService {
      * @param step The step to move
      * @returns If can move with the given step, returns the snapshot after move, otherwise null
      */
-    move(step: number): string;
+    move(step: number): T;
 
     /**
      * Add a new undo snapshot
      * @param snapshot The snapshot to add
      */
-    addSnapshot(snapshot: string, isAutoCompleteSnapshot: boolean): void;
+    addSnapshot(snapshot: T, isAutoCompleteSnapshot: boolean): void;
 
     /**
      * Clear all undo snapshots after the current one


### PR DESCRIPTION
To fix #836 and #838, in this change I switched undo plugin to use ContentMetadata based snapshot. Now every time we take a undo snapshot, it will contain two parts:
- HTML string
- Content metadata

EditorOptions now accept both old and new UndoSnapshotService format.
- When provide new UndoSnapshotService via EditorOptions.undoMetadataSnapshotService, we use it
- When provide old UndoSnapshotService  via EditorOptions.undoSnapshotService, we create a bridge from new service to old one
- When both are provided, use the new one only
- When none of them is provided, create a default UndoSnapshotService on top of ContentMetadata and Snapshot.