### PR TITLE
Update const enum to enum

### DIFF
--- a/demo/scripts/controls/colorPicker/ColorPicker.tsx
+++ b/demo/scripts/controls/colorPicker/ColorPicker.tsx
@@ -10,7 +10,7 @@ export interface ColorPickerProps {
     className?: string;
 }
 
-const enum Keys {
+enum Keys {
     PageUp = 33,
     PageDown = 34,
     End = 35,

--- a/packages-ui/roosterjs-react/lib/ribbon/type/KnownRibbonButton.ts
+++ b/packages-ui/roosterjs-react/lib/ribbon/type/KnownRibbonButton.ts
@@ -1,7 +1,7 @@
 /**
  * Keys of known ribbon buttons (buttons included in roosterjs-react)
  */
-export const enum KnownRibbonButtonKey {
+export enum KnownRibbonButtonKey {
     /**
      * "Bold" button on the format ribbon
      */

--- a/packages-ui/roosterjs-react/lib/rooster/type/UpdateMode.ts
+++ b/packages-ui/roosterjs-react/lib/rooster/type/UpdateMode.ts
@@ -1,7 +1,7 @@
 /**
  * Update mode for UpdateContentPlugins
  */
-export const enum UpdateMode {
+export enum UpdateMode {
     /**
      * Force update, triggered from UpdateContentPlugin.forceUpdate()
      */

--- a/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
@@ -6,7 +6,7 @@ import {
     TransformColor,
 } from 'roosterjs-editor-types';
 
-const enum ColorAttributeEnum {
+enum ColorAttributeEnum {
     CssColor = 0,
     HtmlColor = 1,
     CssDataSet = 2,

--- a/packages/roosterjs-editor-dom/lib/utils/setColor.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/setColor.ts
@@ -4,7 +4,7 @@ const WHITE = '#ffffff';
 const GRAY = '#333333';
 const BLACK = '#000000';
 const TRANSPARENT = 'transparent';
-const enum ColorTones {
+enum ColorTones {
     BRIGHT,
     DARK,
     NONE,

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/checkEditInfoState.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/checkEditInfoState.ts
@@ -16,7 +16,7 @@ const ALL_KEYS = [...ROTATE_CROP_KEYS, ...RESIZE_KEYS];
  * State of an edit info object for image editing.
  * It is returned by checkEditInfoState() function
  */
-export const enum ImageEditInfoState {
+export enum ImageEditInfoState {
     /**
      * Invalid edit info. It means the given edit info object is either null,
      * or not all its member are of correct type

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/types/ImageEditElementClass.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/types/ImageEditElementClass.ts
@@ -2,7 +2,7 @@
  * @internal
  * CSS class names for image editing elements
  */
-export const enum ImageEditElementClass {
+export enum ImageEditElementClass {
     /**
      * CSS class name for resize handle
      */

--- a/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
+++ b/packages/roosterjs-editor-plugins/test/TableResize/tableResizeTest.ts
@@ -18,7 +18,7 @@ type Position = {
     y: number;
 };
 
-const enum ResizeState {
+enum ResizeState {
     None,
     Horizontal,
     Vertical,

--- a/packages/roosterjs-editor-types/lib/browser/ContentType.ts
+++ b/packages/roosterjs-editor-types/lib/browser/ContentType.ts
@@ -1,7 +1,7 @@
 /**
  * Prefix of content types
  */
-export const enum ContentTypePrefix {
+export enum ContentTypePrefix {
     /**
      * Text type prefix
      */
@@ -16,7 +16,7 @@ export const enum ContentTypePrefix {
 /**
  * Known content types
  */
-export const enum ContentType {
+export enum ContentType {
     /**
      * Plain text content type
      */

--- a/packages/roosterjs-editor-types/lib/browser/DocumentCommand.ts
+++ b/packages/roosterjs-editor-types/lib/browser/DocumentCommand.ts
@@ -2,7 +2,7 @@
  * Command strings for Document.execCommand() API
  * https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
  */
-export const enum DocumentCommand {
+export enum DocumentCommand {
     /**
      * Changes the browser auto-link behavior (Internet Explorer only)
      */

--- a/packages/roosterjs-editor-types/lib/browser/DocumentPosition.ts
+++ b/packages/roosterjs-editor-types/lib/browser/DocumentPosition.ts
@@ -2,7 +2,7 @@
  * The is essentially an enum representing result from browser compareDocumentPosition API
  * https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
  */
-export const enum DocumentPosition {
+export enum DocumentPosition {
     /**
      * Same node
      */

--- a/packages/roosterjs-editor-types/lib/browser/Keys.ts
+++ b/packages/roosterjs-editor-types/lib/browser/Keys.ts
@@ -1,7 +1,7 @@
 /**
  * Key numbers common used keys
  */
-export const enum Keys {
+export enum Keys {
     NULL = 0,
     BACKSPACE = 8,
     TAB = 9,

--- a/packages/roosterjs-editor-types/lib/browser/NodeType.ts
+++ b/packages/roosterjs-editor-types/lib/browser/NodeType.ts
@@ -3,7 +3,7 @@
  * https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
  * Values not listed here are deprecated.
  */
-export const enum NodeType {
+export enum NodeType {
     /**
      * An Element node such as &lt;p&gt; or &lt;div&gt;.
      */

--- a/packages/roosterjs-editor-types/lib/enum/Alignment.ts
+++ b/packages/roosterjs-editor-types/lib/enum/Alignment.ts
@@ -1,7 +1,7 @@
 /**
  * enum for setting block alignment, used by setAlignment API
  */
-export const enum Alignment {
+export enum Alignment {
     /**
      * Align left
      */

--- a/packages/roosterjs-editor-types/lib/enum/Capitalization.ts
+++ b/packages/roosterjs-editor-types/lib/enum/Capitalization.ts
@@ -2,7 +2,7 @@
  * The enum used for controlling the capitalization of text.
  * Used by changeCapitalization API
  */
-export const enum Capitalization {
+export enum Capitalization {
     /**
      * Transforms the first character after punctuation mark followed by space
      * to uppercase and the rest of characters to lowercase.

--- a/packages/roosterjs-editor-types/lib/enum/ChangeSource.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ChangeSource.ts
@@ -2,7 +2,7 @@
  * Possible change sources. Here are the predefined sources.
  * It can also be other string if the change source can't fall into these sources.
  */
-export const enum ChangeSource {
+export enum ChangeSource {
     /**
      * Content changed by auto link
      */

--- a/packages/roosterjs-editor-types/lib/enum/ClearFormatMode.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ClearFormatMode.ts
@@ -1,7 +1,7 @@
 /**
  * Represents the strategy to clear the format of the current editor selection
  */
-export const enum ClearFormatMode {
+export enum ClearFormatMode {
     /**
      * Inline format. Remove text format.
      */

--- a/packages/roosterjs-editor-types/lib/enum/ColorTransformDirection.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ColorTransformDirection.ts
@@ -1,7 +1,7 @@
 /**
  * Represents the mode of color transformation
  */
-export const enum ColorTransformDirection {
+export enum ColorTransformDirection {
     /**
      * Transform from light to dark
      */

--- a/packages/roosterjs-editor-types/lib/enum/ContentPosition.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ContentPosition.ts
@@ -3,7 +3,7 @@
  * On insertion, we will need to specify where we want the content to be placed (begin, end, selection or outside)
  * On content traversing, we will need to specify the start position of traversing
  */
-export const enum ContentPosition {
+export enum ContentPosition {
     /**
      * Begin of the container
      */

--- a/packages/roosterjs-editor-types/lib/enum/DarkModeDatasetNames.ts
+++ b/packages/roosterjs-editor-types/lib/enum/DarkModeDatasetNames.ts
@@ -1,7 +1,7 @@
 /**
  * Constants string for dataset names used by dark mode
  */
-export const enum DarkModeDatasetNames {
+export enum DarkModeDatasetNames {
     /**
      * Original style text color
      */

--- a/packages/roosterjs-editor-types/lib/enum/Direction.ts
+++ b/packages/roosterjs-editor-types/lib/enum/Direction.ts
@@ -1,7 +1,7 @@
 /**
  * enum for setting block direction, used by setDirection API
  */
-export const enum Direction {
+export enum Direction {
     /**
      * Left to right
      */

--- a/packages/roosterjs-editor-types/lib/enum/EntityClasses.ts
+++ b/packages/roosterjs-editor-types/lib/enum/EntityClasses.ts
@@ -1,7 +1,7 @@
 /**
  * CSS Class names for Entity
  */
-export const enum EntityClasses {
+export enum EntityClasses {
     /**
      * Class name to specify this is an entity
      */

--- a/packages/roosterjs-editor-types/lib/enum/EntityOperation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/EntityOperation.ts
@@ -1,7 +1,7 @@
 /**
  * Define possible operations to an entity
  */
-export const enum EntityOperation {
+export enum EntityOperation {
     /**
      * Notify plugins that there is a new plugin was added into editor.
      * Plugin can handle this event to entity hydration.

--- a/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
@@ -1,7 +1,7 @@
 /**
  * Experimental feature flags
  */
-export const enum ExperimentalFeatures {
+export enum ExperimentalFeatures {
     /**
      * @deprecated This feature is always enabled
      */

--- a/packages/roosterjs-editor-types/lib/enum/FontSizeChange.ts
+++ b/packages/roosterjs-editor-types/lib/enum/FontSizeChange.ts
@@ -2,7 +2,7 @@
  * The enum used for increase or decrease font size
  * Used by setFontSize API
  */
-export const enum FontSizeChange {
+export enum FontSizeChange {
     /**
      * Increase font size
      */

--- a/packages/roosterjs-editor-types/lib/enum/GetContentMode.ts
+++ b/packages/roosterjs-editor-types/lib/enum/GetContentMode.ts
@@ -1,7 +1,7 @@
 /**
  * Represents a mode number to indicate what kind of content to retrieve when call Editor.getContent()
  */
-export const enum GetContentMode {
+export enum GetContentMode {
     /**
      * The clean content without any temporary content only for editor.
      * This is the default value. Call to Editor.getContent() with trigger an ExtractContentWithDom event

--- a/packages/roosterjs-editor-types/lib/enum/ImageEditOperation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ImageEditOperation.ts
@@ -1,7 +1,7 @@
 /**
  * Operation flags for ImageEdit plugin
  */
-export const enum ImageEditOperation {
+export enum ImageEditOperation {
     /**
      * No operation
      */

--- a/packages/roosterjs-editor-types/lib/enum/Indentation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/Indentation.ts
@@ -2,7 +2,7 @@
  * The enum used for increase or decrease indentation of a block
  * Used by setIndentation API
  */
-export const enum Indentation {
+export enum Indentation {
     /**
      * Increase indentation
      */

--- a/packages/roosterjs-editor-types/lib/enum/KnownCreateElementDataIndex.ts
+++ b/packages/roosterjs-editor-types/lib/enum/KnownCreateElementDataIndex.ts
@@ -1,7 +1,7 @@
 /**
  * Index of known CreateElementData used by createElement function
  */
-export const enum KnownCreateElementDataIndex {
+export enum KnownCreateElementDataIndex {
     /**
      * Set a none value to help createElement function ignore falsy value
      */

--- a/packages/roosterjs-editor-types/lib/enum/ListType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ListType.ts
@@ -1,7 +1,7 @@
 /**
  * Type of list (numbering or bullet)
  */
-export const enum ListType {
+export enum ListType {
     /**
      * None list type
      * It means this is not a list

--- a/packages/roosterjs-editor-types/lib/enum/PositionType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/PositionType.ts
@@ -1,7 +1,7 @@
 /**
  * Represent the type of a position
  */
-export const enum PositionType {
+export enum PositionType {
     /**
      * At the beginning of a node
      */

--- a/packages/roosterjs-editor-types/lib/enum/QueryScope.ts
+++ b/packages/roosterjs-editor-types/lib/enum/QueryScope.ts
@@ -1,7 +1,7 @@
 /**
  * Query scope for queryElements() API
  */
-export const enum QueryScope {
+export enum QueryScope {
     /**
      * Query from the whole body of root node. This is default value.
      */

--- a/packages/roosterjs-editor-types/lib/enum/RegionType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/RegionType.ts
@@ -1,7 +1,7 @@
 /**
  * Type of all possible regions. Currently we only support region of Table
  */
-export const enum RegionType {
+export enum RegionType {
     /**
      * Region split by Table
      */

--- a/packages/roosterjs-editor-types/lib/enum/TableBorderFormat.ts
+++ b/packages/roosterjs-editor-types/lib/enum/TableBorderFormat.ts
@@ -1,7 +1,7 @@
 /**
  * Table format border
  */
-export const enum TableBorderFormat {
+export enum TableBorderFormat {
     /**
      * All border of the table are displayed
      *  __ __ __

--- a/packages/roosterjs-editor-types/lib/enum/TableOperation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/TableOperation.ts
@@ -1,7 +1,7 @@
 /**
  * Operations used by editTable() API
  */
-export const enum TableOperation {
+export enum TableOperation {
     /**
      * Insert a row above current row
      */

--- a/packages/roosterjs-editor-types/lib/event/PluginEventType.ts
+++ b/packages/roosterjs-editor-types/lib/event/PluginEventType.ts
@@ -1,7 +1,7 @@
 /**
  * Editor plugin event type
  */
-export const enum PluginEventType {
+export enum PluginEventType {
     /**
      * HTML KeyDown event
      */

--- a/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
+++ b/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
@@ -43,7 +43,7 @@ export interface NormalSelectionRange extends SelectionRangeExBase<SelectionRang
 /**
  * Types of Selection Ranges that the SelectionRangeEx can return
  */
-export const enum SelectionRangeTypes {
+export enum SelectionRangeTypes {
     /**
      * Normal selection range provided by browser.
      */


### PR DESCRIPTION
## What?

Updating all `const enum`s to `enum`.


## Why?

`const` enums don't always transpile well on TypeScript projects like Yammer becayse of [this issue](https://ncjamieson.com/dont-export-const-enums/). Also, this should be a harmless change as there is no downside to using a regular `enum` instead.

## References

* Similar [issue](https://github.com/OfficeDev/microsoft-teams-library-js/issues/267) and [fix](https://github.com/OfficeDev/microsoft-teams-library-js/pull/387) in the microsoft-teams-library-js codebase

* [Discussion on TypeScript repo](https://github.com/Microsoft/TypeScript/issues/5243)

## TODO

* Also make corresponding changes at other spots where we use `const enum`