### PR TITLE
Fix start script

### DIFF
--- a/tools/buildTools/normalize.js
+++ b/tools/buildTools/normalize.js
@@ -3,77 +3,15 @@
 const path = require('path');
 const mkdirp = require('mkdirp');
 const fs = require('fs');
+const processConstEnum = require('./processConstEnum');
 const {
-    rootPath,
     packages,
     allPackages,
     distPath,
-    compatibleEnumPath,
     readPackageJson,
     mainPackageJson,
     err,
 } = require('./common');
-
-const EnumRegex = /(^\s*\/\*(?:\*(?!\/)|[^*])*\*\/)?\W*export const enum ([A-Za-z0-9]+)\s{([^}]+)}/gm;
-const CompatibleTypePrefix = 'Compatible';
-
-function parseEnum(source) {
-    const enums = [];
-
-    let enumMatch;
-    while (!!(enumMatch = EnumRegex.exec(source))) {
-        const enumComment = enumMatch[1] || '';
-        const enumName = enumMatch[2];
-        const enumContent = enumMatch[3];
-        const currentEnum = {
-            name: enumName,
-            comment: enumComment,
-            content: enumContent,
-        };
-
-        enums.push(currentEnum);
-    }
-
-    return enums;
-}
-
-function generateCompatibleEnum(currentEnum) {
-    const enumName = currentEnum.name;
-    return `${currentEnum.comment}\r\nexport enum ${CompatibleTypePrefix}${enumName} {\r\n${currentEnum.content}}\r\n`;
-}
-
-function generateCompatibleEnumScript(enums, fileName) {
-    return enums.map(generateCompatibleEnum).join('\r\n');
-}
-
-function processConstEnum() {
-    const sourceDir = path.join(rootPath, 'packages', 'roosterjs-editor-types', 'lib', 'enum');
-    const fileNames = fs.readdirSync(sourceDir);
-    let indexTs = '';
-
-    fileNames.forEach(fileName => {
-        const fullName = path.join(sourceDir, fileName);
-        const content = fs.readFileSync(fullName).toString();
-        const enums = parseEnum(content);
-
-        if (enums.length > 0) {
-            const newContent = generateCompatibleEnumScript(enums, fileName);
-
-            indexTs += `export { ${enums
-                .map(e => `${CompatibleTypePrefix}${e.name}`)
-                .join(', ')} } from './${fileName.replace(/\.ts$/, '')}'\r\n`;
-
-            const newFullName = path.join(compatibleEnumPath, fileName);
-
-            fs.mkdirSync(compatibleEnumPath, { recursive: true });
-            fs.writeFileSync(newFullName, newContent);
-        }
-    });
-
-    if (indexTs) {
-        fs.writeFileSync(path.join(compatibleEnumPath, 'index.ts'), indexTs);
-    }
-}
 
 function normalize() {
     const knownCustomizedPackages = {};

--- a/tools/buildTools/processConstEnum.js
+++ b/tools/buildTools/processConstEnum.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { rootPath, compatibleEnumPath } = require('./common');
+
+const EnumRegex = /(^\s*\/\*(?:\*(?!\/)|[^*])*\*\/)?\W*export const enum ([A-Za-z0-9]+)\s{([^}]+)}/gm;
+const CompatibleTypePrefix = 'Compatible';
+
+function parseEnum(source) {
+    const enums = [];
+
+    let enumMatch;
+    while (!!(enumMatch = EnumRegex.exec(source))) {
+        const enumComment = enumMatch[1] || '';
+        const enumName = enumMatch[2];
+        const enumContent = enumMatch[3];
+        const currentEnum = {
+            name: enumName,
+            comment: enumComment,
+            content: enumContent,
+        };
+
+        enums.push(currentEnum);
+    }
+
+    return enums;
+}
+
+function generateCompatibleEnum(currentEnum) {
+    const enumName = currentEnum.name;
+    return `${currentEnum.comment}\r\nexport enum ${CompatibleTypePrefix}${enumName} {\r\n${currentEnum.content}}\r\n`;
+}
+
+function generateCompatibleEnumScript(enums) {
+    return enums.map(generateCompatibleEnum).join('\r\n');
+}
+
+function processConstEnum() {
+    const sourceDir = path.join(rootPath, 'packages', 'roosterjs-editor-types', 'lib', 'enum');
+    const fileNames = fs.readdirSync(sourceDir);
+    let indexTs = '';
+
+    fileNames.forEach(fileName => {
+        const fullName = path.join(sourceDir, fileName);
+        const content = fs.readFileSync(fullName).toString();
+        const enums = parseEnum(content);
+
+        if (enums.length > 0) {
+            const newContent = generateCompatibleEnumScript(enums);
+
+            indexTs += `export { ${enums
+                .map(e => `${CompatibleTypePrefix}${e.name}`)
+                .join(', ')} } from './${fileName.replace(/\.ts$/, '')}'\r\n`;
+
+            const newFullName = path.join(compatibleEnumPath, fileName);
+
+            fs.mkdirSync(compatibleEnumPath, { recursive: true });
+            fs.writeFileSync(newFullName, newContent);
+        }
+    });
+
+    if (indexTs) {
+        fs.writeFileSync(path.join(compatibleEnumPath, 'index.ts'), indexTs);
+    }
+}
+
+module.exports = processConstEnum;

--- a/tools/start.js
+++ b/tools/start.js
@@ -2,6 +2,7 @@ var webpack = require('webpack');
 var webpackConfig = require('../webpack.config');
 var webpackDevServer = require('webpack-dev-server');
 var detect = require('detect-port');
+var processConstEnum = require('./buildTools/processConstEnum');
 
 function startWebpackDevServer() {
     port = webpackConfig.devServer.port;
@@ -23,4 +24,5 @@ function startWebpackDevServer() {
         });
 }
 
+processConstEnum();
 +startWebpackDevServer();


### PR DESCRIPTION
After the latest change, if you run "npm start" or "yarn start" before the first time run "yarn build", it will fail. Because the code to generate compatible types is not run. This change make sure the script will run before start.