### PR TITLE
Add target to createLink function.

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/createLink.ts
+++ b/packages/roosterjs-editor-api/lib/format/createLink.ts
@@ -8,6 +8,8 @@ const MAILTO_REGEX = /^[\w.%+-]+@/i;
 // Regex matching begin of ftp, i.e. ftp.microsoft.com
 const FTP_REGEX = /^ftp\./i;
 
+type HTMLAnchorElementTarget = '_self' | '_blank' | '_parent' | '_top';
+
 function applyLinkPrefix(url: string): string {
     if (!url) {
         return url;
@@ -42,6 +44,7 @@ function applyLinkPrefix(url: string): string {
  * When protocol is not specified, a best matched protocol will be predicted.
  * @param altText Optional alt text of the link, will be shown when hover on the link
  * @param displayText Optional display text for the link.
+ * @param target Optional display target for the link.
  * If specified, the display text of link will be replaced with this text.
  * If not specified and there wasn't a link, the link url will be used as display text.
  */
@@ -49,7 +52,8 @@ export default function createLink(
     editor: IEditor,
     link: string,
     altText?: string,
-    displayText?: string
+    displayText?: string,
+    target?: HTMLAnchorElementTarget
 ) {
     editor.focus();
     let url = (checkXss(link) || '').trim();
@@ -96,6 +100,9 @@ export default function createLink(
             if (altText && anchor) {
                 anchor.title = altText;
             }
+            if (anchor) {
+                updateAnchorTarget(anchor, target);
+            }
             return anchor;
         }, ChangeSource.CreateLink);
     }
@@ -108,6 +115,14 @@ function getAnchorNodeAtCursor(editor: IEditor): HTMLAnchorElement {
 function updateAnchorDisplayText(anchor: HTMLAnchorElement, displayText: string) {
     if (displayText && anchor.textContent != displayText) {
         anchor.textContent = displayText;
+    }
+}
+
+function updateAnchorTarget(anchor: HTMLAnchorElement, target?: HTMLAnchorElementTarget) {
+    if (target) {
+        anchor.target = target;
+    } else if (!target && anchor.target) {
+        delete anchor.target;
     }
 }
 

--- a/packages/roosterjs-editor-api/lib/format/createLink.ts
+++ b/packages/roosterjs-editor-api/lib/format/createLink.ts
@@ -121,8 +121,8 @@ function updateAnchorDisplayText(anchor: HTMLAnchorElement, displayText: string)
 function updateAnchorTarget(anchor: HTMLAnchorElement, target?: HTMLAnchorElementTarget) {
     if (target) {
         anchor.target = target;
-    } else if (!target && anchor.target) {
-        delete anchor.target;
+    } else if (!target && anchor.getAttribute('target')) {
+        anchor.removeAttribute('target');
     }
 }
 

--- a/packages/roosterjs-editor-api/test/format/createLinkTest.ts
+++ b/packages/roosterjs-editor-api/test/format/createLinkTest.ts
@@ -84,6 +84,15 @@ describe('createLink()', () => {
         expect(link.outerHTML).toBe('<a href="http://www.example.com">this is my link</a>');
     });
 
+    it('sets target attribute in the link', () => {
+        // Act
+        createLink(editor, 'www.example.com', undefined, undefined, '_self');
+
+        // Assert
+        let link = document.getElementsByTagName('a')[0];
+        expect(link.target).toBe('_self');
+    });
+
     it('Issue when selection is under another tag', () => {
         editor.setContent(
             '<div><span id="span1" style="box-sizing:border-box;color:rgba(0, 0, 0, 0.9);background-color:rgb(255, 255, 255);font-family:Calibri, Helvetica, sans-serif;display:inline !important">Hello<span style="box-sizing:border-box">&nbsp;</span></span><b style="box-sizing:border-box;color:rgba(0, 0, 0, 0.9);background-color:rgb(255, 255, 255);font-family:Calibri, Helvetica, sans-serif" id="span2">world<span style="box-sizing:border-box">&nbsp;</span></b><span style="box-sizing:border-box;color:rgba(0, 0, 0, 0.9);background-color:rgb(255, 255, 255);margin:0px;font-family:Calibri, Helvetica, sans-serif">🙂</span><span style="box-sizing:border-box;color:rgba(0, 0, 0, 0.9);background-color:rgb(255, 255, 255);font-family:Calibri, Helvetica, sans-serif;display:inline !important">&nbsp;this is a test</span><br></div><!--{"start":[0,0,0,0],"end":[0,0,0,0]}-->'


### PR DESCRIPTION
Add link target parameter to the `createLink` function to allow adding `target` attribute to the anchor tags.