### PR TITLE
Fix after copy the focus is lost.

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
@@ -78,7 +78,6 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
 
     private onCutCopy(event: Event, isCut: boolean) {
         const selection = this.editor.getSelectionRangeEx();
-        debugger;
         if (selection && !selection.areAllCollapsed) {
             const html = this.editor.getContent(GetContentMode.RawHTMLWithSelection);
             const tempDiv = this.getTempDiv(true /*forceInLightMode*/);

--- a/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
@@ -78,7 +78,7 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
 
     private onCutCopy(event: Event, isCut: boolean) {
         const selection = this.editor.getSelectionRangeEx();
-
+        debugger;
         if (selection && !selection.areAllCollapsed) {
             const html = this.editor.getContent(GetContentMode.RawHTMLWithSelection);
             const tempDiv = this.getTempDiv(true /*forceInLightMode*/);
@@ -168,7 +168,7 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
         range: Range | SelectionRangeEx,
         isCopy: boolean
     ) {
-        if (!!(<SelectionRangeEx>range)?.type) {
+        if (!!(<SelectionRangeEx>range)?.type || (<SelectionRangeEx>range).type == 0) {
             const selection = <SelectionRangeEx>range;
             switch (selection.type) {
                 case SelectionRangeTypes.TableSelection:


### PR DESCRIPTION
After copying the focus is lost, is because a recent change when trying to restore the Selection after copy.

Before
![copybug1](https://user-images.githubusercontent.com/8291124/162014397-f81e3478-bcfe-4cc7-ba49-843d772f436f.gif)

After
![copybug2](https://user-images.githubusercontent.com/8291124/162014638-22527f80-4b82-4968-b194-e1e2b3d622cb.gif)

