### PR TITLE
Handle pasting '\t' characters into editor

### DIFF
--- a/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
@@ -1,7 +1,7 @@
 import * as createDefaultHtmlSanitizerOptions from 'roosterjs-editor-dom/lib/htmlSanitizer/createDefaultHtmlSanitizerOptions';
 import createEditorCore from './createMockEditorCore';
 import { ClipboardData, PluginEventType } from 'roosterjs-editor-types';
-import { createPasteFragment } from '../../lib/coreApi/createPasteFragment';
+import { createPasteFragment, transformTabCharacters } from '../../lib/coreApi/createPasteFragment';
 import { itFirefoxOnly } from '../TestHelper';
 
 describe('createPasteFragment', () => {
@@ -434,6 +434,23 @@ describe('createPasteFragment', () => {
         const html = getHTML(fragment);
         expect(html.trim()).toBe('teststring<img src="">teststring');
         expect(clipboardData.htmlFirstLevelChildTags).toEqual(['', 'IMG', '']);
+    });
+});
+
+describe('transformTabCharacters', () => {
+    it('no \t', () => {
+        const input = 'hello world';
+        expect(transformTabCharacters(input)).toBe(input);
+    });
+
+    it('1 \t', () => {
+        const input = '\tHello';
+        expect(transformTabCharacters(input)).toBe('      Hello');
+    });
+
+    it('complex', () => {
+        const input = '1\t234\t5';
+        expect(transformTabCharacters(input)).toBe('1     234   5');
     });
 });
 


### PR DESCRIPTION
The current behavior is that '\t' characters are simply ignored and left untouched. As such, since \t characters are invisible in HTML, the user gets no visual feedback.

This change will replace \t characters with EN SPACES, imitating the Tab press functionality 

https://github.com/microsoft/roosterjs/blob/51042a4c812155cda7b2404e5b237aea7bd2760d/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/textFeatures.ts#L199-L226