### PR TITLE
Remove unneeded check in getListItemIndex in VList

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/setIndentation.ts
+++ b/packages/roosterjs-editor-api/lib/format/setIndentation.ts
@@ -54,7 +54,7 @@ export default function setIndentation(editor: IEditor, indentation: Indentation
 
                     if (
                         vList.items[0]?.getNode() == startNode &&
-                        vList.getListItemIndex(startNode) == vList.getStart() &&
+                        vList.getListItemIndex(startNode) == (vList.getStart() || 1) &&
                         (indentation == Indentation.Increase ||
                             editor.getElementAtCursor('blockquote', startNode))
                     ) {

--- a/packages/roosterjs-editor-dom/lib/list/VList.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VList.ts
@@ -330,7 +330,7 @@ export default class VList {
      */
     getListItemIndex(input: Node) {
         if (this.items) {
-            let listIndex = this.getStart() - 1;
+            let listIndex = (this.getStart() || 1) - 1;
 
             for (let index = 0; index < this.items.length; index++) {
                 const child = this.items[index];
@@ -351,7 +351,7 @@ export default class VList {
      * @returns Start number of the list
      */
     getStart(): number | undefined {
-        return safeInstanceOf(this.rootList, 'HTMLOListElement') ? this.rootList.start : 1;
+        return safeInstanceOf(this.rootList, 'HTMLOListElement') ? this.rootList.start : undefined;
     }
 
     private findListItems(

--- a/packages/roosterjs-editor-dom/lib/list/VList.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VList.ts
@@ -334,11 +334,7 @@ export default class VList {
 
             for (let index = 0; index < this.items.length; index++) {
                 const child = this.items[index];
-                if (
-                    child.getListType() == ListType.Ordered &&
-                    child.getLevel() == 1 &&
-                    !child.isDummy()
-                ) {
+                if (child.getLevel() == 1 && !child.isDummy()) {
                     listIndex++;
                 }
 
@@ -355,7 +351,7 @@ export default class VList {
      * @returns Start number of the list
      */
     getStart(): number | undefined {
-        return safeInstanceOf(this.rootList, 'HTMLOListElement') ? this.rootList.start : undefined;
+        return safeInstanceOf(this.rootList, 'HTMLOListElement') ? this.rootList.start : 1;
     }
 
     private findListItems(

--- a/packages/roosterjs-editor-dom/lib/list/VList.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VList.ts
@@ -326,6 +326,25 @@ export default class VList {
 
     /**
      * Get the index of the List Item in the current List
+     * If the root list is:
+     * Ordered list, the listIndex start count is going to be the start property of the OL - 1,
+     * @example For example if we want to find the index of Item 2 in the list below, the returned index is going to be 6
+     *  * ```html
+     * <ol start="5">
+     *   <li>item 1</li>
+     *   <li>item 2</li> <!-- Node to find -->
+     *   <li>item 3</li>
+     * </ol>
+     * ```
+     * Unordered list, the listIndex start count starts from 0
+     * @example For example if we want to find the index of Item 2 in the list below, the returned index is going to be 2
+     * ```html
+     * <ul>
+     *   <li>item 1</li>
+     *   <li>item 2</li> <!-- Node to find -->
+     *   <li>item 3</li>
+     * </ul>
+     * ```
      * @param input List item to find in the root list
      */
     getListItemIndex(input: Node) {

--- a/packages/roosterjs-editor-dom/lib/list/VList.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VList.ts
@@ -330,6 +330,7 @@ export default class VList {
      */
     getListItemIndex(input: Node) {
         if (this.items) {
+            debugger;
             let listIndex = (this.getStart() || 1) - 1;
 
             for (let index = 0; index < this.items.length; index++) {

--- a/packages/roosterjs-editor-dom/lib/list/VList.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VList.ts
@@ -330,7 +330,6 @@ export default class VList {
      */
     getListItemIndex(input: Node) {
         if (this.items) {
-            debugger;
             let listIndex = (this.getStart() || 1) - 1;
 
             for (let index = 0; index < this.items.length; index++) {


### PR DESCRIPTION
We were checking whether the List Item was Ordered, but this is not required. 
Checking if the LI was a Ordered Item caused the API to not work with UL Lists, removing this check will fix this issue.