### PR TITLE
Fix Problem with setting content with colgroup #872

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreApi/ensureTypeInContainer.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/ensureTypeInContainer.ts
@@ -28,8 +28,9 @@ export const ensureTypeInContainer: EnsureTypeInContainer = (
     keyboardEvent?: KeyboardEvent
 ) => {
     const table = findClosestElementAncestor(position.node, core.contentDiv, 'table');
-    if (table) {
-        position = new Position(table.querySelector('td,th'), PositionType.Begin);
+    let td: HTMLElement;
+    if (table && (td = table.querySelector('td,th'))) {
+        position = new Position(td, PositionType.Begin);
     }
     position = position.normalize();
 

--- a/packages/roosterjs-editor-core/lib/coreApi/ensureTypeInContainer.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/ensureTypeInContainer.ts
@@ -10,6 +10,7 @@ import {
     applyFormat,
     createElement,
     createRange,
+    findClosestElementAncestor,
     getBlockElementAtNode,
     isNodeEmpty,
     Position,
@@ -26,7 +27,12 @@ export const ensureTypeInContainer: EnsureTypeInContainer = (
     position: NodePosition,
     keyboardEvent?: KeyboardEvent
 ) => {
+    const table = findClosestElementAncestor(position.node, core.contentDiv, 'table');
+    if (table) {
+        position = new Position(table.querySelector('td,th'), PositionType.Begin);
+    }
     position = position.normalize();
+
     const block = getBlockElementAtNode(core.contentDiv, position.node);
     let formatNode: HTMLElement;
 

--- a/packages/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts
@@ -133,6 +133,11 @@ function normalizeTables(tables: HTMLTableElement[]) {
                         tbody = child as HTMLTableSectionElement;
                     }
                     break;
+                case 'COLGROUP':
+                    if (table.tHead) {
+                        table.tHead.prepend(child);
+                    }
+                    break;
                 default:
                     tbody = null;
                     break;

--- a/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
@@ -199,4 +199,16 @@ describe('Editor', () => {
         expect(core.undo.snapshotsService.clearRedo).toBeDefined();
         expect(core.undo.snapshotsService.move).toBeDefined();
     });
+
+    it('create Editor with initial content as a table with colgroup', () => {
+        const div = document.createElement('div');
+        const editor = new Editor(div, {
+            initialContent:
+                '<table><thead><colgroup><col width="100" ><col width="100" ></thead><tbody><tr><td>col 1</td><td>col 2</td></tr><tr><td>col 1</td><td>col 2</td></tr></tbody></table>',
+        });
+
+        expect(editor.getContent()).toEqual(
+            '<table><thead><colgroup><col width="100"><col width="100"></colgroup></thead><tbody><tr><td>col 1</td><td>col 2</td></tr><tr><td>col 1</td><td>col 2</td></tr></tbody></table>'
+        );
+    });
 });


### PR DESCRIPTION
 #872

When setting initial content to start with a table with colgroup the ensureTypeInContainer selected the colgroup element as the initial position.

Then select the block element of the initial position is going to be the thead element that is containing the Colgroup Node. Then the collapseToSingleElement causes the thead to be moved to another table.

Changes:
If the initialContent is a table, try select the first td/th and use it as initial position.