### PR TITLE
Fix dark mode style for demo site

### DIFF
--- a/demo/scripts/controls/MainPane.scss
+++ b/demo/scripts/controls/MainPane.scss
@@ -25,6 +25,15 @@
     position: relative;
 }
 
+@media (prefers-color-scheme: dark) {
+    .editorContainer {
+        a:link,
+        a:visited {
+            color: #ba7cff;
+        }
+    }
+}
+
 .editor {
     border: solid 1px $primaryBorder;
     overflow: auto;

--- a/demo/scripts/controls/sidePane/formatState/FormatStatePane.tsx
+++ b/demo/scripts/controls/sidePane/formatState/FormatStatePane.tsx
@@ -97,7 +97,6 @@ export default class FormatStatePane extends React.Component<
                         <td className={styles.title}>Browser</td>
                         <td>
                             {this.renderSpan(Browser.isChrome, 'Chrome')}
-                            {this.renderSpan(Browser.isEdge, 'Edge')}
                             {this.renderSpan(Browser.isFirefox, 'Firefox')}
                             {this.renderSpan(Browser.isSafari, 'Safari')}
                             {this.renderSpan(Browser.isWebKit, 'Webkit')}

--- a/demo/scripts/controls/theme/theme.scss
+++ b/demo/scripts/controls/theme/theme.scss
@@ -11,10 +11,6 @@ $primaryBorderDark: #007b8b;
 $primaryBackgroundColorDark: #333333;
 
 @media (prefers-color-scheme: dark) {
-    a:link,
-    a:visited {
-        color: #ba7cff;
-    }
     button {
         background-color: $primaryColorDark;
         color: $primaryLighter2;


### PR DESCRIPTION
1. Fix the style of link in title bar for dark mode
Before: 
<img width="252" alt="image" src="https://user-images.githubusercontent.com/23065085/174463095-5223d853-cd85-4e1c-9023-d4535c2f1f54.png">
After:
<img width="216" alt="image" src="https://user-images.githubusercontent.com/23065085/174463110-6bc6b978-f5e2-4714-9015-c645c3a22130.png">

2. Remove "isEdge" from demo site