### PR TITLE
Fix issue in Normalize Table.

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts
@@ -126,7 +126,7 @@ function normalizeTables(tables: HTMLTableElement[]) {
                 case 'TBODY':
                     if (tbody) {
                         moveChildNodes(tbody, child, true /*keepExistingChildren*/);
-                        child.parentNode.removeChild(child);
+                        child.parentNode?.removeChild(child);
                         child = tbody;
                         isDOMChanged = true;
                     } else {
@@ -143,7 +143,7 @@ function normalizeTables(tables: HTMLTableElement[]) {
         const thead = table.querySelector('thead');
         if (thead) {
             colgroups.forEach(colgroup => {
-                if (colgroup && !thead.contains(colgroup)) {
+                if (!thead.contains(colgroup)) {
                     thead.appendChild(colgroup);
                 }
             });

--- a/packages/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts
@@ -133,15 +133,20 @@ function normalizeTables(tables: HTMLTableElement[]) {
                         tbody = child as HTMLTableSectionElement;
                     }
                     break;
-                case 'COLGROUP':
-                    if (table.tHead) {
-                        table.tHead.prepend(child);
-                    }
-                    break;
                 default:
                     tbody = null;
                     break;
             }
+        }
+
+        const colgroups = table.querySelectorAll('colgroup');
+        const thead = table.querySelector('thead');
+        if (thead) {
+            colgroups.forEach(colgroup => {
+                if (colgroup && !thead.contains(colgroup)) {
+                    thead.appendChild(colgroup);
+                }
+            });
         }
     });
 

--- a/packages/roosterjs-editor-core/test/corePlugins/normalizeTablePluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/normalizeTablePluginTest.ts
@@ -260,4 +260,132 @@ describe('NormalizeTablePlugin', () => {
         expect(table.outerHTML).toBe('<table><tbody><tr><td>test1</td></tr></tbody></table>');
         expect(select).toHaveBeenCalledWith(table, coordinates);
     });
+
+    it('Normalize table with THEAD With colgroup, Tbody, Tfoot', () => {
+        runTest(
+            createTable(
+                getTheadWithColgroup(createTableSection),
+                createTableSection('tbody', 'test2'),
+                createTr('test3'),
+                createTableSection('tbody', 'test4'),
+                createTableSection('tfoot', 'test5')
+            ),
+            '<table>' +
+                '<thead><tr><td>test1</td></tr><colgroup><col><col></colgroup></thead>' +
+                '<tbody><tr><td>test2</td></tr><tr><td>test3</td></tr><tr><td>test4</td></tr></tbody>' +
+                '<tfoot><tr><td>test5</td></tr></tfoot>' +
+                '</table>'
+        );
+    });
+
+    it('Table already has THEAD With colgroup/TBODY/TFOOT', () => {
+        runTest(
+            createTable(
+                getTheadWithColgroup(createTableSection),
+                createTableSection('tbody', 'test2', 'test3'),
+                createTableSection('tfoot', 'test4')
+            ),
+            '<table>' +
+                '<thead><tr><td>test1</td></tr><colgroup><col><col></colgroup></thead>' +
+                '<tbody><tr><td>test2</td></tr><tr><td>test3</td></tr></tbody>' +
+                '<tfoot><tr><td>test4</td></tr></tfoot></table>'
+        );
+    });
+
+    it('Table has THEAD With colgroup and TR and TFOOT', () => {
+        debugger;
+        runTest(
+            createTable(
+                getTheadWithColgroup(createTableSection),
+                createTr('test2'),
+                createTr('test3'),
+                createTableSection('tfoot', 'test4')
+            ),
+            '<table>' +
+                '<thead><tr><td>test1</td></tr><colgroup><col><col></colgroup></thead>' +
+                '<tbody><tr><td>test2</td></tr><tr><td>test3</td></tr></tbody>' +
+                '<tfoot><tr><td>test4</td></tr></tfoot></table>'
+        );
+    });
+
+    it('Table has THEAD With colgroup and TR and TBODY and TR and TFOOT', () => {
+        runTest(
+            createTable(
+                getTheadWithColgroup(createTableSection),
+                createTr('test2'),
+                createTableSection('tbody', 'test3'),
+                createTr('test4'),
+                createTableSection('tfoot', 'test5')
+            ),
+            '<table>' +
+                '<thead><tr><td>test1</td></tr><colgroup><col><col></colgroup></thead>' +
+                '<tbody><tr><td>test2</td></tr><tr><td>test3</td></tr><tr><td>test4</td></tr></tbody>' +
+                '<tfoot><tr><td>test5</td></tr></tfoot>' +
+                '</table>'
+        );
+    });
+
+    it('Table has THEAD With colgroup and TBODY and TR and TBODY and TFOOT', () => {
+        runTest(
+            createTable(
+                getTheadWithColgroup(createTableSection),
+                createTableSection('tbody', 'test2'),
+                createTr('test3'),
+                createTableSection('tbody', 'test4'),
+                createTableSection('tfoot', 'test5')
+            ),
+            '<table>' +
+                '<thead><tr><td>test1</td></tr><colgroup><col><col></colgroup></thead>' +
+                '<tbody><tr><td>test2</td></tr><tr><td>test3</td></tr><tr><td>test4</td></tr></tbody>' +
+                '<tfoot><tr><td>test5</td></tr></tfoot>' +
+                '</table>'
+        );
+    });
+
+    it('Table has TR and TBODY and a orphaned colgroup 1', () => {
+        runTest(
+            createTable(
+                getColgroup(),
+                createTr('test1'),
+                getColgroup(),
+                createTableSection('tbody', 'test2'),
+                getColgroup()
+            ),
+            '<table>' +
+                '<colgroup><col><col></colgroup>' +
+                '<tbody><tr><td>test1</td></tr></tbody><colgroup><col><col></colgroup><tbody>' +
+                '<tr><td>test2</td></tr></tbody><colgroup><col><col></colgroup></table>'
+        );
+    });
+
+    it('Table has TR and TBODY and a orphaned colgroup 2', () => {
+        runTest(
+            createTable(createTableSection('tbody', 'test1'), createTr('test2'), getColgroup()),
+            '<table>' +
+                '<tbody><tr><td>test1</td></tr><tr><td>test2</td></tr></tbody>' +
+                '<colgroup><col><col></colgroup></table>'
+        );
+    });
 });
+
+function getTheadWithColgroup(
+    createTableSection: (tag: string, ...texts: string[]) => CreateElementData
+) {
+    const thead = createTableSection('thead', 'test1');
+    thead.children?.push(getColgroup());
+    return thead;
+}
+
+function getColgroup(): CreateElementData {
+    return {
+        tag: 'colgroup',
+        children: [
+            {
+                tag: 'col',
+            },
+            {
+                tag: 'col',
+            },
+        ],
+    };
+}

--- a/packages/roosterjs-editor-core/test/corePlugins/normalizeTablePluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/normalizeTablePluginTest.ts
@@ -324,6 +324,24 @@ describe('NormalizeTablePlugin', () => {
         );
     });
 
+    it('Table has THEAD With colgroup and TR and TBODY and TR and TFOOT 2', () => {
+        runTest(
+            createTable(
+                createTableSection('thead', 'test1'),
+                getColgroup(),
+                createTr('test2'),
+                createTableSection('tbody', 'test3'),
+                createTr('test4'),
+                createTableSection('tfoot', 'test5')
+            ),
+            '<table>' +
+                '<thead><tr><td>test1</td></tr><colgroup><col><col></colgroup></thead>' +
+                '<tbody><tr><td>test2</td></tr><tr><td>test3</td></tr><tr><td>test4</td></tr></tbody>' +
+                '<tfoot><tr><td>test5</td></tr></tfoot>' +
+                '</table>'
+        );
+    });
+
     it('Table has THEAD With colgroup and TBODY and TR and TBODY and TFOOT', () => {
         runTest(
             createTable(

--- a/packages/roosterjs-editor-core/test/corePlugins/normalizeTablePluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/normalizeTablePluginTest.ts
@@ -293,7 +293,6 @@ describe('NormalizeTablePlugin', () => {
     });
 
     it('Table has THEAD With colgroup and TR and TFOOT', () => {
-        debugger;
         runTest(
             createTable(
                 getTheadWithColgroup(createTableSection),


### PR DESCRIPTION
Error
-------------------
COMPONENT ERROR: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.

Callstack
-------------------
/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts:118
Native Browser Function(Array.forEach):undefined
/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts:109
/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts:94
/roosterjs-editor-core/lib/corePlugins/NormalizeTablePlugin.ts:58 
/roosterjs-editor-core/lib/editor/Editor.ts:554