### PR TITLE
Add sup and sub tags to apply style outside them

### DIFF
--- a/packages/roosterjs-editor-dom/lib/inlineElements/applyTextStyle.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/applyTextStyle.ts
@@ -6,7 +6,7 @@ import { getNextLeafSibling } from '../utils/getLeafSibling';
 import { NodePosition, NodeType, PositionType } from 'roosterjs-editor-types';
 import { splitBalancedNodeRange } from '../utils/splitParentNode';
 
-const STYLET_AGS = 'SPAN,B,I,U,EM,STRONG,STRIKE,S,SMALL'.split(',');
+const STYLET_AGS = 'SPAN,B,I,U,EM,STRONG,STRIKE,S,SMALL,SUP,SUB'.split(',');
 
 /**
  * Apply style using a styler function to the given container node in the given range

--- a/packages/roosterjs-editor-dom/test/inlineElements/applyTextStyleTest.ts
+++ b/packages/roosterjs-editor-dom/test/inlineElements/applyTextStyleTest.ts
@@ -186,6 +186,22 @@ describe('applyTextStyle()', () => {
         );
     });
 
+    it('applyTextStyle() text node with SUP/SUB', () => {
+        let div = document.createElement('DIV');
+        div.innerHTML = 'test1<sup>test2</sup><sub>test3</sub>test4<span>test5';
+        let start = new Position(div, PositionType.Begin).normalize().move(2);
+        let end = new Position(div, PositionType.End).normalize().move(-2);
+        applyTextStyle(
+            div,
+            (node, isInnerNode) => (node.style.color = isInnerNode ? '' : 'red'),
+            start,
+            end
+        );
+        expect(div.innerHTML).toBe(
+            'te<span style="color: red;">st1</span><span style="color: red;"><sup>test2</sup></span><span style="color: red;"><sub>test3</sub></span><span style="color: red;">test4</span><span style="color: red;">tes</span><span>t5</span>'
+        );
+    });
+
     it('applyTextStyle() text node with double span', () => {
         let div = document.createElement('DIV');
         div.innerHTML = '<span><span>text</span></span>';


### PR DESCRIPTION
Add sup and sub scripts tag to STYLET_AGS to prevent applyTextStyles to set style directly to these tags.
Then these tags will be wrapped by a span tag and the style will be set to the span tag. 
**Before:**
![subsupbug](https://user-images.githubusercontent.com/87443959/168341480-566b8097-eb3e-4a3e-ab14-75bfa9f31fbd.gif)

**After:**
![subsupfix](https://user-images.githubusercontent.com/87443959/168341489-353e0b17-c4df-4c27-8933-c6fa5125a661.gif)
 