### PR TITLE
Support resize image on mobile and custom resize handle style

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/pluginUtils/DragAndDropHelper.ts
+++ b/packages/roosterjs-editor-plugins/lib/pluginUtils/DragAndDropHelper.ts
@@ -46,7 +46,7 @@ export default class DragAndDropHelper<TContext, TInitValue> implements Disposab
             return {
                 mousedown: 'touchstart',
                 mousemove: 'touchmove',
-                mouseup: 'touchmove',
+                mouseup: 'touchend',
             }
         } else {
             return {

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -76,6 +76,8 @@ const DefaultOptions: Required<ImageEditOptions> = {
     minRotateDeg: 5,
     imageSelector: 'img',
     rotateIconHTML: null,
+    isMobile: false,
+    getCustomResizeHandelStyle: undefined,
 };
 
 /**
@@ -384,6 +386,7 @@ export default class ImageEdit implements EditorPlugin {
                 : LIGHT_MODE_BGCOLOR,
             isSmallImage: isASmallImage(this.editInfo, isExperimentalHandlesEnabled),
             handlesExperimentalFeatures: isExperimentalHandlesEnabled,
+            getCustomResizeHandelStyle: this.options.getCustomResizeHandelStyle,
         };
         const htmlData: CreateElementData[] = [getResizeBordersHTML(options)];
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -568,7 +568,8 @@ export default class ImageEdit implements EditorPlugin {
                           },
                           this.updateWrapper,
                           dragAndDrop,
-                          this.editor.getZoomScale()
+                          this.editor.getZoomScale(),
+                          this.options.isMobile
                       )
               )
             : [];

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
@@ -2,7 +2,7 @@ import DragAndDropContext, { X, Y } from '../types/DragAndDropContext';
 import DragAndDropHandler from '../../../pluginUtils/DragAndDropHandler';
 import ImageEditInfo, { ResizeInfo } from '../types/ImageEditInfo';
 import ImageHtmlOptions from '../types/ImageHtmlOptions';
-import { CreateElementData } from 'roosterjs-editor-types';
+import { CreateElementData, GetResizeHandleStyle } from 'roosterjs-editor-types';
 import { ImageEditElementClass } from '../types/ImageEditElementClass';
 
 const enum HandleTypes {
@@ -114,6 +114,7 @@ export function doubleCheckResize(
 export function getCornerResizeHTML({
     borderColor: resizeBorderColor,
     handlesExperimentalFeatures: handlesExperimentalFeatures,
+    getCustomResizeHandelStyle,
 }: ImageHtmlOptions): CreateElementData[] {
     const result: CreateElementData[] = [];
 
@@ -127,7 +128,8 @@ export function getCornerResizeHTML({
                           resizeBorderColor,
                           handlesExperimentalFeatures
                               ? HandleTypes.CircularHandlesCorner
-                              : HandleTypes.SquareHandles
+                              : HandleTypes.SquareHandles,
+                          getCustomResizeHandelStyle
                       )
                     : null
             )
@@ -144,6 +146,7 @@ export function getSideResizeHTML({
     borderColor: resizeBorderColor,
     isSmallImage: isSmallImage,
     handlesExperimentalFeatures: handlesExperimentalFeatures,
+    getCustomResizeHandelStyle,
 }: ImageHtmlOptions): CreateElementData[] {
     if (isSmallImage) {
         return null;
@@ -160,7 +163,8 @@ export function getSideResizeHTML({
                           resizeBorderColor,
                           handlesExperimentalFeatures
                               ? HandleTypes.CircularHandlesCorner
-                              : HandleTypes.SquareHandles
+                              : HandleTypes.SquareHandles,
+                          getCustomResizeHandelStyle
                       )
                     : null
             )
@@ -186,13 +190,16 @@ function getResizeHandleHTML(
     x: X,
     y: Y,
     borderColor: string,
-    handleTypes: HandleTypes
+    handleTypes: HandleTypes,
+    getCustomResizeHandelStyle?: GetResizeHandleStyle
 ): CreateElementData {
     const leftOrRight = x == 'w' ? 'left' : 'right';
     const topOrBottom = y == 'n' ? 'top' : 'bottom';
     const leftOrRightValue = x == '' ? '50%' : '0px';
     const topOrBottomValue = y == '' ? '50%' : '0px';
-    const direction = y + x;
+    const direction: `${Y}${X}`  = `${y}${x}`;
+    const getResizeHandleHtml: GetResizeHandleStyle = getCustomResizeHandelStyle ?? setHandleStyle[handleTypes];
+
     return x == '' && y == ''
         ? null
         : {
@@ -201,7 +208,7 @@ function getResizeHandleHTML(
               children: [
                   {
                       tag: 'div',
-                      style: setHandleStyle[handleTypes](
+                      style: getResizeHandleHtml(
                           direction,
                           topOrBottom,
                           leftOrRight,
@@ -216,7 +223,7 @@ function getResizeHandleHTML(
 
 const setHandleStyle: Record<
     HandleTypes,
-    (direction: string, topOrBottom: string, leftOrRight: string, borderColor: string) => string
+    GetResizeHandleStyle
 > = {
     0: (direction, leftOrRight, topOrBottom, borderColor) =>
         `position:relative;width:${RESIZE_HANDLE_SIZE}px;height:${RESIZE_HANDLE_SIZE}px;background-color: ${borderColor};cursor:${direction}-resize;${topOrBottom}:-${RESIZE_HANDLE_MARGIN}px;${leftOrRight}:-${RESIZE_HANDLE_MARGIN}px;`,

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/types/ImageHtmlOptions.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/types/ImageHtmlOptions.ts
@@ -1,3 +1,5 @@
+import { GetResizeHandleStyle} from 'roosterjs-editor-types'
+
 /**
  * @internal
  * Options for retrieve HTML string for image editing
@@ -29,4 +31,9 @@ export default interface ImageHtmlOptions {
      * Enable resize handles experimental feature
      */
     handlesExperimentalFeatures?: boolean;
+
+    /**
+     * customized corner resize handle style
+     */
+    getCustomResizeHandelStyle?: GetResizeHandleStyle;
 }

--- a/packages/roosterjs-editor-types/lib/interface/ImageEditOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ImageEditOptions.ts
@@ -41,9 +41,27 @@ export default interface ImageEditOptions {
     imageSelector?: string;
 
     /**
+     * Whether to use touch events due to working on mobile browsers
+     * @default false
+     */
+    isMobile?: boolean
+
+    /**
+     * customized corner resize handle style
+     * @default A predefined style
+     */
+     getCustomResizeHandelStyle?: GetResizeHandleStyle;
+
+    /**
      * @deprecated
      * HTML for the rotate icon
      * @default A predefined SVG icon
      */
     rotateIconHTML?: string;
+}
+
+export type ResizeHandleDirection = 'w' | '' | 'e' | 'n' | 's' | 'nw' | 'ne' | 'sw' | 'se'
+
+export interface GetResizeHandleStyle {
+    (direction: ResizeHandleDirection, topOrBottom: 'top' | 'bottom', leftOrRight: 'left' | 'right', borderColor: string): string
 }

--- a/packages/roosterjs-editor-types/lib/interface/index.ts
+++ b/packages/roosterjs-editor-types/lib/interface/index.ts
@@ -106,7 +106,7 @@ export { default as UndoSnapshotsService } from './UndoSnapshotsService';
 export { default as PickerDataProvider } from './PickerDataProvider';
 export { default as PickerPluginOptions } from './PickerPluginOptions';
 export { default as VCell } from './VCell';
-export { default as ImageEditOptions } from './ImageEditOptions';
+export { default as ImageEditOptions, GetResizeHandleStyle } from './ImageEditOptions';
 export { default as CreateElementData } from './CreateElementData';
 export {
     SelectionRangeExBase,


### PR DESCRIPTION
## Summary 

Currently `DragAndDropHelper` is based on mouse events which are not supported correctly on mobile, to enable `ImageEditPlugin` on mobile we need to support mobile touch events.
And we have some special designs on resize handle, so we need to support customizing it.

## Changes

1. Add new properties `getCustomResizeHandelStyle` and `isMobile` in `ImageEditOptions`
2. Listen to mobile events in `DragAndDropHelper` if `isMobile` is true
3. Use style generated by `getCustomResizeHandelStyle` for resize handle if it's set