### PR TITLE
Uncaught TypeError: Cannot set properties of null (setting 'firstCell')

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -499,8 +499,10 @@ export default class TableCellSelection implements EditorPlugin {
                 this.tableSelection = true;
 
                 this.vTable = this.vTable || new VTable(this.firstTable);
-                this.tableRange.firstCell = getCellCoordinates(this.vTable, this.firstTarget);
-                this.tableRange.lastCell = getCellCoordinates(this.vTable, this.lastTarget);
+                this.tableRange = {
+                    firstCell: getCellCoordinates(this.vTable, this.firstTarget),
+                    lastCell: getCellCoordinates(this.vTable, this.lastTarget),
+                };
                 this.vTable.selection = this.tableRange;
                 this.selectTable();
             }
@@ -508,8 +510,11 @@ export default class TableCellSelection implements EditorPlugin {
             event.preventDefault();
         } else if (this.lastTarget == this.firstTarget && this.tableSelection) {
             this.vTable = new VTable(this.firstTable);
-            this.tableRange.firstCell = getCellCoordinates(this.vTable, this.firstTarget);
-            this.tableRange.lastCell = this.tableRange.firstCell;
+            const cell = getCellCoordinates(this.vTable, this.firstTarget);
+            this.tableRange = {
+                firstCell: cell,
+                lastCell: cell,
+            };
 
             this.vTable.selection = this.tableRange;
             this.selectTable();

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -256,8 +256,10 @@ export default class TableCellSelection implements EditorPlugin {
 
         updateSelection(this.editor, this.firstTarget, 0);
         this.vTable = this.vTable || new VTable(this.firstTable as HTMLTableElement);
-        this.tableRange.firstCell = getCellCoordinates(this.vTable, this.firstTarget as Element);
-        this.tableRange.lastCell = this.getNextTD(event);
+        this.tableRange = {
+            firstCell: getCellCoordinates(this.vTable, this.firstTarget as Element),
+            lastCell: this.getNextTD(event),
+        };
 
         if (
             !this.tableRange.lastCell ||


### PR DESCRIPTION
Try fix the following error:

Uncaught TypeError: Cannot set properties of null (setting 'firstCell')

roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts:259
roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts:234
roosterjs-editor-core/lib/editor/Editor.ts:708
ORIGINAL ERROR:
Uncaught TypeError: Cannot set properties of null (setting 'firstCell')

Not sure why this error is happening, as we only set this.tableRange to null when setting the content to the editor.