### PR TITLE
Fix #974: change regex so that text node starts with \r\n should not be skipped

### DIFF
--- a/packages/roosterjs-editor-dom/lib/utils/shouldSkipNode.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/shouldSkipNode.ts
@@ -2,7 +2,7 @@ import getTagOfNode from './getTagOfNode';
 import { getComputedStyle } from './getComputedStyles';
 import { NodeType } from 'roosterjs-editor-types';
 
-const CRLF = /^[\r\n]+$/gm;
+const CRLF = /^[\r\n]+$/g;
 const CRLF_SPACE = /[\t\r\n\u0020\u200B]/gm; // We should only find new line, real space or ZeroWidthSpace (TAB, %20, but not &nbsp;)
 
 /**

--- a/packages/roosterjs-editor-dom/test/utils/shouldSkipNodeTest.ts
+++ b/packages/roosterjs-editor-dom/test/utils/shouldSkipNodeTest.ts
@@ -30,6 +30,17 @@ describe('shouldSkipNode, shouldSkipNode()', () => {
         expect(shouldSkip).toBe(true);
     });
 
+    it('CRLF+text textNode', () => {
+        // Arrange
+        let node = document.createTextNode('\r\ntest');
+
+        // Act
+        let shouldSkip = shouldSkipNode(node);
+
+        // Assert
+        expect(shouldSkip).toBe(false);
+    });
+
     it('DisplayNone', () => {
         // Arrange
         let node = DomTestHelper.createElementFromContent(


### PR DESCRIPTION
shouldSkipNode() function uses a regex to check if a text node contains only new line char (\r, \n). But the regex actually matches any string that starts with \r\n in a single line.

Change to do full string match instead.

This impact the format API to apply format to a selection with multiple paragraphs.