### PR TITLE
Allow return null for UndoSnapshotService.move

### DIFF
--- a/packages/roosterjs-editor-types/lib/interface/UndoSnapshotsService.ts
+++ b/packages/roosterjs-editor-types/lib/interface/UndoSnapshotsService.ts
@@ -14,7 +14,7 @@ export default interface UndoSnapshotsService<T = string> {
      * @param step The step to move
      * @returns If can move with the given step, returns the snapshot after move, otherwise null
      */
-    move(step: number): T;
+    move(step: number): T | null;
 
     /**
      * Add a new undo snapshot


### PR DESCRIPTION
We are returning null for this function today when no more undo/redo snapshot to move. However the function signature doesn't allow it, this prevent us moving towards strict mode.