### PR TITLE
Fix #931

### DIFF
--- a/packages/roosterjs-color-utils/package.json
+++ b/packages/roosterjs-color-utils/package.json
@@ -2,9 +2,8 @@
     "name": "roosterjs-color-utils",
     "description": "Color utilities for roosterjs",
     "dependencies": {
-        "color": "^3.0.0",
-        "roosterjs-editor-types": ""
+        "color": "^3.0.0"
     },
     "main": "./lib/index.ts",
-    "version": "1.0.0"
+    "version": "1.0.1"
 }


### PR DESCRIPTION
We changed the source map to be inline before. However, since we didn't bump up version of roosterjs-color-utils, new version of this package was not published. So this issue still exists there.

To fix it, I bump up package version, also remove an unnecessary dependency.