### PR TITLE
Fix const enum issue (Fix #641)

### DIFF
--- a/.github/workflows/publish-size-optimized-package.yml
+++ b/.github/workflows/publish-size-optimized-package.yml
@@ -1,4 +1,4 @@
-name: Publish smaller package
+name: Publish size optimized package
 on:
     push:
         branches:

--- a/.github/workflows/publish-smaller-pack.yml
+++ b/.github/workflows/publish-smaller-pack.yml
@@ -1,0 +1,30 @@
+name: Publish smaller package
+on:
+    push:
+        branches:
+            - master
+jobs:
+    publish-smaller-pack:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2.3.1
+              with:
+                  persist-credentials: false
+
+            - name: Set Node Version
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 'v14.18.2'
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Preprocess package and const enum
+              run: node tools/build.js replaceConstEnum
+
+            - name: Build
+              run: npm run-script build:ci
+
+            - name: Publish
+              run: node tools/build.js publish --token ${{ secrets.NPM_TOKEN }}

--- a/packages-ui/roosterjs-react/lib/ribbon/type/KnownRibbonButton.ts
+++ b/packages-ui/roosterjs-react/lib/ribbon/type/KnownRibbonButton.ts
@@ -1,7 +1,7 @@
 /**
  * Keys of known ribbon buttons (buttons included in roosterjs-react)
  */
-export const enum KnownRibbonButtonKey {
+export /*--const--*/ enum KnownRibbonButtonKey {
     /**
      * "Bold" button on the format ribbon
      */

--- a/packages-ui/roosterjs-react/lib/rooster/type/UpdateMode.ts
+++ b/packages-ui/roosterjs-react/lib/rooster/type/UpdateMode.ts
@@ -1,7 +1,7 @@
 /**
  * Update mode for UpdateContentPlugins
  */
-export const enum UpdateMode {
+export /*--const--*/ enum UpdateMode {
     /**
      * Force update, triggered from UpdateContentPlugin.forceUpdate()
      */

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -256,8 +256,10 @@ export default class TableCellSelection implements EditorPlugin {
 
         updateSelection(this.editor, this.firstTarget, 0);
         this.vTable = this.vTable || new VTable(this.firstTable as HTMLTableElement);
-        this.tableRange.firstCell = getCellCoordinates(this.vTable, this.firstTarget as Element);
-        this.tableRange.lastCell = this.getNextTD(event);
+        this.tableRange = {
+            firstCell: getCellCoordinates(this.vTable, this.firstTarget as Element),
+            lastCell: this.getNextTD(event),
+        };
 
         if (
             !this.tableRange.lastCell ||
@@ -497,8 +499,10 @@ export default class TableCellSelection implements EditorPlugin {
                 this.tableSelection = true;
 
                 this.vTable = this.vTable || new VTable(this.firstTable);
-                this.tableRange.firstCell = getCellCoordinates(this.vTable, this.firstTarget);
-                this.tableRange.lastCell = getCellCoordinates(this.vTable, this.lastTarget);
+                this.tableRange = {
+                    firstCell: getCellCoordinates(this.vTable, this.firstTarget),
+                    lastCell: getCellCoordinates(this.vTable, this.lastTarget),
+                };
                 this.vTable.selection = this.tableRange;
                 this.selectTable();
             }
@@ -506,8 +510,11 @@ export default class TableCellSelection implements EditorPlugin {
             event.preventDefault();
         } else if (this.lastTarget == this.firstTarget && this.tableSelection) {
             this.vTable = new VTable(this.firstTable);
-            this.tableRange.firstCell = getCellCoordinates(this.vTable, this.firstTarget);
-            this.tableRange.lastCell = this.tableRange.firstCell;
+            const cell = getCellCoordinates(this.vTable, this.firstTarget);
+            this.tableRange = {
+                firstCell: cell,
+                lastCell: cell,
+            };
 
             this.vTable.selection = this.tableRange;
             this.selectTable();

--- a/packages/roosterjs-editor-types/lib/browser/ContentType.ts
+++ b/packages/roosterjs-editor-types/lib/browser/ContentType.ts
@@ -1,7 +1,7 @@
 /**
  * Prefix of content types
  */
-export const enum ContentTypePrefix {
+export /*--const--*/ enum ContentTypePrefix {
     /**
      * Text type prefix
      */
@@ -16,7 +16,7 @@ export const enum ContentTypePrefix {
 /**
  * Known content types
  */
-export const enum ContentType {
+export /*--const--*/ enum ContentType {
     /**
      * Plain text content type
      */

--- a/packages/roosterjs-editor-types/lib/browser/DocumentCommand.ts
+++ b/packages/roosterjs-editor-types/lib/browser/DocumentCommand.ts
@@ -2,7 +2,7 @@
  * Command strings for Document.execCommand() API
  * https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
  */
-export const enum DocumentCommand {
+export /*--const--*/ enum DocumentCommand {
     /**
      * Changes the browser auto-link behavior (Internet Explorer only)
      */

--- a/packages/roosterjs-editor-types/lib/browser/DocumentPosition.ts
+++ b/packages/roosterjs-editor-types/lib/browser/DocumentPosition.ts
@@ -2,7 +2,7 @@
  * The is essentially an enum representing result from browser compareDocumentPosition API
  * https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition
  */
-export const enum DocumentPosition {
+export /*--const--*/ enum DocumentPosition {
     /**
      * Same node
      */

--- a/packages/roosterjs-editor-types/lib/browser/Keys.ts
+++ b/packages/roosterjs-editor-types/lib/browser/Keys.ts
@@ -1,7 +1,7 @@
 /**
  * Key numbers common used keys
  */
-export const enum Keys {
+export /*--const--*/ enum Keys {
     NULL = 0,
     BACKSPACE = 8,
     TAB = 9,

--- a/packages/roosterjs-editor-types/lib/browser/NodeType.ts
+++ b/packages/roosterjs-editor-types/lib/browser/NodeType.ts
@@ -3,7 +3,7 @@
  * https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
  * Values not listed here are deprecated.
  */
-export const enum NodeType {
+export /*--const--*/ enum NodeType {
     /**
      * An Element node such as &lt;p&gt; or &lt;div&gt;.
      */

--- a/packages/roosterjs-editor-types/lib/enum/Alignment.ts
+++ b/packages/roosterjs-editor-types/lib/enum/Alignment.ts
@@ -1,7 +1,7 @@
 /**
  * enum for setting block alignment, used by setAlignment API
  */
-export const enum Alignment {
+export /*--const--*/ enum Alignment {
     /**
      * Align left
      */

--- a/packages/roosterjs-editor-types/lib/enum/Capitalization.ts
+++ b/packages/roosterjs-editor-types/lib/enum/Capitalization.ts
@@ -2,7 +2,7 @@
  * The enum used for controlling the capitalization of text.
  * Used by changeCapitalization API
  */
-export const enum Capitalization {
+export /*--const--*/ enum Capitalization {
     /**
      * Transforms the first character after punctuation mark followed by space
      * to uppercase and the rest of characters to lowercase.

--- a/packages/roosterjs-editor-types/lib/enum/ChangeSource.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ChangeSource.ts
@@ -2,7 +2,7 @@
  * Possible change sources. Here are the predefined sources.
  * It can also be other string if the change source can't fall into these sources.
  */
-export const enum ChangeSource {
+export /*--const--*/ enum ChangeSource {
     /**
      * Content changed by auto link
      */

--- a/packages/roosterjs-editor-types/lib/enum/ClearFormatMode.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ClearFormatMode.ts
@@ -1,7 +1,7 @@
 /**
  * Represents the strategy to clear the format of the current editor selection
  */
-export const enum ClearFormatMode {
+export /*--const--*/ enum ClearFormatMode {
     /**
      * Inline format. Remove text format.
      */

--- a/packages/roosterjs-editor-types/lib/enum/ColorTransformDirection.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ColorTransformDirection.ts
@@ -1,7 +1,7 @@
 /**
  * Represents the mode of color transformation
  */
-export const enum ColorTransformDirection {
+export /*--const--*/ enum ColorTransformDirection {
     /**
      * Transform from light to dark
      */

--- a/packages/roosterjs-editor-types/lib/enum/ContentPosition.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ContentPosition.ts
@@ -3,7 +3,7 @@
  * On insertion, we will need to specify where we want the content to be placed (begin, end, selection or outside)
  * On content traversing, we will need to specify the start position of traversing
  */
-export const enum ContentPosition {
+export /*--const--*/ enum ContentPosition {
     /**
      * Begin of the container
      */

--- a/packages/roosterjs-editor-types/lib/enum/DarkModeDatasetNames.ts
+++ b/packages/roosterjs-editor-types/lib/enum/DarkModeDatasetNames.ts
@@ -1,7 +1,7 @@
 /**
  * Constants string for dataset names used by dark mode
  */
-export const enum DarkModeDatasetNames {
+export /*--const--*/ enum DarkModeDatasetNames {
     /**
      * Original style text color
      */

--- a/packages/roosterjs-editor-types/lib/enum/Direction.ts
+++ b/packages/roosterjs-editor-types/lib/enum/Direction.ts
@@ -1,7 +1,7 @@
 /**
  * enum for setting block direction, used by setDirection API
  */
-export const enum Direction {
+export /*--const--*/ enum Direction {
     /**
      * Left to right
      */

--- a/packages/roosterjs-editor-types/lib/enum/EntityClasses.ts
+++ b/packages/roosterjs-editor-types/lib/enum/EntityClasses.ts
@@ -1,7 +1,7 @@
 /**
  * CSS Class names for Entity
  */
-export const enum EntityClasses {
+export /*--const--*/ enum EntityClasses {
     /**
      * Class name to specify this is an entity
      */

--- a/packages/roosterjs-editor-types/lib/enum/EntityOperation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/EntityOperation.ts
@@ -1,7 +1,7 @@
 /**
  * Define possible operations to an entity
  */
-export const enum EntityOperation {
+export /*--const--*/ enum EntityOperation {
     /**
      * Notify plugins that there is a new plugin was added into editor.
      * Plugin can handle this event to entity hydration.

--- a/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
@@ -1,7 +1,7 @@
 /**
  * Experimental feature flags
  */
-export const enum ExperimentalFeatures {
+export /*--const--*/ enum ExperimentalFeatures {
     /**
      * @deprecated This feature is always enabled
      */

--- a/packages/roosterjs-editor-types/lib/enum/FontSizeChange.ts
+++ b/packages/roosterjs-editor-types/lib/enum/FontSizeChange.ts
@@ -2,7 +2,7 @@
  * The enum used for increase or decrease font size
  * Used by setFontSize API
  */
-export const enum FontSizeChange {
+export /*--const--*/ enum FontSizeChange {
     /**
      * Increase font size
      */

--- a/packages/roosterjs-editor-types/lib/enum/GetContentMode.ts
+++ b/packages/roosterjs-editor-types/lib/enum/GetContentMode.ts
@@ -1,7 +1,7 @@
 /**
  * Represents a mode number to indicate what kind of content to retrieve when call Editor.getContent()
  */
-export const enum GetContentMode {
+export /*--const--*/ enum GetContentMode {
     /**
      * The clean content without any temporary content only for editor.
      * This is the default value. Call to Editor.getContent() with trigger an ExtractContentWithDom event

--- a/packages/roosterjs-editor-types/lib/enum/ImageEditOperation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ImageEditOperation.ts
@@ -1,7 +1,7 @@
 /**
  * Operation flags for ImageEdit plugin
  */
-export const enum ImageEditOperation {
+export /*--const--*/ enum ImageEditOperation {
     /**
      * No operation
      */

--- a/packages/roosterjs-editor-types/lib/enum/Indentation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/Indentation.ts
@@ -2,7 +2,7 @@
  * The enum used for increase or decrease indentation of a block
  * Used by setIndentation API
  */
-export const enum Indentation {
+export /*--const--*/ enum Indentation {
     /**
      * Increase indentation
      */

--- a/packages/roosterjs-editor-types/lib/enum/KnownCreateElementDataIndex.ts
+++ b/packages/roosterjs-editor-types/lib/enum/KnownCreateElementDataIndex.ts
@@ -1,7 +1,7 @@
 /**
  * Index of known CreateElementData used by createElement function
  */
-export const enum KnownCreateElementDataIndex {
+export /*--const--*/ enum KnownCreateElementDataIndex {
     /**
      * Set a none value to help createElement function ignore falsy value
      */

--- a/packages/roosterjs-editor-types/lib/enum/ListType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ListType.ts
@@ -1,7 +1,7 @@
 /**
  * Type of list (numbering or bullet)
  */
-export const enum ListType {
+export /*--const--*/ enum ListType {
     /**
      * None list type
      * It means this is not a list

--- a/packages/roosterjs-editor-types/lib/enum/PositionType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/PositionType.ts
@@ -1,7 +1,7 @@
 /**
  * Represent the type of a position
  */
-export const enum PositionType {
+export /*--const--*/ enum PositionType {
     /**
      * At the beginning of a node
      */

--- a/packages/roosterjs-editor-types/lib/enum/QueryScope.ts
+++ b/packages/roosterjs-editor-types/lib/enum/QueryScope.ts
@@ -1,7 +1,7 @@
 /**
  * Query scope for queryElements() API
  */
-export const enum QueryScope {
+export /*--const--*/ enum QueryScope {
     /**
      * Query from the whole body of root node. This is default value.
      */

--- a/packages/roosterjs-editor-types/lib/enum/RegionType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/RegionType.ts
@@ -1,7 +1,7 @@
 /**
  * Type of all possible regions. Currently we only support region of Table
  */
-export const enum RegionType {
+export /*--const--*/ enum RegionType {
     /**
      * Region split by Table
      */

--- a/packages/roosterjs-editor-types/lib/enum/TableBorderFormat.ts
+++ b/packages/roosterjs-editor-types/lib/enum/TableBorderFormat.ts
@@ -1,7 +1,7 @@
 /**
  * Table format border
  */
-export const enum TableBorderFormat {
+export /*--const--*/ enum TableBorderFormat {
     /**
      * All border of the table are displayed
      *  __ __ __

--- a/packages/roosterjs-editor-types/lib/enum/TableOperation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/TableOperation.ts
@@ -1,7 +1,7 @@
 /**
  * Operations used by editTable() API
  */
-export const enum TableOperation {
+export /*--const--*/ enum TableOperation {
     /**
      * Insert a row above current row
      */

--- a/packages/roosterjs-editor-types/lib/event/PluginEventType.ts
+++ b/packages/roosterjs-editor-types/lib/event/PluginEventType.ts
@@ -1,7 +1,7 @@
 /**
  * Editor plugin event type
  */
-export const enum PluginEventType {
+export /*--const--*/ enum PluginEventType {
     /**
      * HTML KeyDown event
      */

--- a/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
+++ b/packages/roosterjs-editor-types/lib/interface/SelectionRangeEx.ts
@@ -43,7 +43,7 @@ export interface NormalSelectionRange extends SelectionRangeExBase<SelectionRang
 /**
  * Types of Selection Ranges that the SelectionRangeEx can return
  */
-export const enum SelectionRangeTypes {
+export /*--const--*/ enum SelectionRangeTypes {
     /**
      * Normal selection range provided by browser.
      */

--- a/tools/build.js
+++ b/tools/build.js
@@ -16,7 +16,9 @@ const dts = require('./buildTools/dts');
 const buildDemoStep = require('./buildTools/buildDemo');
 const buildDocumentStep = require('./buildTools/buildDocument');
 const publishStep = require('./buildTools/publish');
+const replaceConstEnum = require('./buildTools/replaceConstEnum');
 const allTasks = [
+    replaceConstEnum,
     tslintStep,
     checkDependencyStep,
     cleanStep,
@@ -42,6 +44,7 @@ const allTasks = [
 
 // Commands
 const commands = [
+    'replaceConstEnum', // Replace enum with const enum
     'tslint', // Run tslint to check code style
     'checkdep', // Check circular dependency among files
     'clean', // Clean target folder

--- a/tools/buildTools/checkDependency.js
+++ b/tools/buildTools/checkDependency.js
@@ -65,7 +65,7 @@ function checkDependency() {
     allPackages.forEach(packageName => {
         const packageRoot = findPackageRoot(packageName);
 
-        var packageJson = readPackageJson(packageName, true /*readFromSourceFolder*/);
+        var [packageJson] = readPackageJson(packageName, true /*readFromSourceFolder*/);
         var dependencies = Object.keys(packageJson.dependencies);
         var peerDependencies = packageJson.peerDependencies
             ? Object.keys(packageJson.peerDependencies)

--- a/tools/buildTools/common.js
+++ b/tools/buildTools/common.js
@@ -88,7 +88,10 @@ function readPackageJson(packageName, readFromSourceFolder) {
         'package.json'
     );
     const content = fs.readFileSync(packageJsonFilePath);
-    return JSON.parse(content);
+    const writeBack = content => {
+        fs.writeFileSync(packageJsonFilePath, content);
+    };
+    return [JSON.parse(content), writeBack];
 }
 
 const mainPackageJson = JSON.parse(fs.readFileSync(path.join(rootPath, 'package.json')));

--- a/tools/buildTools/normalize.js
+++ b/tools/buildTools/normalize.js
@@ -16,7 +16,7 @@ function normalize() {
     const knownCustomizedPackages = {};
 
     allPackages.forEach(packageName => {
-        const packageJson = readPackageJson(packageName, true /*readFromSourceFolder*/);
+        const [packageJson] = readPackageJson(packageName, true /*readFromSourceFolder*/);
 
         Object.keys(packageJson.dependencies).forEach(dep => {
             if (packageJson.dependencies[dep]) {

--- a/tools/buildTools/publish.js
+++ b/tools/buildTools/publish.js
@@ -10,7 +10,7 @@ const NpmrcContent = 'registry=https://registry.npmjs.com/\n//registry.npmjs.com
 
 function publish(options) {
     allPackages.forEach(packageName => {
-        const json = readPackageJson(packageName, false /*readFromSourceFolder*/);
+        const [json] = readPackageJson(packageName, false /*readFromSourceFolder*/);
         const localVersion = json.version;
         const versionMatch = VersionRegex.exec(localVersion);
         const tagname = (versionMatch && versionMatch[2]) || 'latest';

--- a/tools/buildTools/replaceConstEnum.js
+++ b/tools/buildTools/replaceConstEnum.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const {
+    packages,
+    packagesUI,
+    rootPath,
+    readPackageJson,
+    mainPackageJson,
+    err,
+} = require('./common');
+const fs = require('fs');
+const path = require('path');
+
+function processDir(dir) {
+    const fileNames = fs.readdirSync(dir);
+
+    fileNames.forEach(fileName => {
+        const fullName = path.join(dir, fileName);
+        const stats = fs.statSync(fullName);
+
+        if (stats.isDirectory()) {
+            processDir(fullName);
+        } else if (stats.isFile() && /\.tsx?$/.test(fullName)) {
+            const content = fs.readFileSync(fullName).toString();
+            const newContent = content.replace(/\/\*--const--\*\//g, 'const');
+
+            if (content != newContent) {
+                fs.writeFileSync(fullName, newContent);
+            }
+        }
+    });
+}
+
+function processPackage(p, parentPath) {
+    const [json, writeBack] = readPackageJson(p, true);
+    const ver = json.version || mainPackageJson.version;
+
+    if (/^\d+\.\d+\.\d+$/.test(ver)) {
+        json.version = ver + '-constenum.0';
+        writeBack(JSON.stringify(json, null, 4));
+
+        processDir(path.join(rootPath, parentPath, p, 'lib'));
+    } else {
+        err(`Cannot replace const enum for package ${p}@${ver}`);
+    }
+}
+
+function replaceConstEnum() {
+    packages.forEach(p => {
+        processPackage(p, 'packages');
+    });
+
+    packagesUI.forEach(p => {
+        processPackage(p, 'packages-ui');
+    });
+}
+
+module.exports = {
+    message: 'Replacing enum with const enum...',
+    callback: replaceConstEnum,
+    enabled: options => options.replaceConstEnum,
+};

--- a/tools/buildTools/replaceConstEnum.js
+++ b/tools/buildTools/replaceConstEnum.js
@@ -36,7 +36,7 @@ function processPackage(p, parentPath) {
     const ver = json.version || mainPackageJson.version;
 
     if (/^\d+\.\d+\.\d+$/.test(ver)) {
-        json.version = ver + '-constenum.0';
+        json.version = ver + '-size-optimized.0';
         writeBack(JSON.stringify(json, null, 4));
 
         processDir(path.join(rootPath, parentPath, p, 'lib'));


### PR DESCRIPTION
We have got a lot of complain that exporting const enum will cause compatibility issue, e.g. #641 . To fix, we are doing this:
1. Replace current public const enum to enum to satisfy the requirement
2. Add build script to replace those enum back to const enum when build in a separate agent with a tagged version "*.*.*-constenum.0"
3. After 2, build and publish the code with tagged version
So that people can use code from @latest to get best compatibility, and we can also use code from @constenum to get best bundle size.