### PR TITLE
Inserting a table after a non content editable entity, makes the table not editable

### DIFF
--- a/packages/roosterjs-editor-api/test/table/insertTableTest.ts
+++ b/packages/roosterjs-editor-api/test/table/insertTableTest.ts
@@ -1,0 +1,35 @@
+import * as TestHelper from '../TestHelper';
+import insertTable from '../../lib/table/insertTable';
+import { IEditor } from 'roosterjs-editor-types';
+
+describe('InsertTable', () => {
+    let testID = 'insertTableId';
+    let testElementId = 'insertTableId2';
+    let editor: IEditor;
+
+    beforeEach(() => {
+        editor = TestHelper.initEditor(testID);
+    });
+
+    afterEach(() => {
+        editor.dispose();
+    });
+
+    it('Insert Table after not editable inline-block', () => {
+        editor.setContent(
+            `<div id="${testElementId}"><span class="_Entity _EType_ _EReadonly_1" contenteditable="false" style="display: inline-block;"><span data-hydrated-html=""><span><span><a><img>Document44.docx<span><img></span></a></span></span></span></span></div>`
+        );
+        const target = document.getElementById(testElementId);
+        const range = new Range();
+        range.setStart(target, 1);
+        editor.select(range);
+        insertTable(editor, 1, 2);
+
+        editor.queryElements('table', table => {
+            expect(table.isContentEditable).toBe(true);
+            expect(target.contains(table)).toBe(false);
+        });
+        const contentDiv = document.getElementById(testID);
+        expect(contentDiv.childElementCount).toBe(2);
+    });
+});


### PR DESCRIPTION
To repro, restore the following snapshot:

`<div data-ogsc="rgb(0,0,0)" data-ogsb="rgb(255,255,255)" style="font-family: &quot;Times New Roman&quot;; font-size: 12pt; color: rgb(255, 255, 255); background-color: rgb(51, 51, 51);"><span class="_Entity _EType_ _EReadonly_1" contenteditable="false" style="display: inline-block;"><span data-hydrated-html=""><span><span><a data-ogsc="" data-ogsb="rgb(244,244,244)" style="pointer-events: auto; padding: 0px 1px; border-radius: 2px; user-select: all; background-color: rgb(243, 242, 241);" class="OWAAutoLink OxGIL wOeYL" id="OLK_Beautified_OWA63443add-d99e-6fa0-2620-c7a4898bd7f2" href="https://microsoft-my.sharepoint.com/personal/bvalverde_microsoft_com/_layouts/15/doc.aspx?sourcedoc={adf896dd-dad6-4422-a561-187bdf5e6c39}&amp;action=edit"><img style="width: 16px; height: 16px; vertical-align: middle; padding: 1px 2px 2px 0px;" role="presentation" alt="" src="https://res-sdf.cdn.office.net/assets/mail/file-icon/png/docx_16x16.png">Document44.docx<span class="owaAttachmentRemoveOnSend"><img style="width: 12px; height: 12px; vertical-align: top;" hidden="" src="" role="presentation" alt=""></span></a></span></span></span></span><br></div><!--{"type":0,"isDarkMode":true,"start":[0,1],"end":[0,1]}-->`

Place cursor next to the not editable entity and then insert a table, notice how the table is not editable since it is inside of the read only entity.

This PR fixes this issue inserting the table after the not content editable element