### PR TITLE
Fix a dark mode issue

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
@@ -94,11 +94,17 @@ function transformToDarkMode(elements: HTMLElement[], getDarkColor: (color: stri
                     names[ColorAttributeEnum.CssColor]
                 );
                 const attrColor = element.getAttribute(names[ColorAttributeEnum.HtmlColor]);
-
-                return !element.dataset[names[ColorAttributeEnum.CssDataSet]] &&
-                    !element.dataset[names[ColorAttributeEnum.HtmlDataSet]] &&
+                const existingDataSetCssValue =
+                    element.dataset[names[ColorAttributeEnum.CssDataSet]];
+                const existingDataSetHtmlValue =
+                    element.dataset[names[ColorAttributeEnum.HtmlDataSet]];
+                const needProcess =
+                    (!existingDataSetCssValue || existingDataSetCssValue == styleColor) &&
+                    (!existingDataSetHtmlValue || existingDataSetHtmlValue == attrColor) &&
                     (styleColor || attrColor) &&
-                    styleColor != 'inherit' // For inherit style, no need to change it and let it keep inherit from parent element
+                    styleColor != 'inherit'; // For inherit style, no need to change it and let it keep inherit from parent element
+
+                return needProcess
                     ? {
                           element,
                           styleColor,


### PR DESCRIPTION
When copy from dark mode reading pane, sometimes the data-ogsb attribute is not removed, this causes we skip those elements when convert back to dark mode. So add a check, if the data-ogsb value is the same with current value, ignore those data-ogsb value.