### PR TITLE
Improve PasteOptionPlugin

### DIFF
--- a/packages-ui/roosterjs-react/lib/pasteOptions/component/showPasteOptionPane.tsx
+++ b/packages-ui/roosterjs-react/lib/pasteOptions/component/showPasteOptionPane.tsx
@@ -186,27 +186,24 @@ const PasteOptionComponent = React.forwardRef(function PasteOptionFunc(
  * @param position Target position
  * @param strings Localize string for this component
  * @param onPaste A callback to be called when user click on a paste button
- * @param onDismissed A callback to be called when this component is dismissed
- * @param onGetRef A callback to be called to set a reference of this component
+ * @param ref Referenace object for this component
  */
 export default function showPasteOptionPane(
     uiUtilities: UIUtilities,
     position: NodePosition,
     strings: LocalizedStrings<PasteOptionStringKeys>,
     onPaste: (key: PasteOptionButtonKeys) => void,
-    onDismissed: () => void,
-    onGetRef: (ref: PasteOptionPane) => void
+    ref: React.RefObject<PasteOptionPane>
 ) {
     let disposer: (() => void) | null = null;
     const onDismiss = () => {
         disposer?.();
         disposer = null;
-        onDismissed();
     };
 
     disposer = uiUtilities.renderComponent(
         <PasteOptionComponent
-            ref={onGetRef}
+            ref={ref}
             position={position}
             strings={strings}
             isRtl={uiUtilities.isRightToLeft()}

--- a/packages-ui/roosterjs-react/lib/pasteOptions/component/showPasteOptionPane.tsx
+++ b/packages-ui/roosterjs-react/lib/pasteOptions/component/showPasteOptionPane.tsx
@@ -186,7 +186,7 @@ const PasteOptionComponent = React.forwardRef(function PasteOptionFunc(
  * @param position Target position
  * @param strings Localize string for this component
  * @param onPaste A callback to be called when user click on a paste button
- * @param ref Referenace object for this component
+ * @param ref Reference object for this component
  */
 export default function showPasteOptionPane(
     uiUtilities: UIUtilities,


### PR DESCRIPTION
Use a RefObject to store the reference of paste option pane in PasteOptionPlugin so that no need to manually clear it when dispose.