### PR TITLE
Fix demo page ContentEdit Pane

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/ContentEditFeatures.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/ContentEditFeatures.tsx
@@ -37,6 +37,10 @@ const EditFeatureDescriptionMap: Record<keyof ContentEditFeatureSettings, string
     maintainListChainWhenDelete:
         'Maintain the list of number in the right order after press delete before the first item',
     indentTableOnTab: 'Indent the table if it is all cells are selected.',
+    indentWhenTabText:
+        'On Tab indent the selection or add Tab, requires TabKeyFeatures Experimental Feature',
+    outdentWhenTabText:
+        'On Shift + Tab outdent the selection, requires TabKeyFeatures Experimental Feature',
 };
 
 export interface ContentEditFeaturessProps {

--- a/packages/roosterjs-editor-types/lib/interface/ContentEditFeatureSettings.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ContentEditFeatureSettings.ts
@@ -240,4 +240,5 @@ export default interface ContentEditFeatureSettings
         ShortcutFeatureSettings,
         CursorFeatureSettings,
         MarkdownFeatureSettings,
-        EntityFeatureSettings {}
+        EntityFeatureSettings,
+        TextFeatureSettings {}


### PR DESCRIPTION
Add content to empty Checkboxes in the demo page:
![image](https://user-images.githubusercontent.com/8291124/165186537-d94f7621-ac9e-4179-9728-947c55c0f426.png)

Fix:
![image](https://user-images.githubusercontent.com/8291124/165186599-b93c8167-aac8-44a0-b248-c3a7be9bb6f5.png)
