### PR TITLE
Prevent Table Selection to be cleared on some keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "8.22.0",
+    "version": "8.22.1",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -31,7 +31,13 @@ import {
 const TABLE_CELL_SELECTOR = 'td,th';
 const LEFT_CLICK = 1;
 const RIGHT_CLICK = 3;
-
+const IGNORE_KEY_UP_KEYS = [
+    Keys.SHIFT,
+    Keys.ALT,
+    Keys.META_LEFT,
+    Keys.CTRL_LEFT,
+    Keys.PRINT_SCREEN,
+];
 /**
  * TableCellSelectionPlugin help highlight table cells
  */
@@ -242,8 +248,14 @@ export default class TableCellSelection implements EditorPlugin {
     }
 
     private handleKeyUpEvent(event: PluginKeyUpEvent) {
-        const { shiftKey, which } = event.rawEvent;
-        if (!shiftKey && which != Keys.SHIFT && this.firstTarget && !this.preventKeyUp) {
+        const { shiftKey, which, ctrlKey } = event.rawEvent;
+        if (
+            !shiftKey &&
+            !ctrlKey &&
+            this.firstTarget &&
+            !this.preventKeyUp &&
+            IGNORE_KEY_UP_KEYS.indexOf(which) == -1
+        ) {
             this.clearState();
         }
         this.preventKeyUp = false;

--- a/packages/roosterjs-editor-types/lib/enum/Keys.ts
+++ b/packages/roosterjs-editor-types/lib/enum/Keys.ts
@@ -7,6 +7,8 @@ export const enum Keys {
     TAB = 9,
     ENTER = 13,
     SHIFT = 16,
+    CTRL_LEFT = 17,
+    ALT = 18,
     ESCAPE = 27,
     SPACE = 32,
     PAGEUP = 33,
@@ -14,6 +16,7 @@ export const enum Keys {
     UP = 38,
     RIGHT = 39,
     DOWN = 40,
+    PRINT_SCREEN = 44,
     DELETE = 46,
     /**
      * @deprecated Just for backward compatibility
@@ -25,6 +28,7 @@ export const enum Keys {
     U = 85,
     Y = 89,
     Z = 90,
+    META_LEFT = 91,
     COMMA = 188,
     DASH_UNDERSCORE = 189,
     PERIOD = 190,


### PR DESCRIPTION
Right now, on key up the table selection is cleared when the key is different from SHIFT, adding other keys to prevent the selection from being cleared on CTRL, ALT, Meta Key, Print screen.