### PR TITLE
Change conserveConstEnums for compatibility

### DIFF
--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -8,7 +8,7 @@
         "declaration": true,
         "removeComments": false,
         "noImplicitAny": true,
-        "preserveConstEnums": true,
+        "preserveConstEnums": false,
         "noUnusedLocals": true,
         "baseUrl": ".",
         "paths": {


### PR DESCRIPTION
This makes sure your interface is not using const enums for your external interface, which makes it compatible with all external projects. Notably Create React App is using `isolatedModules` which is not compatible with const enums. The TypeScript team outlines the issue in the const enums pitfalls documentation. https://www.typescriptlang.org/docs/handbook/enums.html#const-enum-pitfalls