### PR TITLE
Add aria labels to ribbon buttons, fixes #846

### DIFF
--- a/packages-ui/roosterjs-react/lib/ribbon/component/Ribbon.tsx
+++ b/packages-ui/roosterjs-react/lib/ribbon/component/Ribbon.tsx
@@ -7,6 +7,7 @@ import { FocusZoneDirection } from '@fluentui/react/lib/FocusZone';
 import { FormatState } from 'roosterjs-editor-types';
 import { IContextualMenuItem, IContextualMenuItemProps } from '@fluentui/react/lib/ContextualMenu';
 import { mergeStyles } from '@fluentui/react/lib/Styling';
+import { moreCommands } from './buttons/moreCommands';
 
 const ribbonClassName = mergeStyles({
     '& .ms-CommandBar': {
@@ -72,6 +73,7 @@ export default function Ribbon<T extends string>(props: RibbonProps<T>) {
                     onRenderIcon: isRtl && button.flipWhenRtl ? flipIcon : undefined,
                     iconOnly: true,
                     text: getLocalizedString(strings, button.key, button.unlocalizedText),
+                    ariaLabel: getLocalizedString(strings, button.key, button.unlocalizedText),
                     canCheck: true,
                     checked: (formatState && button.isChecked?.(formatState)) || false,
                     disabled: (formatState && button.isDisabled?.(formatState)) || false,
@@ -121,11 +123,20 @@ export default function Ribbon<T extends string>(props: RibbonProps<T>) {
         };
     }, [plugin]);
 
+    const moreCommandsBtn = moreCommands as RibbonButton<T>;
+
     return (
         <CommandBar
             items={commandBarItems}
             {...props}
             className={ribbonClassName + ' ' + (props?.className || '')}
+            overflowButtonProps={{
+                ariaLabel: getLocalizedString(
+                    strings,
+                    moreCommandsBtn.key,
+                    moreCommandsBtn.unlocalizedText
+                ),
+            }}
         />
     );
 }

--- a/packages-ui/roosterjs-react/lib/ribbon/component/buttons/moreCommands.ts
+++ b/packages-ui/roosterjs-react/lib/ribbon/component/buttons/moreCommands.ts
@@ -1,0 +1,15 @@
+import RibbonButton from '../../type/RibbonButton';
+import { MoreCommandsButtonStringKey } from '../../type/RibbonButtonStringKeys';
+
+/**
+ * @internal
+ * "More commands" (overflow) button on the format ribbon
+ */
+export const moreCommands: RibbonButton<MoreCommandsButtonStringKey> = {
+    key: 'buttonNameMoreCommands',
+    unlocalizedText: 'More commands',
+    iconName: 'MoreCommands',
+    onClick: editor => {
+        return true;
+    },
+};

--- a/packages-ui/roosterjs-react/lib/ribbon/index.ts
+++ b/packages-ui/roosterjs-react/lib/ribbon/index.ts
@@ -15,6 +15,7 @@ export {
     BackgroundColorButtonStringKey,
     BulletedListButtonStringKey,
     NumberedListButtonStringKey,
+    MoreCommandsButtonStringKey,
     DecreaseIndentButtonStringKey,
     IncreaseIndentButtonStringKey,
     QuoteButtonStringKey,

--- a/packages-ui/roosterjs-react/lib/ribbon/type/RibbonButtonStringKeys.ts
+++ b/packages-ui/roosterjs-react/lib/ribbon/type/RibbonButtonStringKeys.ts
@@ -163,6 +163,11 @@ export type ItalicButtonStringKey = 'buttonNameItalic';
 export type LtrButtonStringKey = 'buttonNameLtr';
 
 /**
+ * Key of localized strings of More commands (overflow) button
+ */
+export type MoreCommandsButtonStringKey = 'buttonNameMoreCommands';
+
+/**
  * Key of localized strings of Numbered list button
  */
 export type NumberedListButtonStringKey = 'buttonNameNumberedList';
@@ -246,6 +251,7 @@ export type AllButtonStringKeys =
     | InsertTableButtonStringKey
     | ItalicButtonStringKey
     | LtrButtonStringKey
+    | MoreCommandsButtonStringKey
     | NumberedListButtonStringKey
     | QuoteButtonStringKey
     | RedoButtonStringKey


### PR DESCRIPTION
Added an aria label to all ribbon buttons, using the same string as the tooltip. Did the same for the overflow button, which required adding it to most places where ribbon buttons are listed.