### PR TITLE
Allow customization of TableResize helper elements

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -1,6 +1,13 @@
 import TableEditor from './editors/TableEditor';
-import { EditorPlugin, IEditor, PluginEvent, PluginEventType, Rect } from 'roosterjs-editor-types';
 import { normalizeRect } from 'roosterjs-editor-dom';
+import {
+    CreateElementData,
+    EditorPlugin,
+    IEditor,
+    PluginEvent,
+    PluginEventType,
+    Rect,
+} from 'roosterjs-editor-types';
 
 const TABLE_RESIZER_LENGTH = 12;
 
@@ -12,6 +19,17 @@ export default class TableResize implements EditorPlugin {
     private onMouseMoveDisposer: () => void;
     private tableRectMap: { table: HTMLTableElement; rect: Rect }[] = null;
     private tableEditor: TableEditor;
+
+    /**
+     * Construct a new instance of TableResize plugin
+     * @param options
+     */
+    constructor(
+        private onShowHelperElement?: (
+            elementData: CreateElementData,
+            helperType: 'CellResizer' | 'TableInserter' | 'TableResizer' | 'TableSelector'
+        ) => void
+    ) {}
 
     /**
      * Get a friendly name of  this plugin
@@ -92,7 +110,12 @@ export default class TableResize implements EditorPlugin {
         }
 
         if (!this.tableEditor && table) {
-            this.tableEditor = new TableEditor(this.editor, table, this.invalidateTableRects);
+            this.tableEditor = new TableEditor(
+                this.editor,
+                table,
+                this.invalidateTableRects,
+                this.onShowHelperElement
+            );
         }
     }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -22,7 +22,9 @@ export default class TableResize implements EditorPlugin {
 
     /**
      * Construct a new instance of TableResize plugin
-     * @param options
+     * @param onShowHelperElement An optional callback to allow customize helper element of table resizing.
+     * To customize the helper element, add this callback and change the attributes of elementData then it
+     * will be picked up by TableResize code
      */
     constructor(
         private onShowHelperElement?: (

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/CellResizer.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/CellResizer.ts
@@ -2,7 +2,7 @@ import DragAndDropHandler from '../../../pluginUtils/DragAndDropHandler';
 import DragAndDropHelper from '../../../pluginUtils/DragAndDropHelper';
 import TableEditFeature from './TableEditorFeature';
 import { createElement, normalizeRect, VTable } from 'roosterjs-editor-dom';
-import { KnownCreateElementDataIndex, Rect } from 'roosterjs-editor-types';
+import { CreateElementData, Rect } from 'roosterjs-editor-types';
 
 const CELL_RESIZER_WIDTH = 4;
 const MIN_CELL_WIDTH = 30;
@@ -16,15 +16,21 @@ export default function createCellResizer(
     isRTL: boolean,
     isHorizontal: boolean,
     onStart: () => void,
-    onEnd: () => false
+    onEnd: () => false,
+    onShowHelperElement: (
+        elementData: CreateElementData,
+        helperType: 'CellResizer' | 'TableInserter' | 'TableResizer' | 'TableSelector'
+    ) => void
 ): TableEditFeature {
     const document = td.ownerDocument;
-    const div = createElement(
-        isHorizontal
-            ? KnownCreateElementDataIndex.TableHorizontalResizer
-            : KnownCreateElementDataIndex.TableVerticalResizer,
-        document
-    ) as HTMLDivElement;
+    const createElementData = {
+        tag: 'div',
+        style: `position: fixed; cursor: ${isHorizontal ? 'row' : 'col'}-resize; user-select: none`,
+    };
+
+    onShowHelperElement?.(createElementData, 'CellResizer');
+
+    const div = createElement(createElementData, document) as HTMLDivElement;
 
     document.body.appendChild(div);
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -3,8 +3,14 @@ import createTableInserter from './TableInserter';
 import createTableResizer from './TableResizer';
 import createTableSelector from './TableSelector';
 import TableEditFeature, { disposeTableEditFeature } from './TableEditorFeature';
-import { ChangeSource, IEditor, NodePosition, TableSelection } from 'roosterjs-editor-types';
 import { getComputedStyle, normalizeRect, Position, VTable } from 'roosterjs-editor-dom';
+import {
+    ChangeSource,
+    IEditor,
+    NodePosition,
+    TableSelection,
+    CreateElementData,
+} from 'roosterjs-editor-types';
 
 const INSERTER_HOVER_OFFSET = 5;
 
@@ -59,7 +65,11 @@ export default class TableEditor {
     constructor(
         private editor: IEditor,
         public readonly table: HTMLTableElement,
-        private onChanged: () => void
+        private onChanged: () => void,
+        private onShowHelperElement?: (
+            elementData: CreateElementData,
+            helperType: 'CellResizer' | 'TableInserter' | 'TableResizer' | 'TableSelector'
+        ) => void
     ) {
         this.isRTL = getComputedStyle(table, 'direction') == 'rtl';
         this.tableResizer = createTableResizer(
@@ -67,9 +77,15 @@ export default class TableEditor {
             editor.getZoomScale(),
             this.isRTL,
             this.onStartTableResize,
-            this.onFinishEditing
+            this.onFinishEditing,
+            this.onShowHelperElement
         );
-        this.tableSelector = createTableSelector(table, editor.getZoomScale(), this.onSelect);
+        this.tableSelector = createTableSelector(
+            table,
+            editor.getZoomScale(),
+            this.onSelect,
+            this.onShowHelperElement
+        );
     }
 
     dispose() {
@@ -143,7 +159,8 @@ export default class TableEditor {
                 this.isRTL,
                 true /*isHorizontal*/,
                 this.onStartCellResize,
-                this.onFinishEditing
+                this.onFinishEditing,
+                this.onShowHelperElement
             );
             this.verticalResizer = createCellResizer(
                 td,
@@ -151,7 +168,8 @@ export default class TableEditor {
                 this.isRTL,
                 false /*isHorizontal*/,
                 this.onStartCellResize,
-                this.onFinishEditing
+                this.onFinishEditing,
+                this.onShowHelperElement
             );
         }
     }
@@ -168,7 +186,8 @@ export default class TableEditor {
                 td,
                 this.isRTL,
                 isHorizontal,
-                this.onInserted
+                this.onInserted,
+                this.onShowHelperElement
             );
             if (isHorizontal) {
                 this.horizontalInserter = newInserter;

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
@@ -16,7 +16,11 @@ export default function createTableInserter(
     td: HTMLTableCellElement,
     isRTL: boolean,
     isHorizontal: boolean,
-    onInsert: (table: HTMLTableElement) => void
+    onInsert: (table: HTMLTableElement) => void,
+    onShowHelperElement: (
+        elementData: CreateElementData,
+        helperType: 'CellResizer' | 'TableInserter' | 'TableResizer' | 'TableSelector'
+    ) => void
 ): TableEditFeature {
     const table = editor.getElementAtCursor('table', td);
     const tdRect = normalizeRect(td.getBoundingClientRect());
@@ -25,15 +29,16 @@ export default function createTableInserter(
     // set inserter position
     if (tdRect && tableRect) {
         const document = td.ownerDocument;
-        const div = createElement(
-            getInsertElementData(
-                isHorizontal,
-                editor.isDarkMode(),
-                isRTL,
-                editor.getDefaultFormat().backgroundColor || 'white'
-            ),
-            document
-        ) as HTMLDivElement;
+        const createElementData = getInsertElementData(
+            isHorizontal,
+            editor.isDarkMode(),
+            isRTL,
+            editor.getDefaultFormat().backgroundColor || 'white'
+        );
+
+        onShowHelperElement?.(createElementData, 'TableInserter');
+
+        const div = createElement(createElementData, document) as HTMLDivElement;
 
         if (isHorizontal) {
             div.style.left = `${

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableResizer.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableResizer.ts
@@ -1,7 +1,7 @@
 import DragAndDropHelper from '../../../pluginUtils/DragAndDropHelper';
 import TableEditFeature from './TableEditorFeature';
 import { createElement, normalizeRect, VTable } from 'roosterjs-editor-dom';
-import { KnownCreateElementDataIndex } from 'roosterjs-editor-types';
+import { CreateElementData } from 'roosterjs-editor-types';
 
 const TABLE_RESIZER_LENGTH = 12;
 const MIN_CELL_WIDTH = 30;
@@ -15,15 +15,23 @@ export default function createTableResizer(
     zoomScale: number,
     isRTL: boolean,
     onStart: () => void,
-    onDragEnd: () => false
+    onDragEnd: () => false,
+    onShowHelperElement: (
+        elementData: CreateElementData,
+        helperType: 'CellResizer' | 'TableInserter' | 'TableResizer' | 'TableSelector'
+    ) => void
 ): TableEditFeature {
     const document = table.ownerDocument;
-    const div = createElement(
-        isRTL
-            ? KnownCreateElementDataIndex.TableResizerRTL
-            : KnownCreateElementDataIndex.TableResizerLTR,
-        document
-    ) as HTMLDivElement;
+    const createElementData = {
+        tag: 'div',
+        style: `position: fixed; cursor: ${
+            isRTL ? 'ne' : 'nw'
+        }-resize; user-select: none; border: 1px solid #808080`,
+    };
+
+    onShowHelperElement?.(createElementData, 'TableResizer');
+
+    const div = createElement(createElementData, document) as HTMLDivElement;
 
     div.style.width = `${TABLE_RESIZER_LENGTH}px`;
     div.style.height = `${TABLE_RESIZER_LENGTH}px`;

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableSelector.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableSelector.ts
@@ -1,7 +1,7 @@
 import DragAndDropHelper from '../../../pluginUtils/DragAndDropHelper';
 import TableEditorFeature from './TableEditorFeature';
 import { createElement, normalizeRect } from 'roosterjs-editor-dom';
-import { KnownCreateElementDataIndex } from 'roosterjs-editor-types';
+import { CreateElementData } from 'roosterjs-editor-types';
 
 const TABLE_SELECTOR_LENGTH = 12;
 const TABLE_SELECTOR_ID = '_Table_Selector';
@@ -12,13 +12,21 @@ const TABLE_SELECTOR_ID = '_Table_Selector';
 export default function createTableSelector(
     table: HTMLTableElement,
     zoomScale: number,
-    onFinishDragging: (table: HTMLTableElement) => void
+    onFinishDragging: (table: HTMLTableElement) => void,
+    onShowHelperElement: (
+        elementData: CreateElementData,
+        helperType: 'CellResizer' | 'TableInserter' | 'TableResizer' | 'TableSelector'
+    ) => void
 ): TableEditorFeature {
     const document = table.ownerDocument;
-    const div = createElement(
-        KnownCreateElementDataIndex.TableSelector,
-        document
-    ) as HTMLDivElement;
+    const createElementData = {
+        tag: 'div',
+        style: 'position: fixed; cursor: all-scroll; user-select: none; border: 1px solid #808080',
+    };
+
+    onShowHelperElement?.(createElementData, 'TableSelector');
+
+    const div = createElement(createElementData, document) as HTMLDivElement;
 
     div.id = TABLE_SELECTOR_ID;
     div.style.width = `${TABLE_SELECTOR_LENGTH}px`;

--- a/packages/roosterjs-editor-types/lib/enum/KnownCreateElementDataIndex.ts
+++ b/packages/roosterjs-editor-types/lib/enum/KnownCreateElementDataIndex.ts
@@ -38,14 +38,27 @@ export const enum KnownCreateElementDataIndex {
     ImageEditWrapper = 6,
 
     /**
-     * Table resizer elements
+     * @deprecated
      */
     TableHorizontalResizer = 7,
-    TableVerticalResizer = 8,
-    TableResizerLTR = 9,
-    TableResizerRTL = 10,
+
     /**
-     * Table Selector element
+     * @deprecated
+     */
+    TableVerticalResizer = 8,
+
+    /**
+     * @deprecated
+     */
+    TableResizerLTR = 9,
+
+    /**
+     * @deprecated
+     */
+    TableResizerRTL = 10,
+
+    /**
+     * @deprecated
      */
     TableSelector = 11,
 }


### PR DESCRIPTION
To help solve #898 , add a customization callback to TableResize plugin.

e.g: The code below will add a red background to table resize helper:

```ts
        new TableResize((data, type) => {
            if (type == 'TableResizer') {
                data.style = (data.style || '') + ';background-color: red';
            }
        });
```

![image](https://user-images.githubusercontent.com/23065085/163858332-aac22e60-fe09-4ef5-b803-4d67b7b73604.png)
