### PR TITLE
Fix ENOENT build error on WSL Ubuntu

### DIFF
--- a/packages/roosterjs-editor-types/package.json
+++ b/packages/roosterjs-editor-types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "roosterjs-editor-types",
     "description": "Type definition for roosterjs",
-    "dependencies": {
+    "devDependencies": {
         "@types/dom-inputevent": "^1.0.3"
     },
     "main": "./lib/index.ts"

--- a/tools/buildTools/common.js
+++ b/tools/buildTools/common.js
@@ -95,7 +95,7 @@ function readPackageJson(packageName, readFromSourceFolder) {
     );
     const content = fs.readFileSync(packageJsonFilePath);
 
-    return JSON.parse(content);
+    return { dependencies: {}, devDependencies: {}, ...JSON.parse(content) };
 }
 
 const mainPackageJson = JSON.parse(fs.readFileSync(path.join(rootPath, 'package.json')));


### PR DESCRIPTION
Using `yarn build:ci` is currently failing on WSL2 due to errors being thrown in the `normalize` and `checkDependency` steps. 

Setting default values to the return value of `readPackageJson` prevents the `Object.keys` statements from raising an exception.

Additionally, having `@types/dom-inputevent` as a dependency was causing the `normalize` step to look for a package called `dom-inputevent` inside `/packages/`