### PR TITLE
Add null check during to editor instance in extractClipboardEvent callbacks

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
@@ -117,14 +117,14 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
 
         extractClipboardEvent(
             event as ClipboardEvent,
-            clipboardData => this.editor.paste(clipboardData),
+            clipboardData => this.editor?.paste(clipboardData),
             {
-                allowLinkPreview: this.editor.isFeatureEnabled(
+                allowLinkPreview: this.editor?.isFeatureEnabled(
                     ExperimentalFeatures.PasteWithLinkPreview
                 ),
                 allowedCustomPasteType: this.state.allowedCustomPasteType,
                 getTempDiv: () => {
-                    range = this.editor.getSelectionRange();
+                    range = this.editor?.getSelectionRange();
                     return this.getTempDiv();
                 },
                 removeTempDiv: div => {


### PR DESCRIPTION
Sometimes there is a null exception during the extractClipboardEvent. Adding a null check in case the editor got disposed during the Async promise to extract the ClipboardData.