### PR TITLE
[Part 2] Refactor Auto format - Refactor Apply List Style

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
@@ -20,6 +20,7 @@ export default function toggleBullet(
         ListType.Unordered,
         undefined /* startNumber */,
         false /* includeSiblingLists */,
+        undefined /** orderedStyle  */,
         listStyle
     );
 }

--- a/packages/roosterjs-editor-api/lib/utils/toggleListType.ts
+++ b/packages/roosterjs-editor-api/lib/utils/toggleListType.ts
@@ -29,18 +29,16 @@ import type {
  * @param listType The list type to toggle
  * @param startNumber (Optional) Start number of the list
  * @param includeSiblingLists Sets wether the operation should include Sibling Lists, by default true
- * @param listStyle (Optional) the style of an ordered or unordered list. If If not defined, the style will be set to disc or decimal.
+ * @param orderedStyle (Optional) the style of an ordered. If not defined, the style will be set to decimal.
+ * @param unorderedStyle (Optional) the style of an unordered list. If not defined, the style will be set to disc.
  */
 export default function toggleListType(
     editor: IEditor,
     listType: ListType | CompatibleListType,
     startNumber?: number,
     includeSiblingLists: boolean = true,
-    listStyle?:
-        | BulletListType
-        | NumberingListType
-        | CompatibleBulletListType
-        | CompatibleNumberingListType
+    orderedStyle?: NumberingListType | CompatibleNumberingListType,
+    unorderedStyle?: BulletListType | CompatibleBulletListType
 ) {
     blockFormat(editor, (region, start, end, chains) => {
         const chain =
@@ -55,8 +53,8 @@ export default function toggleListType(
 
         if (vList) {
             vList.changeListType(start, end, listType);
-            if (listStyle && editor.isFeatureEnabled(ExperimentalFeatures.AutoFormatList)) {
-                vList.setListStyleType(listStyle);
+            if (editor.isFeatureEnabled(ExperimentalFeatures.AutoFormatList)) {
+                vList.setListStyleType(orderedStyle, unorderedStyle);
             }
             vList.writeBack();
         }

--- a/packages/roosterjs-editor-dom/lib/list/VListItem.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VListItem.ts
@@ -37,20 +37,20 @@ const NEGATIVE_MARGIN = '-.25in';
 export const ListStyleDefinitionMetadata = createObjectDefinition<ListStyleMetadata>(
     {
         orderedStyleType: createNumberDefinition(
-            true,
+            true /** isOptional */,
             undefined /** value **/,
             NumberingListType.Min,
             NumberingListType.Max
         ),
         unorderedStyleType: createNumberDefinition(
-            true,
+            true /** isOptional */,
             undefined /** value **/,
             BulletListType.Min,
             BulletListType.Max
         ),
     },
-    true,
-    true
+    true /** isOptional */,
+    true /** allowNull */
 );
 
 /**

--- a/packages/roosterjs-editor-dom/lib/list/VListItem.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VListItem.ts
@@ -10,19 +10,58 @@ import setNumberingListMarkers from './setNumberingListMarkers';
 import toArray from '../utils/toArray';
 import unwrap from '../utils/unwrap';
 import wrap from '../utils/wrap';
-import { getMetadata } from '../metadata/metadata';
+import { createNumberDefinition, createObjectDefinition } from '../metadata/definitionCreators';
+import { getMetadata, setMetadata } from '../metadata/metadata';
 import {
     BulletListType,
     KnownCreateElementDataIndex,
     ListType,
     NumberingListType,
 } from 'roosterjs-editor-types';
-import type { CompatibleListType } from 'roosterjs-editor-types/lib/compatibleTypes';
+import type {
+    CompatibleBulletListType,
+    CompatibleListType,
+    CompatibleNumberingListType,
+} from 'roosterjs-editor-types/lib/compatibleTypes';
 
 const orderListStyles = [null, 'lower-alpha', 'lower-roman'];
+const unorderedListStyles = ['disc', 'circle', 'square'];
 
 const MARGIN_BASE = '0in 0in 0in 0.5in';
 const NEGATIVE_MARGIN = '-.25in';
+
+/**
+ * @internal
+ * The definition for the number of BulletListType or NumberingListType
+ */
+export const ListStyleDefinitionMetadata = createObjectDefinition<ListStyleMetadata>(
+    {
+        orderedStyleType: createNumberDefinition(
+            true,
+            undefined /** value **/,
+            NumberingListType.Min,
+            NumberingListType.Max
+        ),
+        unorderedStyleType: createNumberDefinition(
+            true,
+            undefined /** value **/,
+            BulletListType.Min,
+            BulletListType.Max
+        ),
+    },
+    true,
+    true
+);
+
+/**
+ * @internal
+ * Represents the metadata of the style of a list element
+ */
+export interface ListStyleMetadata {
+    orderedStyleType?: NumberingListType | CompatibleNumberingListType;
+    unorderedStyleType?: BulletListType | CompatibleBulletListType;
+}
+
 /**
  * !!! Never directly create instance of this class. It should be created within VList class !!!
  *
@@ -216,14 +255,22 @@ export default class VListItem {
      * @param index the list item index
      */
     applyListStyle(rootList: HTMLOListElement | HTMLUListElement, index: number) {
-        const style = getMetadata(rootList) ? getMetadata(rootList) : undefined;
+        const style = getMetadata<ListStyleMetadata>(rootList, ListStyleDefinitionMetadata);
+        // The list just need to be styled if it is at top level, so the listType length for this Vlist must be 2.
+        const isFirstLevel = this.listTypes.length < 3;
         if (style) {
-            if (this.listTypes.length < 3) {
-                if (this.listTypes[1] === ListType.Unordered) {
-                    setBulletListMarkers(this.node, style as BulletListType);
-                } else if (this.listTypes[1] === ListType.Ordered) {
-                    setNumberingListMarkers(this.node, style as NumberingListType, index);
-                }
+            if (
+                isFirstLevel &&
+                this.listTypes[1] === ListType.Unordered &&
+                style.unorderedStyleType
+            ) {
+                setBulletListMarkers(this.node, style.unorderedStyleType);
+            } else if (
+                isFirstLevel &&
+                this.listTypes[1] === ListType.Ordered &&
+                style.orderedStyleType
+            ) {
+                setNumberingListMarkers(this.node, style.orderedStyleType, index);
             } else {
                 this.node.style.removeProperty('list-style-type');
             }
@@ -360,10 +407,25 @@ function createListElement(
         result = doc.createElement(listType == ListType.Ordered ? 'ol' : 'ul');
     }
 
+    // Always maintain the metadata saved in the list
+    if (originalRoot && nextLevel == 1 && listType != getListTypeFromNode(originalRoot)) {
+        const style = getMetadata<ListStyleMetadata>(originalRoot, ListStyleDefinitionMetadata);
+        if (style) {
+            setMetadata(result, style, ListStyleDefinitionMetadata);
+        }
+    }
+
     if (listType == ListType.Ordered && nextLevel > 1) {
         result.style.setProperty(
             'list-style-type',
             orderListStyles[(nextLevel - 1) % orderListStyles.length]
+        );
+    }
+
+    if (listType == ListType.Unordered && nextLevel > 1) {
+        result.style.setProperty(
+            'list-style-type',
+            unorderedListStyles[(nextLevel - 1) % unorderedListStyles.length]
         );
     }
 

--- a/packages/roosterjs-editor-dom/lib/list/setBulletListMarkers.ts
+++ b/packages/roosterjs-editor-dom/lib/list/setBulletListMarkers.ts
@@ -1,4 +1,5 @@
 import { BulletListType } from 'roosterjs-editor-types';
+import type { CompatibleBulletListType } from 'roosterjs-editor-types/lib/compatibleTypes';
 
 /**
  * @internal
@@ -6,7 +7,10 @@ import { BulletListType } from 'roosterjs-editor-types';
  * @param li
  * @param listStyleType
  */
-export default function setBulletListMarkers(li: HTMLLIElement, listStyleType: BulletListType) {
+export default function setBulletListMarkers(
+    li: HTMLLIElement,
+    listStyleType: BulletListType | CompatibleBulletListType
+) {
     const marker = bulletListStyle[listStyleType];
     const isDiscOrSquare =
         listStyleType === BulletListType.Disc || listStyleType === BulletListType.Square;

--- a/packages/roosterjs-editor-dom/lib/list/setNumberingListMarkers.ts
+++ b/packages/roosterjs-editor-dom/lib/list/setNumberingListMarkers.ts
@@ -1,6 +1,7 @@
 import convertDecimalsToAlpha from './convertDecimalsToAlpha';
 import convertDecimalsToRoman from './convertDecimalsToRomans';
 import { NumberingListType } from 'roosterjs-editor-types';
+import type { CompatibleNumberingListType } from 'roosterjs-editor-types/lib/compatibleTypes';
 
 interface MarkerStyle {
     markerType: number;
@@ -23,7 +24,7 @@ enum MarkerTypes {
  */
 export default function setNumberingListMarkers(
     li: HTMLLIElement,
-    listStyleType: NumberingListType,
+    listStyleType: NumberingListType | CompatibleNumberingListType,
     level: number
 ) {
     const { markerSeparator, markerSecondSeparator, markerType, lowerCase } = numberingListStyle[

--- a/packages/roosterjs-editor-dom/test/list/VListItemTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/VListItemTest.ts
@@ -280,7 +280,7 @@ describe('VListItem.writeBack', () => {
         runTest(
             ['div', 'ol'],
             [ListType.Ordered, ListType.Unordered],
-            '<ol><ul><li><div></div></li></ul></ol>'
+            '<ol><ul style="list-style-type: circle;"><li><div></div></li></ul></ol>'
         );
     });
 
@@ -288,7 +288,7 @@ describe('VListItem.writeBack', () => {
         runTest(
             ['div', 'ol', 'ol'],
             [ListType.Ordered, ListType.Unordered],
-            '<ol><ol></ol><ul><li><div></div></li></ul></ol>'
+            '<ol><ol></ol><ul style="list-style-type: circle;"><li><div></div></li></ul></ol>'
         );
     });
 
@@ -378,7 +378,7 @@ describe('VListItem.writeBack', () => {
         runTest(
             ['div'],
             [ListType.Ordered, ListType.Unordered],
-            '<ol id="id1" data-test="test"><ul><li><div></div></li></ul></ol>',
+            '<ol id="id1" data-test="test"><ul style="list-style-type: circle;"><li><div></div></li></ul></ol>',
             ol
         );
     });
@@ -439,7 +439,8 @@ describe('VListItem.writeBack', () => {
 describe('VListItem.applyListStyle', () => {
     function runTest(
         listType: ListType,
-        styleType: NumberingListType | BulletListType,
+        orderedStyle: NumberingListType | undefined,
+        unorderedStyle: BulletListType | undefined,
         marker: string
     ) {
         const list =
@@ -450,7 +451,7 @@ describe('VListItem.applyListStyle', () => {
         const li = document.createElement('li');
         list.appendChild(li);
         const vList = new VList(list);
-        vList.setListStyleType(styleType);
+        vList.setListStyleType(orderedStyle, unorderedStyle);
         vList.items.forEach(item => {
             const index = vList.getListItemIndex(item.getNode());
             item.applyListStyle(list, index);
@@ -460,42 +461,47 @@ describe('VListItem.applyListStyle', () => {
     }
 
     it('DecimalParenthesis Numbering List', () => {
-        runTest(ListType.Ordered, NumberingListType.DecimalParenthesis, '"1) "');
+        runTest(ListType.Ordered, NumberingListType.DecimalParenthesis, undefined, '"1) "');
     });
 
     it('LowerRoman Numbering List', () => {
-        runTest(ListType.Ordered, NumberingListType.LowerRoman, '"i. "');
+        runTest(ListType.Ordered, NumberingListType.LowerRoman, undefined, '"i. "');
     });
 
     it('UpperRomanDoubleParenthesis Numbering List', () => {
-        runTest(ListType.Ordered, NumberingListType.UpperRomanDoubleParenthesis, '"(I) "');
+        runTest(
+            ListType.Ordered,
+            NumberingListType.UpperRomanDoubleParenthesis,
+            undefined,
+            '"(I) "'
+        );
     });
 
     it('LowerAlphaDash Numbering List', () => {
-        runTest(ListType.Ordered, NumberingListType.LowerAlphaDash, '"a- "');
+        runTest(ListType.Ordered, NumberingListType.LowerAlphaDash, undefined, '"a- "');
     });
 
     it('UpperAlphaParenthesis Numbering List', () => {
-        runTest(ListType.Ordered, NumberingListType.UpperAlphaParenthesis, '"A) "');
+        runTest(ListType.Ordered, NumberingListType.UpperAlphaParenthesis, undefined, '"A) "');
     });
 
     it('LongArrow Bullet List', () => {
-        runTest(ListType.Unordered, BulletListType.LongArrow, '"→ "');
+        runTest(ListType.Unordered, undefined, BulletListType.LongArrow, '"→ "');
     });
 
     it('ShortArrow Bullet List', () => {
-        runTest(ListType.Unordered, BulletListType.ShortArrow, '"➢ "');
+        runTest(ListType.Unordered, undefined, BulletListType.ShortArrow, '"➢ "');
     });
 
     it('UnfilledArrow Bullet List', () => {
-        runTest(ListType.Unordered, BulletListType.UnfilledArrow, '"➪ "');
+        runTest(ListType.Unordered, undefined, BulletListType.UnfilledArrow, '"➪ "');
     });
 
     it('Dash Bullet List', () => {
-        runTest(ListType.Unordered, BulletListType.Dash, '"- "');
+        runTest(ListType.Unordered, undefined, BulletListType.Dash, '"- "');
     });
 
     it('Square Bullet List', () => {
-        runTest(ListType.Unordered, BulletListType.Square, 'square');
+        runTest(ListType.Unordered, undefined, BulletListType.Square, 'square');
     });
 });

--- a/packages/roosterjs-editor-dom/test/list/VListTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/VListTest.ts
@@ -1,7 +1,7 @@
 import * as DomTestHelper from '../DomTestHelper';
 import Position from '../../lib/selection/Position';
 import VList from '../../lib/list/VList';
-import VListItem from '../../lib/list/VListItem';
+import VListItem, { ListStyleMetadata } from '../../lib/list/VListItem';
 import {
     Indentation,
     ListType,
@@ -1298,7 +1298,12 @@ describe('VList.setListStyleType', () => {
         DomTestHelper.removeElement(testId);
     });
 
-    function runTest(source: string, listStyle: NumberingListType | BulletListType, style: string) {
+    function runTest(
+        source: string,
+        orderedStyle: NumberingListType | undefined,
+        unorderedStyle: BulletListType | undefined,
+        style: ListStyleMetadata
+    ) {
         DomTestHelper.createElementFromContent(testId, source);
         const list = document.getElementById(ListRoot) as HTMLOListElement;
         const focus = document.getElementById(FocusNode);
@@ -1315,9 +1320,8 @@ describe('VList.setListStyleType', () => {
         const vList = new VList(list);
 
         // Act
-        vList.setListStyleType(listStyle);
-
-        expect(list.dataset[editingInfo]).toEqual(style);
+        vList.setListStyleType(orderedStyle, unorderedStyle);
+        expect(list.dataset[editingInfo]).toEqual(JSON.stringify(style));
         DomTestHelper.removeElement(testId);
     }
 
@@ -1325,7 +1329,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"></ol><div id="${FocusNode}"></div>`,
             NumberingListType.Decimal,
-            '1'
+            undefined,
+            { orderedStyleType: 1, unorderedStyleType: 1 }
         );
     });
 
@@ -1333,7 +1338,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.Decimal,
-            '1'
+            undefined,
+            { orderedStyleType: 1, unorderedStyleType: 1 }
         );
     });
 
@@ -1341,7 +1347,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.DecimalDash,
-            '2'
+            undefined,
+            { orderedStyleType: 2, unorderedStyleType: 1 }
         );
     });
 
@@ -1349,7 +1356,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.DecimalParenthesis,
-            '3'
+            undefined,
+            { orderedStyleType: 3, unorderedStyleType: 1 }
         );
     });
 
@@ -1357,7 +1365,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.DecimalDoubleParenthesis,
-            '4'
+            undefined,
+            { orderedStyleType: 4, unorderedStyleType: 1 }
         );
     });
 
@@ -1365,7 +1374,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.LowerAlpha,
-            '5'
+            undefined,
+            { orderedStyleType: 5, unorderedStyleType: 1 }
         );
     });
 
@@ -1373,7 +1383,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.LowerAlphaDash,
-            '8'
+            undefined,
+            { orderedStyleType: 8, unorderedStyleType: 1 }
         );
     });
 
@@ -1381,7 +1392,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.LowerAlphaParenthesis,
-            '6'
+            undefined,
+            { orderedStyleType: 6, unorderedStyleType: 1 }
         );
     });
 
@@ -1389,7 +1401,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.LowerAlphaDoubleParenthesis,
-            '7'
+            undefined,
+            { orderedStyleType: 7, unorderedStyleType: 1 }
         );
     });
 
@@ -1397,7 +1410,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.UpperAlpha,
-            '9'
+            undefined,
+            { orderedStyleType: 9, unorderedStyleType: 1 }
         );
     });
 
@@ -1405,7 +1419,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.UpperAlphaDash,
-            '12'
+            undefined,
+            { orderedStyleType: 12, unorderedStyleType: 1 }
         );
     });
 
@@ -1413,7 +1428,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.UpperAlphaParenthesis,
-            '10'
+            undefined,
+            { orderedStyleType: 10, unorderedStyleType: 1 }
         );
     });
 
@@ -1421,7 +1437,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.UpperAlphaDoubleParenthesis,
-            '11'
+            undefined,
+            { orderedStyleType: 11, unorderedStyleType: 1 }
         );
     });
 
@@ -1429,7 +1446,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.LowerRoman,
-            '13'
+            undefined,
+            { orderedStyleType: 13, unorderedStyleType: 1 }
         );
     });
 
@@ -1437,7 +1455,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.LowerRomanDash,
-            '16'
+            undefined,
+            { orderedStyleType: 16, unorderedStyleType: 1 }
         );
     });
 
@@ -1445,7 +1464,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.LowerRomanParenthesis,
-            '14'
+            undefined,
+            { orderedStyleType: 14, unorderedStyleType: 1 }
         );
     });
 
@@ -1453,7 +1473,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.LowerRomanDoubleParenthesis,
-            '15'
+            undefined,
+            { orderedStyleType: 15, unorderedStyleType: 1 }
         );
     });
 
@@ -1461,7 +1482,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.UpperRoman,
-            '17'
+            undefined,
+            { orderedStyleType: 17, unorderedStyleType: 1 }
         );
     });
 
@@ -1469,7 +1491,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.UpperRomanDash,
-            '20'
+            undefined,
+            { orderedStyleType: 20, unorderedStyleType: 1 }
         );
     });
 
@@ -1477,7 +1500,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.UpperRomanParenthesis,
-            '18'
+            undefined,
+            { orderedStyleType: 18, unorderedStyleType: 1 }
         );
     });
 
@@ -1485,7 +1509,8 @@ describe('VList.setListStyleType', () => {
         runTest(
             `<ol id="${ListRoot}"><li id="${FocusNode}">test</li></ol><div id="${FocusNode}"></div>`,
             NumberingListType.UpperRomanDoubleParenthesis,
-            '19'
+            undefined,
+            { orderedStyleType: 19, unorderedStyleType: 1 }
         );
     });
 });


### PR DESCRIPTION
Apply list style using the ListStyleMetadata object 
Part of the refactor Auto Format series: 
[Refactor list triggers](https://github.com/microsoft/roosterjs/pull/1025)
[Refactor Apply List Style](https://github.com/microsoft/roosterjs/pull/1026)
[AutoBulletList and AutoNumberingList](https://github.com/microsoft/roosterjs/pull/1028)
[Trigger list with Hyphen](https://github.com/microsoft/roosterjs/pull/1029)

