### PR TITLE
Add zIndex option for TableResizer

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -1,5 +1,12 @@
 import TableEditor from './editors/TableEditor';
-import { EditorPlugin, IEditor, PluginEvent, PluginEventType, Rect } from 'roosterjs-editor-types';
+import {
+    EditorPlugin,
+    IEditor,
+    PluginEvent,
+    PluginEventType,
+    Rect,
+    TableResizeOptions,
+} from 'roosterjs-editor-types';
 import { normalizeRect } from 'roosterjs-editor-dom';
 
 const TABLE_RESIZER_LENGTH = 12;
@@ -9,9 +16,14 @@ const TABLE_RESIZER_LENGTH = 12;
  */
 export default class TableResize implements EditorPlugin {
     private editor: IEditor;
+    private options: TableResizeOptions;
     private onMouseMoveDisposer: () => void;
     private tableRectMap: { table: HTMLTableElement; rect: Rect }[] = null;
     private tableEditor: TableEditor;
+
+    constructor(options?: TableResizeOptions) {
+        this.options = options || {};
+    }
 
     /**
      * Get a friendly name of  this plugin
@@ -26,7 +38,9 @@ export default class TableResize implements EditorPlugin {
      */
     initialize(editor: IEditor) {
         this.editor = editor;
-        this.onMouseMoveDisposer = this.editor.addDomEventHandler({ mousemove: this.onMouseMove });
+        this.onMouseMoveDisposer = this.editor.addDomEventHandler({
+            mousemove: this.onMouseMove,
+        });
     }
 
     /**
@@ -92,7 +106,12 @@ export default class TableResize implements EditorPlugin {
         }
 
         if (!this.tableEditor && table) {
-            this.tableEditor = new TableEditor(this.editor, table, this.invalidateTableRects);
+            this.tableEditor = new TableEditor(
+                this.editor,
+                table,
+                this.invalidateTableRects,
+                this.options
+            );
         }
     }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/CellResizer.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/CellResizer.ts
@@ -13,6 +13,7 @@ const MIN_CELL_WIDTH = 30;
 export default function createCellResizer(
     td: HTMLTableCellElement,
     zoomScale: number,
+    zIndex: number,
     isRTL: boolean,
     isHorizontal: boolean,
     onStart: () => void,
@@ -25,6 +26,10 @@ export default function createCellResizer(
             : KnownCreateElementDataIndex.TableVerticalResizer,
         document
     ) as HTMLDivElement;
+
+    if (zIndex !== undefined) {
+        div.style.zIndex = zIndex.toString();
+    }
 
     document.body.appendChild(div);
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -3,7 +3,13 @@ import createTableInserter from './TableInserter';
 import createTableResizer from './TableResizer';
 import createTableSelector from './TableSelector';
 import TableEditFeature, { disposeTableEditFeature } from './TableEditorFeature';
-import { ChangeSource, IEditor, NodePosition, TableSelection } from 'roosterjs-editor-types';
+import {
+    ChangeSource,
+    IEditor,
+    NodePosition,
+    TableResizeOptions,
+    TableSelection,
+} from 'roosterjs-editor-types';
 import { getComputedStyle, normalizeRect, Position, VTable } from 'roosterjs-editor-dom';
 
 const INSERTER_HOVER_OFFSET = 5;
@@ -59,17 +65,24 @@ export default class TableEditor {
     constructor(
         private editor: IEditor,
         public readonly table: HTMLTableElement,
-        private onChanged: () => void
+        private onChanged: () => void,
+        private options: TableResizeOptions
     ) {
         this.isRTL = getComputedStyle(table, 'direction') == 'rtl';
         this.tableResizer = createTableResizer(
             table,
+            this.options.zIndex,
             editor.getZoomScale(),
             this.isRTL,
             this.onStartTableResize,
             this.onFinishEditing
         );
-        this.tableSelector = createTableSelector(table, editor.getZoomScale(), this.onSelect);
+        this.tableSelector = createTableSelector(
+            table,
+            this.options.zIndex,
+            editor.getZoomScale(),
+            this.onSelect
+        );
     }
 
     dispose() {
@@ -140,6 +153,7 @@ export default class TableEditor {
             this.horizontalResizer = createCellResizer(
                 td,
                 zoomScale,
+                this.options.zIndex,
                 this.isRTL,
                 true /*isHorizontal*/,
                 this.onStartCellResize,
@@ -148,6 +162,7 @@ export default class TableEditor {
             this.verticalResizer = createCellResizer(
                 td,
                 zoomScale,
+                this.options.zIndex,
                 this.isRTL,
                 false /*isHorizontal*/,
                 this.onStartCellResize,
@@ -166,6 +181,7 @@ export default class TableEditor {
             const newInserter = createTableInserter(
                 this.editor,
                 td,
+                this.options.zIndex,
                 this.isRTL,
                 isHorizontal,
                 this.onInserted

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
@@ -14,6 +14,7 @@ const INSERTER_BORDER_SIZE = 1;
 export default function createTableInserter(
     editor: IEditor,
     td: HTMLTableCellElement,
+    zIndex: number,
     isRTL: boolean,
     isHorizontal: boolean,
     onInsert: (table: HTMLTableElement) => void
@@ -34,6 +35,10 @@ export default function createTableInserter(
             ),
             document
         ) as HTMLDivElement;
+
+        if (zIndex !== undefined) {
+            div.style.zIndex = zIndex.toString();
+        }
 
         if (isHorizontal) {
             div.style.left = `${

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableResizer.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableResizer.ts
@@ -12,6 +12,7 @@ const MIN_CELL_HEIGHT = 20;
  */
 export default function createTableResizer(
     table: HTMLTableElement,
+    zIndex: number,
     zoomScale: number,
     isRTL: boolean,
     onStart: () => void,
@@ -27,6 +28,11 @@ export default function createTableResizer(
 
     div.style.width = `${TABLE_RESIZER_LENGTH}px`;
     div.style.height = `${TABLE_RESIZER_LENGTH}px`;
+
+    if (zIndex !== undefined) {
+        div.style.zIndex = zIndex.toString();
+    }
+
     document.body.appendChild(div);
 
     const context: DragAndDropContext = {

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableSelector.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableSelector.ts
@@ -11,6 +11,7 @@ const TABLE_SELECTOR_ID = '_Table_Selector';
  */
 export default function createTableSelector(
     table: HTMLTableElement,
+    zIndex: number,
     zoomScale: number,
     onFinishDragging: (table: HTMLTableElement) => void
 ): TableEditorFeature {
@@ -23,6 +24,11 @@ export default function createTableSelector(
     div.id = TABLE_SELECTOR_ID;
     div.style.width = `${TABLE_SELECTOR_LENGTH}px`;
     div.style.height = `${TABLE_SELECTOR_LENGTH}px`;
+
+    if (zIndex !== undefined) {
+        div.style.zIndex = zIndex.toString();
+    }
+
     document.body.appendChild(div);
 
     const context: DragAndDropContext = {

--- a/packages/roosterjs-editor-types/lib/index.ts
+++ b/packages/roosterjs-editor-types/lib/index.ts
@@ -113,6 +113,7 @@ export {
 } from './interface/ContentMetadata';
 export { default as Snapshot } from './interface/Snapshot';
 export { default as TableFormat } from './interface/TableFormat';
+export { default as TableResizeOptions } from './interface/TableResizeOptions';
 export { default as TableSelection } from './interface/TableSelection';
 export { default as Coordinates } from './interface/Coordinates';
 export { default as HtmlSanitizerOptions } from './interface/HtmlSanitizerOptions';

--- a/packages/roosterjs-editor-types/lib/interface/TableResizeOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/TableResizeOptions.ts
@@ -1,0 +1,10 @@
+/**
+ * Options for TableResize plugin
+ */
+export default interface TableResizeOptions {
+    /**
+     * z-index of TableResizer overlay elements.
+     * Useful when the Editor is in a stacking context above overlay elements.
+     */
+    zIndex?: number;
+}


### PR DESCRIPTION
Hello,

TableResizer overlay elements on hover are appended to the matching document `body` and may be hidden below the editor itself when there is a stacking context defined.
(since d2e134d0515eba8807af2f97d82f75af88359f6b)

I've been thinking of an easy solution, by adding a `class` to all overlay elements, so we can safely add z-index to them, but I assume that is not "the way" this lib solves such cases. If you think it's a better solution feel free to reject this PR and I will do it in another one.

Maybe we can also insert those elements right after the Editor but I think there is a reason it is now appended on the `body`.

Otherwise, here is my proposal : 

TableResize plugin can now accept an `options` object with a `zIndex`
property, which will add `z-index` style to all overlay elements.




