### PR TITLE
Adding custom attributes to image element.

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/insertImage.ts
+++ b/packages/roosterjs-editor-api/lib/format/insertImage.ts
@@ -6,32 +6,53 @@ import { readFile } from 'roosterjs-editor-dom';
  * @param editor The editor instance
  * @param imageFile The image file. There are at least 3 ways to obtain the file object:
  * From local file, from clipboard data, from drag-and-drop
+ * @param attributes Optional image element attributes
  */
-export default function insertImage(editor: IEditor, imageFile: File): void;
+export default function insertImage(
+    editor: IEditor,
+    imageFile: File,
+    attributes?: Record<string, string>
+): void;
 
 /**
  * Insert an image to editor at current selection
  * @param editor The editor instance
- * @param imageFile The image link.
+ * @param url The image link
+ * @param attributes Optional image element attributes
  */
-export default function insertImage(editor: IEditor, url: string): void;
+export default function insertImage(
+    editor: IEditor,
+    url: string,
+    attributes?: Record<string, string>
+): void;
 
-export default function insertImage(editor: IEditor, imageFile: File | string): void {
+export default function insertImage(
+    editor: IEditor,
+    imageFile: File | string,
+    attributes?: Record<string, string>
+): void {
     if (typeof imageFile == 'string') {
-        insertImageWithSrc(editor, imageFile);
+        insertImageWithSrc(editor, imageFile, attributes);
     } else {
         readFile(imageFile, dataUrl => {
             if (dataUrl && !editor.isDisposed()) {
-                insertImageWithSrc(editor, dataUrl);
+                insertImageWithSrc(editor, dataUrl, attributes);
             }
         });
     }
 }
 
-function insertImageWithSrc(editor: IEditor, src: string) {
+function insertImageWithSrc(editor: IEditor, src: string, attributes?: Record<string, string>) {
     editor.addUndoSnapshot(() => {
         const image = editor.getDocument().createElement('img');
         image.src = src;
+
+        if (attributes) {
+            Object.keys(attributes).forEach(attribute =>
+                image.setAttribute(attribute, attributes[attribute])
+            );
+        }
+
         image.style.maxWidth = '100%';
         editor.insertNode(image);
     }, ChangeSource.Format);


### PR DESCRIPTION
Add optional `attributes` parameter to `insertImage` function to enable setting optional attributes on the `<img>` element which allows specifying `aria-` and `alt` tags for accessibility support.