### PR TITLE
Fix dts.js to be compatible for react export

### DIFF
--- a/tools/buildTools/dts.js
+++ b/tools/buildTools/dts.js
@@ -260,7 +260,13 @@ function parseImportFrom(content, currentFileName, queue, baseDir, projDir, exte
         } else {
             const imports = matches[1]
                 .split(',')
-                .map(x => x.replace('{', '').replace('}', '').trim())
+                .map(x =>
+                    x
+                        .replace('{', '')
+                        .replace('}', '')
+                        .replace(/[\.\*\(\)\{\}\[\]\\]/g, '\\$&')
+                        .trim()
+                )
                 .filter(x => !!x);
             imports.forEach(x => {
                 newContent = newContent.replace(


### PR DESCRIPTION
If we export a react type from a file, we may see something like:
`import * as React from 'react';`

Our dts.js will use a regex to match and replace the keyword "React" to something else. So we need to replace the character "*" to be "\*" to make it work in a regex. Also replace some other characters for regex such as ".", "[", "\\", ...