### PR TITLE
Introduce new Alt+Backspace combo for undo

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/UndoPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/UndoPlugin.ts
@@ -137,7 +137,8 @@ export default class UndoPlugin implements PluginWithState<UndoPluginState> {
     private onKeyDown(evt: KeyboardEvent): void {
         // Handle backspace/delete when there is a selection to take a snapshot
         // since we want the state prior to deletion restorable
-        if (evt.which == Keys.BACKSPACE || evt.which == Keys.DELETE) {
+        // Ignore if keycombo is ALT+BACKSPACE
+        if ((evt.which == Keys.BACKSPACE && !evt.altKey) || evt.which == Keys.DELETE) {
             if (evt.which == Keys.BACKSPACE && this.canUndoAutoComplete()) {
                 evt.preventDefault();
                 this.editor.undo();

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/shortcutFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/shortcutFeatureTest.ts
@@ -95,22 +95,27 @@ parameters.forEach(({ description, key, command }) => {
     });
 });
 
-it('default shortcut calls the undo command on the editor when typing CTRL+Z', () => {
-    const rawEvent = new KeyboardEvent('keydown', {
-        ctrlKey: true,
-    });
-    Object.defineProperty(rawEvent, 'which', {
-        get: () => 90,
-    });
-    const event = {
-        rawEvent,
-        eventType: 0,
-    };
+[
+    { key: 90, mod: 'ctrl', keyCombo: 'Ctrl+Z' },
+    { key: 8, mod: 'alt', keyCombo: 'Alt+Backspace' },
+].forEach(({ key, mod, keyCombo }) => {
+    it(`default shortcut calls the undo command on the editor when typing ${keyCombo}`, () => {
+        const rawEvent = new KeyboardEvent('keydown', {
+            [`${mod}Key`]: true,
+        });
+        Object.defineProperty(rawEvent, 'which', {
+            get: () => key,
+        });
+        const event = {
+            rawEvent,
+            eventType: 0,
+        };
 
-    const shortCutFeature = ShortcutFeatures.defaultShortcut;
-    const spyUndo = spyOn(editor, 'undo');
-    shortCutFeature.handleEvent(event, editor);
-    expect(spyUndo).toHaveBeenCalled();
+        const shortCutFeature = ShortcutFeatures.defaultShortcut;
+        const spyUndo = spyOn(editor, 'undo');
+        shortCutFeature.handleEvent(event, editor);
+        expect(spyUndo).toHaveBeenCalled();
+    });
 });
 
 it('default shortcut calls the redo command on the editor when typing CTRL+Y', () => {
@@ -166,4 +171,3 @@ it('default shortcut calls the changeFontSize increase when typing CTRL+SHiFT+, 
     shortCutFeature.handleEvent(event, editor);
     expect(changeFontSizeSpy).toHaveBeenCalledWith(editor, FontSizeChange.Decrease);
 });
-


### PR DESCRIPTION
This PR removes the unpredictability of pressing Alt+Backspace multiple times, see issue for additional context

This was done by adding a new keyboard shortcut to the ContentEdit plugin, as well as making UndoPlugin ignore Alt+Backspace presses