### PR TITLE
Add key binding for clearing format

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/shortcutFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/shortcutFeatures.ts
@@ -15,6 +15,7 @@ import {
     toggleUnderline,
     toggleBullet,
     toggleNumbering,
+    clearFormat,
 } from 'roosterjs-editor-api';
 
 interface ShortcutCommand {
@@ -35,6 +36,7 @@ const commands: ShortcutCommand[] = [
     createCommand(Keys.Ctrl | Keys.B, Keys.Meta | Keys.B, toggleBold),
     createCommand(Keys.Ctrl | Keys.I, Keys.Meta | Keys.I, toggleItalic),
     createCommand(Keys.Ctrl | Keys.U, Keys.Meta | Keys.U, toggleUnderline),
+    createCommand(Keys.Ctrl | Keys.SPACE, Keys.Meta | Keys.SPACE, clearFormat),
     createCommand(Keys.Ctrl | Keys.Z, Keys.Meta | Keys.Z, editor => editor.undo()),
     createCommand(Keys.Ctrl | Keys.Y, Keys.Meta | Keys.Shift | Keys.Z, editor => editor.redo()),
     createCommand(Keys.Ctrl | Keys.PERIOD, Keys.Meta | Keys.PERIOD, toggleBullet),
@@ -65,7 +67,17 @@ const commands: ShortcutCommand[] = [
  */
 const DefaultShortcut: BuildInEditFeature<PluginKeyboardEvent> = {
     allowFunctionKeys: true,
-    keys: [Keys.B, Keys.I, Keys.U, Keys.Y, Keys.Z, Keys.COMMA, Keys.PERIOD, Keys.FORWARD_SLASH],
+    keys: [
+        Keys.B,
+        Keys.I,
+        Keys.U,
+        Keys.Y,
+        Keys.Z,
+        Keys.COMMA,
+        Keys.PERIOD,
+        Keys.FORWARD_SLASH,
+        Keys.SPACE,
+    ],
     shouldHandleEvent: cacheGetCommand,
     handleEvent: (event, editor) => {
         let command = cacheGetCommand(event);
@@ -102,3 +114,4 @@ export const ShortcutFeatures: Record<
 > = {
     defaultShortcut: DefaultShortcut,
 };
+

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/shortcutFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/shortcutFeatures.ts
@@ -58,6 +58,7 @@ const commands: ShortcutCommand[] = [
  * Ctrl/Meta+B: toggle bold style
  * Ctrl/Meta+I: toggle italic style
  * Ctrl/Meta+U: toggle underline style
+ * Ctrl/Meta+Space: clear formatting
  * Ctrl/Meta+Z: undo
  * Ctrl+Y/Meta+Shift+Z: redo
  * Ctrl/Meta+PERIOD: toggle bullet list
@@ -114,4 +115,3 @@ export const ShortcutFeatures: Record<
 > = {
     defaultShortcut: DefaultShortcut,
 };
-

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/shortcutFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/shortcutFeatureTest.ts
@@ -68,6 +68,12 @@ const parameters = [
         key: 85,
         command: DocumentCommand.Underline,
     },
+    {
+        description:
+            'default shortcut calls the clearFormat command on the editor when typing CTLR+Space',
+        key: 32,
+        command: DocumentCommand.RemoveFormat,
+    },
 ];
 
 parameters.forEach(({ description, key, command }) => {
@@ -160,3 +166,4 @@ it('default shortcut calls the changeFontSize increase when typing CTRL+SHiFT+, 
     shortCutFeature.handleEvent(event, editor);
     expect(changeFontSizeSpy).toHaveBeenCalledWith(editor, FontSizeChange.Decrease);
 });
+


### PR DESCRIPTION
Currently we lack a keyboard shortcut for clearing the format of the selection. 
This change binds this action to the Ctrl + Spacebar press.