### PR TITLE
Fix issue when using Tab before Anchor Element

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/textFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/textFeatures.ts
@@ -1,4 +1,4 @@
-import { createRange, Position, queryElements } from 'roosterjs-editor-dom';
+import { createRange, getTagOfNode, Position, queryElements } from 'roosterjs-editor-dom';
 import { setIndentation } from 'roosterjs-editor-api';
 import {
     BuildInEditFeature,
@@ -142,18 +142,27 @@ function insertTab(editor: IEditor, event: PluginKeyboardEvent) {
     const span = editor.getDocument().createElement('span');
     let searcher = editor.getContentSearcherOfCursor(event);
     const charsBefore = searcher.getSubStringBefore(Number.MAX_SAFE_INTEGER);
-
     const numberOfChars = TAB_SPACES - (charsBefore.length % TAB_SPACES);
+    let span2: HTMLSpanElement;
 
     let textContent = '';
     for (let index = 0; index < numberOfChars; index++) {
         textContent += '&ensp;';
     }
     editor.insertNode(span);
+    if (span.nextElementSibling && getTagOfNode(span.nextElementSibling) == 'A') {
+        span2 = editor.getDocument().createElement('span');
+        span2.textContent = ' ';
+        editor.insertNode(span2);
+        editor.select(createRange(span2, PositionType.Before));
+    }
     editor.insertContent(textContent, {
         position: ContentPosition.Range,
         range: createRange(span, PositionType.Begin),
         updateCursor: false,
     });
     editor.select(createRange(span, PositionType.After));
+    if (span2) {
+        editor.deleteNode(span2);
+    }
 }

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/textFeaturesTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/textFeaturesTest.ts
@@ -120,7 +120,8 @@ describe('Text Features |', () => {
                 feature: BuildInEditFeature<PluginKeyboardEvent>,
                 content: string,
                 selectCallback: () => void,
-                contentExpected: string
+                contentExpected: string,
+                additionalExpect?: () => void
             ) {
                 //Arrange
                 const keyboardEvent: PluginKeyboardEvent = {
@@ -135,6 +136,7 @@ describe('Text Features |', () => {
 
                 //Assert
                 expect(editor.getContent()).toBe(contentExpected);
+                additionalExpect?.();
             }
             TestHelper.itFirefoxOnly('Handle event, text collapsed', () => {
                 runHandleTest(
@@ -378,6 +380,29 @@ describe('Text Features |', () => {
                     );
                 }
             );
+
+            TestHelper.itFirefoxOnly('Handle, Insert Tab before a Anchor Element', () => {
+                runHandleTest(
+                    TextFeatures.indentWhenTabText,
+                    `<div id='${TEST_ELEMENT_ID}'>Test<a href='test'>TestAnchor</a></div>`,
+                    () => {
+                        const element = editor.getDocument().getElementById(TEST_ELEMENT_ID);
+                        const range = new Range();
+                        range.setStart(element, 1);
+                        range.setEnd(element, 1);
+                        editor.select(range);
+                    },
+                    '<div id="test">Test<span>  </span><a href="test">TestAnchor</a></div>',
+                    () => {
+                        const range = editor.getSelectionRange();
+
+                        const element = editor.getDocument().getElementById(TEST_ELEMENT_ID);
+                        const expectedRange = new Range();
+                        expectedRange.setStart(element, 2);
+                        expect(range).toEqual(expectedRange);
+                    }
+                );
+            });
         });
     });
 


### PR DESCRIPTION
When using the tab key with the TabKeyFeatures experimental feature enabled, we add the tab spaces correctly, but the cursor is not updated.

Before
![Tab before link](https://user-images.githubusercontent.com/8291124/161084281-a9326bb2-8a90-419f-a0cb-9f47a4fadc9f.gif)

After
![Tab before link 2](https://user-images.githubusercontent.com/8291124/161084851-71629ed1-cbd1-4da7-9a02-d013e0b919b7.gif)

