### PR TITLE
TypeError: Cannot read properties of null (reading 'node')

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -228,7 +228,10 @@ export default class TableCellSelection implements EditorPlugin {
             }
             this.editor.runAsync(editor => {
                 const pos = editor.getFocusedPosition();
-                pos && this.setData(this.tableSelection ? this.lastTarget : pos.node);
+                const newTarget = this.tableSelection ? this.lastTarget : pos?.node;
+                if (newTarget) {
+                    this.setData(newTarget);
+                }
 
                 if (this.firstTable! == this.targetTable!) {
                     if (!this.shouldConvertToTableSelection() && !this.tableSelection) {

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -217,8 +217,7 @@ export default class TableCellSelection implements EditorPlugin {
         if (shiftKey) {
             if (!this.firstTarget) {
                 const pos = this.editor.getFocusedPosition();
-
-                const cell = getCellAtCursor(this.editor, pos.node);
+                const cell = pos && getCellAtCursor(this.editor, pos.node);
 
                 this.firstTarget = this.firstTarget || cell;
             }
@@ -229,7 +228,7 @@ export default class TableCellSelection implements EditorPlugin {
             }
             this.editor.runAsync(editor => {
                 const pos = editor.getFocusedPosition();
-                this.setData(this.tableSelection ? this.lastTarget : pos.node);
+                pos && this.setData(this.tableSelection ? this.lastTarget : pos.node);
 
                 if (this.firstTable! == this.targetTable!) {
                     if (!this.shouldConvertToTableSelection() && !this.tableSelection) {


### PR DESCRIPTION
    at TableCellSelection.handleKeyDownEvent (webpack-internal:///./node_modules/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.js:250:61)
    at TableCellSelection.onPluginEvent (webpack-internal:///./node_modules/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.js:159:30)
   