### PR TITLE
Add metadata API for roosterjs

### DIFF
--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -121,4 +121,4 @@ export {
     createArrayDefinition,
     createObjectDefinition,
 } from './metadata/definitionCreators';
-export { getMetadata, setMetadata } from './metadata/metadata';
+export { getMetadata, setMetadata, removeMetadata } from './metadata/metadata';

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -112,3 +112,13 @@ export { default as setStyles } from './style/setStyles';
 export { default as adjustInsertPosition } from './edit/adjustInsertPosition';
 export { default as deleteSelectedContent } from './edit/deleteSelectedContent';
 export { default as getTextContent } from './edit/getTextContent';
+
+export { default as validate } from './metadata/validate';
+export {
+    createNumberDefinition,
+    createBooleanDefinition,
+    createStringDefinition,
+    createArrayDefinition,
+    createObjectDefinition,
+} from './metadata/definitionCreators';
+export { getMetadata, setMetadata } from './metadata/metadata';

--- a/packages/roosterjs-editor-dom/lib/metadata/definitionCreators.ts
+++ b/packages/roosterjs-editor-dom/lib/metadata/definitionCreators.ts
@@ -1,0 +1,94 @@
+import {
+    Definition,
+    DefinitionType,
+    NumberDefinition,
+    ArrayDefinition,
+    BooleanDefinition,
+    StringDefinition,
+    ObjectDefinition,
+} from 'roosterjs-editor-types';
+
+/**
+ * Create a number definition
+ * @param value Optional value of the number
+ * @param isOptional Whether this property is optional
+ * @param minValue Optional minimum value
+ * @param maxValue Optional maximum value
+ * @returns The number definition object
+ */
+export function createNumberDefinition(
+    value?: number,
+    isOptional?: boolean,
+    minValue?: number,
+    maxValue?: number
+): NumberDefinition {
+    return {
+        type: DefinitionType.Number,
+        isOptional,
+        value,
+        maxValue,
+        minValue,
+    };
+}
+
+/**
+ * Create a boolean definition
+ * @param value Optional expected boolean value
+ * @param isOptional  Whether this property is optional
+ * @returns  The boolean definition object
+ */
+export function createBooleanDefinition(value?: boolean, isOptional?: boolean): BooleanDefinition {
+    return {
+        type: DefinitionType.Boolean,
+        isOptional,
+        value,
+    };
+}
+
+/**
+ * Create a string definition
+ * @param value Optional expected string value
+ * @param isOptional  Whether this property is optional
+ * @returns  The string definition object
+ */
+export function createStringDefinition(value?: string, isOptional?: boolean): StringDefinition {
+    return {
+        type: DefinitionType.String,
+        isOptional,
+        value,
+    };
+}
+
+/**
+ * Create an array definition
+ * @param itemDef Definition of each item of the related array
+ * @param isOptional  Whether this property is optional
+ * @returns  The array definition object
+ */
+export function createArrayDefinition<T>(
+    itemDef: Definition<T>,
+    isOptional?: boolean
+): ArrayDefinition<T[]> {
+    return {
+        type: DefinitionType.Array,
+        isOptional,
+        itemDef,
+    };
+}
+
+/**
+ * Create an object definition
+ * @param propertyDef Definition of each property of the related object
+ * @param isOptional  Whether this property is optional
+ * @returns  The object definition object
+ */
+export function createObjectDefinition<T extends Record<string, any>>(
+    propertyDef: { [Key in keyof T]: Definition<T[Key]> },
+    isOptional?: boolean
+): ObjectDefinition<T> {
+    return {
+        type: DefinitionType.Object,
+        isOptional,
+        propertyDef,
+    };
+}

--- a/packages/roosterjs-editor-dom/lib/metadata/definitionCreators.ts
+++ b/packages/roosterjs-editor-dom/lib/metadata/definitionCreators.ts
@@ -6,19 +6,20 @@ import {
     BooleanDefinition,
     StringDefinition,
     ObjectDefinition,
+    ObjectPropertyDefinition,
 } from 'roosterjs-editor-types';
 
 /**
  * Create a number definition
- * @param value Optional value of the number
  * @param isOptional Whether this property is optional
+ * @param value Optional value of the number
  * @param minValue Optional minimum value
  * @param maxValue Optional maximum value
  * @returns The number definition object
  */
 export function createNumberDefinition(
-    value?: number,
     isOptional?: boolean,
+    value?: number,
     minValue?: number,
     maxValue?: number
 ): NumberDefinition {
@@ -33,11 +34,11 @@ export function createNumberDefinition(
 
 /**
  * Create a boolean definition
- * @param value Optional expected boolean value
  * @param isOptional  Whether this property is optional
+ * @param value Optional expected boolean value
  * @returns  The boolean definition object
  */
-export function createBooleanDefinition(value?: boolean, isOptional?: boolean): BooleanDefinition {
+export function createBooleanDefinition(isOptional?: boolean, value?: boolean): BooleanDefinition {
     return {
         type: DefinitionType.Boolean,
         isOptional,
@@ -47,11 +48,11 @@ export function createBooleanDefinition(value?: boolean, isOptional?: boolean): 
 
 /**
  * Create a string definition
- * @param value Optional expected string value
  * @param isOptional  Whether this property is optional
+ * @param value Optional expected string value
  * @returns  The string definition object
  */
-export function createStringDefinition(value?: string, isOptional?: boolean): StringDefinition {
+export function createStringDefinition(isOptional?: boolean, value?: string): StringDefinition {
     return {
         type: DefinitionType.String,
         isOptional,
@@ -67,12 +68,16 @@ export function createStringDefinition(value?: string, isOptional?: boolean): St
  */
 export function createArrayDefinition<T>(
     itemDef: Definition<T>,
-    isOptional?: boolean
+    isOptional?: boolean,
+    minLength?: number,
+    maxLength?: number
 ): ArrayDefinition<T[]> {
     return {
         type: DefinitionType.Array,
         isOptional,
         itemDef,
+        minLength,
+        maxLength,
     };
 }
 
@@ -82,8 +87,8 @@ export function createArrayDefinition<T>(
  * @param isOptional  Whether this property is optional
  * @returns  The object definition object
  */
-export function createObjectDefinition<T extends Record<string, any>>(
-    propertyDef: { [Key in keyof T]: Definition<T[Key]> },
+export function createObjectDefinition<T extends Object>(
+    propertyDef: ObjectPropertyDefinition<T>,
     isOptional?: boolean
 ): ObjectDefinition<T> {
     return {

--- a/packages/roosterjs-editor-dom/lib/metadata/metadata.ts
+++ b/packages/roosterjs-editor-dom/lib/metadata/metadata.ts
@@ -6,11 +6,17 @@ const MetadataDataSetName = 'editingInfo';
 /**
  * Get metadata object from an HTML element
  * @param element The HTML element to get metadata object from
- * @param def The type definition of this metadata used for validate this metadata object.
+ * @param definition The type definition of this metadata used for validate this metadata object.
  * If not specified, no validation will be performed and always return whatever we get from the element
+ * @param defaultValue The default value to return if the retrieved object cannot pass the validation,
+ * or there is no metadata object at all
  * @returns The strong-type metadata object if it can be validated, or null
  */
-export function getMetadata<T>(element: HTMLElement, def?: Definition<T>): T | null {
+export function getMetadata<T>(
+    element: HTMLElement,
+    definition?: Definition<T>,
+    defaultValue?: T
+): T | null {
     const str = element.dataset[MetadataDataSetName];
     let obj: any;
 
@@ -18,7 +24,19 @@ export function getMetadata<T>(element: HTMLElement, def?: Definition<T>): T | n
         obj = str ? JSON.parse(str) : null;
     } catch {}
 
-    return !def ? (obj as T) : validate(obj, def) ? obj : null;
+    if (typeof obj !== 'undefined') {
+        if (!definition) {
+            return obj as T;
+        } else if (validate(obj, definition)) {
+            return obj;
+        }
+    }
+
+    if (defaultValue) {
+        return defaultValue;
+    } else {
+        return null;
+    }
 }
 
 /**
@@ -36,4 +54,12 @@ export function setMetadata<T>(element: HTMLElement, metadata: T, def?: Definiti
     } else {
         return false;
     }
+}
+
+/**
+ * Remove metadata from the given element if any
+ * @param element The element to remove metadata from
+ */
+export function removeMetadata(element: HTMLElement) {
+    delete element.dataset[MetadataDataSetName];
 }

--- a/packages/roosterjs-editor-dom/lib/metadata/metadata.ts
+++ b/packages/roosterjs-editor-dom/lib/metadata/metadata.ts
@@ -1,0 +1,39 @@
+import validate from './validate';
+import { Definition } from 'roosterjs-editor-types';
+
+const MetadataDataSetName = 'editingInfo';
+
+/**
+ * Get metadata object from an HTML element
+ * @param element The HTML element to get metadata object from
+ * @param def The type definition of this metadata used for validate this metadata object.
+ * If not specified, no validation will be performed and always return whatever we get from the element
+ * @returns The strong-type metadata object if it can be validated, or null
+ */
+export function getMetadata<T>(element: HTMLElement, def?: Definition<T>): T | null {
+    const str = element.dataset[MetadataDataSetName];
+    let obj: any;
+
+    try {
+        obj = str ? JSON.parse(str) : null;
+    } catch {}
+
+    return !def ? (obj as T) : validate(obj, def) ? obj : null;
+}
+
+/**
+ * Set metadata object into an HTML element
+ * @param element The HTML element to set metadata object to
+ * @param metadata The metadata object to set
+ * @param def An optional type definition object used for validate this metadata object.
+ * If not specified, metadata will be set without validation
+ * @returns True if metadata is set, otherwise false
+ */
+export function setMetadata<T>(element: HTMLElement, metadata: T, def?: Definition<T>): boolean {
+    if (!def || validate(metadata, def)) {
+        element.dataset[MetadataDataSetName] = JSON.stringify(metadata);
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/packages/roosterjs-editor-dom/lib/metadata/validate.ts
+++ b/packages/roosterjs-editor-dom/lib/metadata/validate.ts
@@ -1,0 +1,58 @@
+import { Definition, DefinitionType } from 'roosterjs-editor-types';
+
+/**
+ * Validate the given object with a type definition object
+ * @param input The object to validate
+ * @param def The type definition object used for validation
+ * @returns True if the object passed the validation, otherwise false
+ */
+export default function validate<T>(input: any, def: Definition<T>): input is T {
+    let result = false;
+    if (def.isOptional && typeof input === 'undefined') {
+        result = true;
+    } else {
+        switch (def.type) {
+            case DefinitionType.String:
+                result =
+                    typeof input === 'string' &&
+                    (typeof def.value === 'undefined' || input === def.value);
+                break;
+
+            case DefinitionType.Number:
+                result =
+                    typeof input === 'number' &&
+                    (typeof def.value === 'undefined' || areSameNumbers(def.value, input)) &&
+                    (typeof def.minValue === 'undefined' || input >= def.minValue) &&
+                    (typeof def.maxValue === 'undefined' || input <= def.maxValue);
+                break;
+
+            case DefinitionType.Boolean:
+                result = typeof input === 'boolean';
+                break;
+
+            case DefinitionType.Array:
+                result =
+                    Array.isArray(input) &&
+                    (typeof def.minLength === 'undefined' || input.length >= def.minLength) &&
+                    (typeof def.maxLength === 'undefined' || input.length <= def.maxLength) &&
+                    input.every(x => validate(x, def.itemDef));
+                break;
+
+            case DefinitionType.Object:
+                result =
+                    typeof input === 'object' &&
+                    Object.keys(def.propertyDef).every(x => validate(input[x], def.propertyDef[x]));
+                break;
+
+            case DefinitionType.Customize:
+                result = def.validator(input);
+                break;
+        }
+    }
+
+    return result;
+}
+
+function areSameNumbers(n1: number, n2: number) {
+    return Math.abs(n1 - n2) < 1e-3;
+}

--- a/packages/roosterjs-editor-dom/lib/metadata/validate.ts
+++ b/packages/roosterjs-editor-dom/lib/metadata/validate.ts
@@ -27,7 +27,9 @@ export default function validate<T>(input: any, def: Definition<T>): input is T 
                 break;
 
             case DefinitionType.Boolean:
-                result = typeof input === 'boolean';
+                result =
+                    typeof input === 'boolean' &&
+                    (typeof def.value === 'undefined' || input === def.value);
                 break;
 
             case DefinitionType.Array:

--- a/packages/roosterjs-editor-dom/lib/selection/setHtmlWithSelectionPath.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/setHtmlWithSelectionPath.ts
@@ -17,6 +17,30 @@ import {
     Coordinates,
 } from 'roosterjs-editor-types';
 
+const NumberArrayDefinition = createArrayDefinition<number>(createNumberDefinition());
+
+const CoordinatesDefinition = createObjectDefinition<Coordinates>({
+    x: createNumberDefinition(),
+    y: createNumberDefinition(),
+});
+
+const IsDarkModeDefinition = createBooleanDefinition(true /*isOptional*/);
+
+const NormalContentMetadataDefinition = createObjectDefinition<NormalContentMetadata>({
+    type: createNumberDefinition(true /*isOptional*/, SelectionRangeTypes.Normal),
+    isDarkMode: IsDarkModeDefinition,
+    start: NumberArrayDefinition,
+    end: NumberArrayDefinition,
+});
+
+const TableContentMetadataDefinition = createObjectDefinition<TableContentMetadata>({
+    type: createNumberDefinition(false /*isOptional*/, SelectionRangeTypes.TableSelection),
+    isDarkMode: IsDarkModeDefinition,
+    tableId: createStringDefinition(),
+    firstCell: CoordinatesDefinition,
+    lastCell: CoordinatesDefinition,
+});
+
 /**
  * @deprecated Use setHtmlWithMetadata instead
  * Restore inner HTML of a root element from given html string. If the string contains selection path,
@@ -68,6 +92,9 @@ export function setHtmlWithMetadata(
                 validate(obj, TableContentMetadataDefinition)
             ) {
                 rootNode.removeChild(potentialMetadataComment);
+                obj.type = typeof obj.type === 'undefined' ? SelectionRangeTypes.Normal : obj.type;
+                obj.isDarkMode = obj.isDarkMode || false;
+
                 return obj;
             }
         } catch {}
@@ -75,25 +102,3 @@ export function setHtmlWithMetadata(
 
     return undefined;
 }
-
-const NumberArrayDefinition = createArrayDefinition<number>(createNumberDefinition());
-
-const CoordinatesDefinition = createObjectDefinition<Coordinates>({
-    x: createNumberDefinition(),
-    y: createNumberDefinition(),
-});
-
-const NormalContentMetadataDefinition = createObjectDefinition<NormalContentMetadata>({
-    start: NumberArrayDefinition,
-    end: NumberArrayDefinition,
-    isDarkMode: createBooleanDefinition(),
-    type: createNumberDefinition(SelectionRangeTypes.Normal),
-});
-
-const TableContentMetadataDefinition = createObjectDefinition<TableContentMetadata>({
-    tableId: createStringDefinition(),
-    firstCell: CoordinatesDefinition,
-    lastCell: CoordinatesDefinition,
-    isDarkMode: createBooleanDefinition(),
-    type: createNumberDefinition(SelectionRangeTypes.TableSelection),
-});

--- a/packages/roosterjs-editor-dom/test/metadata/definitionCreatorsTest.ts
+++ b/packages/roosterjs-editor-dom/test/metadata/definitionCreatorsTest.ts
@@ -1,0 +1,130 @@
+import { Definition, DefinitionType, ObjectPropertyDefinition } from 'roosterjs-editor-types';
+import {
+    createNumberDefinition,
+    createBooleanDefinition,
+    createStringDefinition,
+    createArrayDefinition,
+    createObjectDefinition,
+} from '../../lib/metadata/definitionCreators';
+
+describe('createNumberDefinition', () => {
+    it('normal case', () => {
+        const def = createNumberDefinition();
+        expect(def).toEqual({
+            type: DefinitionType.Number,
+            isOptional: undefined,
+            value: undefined,
+            maxValue: undefined,
+            minValue: undefined,
+        });
+    });
+
+    it('full case', () => {
+        const def = createNumberDefinition(true, 2, 1, 3);
+        expect(def).toEqual({
+            type: DefinitionType.Number,
+            isOptional: true,
+            value: 2,
+            minValue: 1,
+            maxValue: 3,
+        });
+    });
+});
+
+describe('createBooleanDefinition', () => {
+    it('normal case', () => {
+        const def = createBooleanDefinition();
+        expect(def).toEqual({
+            type: DefinitionType.Boolean,
+            isOptional: undefined,
+            value: undefined,
+        });
+    });
+
+    it('full case', () => {
+        const def = createBooleanDefinition(true, false);
+        expect(def).toEqual({
+            type: DefinitionType.Boolean,
+            isOptional: true,
+            value: false,
+        });
+    });
+});
+
+describe('createStringDefinition', () => {
+    it('normal case', () => {
+        const def = createStringDefinition();
+        expect(def).toEqual({
+            type: DefinitionType.String,
+            isOptional: undefined,
+            value: undefined,
+        });
+    });
+
+    it('full case', () => {
+        const def = createStringDefinition(true, 'test');
+        expect(def).toEqual({
+            type: DefinitionType.String,
+            isOptional: true,
+            value: 'test',
+        });
+    });
+});
+
+describe('createArrayDefinition', () => {
+    const itemDef: Definition<number> = {
+        type: DefinitionType.Number,
+    };
+
+    it('normal case', () => {
+        const def = createArrayDefinition<number>(itemDef);
+        expect(def).toEqual({
+            type: DefinitionType.Array,
+            itemDef,
+            isOptional: undefined,
+            minLength: undefined,
+            maxLength: undefined,
+        });
+    });
+
+    it('full case', () => {
+        const def = createArrayDefinition<number>(itemDef, true, 1, 3);
+        expect(def).toEqual({
+            type: DefinitionType.Array,
+            isOptional: true,
+            itemDef,
+            minLength: 1,
+            maxLength: 3,
+        });
+    });
+});
+
+interface TestType {
+    x: number;
+    y: string;
+}
+
+describe('createObjectDefinition', () => {
+    const propertyDef: ObjectPropertyDefinition<TestType> = {
+        x: { type: DefinitionType.Number },
+        y: { type: DefinitionType.String },
+    };
+
+    it('normal case', () => {
+        const def = createObjectDefinition<TestType>(propertyDef);
+        expect(def).toEqual({
+            type: DefinitionType.Object,
+            propertyDef,
+            isOptional: undefined,
+        });
+    });
+
+    it('full case', () => {
+        const def = createObjectDefinition<TestType>(propertyDef, true);
+        expect(def).toEqual({
+            type: DefinitionType.Object,
+            isOptional: true,
+            propertyDef,
+        });
+    });
+});

--- a/packages/roosterjs-editor-dom/test/metadata/metadataTest.ts
+++ b/packages/roosterjs-editor-dom/test/metadata/metadataTest.ts
@@ -1,0 +1,90 @@
+import { CustomizeDefinition, DefinitionType } from 'roosterjs-editor-types';
+import { getMetadata, setMetadata } from '../../lib/metadata/metadata';
+
+describe('metadata', () => {
+    it('getMetadata gets a valid metadata', () => {
+        const validators = {
+            trueValidator: (input: any) => true,
+            falseValidator: (input: any) => false,
+        };
+        const obj = { x: 1, y: 'test' };
+        const validatorSpy = spyOn(validators, 'trueValidator').and.callThrough();
+        const div = document.createElement('div');
+        div.innerHTML = '<span>test</span>';
+        const node = div.firstChild as HTMLElement;
+        node.setAttribute('data-editing-info', JSON.stringify(obj));
+        const def: CustomizeDefinition = {
+            type: DefinitionType.Customize,
+            validator: validators.trueValidator,
+        };
+
+        const metadata = getMetadata(node, def);
+
+        expect(validatorSpy).toHaveBeenCalled();
+        expect(metadata).toEqual(obj);
+    });
+
+    it('getMetadata gets an invalid metadata', () => {
+        const validators = {
+            trueValidator: (input: any) => true,
+            falseValidator: (input: any) => false,
+        };
+        const obj = { x: 1, y: 'test' };
+        const validatorSpy = spyOn(validators, 'falseValidator').and.callThrough();
+        const div = document.createElement('div');
+        div.innerHTML = '<span>test</span>';
+        const node = div.firstChild as HTMLElement;
+
+        node.setAttribute('data-editing-info', JSON.stringify(obj));
+
+        const def: CustomizeDefinition = {
+            type: DefinitionType.Customize,
+            validator: validators.falseValidator,
+        };
+
+        const metadata = getMetadata(node, def);
+
+        expect(validatorSpy).toHaveBeenCalled();
+        expect(metadata).toBeNull();
+    });
+
+    it('setMetadata sets a valid metadata', () => {
+        const validators = {
+            trueValidator: (input: any) => true,
+            falseValidator: (input: any) => false,
+        };
+        const obj = { x: 1, y: 'test' };
+        const validatorSpy = spyOn(validators, 'trueValidator').and.callThrough();
+        const node = document.createElement('div');
+        const def: CustomizeDefinition = {
+            type: DefinitionType.Customize,
+            validator: validators.trueValidator,
+        };
+        const result = setMetadata(node, obj, def);
+
+        expect(validatorSpy).toHaveBeenCalled();
+        expect(result).toBeTrue();
+        expect(node.outerHTML).toBe(
+            '<div data-editing-info="{&quot;x&quot;:1,&quot;y&quot;:&quot;test&quot;}"></div>'
+        );
+    });
+
+    it('setMetadata sets an invalid metadata', () => {
+        const validators = {
+            trueValidator: (input: any) => true,
+            falseValidator: (input: any) => false,
+        };
+        const validatorSpy = spyOn(validators, 'falseValidator').and.callThrough();
+        const node = document.createElement('div');
+        const def: CustomizeDefinition = {
+            type: DefinitionType.Customize,
+            validator: validators.falseValidator,
+        };
+        const obj = { x: 1, y: 'test' };
+        const result = setMetadata(node, obj, def);
+
+        expect(validatorSpy).toHaveBeenCalled();
+        expect(result).toBeFalse();
+        expect(node.outerHTML).toBe('<div></div>');
+    });
+});

--- a/packages/roosterjs-editor-dom/test/metadata/metadataTest.ts
+++ b/packages/roosterjs-editor-dom/test/metadata/metadataTest.ts
@@ -1,5 +1,5 @@
 import { CustomizeDefinition, DefinitionType } from 'roosterjs-editor-types';
-import { getMetadata, setMetadata } from '../../lib/metadata/metadata';
+import { getMetadata, removeMetadata, setMetadata } from '../../lib/metadata/metadata';
 
 describe('metadata', () => {
     it('getMetadata gets a valid metadata', () => {
@@ -48,6 +48,30 @@ describe('metadata', () => {
         expect(metadata).toBeNull();
     });
 
+    it('getMetadata gets an invalid metadata and return default value', () => {
+        const validators = {
+            trueValidator: (input: any) => true,
+            falseValidator: (input: any) => false,
+        };
+        const obj = { x: 1, y: 'test' };
+        const validatorSpy = spyOn(validators, 'falseValidator').and.callThrough();
+        const div = document.createElement('div');
+        div.innerHTML = '<span>test</span>';
+        const node = div.firstChild as HTMLElement;
+
+        node.setAttribute('data-editing-info', JSON.stringify(obj));
+
+        const def: CustomizeDefinition = {
+            type: DefinitionType.Customize,
+            validator: validators.falseValidator,
+        };
+
+        const metadata = getMetadata(node, def, obj);
+
+        expect(validatorSpy).toHaveBeenCalled();
+        expect(metadata).toBe(obj);
+    });
+
     it('setMetadata sets a valid metadata', () => {
         const validators = {
             trueValidator: (input: any) => true,
@@ -86,5 +110,15 @@ describe('metadata', () => {
         expect(validatorSpy).toHaveBeenCalled();
         expect(result).toBeFalse();
         expect(node.outerHTML).toBe('<div></div>');
+    });
+});
+
+describe('removeMetadata', () => {
+    it('removeElement', () => {
+        const obj = { x: 1, y: 'test' };
+        const div = document.createElement('div');
+        div.setAttribute('data-editing-info', JSON.stringify(obj));
+        removeMetadata(div);
+        expect(div.outerHTML).toBe('<div></div>');
     });
 });

--- a/packages/roosterjs-editor-dom/test/metadata/validateTest.ts
+++ b/packages/roosterjs-editor-dom/test/metadata/validateTest.ts
@@ -1,0 +1,295 @@
+import validate from '../../lib/metadata/validate';
+import {
+    Definition,
+    ObjectPropertyDefinition,
+    PluginEventType,
+    DefinitionType,
+} from 'roosterjs-editor-types';
+import {
+    createArrayDefinition,
+    createBooleanDefinition,
+    createNumberDefinition,
+    createObjectDefinition,
+    createStringDefinition,
+} from '../../lib/metadata/definitionCreators';
+
+describe('validate', () => {
+    function runTestInternal(input: any, def: Definition<any>, result: boolean) {
+        expect(validate(input, def)).toBe(result);
+    }
+
+    function runNumberTest(
+        input: any,
+        resultForRequired: boolean,
+        resultForOptional: boolean,
+        value?: number
+    ) {
+        const requiredDef = createNumberDefinition(false, value);
+        const optionalDef = createNumberDefinition(true, value);
+        runTestInternal(input, requiredDef, resultForRequired);
+        runTestInternal(input, optionalDef, resultForOptional);
+    }
+
+    function runStringTest(
+        input: any,
+        resultForRequired: boolean,
+        resultForOptional: boolean,
+        value?: string
+    ) {
+        const requiredDef = createStringDefinition(false, value);
+        const optionalDef = createStringDefinition(true, value);
+        runTestInternal(input, requiredDef, resultForRequired);
+        runTestInternal(input, optionalDef, resultForOptional);
+    }
+
+    function runBooleanTest(
+        input: any,
+        resultForRequired: boolean,
+        resultForOptional: boolean,
+        value?: boolean
+    ) {
+        const requiredDef = createBooleanDefinition(false, value);
+        const optionalDef = createBooleanDefinition(true, value);
+        runTestInternal(input, requiredDef, resultForRequired);
+        runTestInternal(input, optionalDef, resultForOptional);
+    }
+
+    function runArrayTest(
+        input: any,
+        resultForRequired: boolean,
+        resultForOptional: boolean,
+        minLength?: number,
+        maxLength?: number
+    ) {
+        const itemDef = createNumberDefinition();
+        const requiredDef = createArrayDefinition<number>(itemDef, false, minLength, maxLength);
+        const optionalDef = createArrayDefinition<number>(itemDef, true, minLength, maxLength);
+        runTestInternal(input, requiredDef, resultForRequired);
+        runTestInternal(input, optionalDef, resultForOptional);
+    }
+
+    interface TestObj {
+        x: number;
+        y: string;
+    }
+
+    function runObjectTest(input: any, resultForRequired: boolean, resultForOptional: boolean) {
+        const propertyDef: ObjectPropertyDefinition<TestObj> = {
+            x: createNumberDefinition(),
+            y: createStringDefinition(),
+        };
+        const requiredDef = createObjectDefinition<TestObj>(propertyDef, false);
+        const optionalDef = createObjectDefinition<TestObj>(propertyDef, true);
+        runTestInternal(input, requiredDef, resultForRequired);
+        runTestInternal(input, optionalDef, resultForOptional);
+    }
+
+    it('Validate number', () => {
+        runNumberTest(0, true, true);
+        runNumberTest(0, true, true, 0);
+        runNumberTest(0, true, true, 0.000001);
+        runNumberTest(0, false, false, 1);
+        runNumberTest(undefined, false, true);
+        runNumberTest(null, false, false);
+        runNumberTest('test', false, false);
+        runNumberTest(PluginEventType.EditorReady, true, true);
+        runNumberTest(true, false, false);
+        runNumberTest({}, false, false);
+        runNumberTest([], false, false);
+        runNumberTest({ x: 1 }, false, false);
+        runNumberTest([1], false, false);
+    });
+
+    it('Validate string', () => {
+        runStringTest('test', true, true);
+        runStringTest('test', true, true, 'test');
+        runStringTest('test', false, false, 'test1');
+        runStringTest(undefined, false, true);
+        runStringTest(null, false, false);
+        runStringTest(1, false, false);
+        runStringTest(PluginEventType.EditorReady, false, false);
+        runStringTest(true, false, false);
+        runStringTest({}, false, false);
+        runStringTest([], false, false);
+        runStringTest({ x: 1 }, false, false);
+        runStringTest([1], false, false);
+    });
+
+    it('Validate boolean', () => {
+        runBooleanTest(true, true, true);
+        runBooleanTest(true, true, true, true);
+        runBooleanTest(true, false, false, false);
+        runBooleanTest(undefined, false, true);
+        runBooleanTest(null, false, false);
+        runBooleanTest(1, false, false);
+        runBooleanTest(PluginEventType.EditorReady, false, false);
+        runBooleanTest('test', false, false);
+        runBooleanTest({}, false, false);
+        runBooleanTest([], false, false);
+        runBooleanTest({ x: 1 }, false, false);
+        runBooleanTest([1], false, false);
+    });
+
+    it('Validate array', () => {
+        runArrayTest([], true, true);
+        runArrayTest(undefined, false, true);
+        runArrayTest([1, 2, 3], true, true);
+        runArrayTest([1, 2, 'test'], false, false);
+        runArrayTest([null], false, false);
+        runArrayTest([1, 2], true, true, 0, 3);
+        runArrayTest([1, 2], false, false, 3);
+        runArrayTest([1, 2], false, false, undefined, 1);
+        runArrayTest(true, false, false);
+        runArrayTest(null, false, false);
+        runArrayTest(1, false, false);
+        runArrayTest(PluginEventType.EditorReady, false, false);
+        runArrayTest('test', false, false);
+        runArrayTest({}, false, false);
+        runArrayTest({ x: 1 }, false, false);
+    });
+
+    it('Validate object', () => {
+        runObjectTest({ x: 1, y: 'test' }, true, true);
+        runObjectTest(undefined, false, true);
+        runObjectTest({ x: 1, y: 2 }, false, false);
+        runObjectTest({ x: 1 }, false, false);
+        runObjectTest([], false, false);
+        runObjectTest(true, false, false);
+        runObjectTest(1, false, false);
+        runObjectTest('test', false, false);
+    });
+
+    interface TestObj2 {
+        a: number[];
+        b?: TestObj;
+    }
+
+    it('Validate object 2', () => {
+        const def: Definition<TestObj2> = createObjectDefinition<TestObj2>({
+            a: createArrayDefinition<number>(createNumberDefinition()),
+            b: createObjectDefinition<TestObj>(
+                {
+                    x: createNumberDefinition(),
+                    y: createStringDefinition(),
+                },
+                true
+            ),
+        });
+
+        expect(
+            validate(
+                {
+                    a: [1, 2, 3],
+                    b: {
+                        x: 1,
+                        y: 'test',
+                    },
+                },
+                def
+            )
+        ).toBeTrue();
+        expect(
+            validate(
+                {
+                    a: [1, 2, 3],
+                },
+                def
+            )
+        ).toBeTrue();
+        expect(
+            validate(
+                {
+                    a: [1, 2, 3, 'test'],
+                    b: {
+                        x: 1,
+                        y: 'test',
+                    },
+                },
+                def
+            )
+        ).toBeFalse();
+        expect(
+            validate(
+                {
+                    a: null,
+                    b: {
+                        x: 1,
+                        y: 'test',
+                    },
+                },
+                def
+            )
+        ).toBeFalse();
+        expect(
+            validate(
+                {
+                    a: [1, 2, 3],
+                    b: {
+                        x: 1,
+                        y: 'test',
+                    },
+                    c: 0,
+                },
+                def
+            )
+        ).toBeTrue();
+    });
+});
+
+describe('Validate customize', () => {
+    it('Validate true', () => {
+        const validators = {
+            trueValidator: (input: any) => true,
+            falseValidator: (input: any) => false,
+        };
+        const trueSpy = spyOn(validators, 'trueValidator').and.callThrough();
+        const input = {};
+        const result = validate(
+            {},
+            { type: DefinitionType.Customize, validator: validators.trueValidator }
+        );
+
+        expect(result).toBe(true);
+        expect(trueSpy).toHaveBeenCalledWith(input);
+    });
+
+    it('Validate false', () => {
+        const validators = {
+            trueValidator: (input: any) => true,
+            falseValidator: (input: any) => false,
+        };
+        const falseSpy = spyOn(validators, 'falseValidator').and.callThrough();
+        const input = {};
+        const result = validate(
+            {},
+            { type: DefinitionType.Customize, validator: validators.falseValidator }
+        );
+
+        expect(result).toBe(false);
+        expect(falseSpy).toHaveBeenCalledWith(input);
+    });
+
+    it('Validate object', () => {
+        interface TestObj {
+            name: string;
+            value: number;
+        }
+        const validators = {
+            trueValidator: (input: any) => true,
+            falseValidator: (input: any) => false,
+        };
+
+        const trueSpy = spyOn(validators, 'trueValidator').and.callThrough();
+        const def = createObjectDefinition<TestObj>({
+            name: createStringDefinition(),
+            value: {
+                type: DefinitionType.Customize,
+                validator: validators.trueValidator,
+            },
+        });
+        const result = validate({ name: 'test', value: 1 }, def);
+
+        expect(result).toBeTrue();
+        expect(trueSpy).toHaveBeenCalledWith(1);
+    });
+});

--- a/packages/roosterjs-editor-dom/test/selections/deleteSelectedContentTest.ts
+++ b/packages/roosterjs-editor-dom/test/selections/deleteSelectedContentTest.ts
@@ -81,14 +81,14 @@ describe('deleteSelectedContent', () => {
         );
     });
 
-    it('Whole talbe 1', () => {
+    it('Whole table 1', () => {
         runTest(
             'aa<table><tbody><tr><td>line1</td><td>line2</td></tr><tr><td>line3</td><td>line4</td></tr></tbody></table>bb<!--{"start":[0,2],"end":[2,0]}-->',
             'aabb<!--{"start":[0,2],"end":[0,2]}-->'
         );
     });
 
-    it('Whole talbe 2', () => {
+    it('Whole table 2', () => {
         // TODO: the result contains separated continuous text object at root
         // Selection path gives wrong result. Need to revisit here
         runTest(

--- a/packages/roosterjs-editor-types/lib/enum/DefinitionType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/DefinitionType.ts
@@ -1,0 +1,34 @@
+/**
+ * Types of definitions, used by Definition type
+ */
+export const enum DefinitionType {
+    /**
+     * Boolean type definition, represents a boolean type value
+     */
+    Boolean,
+
+    /**
+     * Number type definition, represents a number type value
+     */
+    Number,
+
+    /**
+     * String type definition, represents a string type value
+     */
+    String,
+
+    /**
+     * Array type definition, represents an array with a given item type
+     */
+    Array,
+
+    /**
+     * Object type definition, represents an object with the given property types
+     */
+    Object,
+
+    /**
+     * Customize type definition, represents a customized type with a validator function
+     */
+    Customize,
+}

--- a/packages/roosterjs-editor-types/lib/enum/index.ts
+++ b/packages/roosterjs-editor-types/lib/enum/index.ts
@@ -27,3 +27,4 @@ export { KnownCreateElementDataIndex } from './KnownCreateElementDataIndex';
 export { TableBorderFormat } from './TableBorderFormat';
 export { PluginEventType } from './PluginEventType';
 export { SelectionRangeTypes } from './SelectionRangeTypes';
+export { DefinitionType } from './DefinitionType';

--- a/packages/roosterjs-editor-types/lib/type/Definition.ts
+++ b/packages/roosterjs-editor-types/lib/type/Definition.ts
@@ -1,0 +1,125 @@
+import { DefinitionType } from '../enum/DefinitionType';
+import type { CompatibleDefinitionType } from '../compatibleEnum/DefinitionType';
+
+type ArrayItemType<T extends any[]> = T extends (infer U)[] ? U : never;
+
+/**
+ * Base interface of property definition
+ */
+export interface DefinitionBase<T extends DefinitionType | CompatibleDefinitionType> {
+    /**
+     * Type of this property
+     */
+    type: T;
+
+    /**
+     * Whether this property is optional
+     */
+    isOptional?: boolean;
+}
+
+/**
+ * String property definition. This definition can also be used for string based enum property
+ */
+export interface StringDefinition
+    extends DefinitionBase<DefinitionType.String | CompatibleDefinitionType.String> {
+    /**
+     * An optional value of this property. When specified, the given property must have exactly same value of this value
+     */
+    value?: string;
+}
+
+/**
+ * Number property definition. This definition can also be used for number based enum property
+ */
+export interface NumberDefinition
+    extends DefinitionBase<DefinitionType.Number | CompatibleDefinitionType.Number> {
+    /**
+     * An optional value of this property. When specified, the given property must have same value of this value
+     */
+    value?: number;
+
+    /**
+     * An optional minimum value of this property. When specified, the given property must be greater or equal to this value
+     */
+    minValue?: number;
+
+    /**
+     * An optional maximum value of this property. When specified, the given property must be less or equal to this value
+     */
+    maxValue?: number;
+}
+
+/**
+ * Boolean property definition
+ */
+export interface BooleanDefinition
+    extends DefinitionBase<DefinitionType.Boolean | CompatibleDefinitionType.Boolean> {
+    /**
+     * An optional value of this property. When specified, the given property must have same value of this value
+     */
+    value?: boolean;
+}
+
+/**
+ * Array property definition.
+ */
+export interface ArrayDefinition<T extends any[]>
+    extends DefinitionBase<DefinitionType.Array | CompatibleDefinitionType.Array> {
+    /**
+     * Definition of each item of this array. All items of the given array must have the same type. Otherwise, use CustomizeDefinition instead.
+     */
+    itemDef: Definition<ArrayItemType<T>>;
+
+    /**
+     * An optional minimum length of this array. When specified, the given array must have at least this value of items
+     */
+    minLength?: number;
+
+    /**
+     * An optional maximum length of this array. When specified, the given array must have at most this value of items
+     */
+    maxLength?: number;
+}
+
+/**
+ * Object property definition.
+ */
+export interface ObjectDefinition<T extends Record<string, any>>
+    extends DefinitionBase<DefinitionType.Object | CompatibleDefinitionType.Object> {
+    /**
+     * A key-value map to specify the definition of each possible property of this object
+     */
+    propertyDef: { [Key in keyof T]: Definition<T[Key]> };
+}
+
+/**
+ * Customize property definition. When all other property definition type cannot satisfy your requirement,
+ * use this definition with a customized validator function to do property validation.
+ */
+export interface CustomizeDefinition<V>
+    extends DefinitionBase<DefinitionType.Customize | CompatibleDefinitionType.Customize> {
+    /**
+     * The customized validator function to do customized validation
+     * @param input The value to validate
+     * @returns True means the given value is of the specified type, otherwise false
+     */
+    validator: (input: V) => input is V;
+}
+
+/**
+ * A combination of all definition types
+ */
+export type Definition<T> =
+    | CustomizeDefinition<T>
+    | (T extends any[]
+          ? ArrayDefinition<T>
+          : T extends Record<string, any>
+          ? ObjectDefinition<T>
+          : T extends String
+          ? StringDefinition
+          : T extends Number
+          ? NumberDefinition
+          : T extends Boolean
+          ? BooleanDefinition
+          : never);

--- a/packages/roosterjs-editor-types/lib/type/Definition.ts
+++ b/packages/roosterjs-editor-types/lib/type/Definition.ts
@@ -1,7 +1,10 @@
 import { DefinitionType } from '../enum/DefinitionType';
 import type { CompatibleDefinitionType } from '../compatibleEnum/DefinitionType';
 
-type ArrayItemType<T extends any[]> = T extends (infer U)[] ? U : never;
+/**
+ * A type template to get item type of an array
+ */
+export type ArrayItemType<T extends any[]> = T extends (infer U)[] ? U : never;
 
 /**
  * Base interface of property definition
@@ -83,35 +86,42 @@ export interface ArrayDefinition<T extends any[]>
 }
 
 /**
+ * Object property definition type used by Object Definition
+ */
+export type ObjectPropertyDefinition<T extends Object> = {
+    [Key in keyof T]: Definition<T[Key]>;
+};
+
+/**
  * Object property definition.
  */
-export interface ObjectDefinition<T extends Record<string, any>>
+export interface ObjectDefinition<T extends Object>
     extends DefinitionBase<DefinitionType.Object | CompatibleDefinitionType.Object> {
     /**
      * A key-value map to specify the definition of each possible property of this object
      */
-    propertyDef: { [Key in keyof T]: Definition<T[Key]> };
+    propertyDef: ObjectPropertyDefinition<T>;
 }
 
 /**
  * Customize property definition. When all other property definition type cannot satisfy your requirement,
  * use this definition with a customized validator function to do property validation.
  */
-export interface CustomizeDefinition<V>
+export interface CustomizeDefinition
     extends DefinitionBase<DefinitionType.Customize | CompatibleDefinitionType.Customize> {
     /**
      * The customized validator function to do customized validation
      * @param input The value to validate
      * @returns True means the given value is of the specified type, otherwise false
      */
-    validator: (input: V) => input is V;
+    validator: (input: any) => boolean;
 }
 
 /**
  * A combination of all definition types
  */
 export type Definition<T> =
-    | CustomizeDefinition<T>
+    | CustomizeDefinition
     | (T extends any[]
           ? ArrayDefinition<T>
           : T extends Record<string, any>

--- a/packages/roosterjs-editor-types/lib/type/index.ts
+++ b/packages/roosterjs-editor-types/lib/type/index.ts
@@ -12,12 +12,14 @@ export { DOMEventHandlerFunction, DOMEventHandlerObject, DOMEventHandler } from 
 export { TrustedHTMLHandler } from './TrustedHTMLHandler';
 export { SizeTransformer } from './SizeTransformer';
 export {
+    ArrayItemType,
     DefinitionBase,
     StringDefinition,
     NumberDefinition,
     BooleanDefinition,
     ArrayDefinition,
     ObjectDefinition,
+    ObjectPropertyDefinition,
     CustomizeDefinition,
     Definition,
 } from './Definition';

--- a/packages/roosterjs-editor-types/lib/type/index.ts
+++ b/packages/roosterjs-editor-types/lib/type/index.ts
@@ -11,3 +11,13 @@ export {
 export { DOMEventHandlerFunction, DOMEventHandlerObject, DOMEventHandler } from './domEventHandler';
 export { TrustedHTMLHandler } from './TrustedHTMLHandler';
 export { SizeTransformer } from './SizeTransformer';
+export {
+    DefinitionBase,
+    StringDefinition,
+    NumberDefinition,
+    BooleanDefinition,
+    ArrayDefinition,
+    ObjectDefinition,
+    CustomizeDefinition,
+    Definition,
+} from './Definition';

--- a/tools/buildTools/dts.js
+++ b/tools/buildTools/dts.js
@@ -273,6 +273,10 @@ function parseImportFrom(content, currentFileName, queue, baseDir, projDir, exte
     return newContent.replace(regImportFrom, '');
 }
 
+function parseEmptyExport(content) {
+    return content.replace(/export \{\};/g, '');
+}
+
 function process(baseDir, queue, index, projDir, externalHandler) {
     var item = queue[index];
     var currentFileName = item.filename;
@@ -286,10 +290,15 @@ function process(baseDir, queue, index, projDir, externalHandler) {
     content = parseImportFrom(content, currentFileName, queue, baseDir, projDir, externalHandler);
 
     // 3. Parse all the public elements
-    content = [parseClasses, parseFunctions, parseEnum, parseType, parseConst, parseExport].reduce(
-        (c, func) => func(c, item.elements),
-        content
-    );
+    content = [
+        parseClasses,
+        parseFunctions,
+        parseEnum,
+        parseType,
+        parseConst,
+        parseExport,
+        parseEmptyExport,
+    ].reduce((c, func) => func(c, item.elements), content);
 
     // 4. Remove single line comments
     content = content.replace(singleLineComment, '');


### PR DESCRIPTION
In order to store/retrieve metadata for a given element, add types and functions below:
- API to get/set metadata `getMetadata`, `setMetadata`, `removeMetadata`
- API to validate metadata object `validate`
- Helper functions to create type definition `create*Definition`
- Types of definitions

When get a metadata, we can do:
```ts
const metadata = getMetadata(element, def);
```

Here `def` is an optional type definition object used for validating if the metadata object is valid. For example, we have a metadata type:

```ts
interface MyMetadata {
  x: number;
  y: string;
}
```
and when retrieve it, we can use a type definition object to help validate if the given element contains a valid object with this type:

```ts
const MyMetadataDefinition = createObjectDefinition<MyMetadata>({
  x: createNumberDefinition(),
  y: createStringDefinition(),
});

const metadata = getMetadata(element, MyMetadataDefinition );
```

If the given element doesn't contain a valid metadata string, it will return null.

We can also create definition object for other types like array, boolean. And there is also a CustomizeDefinition type to support customization of a validation.

Related test cases added.