### PR TITLE
Show table selector if it is inside of the Scroll Container

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -93,7 +93,7 @@ export default class TableEditor {
             editor.getZoomScale(),
             this.onSelect,
             this.onShowHelperElement,
-            this.getShouldShowTableSelectorHandler(this.event)
+            this.getShouldShowTableSelectorHandler(this.event, this.editor.getScrollContainer())
         );
     }
 
@@ -303,11 +303,17 @@ export default class TableEditor {
         }
     };
 
-    private getShouldShowTableSelectorHandler(e: MouseEvent): (rect: Rect) => boolean {
+    private getShouldShowTableSelectorHandler(
+        e: MouseEvent,
+        scrollContainer: HTMLElement
+    ): (rect: Rect) => boolean {
         if (safeInstanceOf(e.currentTarget, 'HTMLElement')) {
             const containerRect = normalizeRect(e.currentTarget.getBoundingClientRect());
+            const scrollContainerRect = normalizeRect(scrollContainer.getBoundingClientRect());
+            const scrollContainerVisibleTop = scrollContainer.scrollTop - scrollContainerRect.top;
 
-            return (rect: Rect) => containerRect.top <= rect.top;
+            return (rect: Rect) =>
+                containerRect.top <= rect.top && scrollContainerVisibleTop <= rect.top;
         }
 
         return () => true;


### PR DESCRIPTION
In a previous change we added a check to only display the TableSelector when the top is inside of the EditorDiv, but we also need to check if the table is inside of the visible part of the scroll container.