### PR TITLE
Fix #1062 PluginEvent should support CompatiblePluginEventType

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreApi/triggerEvent.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/triggerEvent.ts
@@ -5,8 +5,9 @@ import {
     PluginEventType,
     TriggerEvent,
 } from 'roosterjs-editor-types';
+import type { CompatiblePluginEventType } from 'roosterjs-editor-types/lib/compatibleTypes';
 
-const allowedEventsInShadowEdit = [
+const allowedEventsInShadowEdit: (PluginEventType | CompatiblePluginEventType)[] = [
     PluginEventType.EditorReady,
     PluginEventType.BeforeDispose,
     PluginEventType.ExtractContentWithDom,

--- a/packages/roosterjs-editor-types/lib/event/BeforeCutCopyEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/BeforeCutCopyEvent.ts
@@ -1,10 +1,11 @@
 import BasePluginEvent from './BasePluginEvent';
 import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
- * Provides a chance for plugin to change the content before it is copied from editor.
+ * Data of BeforeCutCopyEvent
  */
-export default interface BeforeCutCopyEvent extends BasePluginEvent<PluginEventType.BeforeCutCopy> {
+export interface BeforeCutCopyEventData {
     /**
      * Raw DOM event
      */
@@ -25,3 +26,17 @@ export default interface BeforeCutCopyEvent extends BasePluginEvent<PluginEventT
      */
     isCut: boolean;
 }
+
+/**
+ * Provides a chance for plugin to change the content before it is copied from editor.
+ */
+export default interface BeforeCutCopyEvent
+    extends BeforeCutCopyEventData,
+        BasePluginEvent<PluginEventType.BeforeCutCopy> {}
+
+/**
+ * Provides a chance for plugin to change the content before it is copied from editor.
+ */
+export interface CompatibleBeforeCutCopyEvent
+    extends BeforeCutCopyEventData,
+        BasePluginEvent<CompatiblePluginEventType.BeforeCutCopy> {}

--- a/packages/roosterjs-editor-types/lib/event/BeforeDisposeEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/BeforeDisposeEvent.ts
@@ -1,8 +1,15 @@
 import BasePluginEvent from './BasePluginEvent';
 import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
  * Provides a chance for plugin to change the content before it is pasted into editor.
  */
 export default interface BeforeDisposeEvent
     extends BasePluginEvent<PluginEventType.BeforeDispose> {}
+
+/**
+ * Provides a chance for plugin to change the content before it is pasted into editor.
+ */
+export interface CompatibleBeforeDisposeEvent
+    extends BasePluginEvent<CompatiblePluginEventType.BeforeDispose> {}

--- a/packages/roosterjs-editor-types/lib/event/BeforePasteEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/BeforePasteEvent.ts
@@ -2,11 +2,12 @@ import BasePluginEvent from './BasePluginEvent';
 import ClipboardData from '../interface/ClipboardData';
 import HtmlSanitizerOptions from '../interface/HtmlSanitizerOptions';
 import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
- * Provides a chance for plugin to change the content before it is pasted into editor.
+ * Data of BeforePasteEvent
  */
-export default interface BeforePasteEvent extends BasePluginEvent<PluginEventType.BeforePaste> {
+export interface BeforePasteEventData {
     /**
      * An object contains all related data for pasting
      */
@@ -37,3 +38,17 @@ export default interface BeforePasteEvent extends BasePluginEvent<PluginEventTyp
      */
     htmlAttributes: Record<string, string>;
 }
+
+/**
+ * Provides a chance for plugin to change the content before it is pasted into editor.
+ */
+export default interface BeforePasteEvent
+    extends BeforePasteEventData,
+        BasePluginEvent<PluginEventType.BeforePaste> {}
+
+/**
+ * Provides a chance for plugin to change the content before it is pasted into editor.
+ */
+export interface CompatibleBeforePasteEvent
+    extends BeforePasteEventData,
+        BasePluginEvent<CompatiblePluginEventType.BeforePaste> {}

--- a/packages/roosterjs-editor-types/lib/event/BeforeSetContentEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/BeforeSetContentEvent.ts
@@ -1,14 +1,29 @@
 import BasePluginEvent from './BasePluginEvent';
 import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
+
+/**
+ * Data of BeforeSetContentEvent
+ */
+export interface BeforeSetContentEventData {
+    /**
+     * New content HTML that is about to set to editor
+     */
+    newContent: string;
+}
 
 /**
  * The event to be triggered before SetContent API is called.
  * Handle this event to cache anything you need from editor before it is gone.
  */
 export default interface BeforeSetContentEvent
-    extends BasePluginEvent<PluginEventType.BeforeSetContent> {
-    /**
-     * New content HTML that is about to set to editor
-     */
-    newContent: string;
-}
+    extends BeforeSetContentEventData,
+        BasePluginEvent<PluginEventType.BeforeSetContent> {}
+
+/**
+ * The event to be triggered before SetContent API is called.
+ * Handle this event to cache anything you need from editor before it is gone.
+ */
+export interface CompatibleBeforeSetContentEvent
+    extends BeforeSetContentEventData,
+        BasePluginEvent<CompatiblePluginEventType.BeforeSetContent> {}

--- a/packages/roosterjs-editor-types/lib/event/ContentChangedEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/ContentChangedEvent.ts
@@ -3,12 +3,12 @@ import ContentChangedData from '../interface/ContentChangedData';
 import { ChangeSource } from '../enum/ChangeSource';
 import { PluginEventType } from '../enum/PluginEventType';
 import type { CompatibleChangeSource } from '../compatibleEnum/ChangeSource';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
- * Represents a change to the editor made by another plugin
+ * Data of ContentChangedEvent
  */
-export default interface ContentChangedEvent
-    extends BasePluginEvent<PluginEventType.ContentChanged> {
+export interface ContentChangedEventData {
     /**
      * Source of the change
      */
@@ -24,3 +24,17 @@ export default interface ContentChangedEvent
      */
     additionalData?: ContentChangedData;
 }
+
+/**
+ * Represents a change to the editor made by another plugin
+ */
+export default interface ContentChangedEvent
+    extends ContentChangedEventData,
+        BasePluginEvent<PluginEventType.ContentChanged> {}
+
+/**
+ * Represents a change to the editor made by another plugin
+ */
+export interface CompatibleContentChangedEvent
+    extends ContentChangedEventData,
+        BasePluginEvent<CompatiblePluginEventType.ContentChanged> {}

--- a/packages/roosterjs-editor-types/lib/event/EditImageEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/EditImageEvent.ts
@@ -1,11 +1,11 @@
 import BasePluginEvent from './BasePluginEvent';
 import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
- * Represents an event that will be fired when an inline image is edited by user, and the src
- * attribute of the image is about to be changed
+ * Data of EditImageEvent
  */
-export default interface EditImageEvent extends BasePluginEvent<PluginEventType.EditImage> {
+export interface EditImageEventData {
     /**
      * The image element that is being changed
      */
@@ -28,3 +28,19 @@ export default interface EditImageEvent extends BasePluginEvent<PluginEventType.
      */
     newSrc: string;
 }
+
+/**
+ * Represents an event that will be fired when an inline image is edited by user, and the src
+ * attribute of the image is about to be changed
+ */
+export default interface EditImageEvent
+    extends EditImageEventData,
+        BasePluginEvent<PluginEventType.EditImage> {}
+
+/**
+ * Represents an event that will be fired when an inline image is edited by user, and the src
+ * attribute of the image is about to be changed
+ */
+export interface CompatibleEditImageEvent
+    extends EditImageEventData,
+        BasePluginEvent<CompatiblePluginEventType.EditImage> {}

--- a/packages/roosterjs-editor-types/lib/event/EditorReadyEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/EditorReadyEvent.ts
@@ -1,7 +1,14 @@
 import BasePluginEvent from './BasePluginEvent';
 import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
  * Provides a chance for plugin to change the content before it is pasted into editor.
  */
 export default interface EditorReadyEvent extends BasePluginEvent<PluginEventType.EditorReady> {}
+
+/**
+ * Provides a chance for plugin to change the content before it is pasted into editor.
+ */
+export interface CompatibleEditorReadyEvent
+    extends BasePluginEvent<CompatiblePluginEventType.EditorReady> {}

--- a/packages/roosterjs-editor-types/lib/event/EntityOperationEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/EntityOperationEvent.ts
@@ -3,13 +3,12 @@ import Entity from '../interface/Entity';
 import { EntityOperation } from '../enum/EntityOperation';
 import { PluginEventType } from '../enum/PluginEventType';
 import type { CompatibleEntityOperation } from '../compatibleEnum/EntityOperation';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
- * Provide a chance for plugins to handle entity related events.
- * See enum EntityOperation for more details about each operation
+ * Data of EntityOperationEvent
  */
-export default interface EntityOperationEvent
-    extends BasePluginEvent<PluginEventType.EntityOperation> {
+export interface EntityOperationEventData {
     /**
      * Operation to this entity
      */
@@ -38,3 +37,19 @@ export default interface EntityOperationEvent
      */
     contentForShadowEntity?: DocumentFragment;
 }
+
+/**
+ * Provide a chance for plugins to handle entity related events.
+ * See enum EntityOperation for more details about each operation
+ */
+export default interface EntityOperationEvent
+    extends EntityOperationEventData,
+        BasePluginEvent<PluginEventType.EntityOperation> {}
+
+/**
+ * Provide a chance for plugins to handle entity related events.
+ * See enum EntityOperation for more details about each operation
+ */
+export interface CompatibleEntityOperationEvent
+    extends EntityOperationEventData,
+        BasePluginEvent<CompatiblePluginEventType.EntityOperation> {}

--- a/packages/roosterjs-editor-types/lib/event/ExtractContentWithDomEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/ExtractContentWithDomEvent.ts
@@ -1,5 +1,17 @@
 import BasePluginEvent from './BasePluginEvent';
 import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
+
+/**
+ * Data of ExtractContentWithDomEvent
+ */
+export interface ExtractContentWithDomEventData {
+    /**
+     * Cloned root element of editor
+     * Plugin can change this DOM tree to clean up the markups it added before
+     */
+    clonedRoot: HTMLElement;
+}
 
 /**
  * Extract Content with a DOM tree event
@@ -8,10 +20,15 @@ import { PluginEventType } from '../enum/PluginEventType';
  * by operating on a cloned DOM tree
  */
 export default interface ExtractContentWithDomEvent
-    extends BasePluginEvent<PluginEventType.ExtractContentWithDom> {
-    /**
-     * Cloned root element of editor
-     * Plugin can change this DOM tree to clean up the markups it added before
-     */
-    clonedRoot: HTMLElement;
-}
+    extends ExtractContentWithDomEventData,
+        BasePluginEvent<PluginEventType.ExtractContentWithDom> {}
+
+/**
+ * Extract Content with a DOM tree event
+ * This event is triggered when getContent() is called with triggerExtractContentEvent = true
+ * Plugin can handle this event to remove the UI only markups to return clean HTML
+ * by operating on a cloned DOM tree
+ */
+export interface CompatibleExtractContentWithDomEvent
+    extends ExtractContentWithDomEventData,
+        BasePluginEvent<CompatiblePluginEventType.ExtractContentWithDom> {}

--- a/packages/roosterjs-editor-types/lib/event/PendingFormatStateChangedEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/PendingFormatStateChangedEvent.ts
@@ -1,11 +1,20 @@
 import BasePluginEvent from './BasePluginEvent';
 import { PendableFormatState } from '../interface/FormatState';
 import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
  * An event fired when pending format state (bold, italic, underline, ... with collapsed selection) is changed
  */
 export default interface PendingFormatStateChangedEvent
     extends BasePluginEvent<PluginEventType.PendingFormatStateChanged> {
+    formatState: PendableFormatState;
+}
+
+/**
+ * An event fired when pending format state (bold, italic, underline, ... with collapsed selection) is changed
+ */
+export interface CompatiblePendingFormatStateChangedEvent
+    extends BasePluginEvent<CompatiblePluginEventType.PendingFormatStateChanged> {
     formatState: PendableFormatState;
 }

--- a/packages/roosterjs-editor-types/lib/event/PluginDomEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/PluginDomEvent.ts
@@ -3,6 +3,38 @@ import { PluginEventType } from '../enum/PluginEventType';
 import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
+ * Data of PluginMouseUpEvent
+ */
+export interface PluginMouseUpEventData {
+    /**
+     * Whether this is a mouse click event (mouse up and down on the same position)
+     */
+    isClicking?: boolean;
+}
+
+/**
+ * Data of PluginContextMenuEvent
+ */
+export interface PluginContextMenuEventData {
+    /**
+     * A callback array to let editor retrieve context menu item related to this event.
+     * Plugins can add their own getter callback to this array,
+     * items from each getter will be separated by a splitter item represented by null
+     */
+    items: any[];
+}
+
+/**
+ * Data of PluginScrollEvent
+ */
+export interface PluginScrollEventData {
+    /**
+     * Current scroll container that triggers this scroll event
+     */
+    scrollContainer: HTMLElement;
+}
+
+/**
  * A base interface of all DOM events
  */
 export interface PluginDomEventBase<
@@ -28,25 +60,15 @@ export interface PluginMouseDownEvent
  * This interface represents a PluginEvent wrapping native MouseUp event
  */
 export interface PluginMouseUpEvent
-    extends PluginDomEventBase<PluginEventType.MouseUp, MouseEvent> {
-    /**
-     * Whether this is a mouse click event (mouse up and down on the same position)
-     */
-    isClicking?: boolean;
-}
+    extends PluginMouseUpEventData,
+        PluginDomEventBase<PluginEventType.MouseUp, MouseEvent> {}
 
 /**
  * This interface represents a PluginEvent wrapping native ContextMenu event
  */
 export interface PluginContextMenuEvent
-    extends PluginDomEventBase<PluginEventType.ContextMenu, MouseEvent> {
-    /**
-     * A callback array to let editor retrieve context menu item related to this event.
-     * Plugins can add their own getter callback to this array,
-     * items from each getter will be separated by a splitter item represented by null
-     */
-    items: any[];
-}
+    extends PluginContextMenuEventData,
+        PluginDomEventBase<PluginEventType.ContextMenu, MouseEvent> {}
 
 /**
  * This interface represents a PluginEvent wrapping native Mouse event
@@ -84,9 +106,82 @@ export interface PluginInputEvent extends PluginDomEventBase<PluginEventType.Inp
 /**
  * This interface represents a PluginEvent wrapping native scroll event
  */
-export interface PluginScrollEvent extends PluginDomEventBase<PluginEventType.Scroll, UIEvent> {
-    scrollContainer: HTMLElement;
-}
+export interface PluginScrollEvent
+    extends PluginScrollEventData,
+        PluginDomEventBase<PluginEventType.Scroll, UIEvent> {}
+
+/**
+ * This interface represents a PluginEvent wrapping native CompositionEnd event
+ */
+export interface CompatiblePluginCompositionEvent
+    extends PluginDomEventBase<CompatiblePluginEventType.CompositionEnd, CompositionEvent> {}
+
+/**
+ * This interface represents a PluginEvent wrapping native MouseDown event
+ */
+export interface CompatiblePluginMouseDownEvent
+    extends PluginDomEventBase<CompatiblePluginEventType.MouseDown, MouseEvent> {}
+
+/**
+ * This interface represents a PluginEvent wrapping native MouseUp event
+ */
+export interface CompatiblePluginMouseUpEvent
+    extends PluginMouseUpEventData,
+        PluginDomEventBase<CompatiblePluginEventType.MouseUp, MouseEvent> {}
+
+/**
+ * This interface represents a PluginEvent wrapping native ContextMenu event
+ */
+export interface CompatiblePluginContextMenuEvent
+    extends PluginContextMenuEventData,
+        PluginDomEventBase<CompatiblePluginEventType.ContextMenu, MouseEvent> {}
+
+/**
+ * This interface represents a PluginEvent wrapping native Mouse event
+ */
+export type CompatiblePluginMouseEvent =
+    | CompatiblePluginMouseDownEvent
+    | CompatiblePluginMouseUpEvent
+    | CompatiblePluginContextMenuEvent;
+
+/**
+ * This interface represents a PluginEvent wrapping native KeyDown event
+ */
+export interface CompatiblePluginKeyDownEvent
+    extends PluginDomEventBase<CompatiblePluginEventType.KeyDown, KeyboardEvent> {}
+
+/**
+ * This interface represents a PluginEvent wrapping native KeyPress event
+ */
+export interface CompatiblePluginKeyPressEvent
+    extends PluginDomEventBase<CompatiblePluginEventType.KeyPress, KeyboardEvent> {}
+
+/**
+ * This interface represents a PluginEvent wrapping native KeyUp event
+ */
+export interface CompatiblePluginKeyUpEvent
+    extends PluginDomEventBase<CompatiblePluginEventType.KeyUp, KeyboardEvent> {}
+
+/**
+ * The interface represents a PluginEvent wrapping native Keyboard event
+ */
+export type CompatiblePluginKeyboardEvent =
+    | CompatiblePluginKeyDownEvent
+    | CompatiblePluginKeyPressEvent
+    | CompatiblePluginKeyUpEvent;
+
+/**
+ * This interface represents a PluginEvent wrapping native input / textinput event
+ */
+export interface CompatiblePluginInputEvent
+    extends PluginDomEventBase<CompatiblePluginEventType.Input, InputEvent> {}
+
+/**
+ * This interface represents a PluginEvent wrapping native scroll event
+ */
+export interface CompatiblePluginScrollEvent
+    extends PluginScrollEventData,
+        PluginDomEventBase<CompatiblePluginEventType.Scroll, UIEvent> {}
 
 /**
  * This represents a PluginEvent wrapping native browser event
@@ -97,3 +192,13 @@ export type PluginDomEvent =
     | PluginKeyboardEvent
     | PluginInputEvent
     | PluginScrollEvent;
+
+/**
+ * This represents a PluginEvent wrapping native browser event
+ */
+export type CompatiblePluginDomEvent =
+    | CompatiblePluginCompositionEvent
+    | CompatiblePluginMouseEvent
+    | CompatiblePluginKeyboardEvent
+    | CompatiblePluginInputEvent
+    | CompatiblePluginScrollEvent;

--- a/packages/roosterjs-editor-types/lib/event/PluginEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/PluginEvent.ts
@@ -1,16 +1,25 @@
-import BeforeCutCopyEvent from './BeforeCutCopyEvent';
-import BeforeDisposeEvent from './BeforeDisposeEvent';
-import BeforePasteEvent from './BeforePasteEvent';
-import BeforeSetContentEvent from './BeforeSetContentEvent';
-import ContentChangedEvent from './ContentChangedEvent';
-import EditImageEvent from './EditImageEvent';
-import EditorReadyEvent from './EditorReadyEvent';
-import EntityOperationEvent from './EntityOperationEvent';
-import ExtractContentWithDomEvent from './ExtractContentWithDomEvent';
-import PendingFormatStateChangedEvent from './PendingFormatStateChangedEvent';
-import ZoomChangedEvent from './ZoomChangedEvent';
-import { EnterShadowEditEvent, LeaveShadowEditEvent } from './ShadowEditEvent';
-import { PluginDomEvent } from './PluginDomEvent';
+import BeforeCutCopyEvent, { CompatibleBeforeCutCopyEvent } from './BeforeCutCopyEvent';
+import BeforeDisposeEvent, { CompatibleBeforeDisposeEvent } from './BeforeDisposeEvent';
+import BeforePasteEvent, { CompatibleBeforePasteEvent } from './BeforePasteEvent';
+import BeforeSetContentEvent, { CompatibleBeforeSetContentEvent } from './BeforeSetContentEvent';
+import ContentChangedEvent, { CompatibleContentChangedEvent } from './ContentChangedEvent';
+import EditImageEvent, { CompatibleEditImageEvent } from './EditImageEvent';
+import EditorReadyEvent, { CompatibleEditorReadyEvent } from './EditorReadyEvent';
+import EntityOperationEvent, { CompatibleEntityOperationEvent } from './EntityOperationEvent';
+import ZoomChangedEvent, { CompatibleZoomChangedEvent } from './ZoomChangedEvent';
+import { CompatiblePluginDomEvent, PluginDomEvent } from './PluginDomEvent';
+import {
+    CompatibleEnterShadowEditEvent,
+    CompatibleLeaveShadowEditEvent,
+    EnterShadowEditEvent,
+    LeaveShadowEditEvent,
+} from './ShadowEditEvent';
+import PendingFormatStateChangedEvent, {
+    CompatiblePendingFormatStateChangedEvent,
+} from './PendingFormatStateChangedEvent';
+import ExtractContentWithDomEvent, {
+    CompatibleExtractContentWithDomEvent,
+} from './ExtractContentWithDomEvent';
 
 /**
  * Editor plugin event interface
@@ -29,4 +38,18 @@ export type PluginEvent =
     | LeaveShadowEditEvent
     | EditImageEvent
     | BeforeSetContentEvent
-    | ZoomChangedEvent;
+    | ZoomChangedEvent
+    | CompatibleBeforeCutCopyEvent
+    | CompatibleBeforeDisposeEvent
+    | CompatibleBeforePasteEvent
+    | CompatibleBeforeSetContentEvent
+    | CompatibleContentChangedEvent
+    | CompatibleEditImageEvent
+    | CompatibleEditorReadyEvent
+    | CompatibleEntityOperationEvent
+    | CompatibleExtractContentWithDomEvent
+    | CompatiblePendingFormatStateChangedEvent
+    | CompatiblePluginDomEvent
+    | CompatibleEnterShadowEditEvent
+    | CompatibleLeaveShadowEditEvent
+    | CompatibleZoomChangedEvent;

--- a/packages/roosterjs-editor-types/lib/event/ShadowEditEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/ShadowEditEvent.ts
@@ -1,11 +1,12 @@
 import BasePluginEvent from './BasePluginEvent';
 import SelectionPath from '../interface/SelectionPath';
 import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
- * A plugin triggered right after editor has entered Shadow Edit mode
+ * Data of EnterShadowEditEvent
  */
-export interface EnterShadowEditEvent extends BasePluginEvent<PluginEventType.EnteredShadowEdit> {
+export interface EnterShadowEditEventData {
     /**
      * The document fragment of original editor content
      */
@@ -18,6 +19,26 @@ export interface EnterShadowEditEvent extends BasePluginEvent<PluginEventType.En
 }
 
 /**
+ * A plugin triggered right after editor has entered Shadow Edit mode
+ */
+export interface EnterShadowEditEvent
+    extends EnterShadowEditEventData,
+        BasePluginEvent<PluginEventType.EnteredShadowEdit> {}
+
+/**
  * A plugin triggered right before editor leave Shadow Edit mode
  */
 export interface LeaveShadowEditEvent extends BasePluginEvent<PluginEventType.LeavingShadowEdit> {}
+
+/**
+ * A plugin triggered right after editor has entered Shadow Edit mode
+ */
+export interface CompatibleEnterShadowEditEvent
+    extends EnterShadowEditEventData,
+        BasePluginEvent<CompatiblePluginEventType.EnteredShadowEdit> {}
+
+/**
+ * A plugin triggered right before editor leave Shadow Edit mode
+ */
+export interface CompatibleLeaveShadowEditEvent
+    extends BasePluginEvent<CompatiblePluginEventType.LeavingShadowEdit> {}

--- a/packages/roosterjs-editor-types/lib/event/ZoomChangedEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/ZoomChangedEvent.ts
@@ -1,12 +1,11 @@
 import BasePluginEvent from './BasePluginEvent';
 import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
 
 /**
- * Represents an event object triggered from Editor.setZoomScale() API.
- * Plugins can handle this event when they need to do something for zoom changing.
- *
+ * Data of ZoomChangedEvent
  */
-export default interface ZoomChangedEvent extends BasePluginEvent<PluginEventType.ZoomChanged> {
+export interface ZoomChangedEventData {
     /**
      * Zoom scale value before this change
      */
@@ -17,3 +16,21 @@ export default interface ZoomChangedEvent extends BasePluginEvent<PluginEventTyp
      */
     newZoomScale: number;
 }
+
+/**
+ * Represents an event object triggered from Editor.setZoomScale() API.
+ * Plugins can handle this event when they need to do something for zoom changing.
+ *
+ */
+export default interface ZoomChangedEvent
+    extends ZoomChangedEventData,
+        BasePluginEvent<PluginEventType.ZoomChanged> {}
+
+/**
+ * Represents an event object triggered from Editor.setZoomScale() API.
+ * Plugins can handle this event when they need to do something for zoom changing.
+ *
+ */
+export interface CompatibleZoomChangedEvent
+    extends ZoomChangedEventData,
+        BasePluginEvent<CompatiblePluginEventType.ZoomChanged> {}

--- a/packages/roosterjs-editor-types/lib/event/index.ts
+++ b/packages/roosterjs-editor-types/lib/event/index.ts
@@ -1,14 +1,45 @@
-export { default as BeforeCutCopyEvent } from './BeforeCutCopyEvent';
+export {
+    default as BeforeCutCopyEvent,
+    BeforeCutCopyEventData,
+    CompatibleBeforeCutCopyEvent,
+} from './BeforeCutCopyEvent';
 export { default as BasePluginEvent } from './BasePluginEvent';
-export { default as BeforeDisposeEvent } from './BeforeDisposeEvent';
-export { default as BeforePasteEvent } from './BeforePasteEvent';
-export { default as BeforeSetContentEvent } from './BeforeSetContentEvent';
-export { default as ContentChangedEvent } from './ContentChangedEvent';
-export { default as EditImageEvent } from './EditImageEvent';
-export { default as EditorReadyEvent } from './EditorReadyEvent';
-export { default as EntityOperationEvent } from './EntityOperationEvent';
-export { default as ExtractContentWithDomEvent } from './ExtractContentWithDomEvent';
-export { default as PendingFormatStateChangedEvent } from './PendingFormatStateChangedEvent';
+export { default as BeforeDisposeEvent, CompatibleBeforeDisposeEvent } from './BeforeDisposeEvent';
+export {
+    default as BeforePasteEvent,
+    BeforePasteEventData,
+    CompatibleBeforePasteEvent,
+} from './BeforePasteEvent';
+export {
+    default as BeforeSetContentEvent,
+    BeforeSetContentEventData,
+    CompatibleBeforeSetContentEvent,
+} from './BeforeSetContentEvent';
+export {
+    default as ContentChangedEvent,
+    ContentChangedEventData,
+    CompatibleContentChangedEvent,
+} from './ContentChangedEvent';
+export {
+    default as EditImageEvent,
+    EditImageEventData,
+    CompatibleEditImageEvent,
+} from './EditImageEvent';
+export { default as EditorReadyEvent, CompatibleEditorReadyEvent } from './EditorReadyEvent';
+export {
+    default as EntityOperationEvent,
+    EntityOperationEventData,
+    CompatibleEntityOperationEvent,
+} from './EntityOperationEvent';
+export {
+    default as ExtractContentWithDomEvent,
+    ExtractContentWithDomEventData,
+    CompatibleExtractContentWithDomEvent,
+} from './ExtractContentWithDomEvent';
+export {
+    default as PendingFormatStateChangedEvent,
+    CompatiblePendingFormatStateChangedEvent,
+} from './PendingFormatStateChangedEvent';
 export {
     PluginDomEvent,
     PluginDomEventBase,
@@ -23,6 +54,21 @@ export {
     PluginMouseUpEvent,
     PluginInputEvent,
     PluginScrollEvent,
+    CompatiblePluginDomEvent,
+    CompatiblePluginCompositionEvent,
+    CompatiblePluginContextMenuEvent,
+    CompatiblePluginKeyboardEvent,
+    CompatiblePluginKeyDownEvent,
+    CompatiblePluginKeyPressEvent,
+    CompatiblePluginKeyUpEvent,
+    CompatiblePluginMouseEvent,
+    CompatiblePluginMouseDownEvent,
+    CompatiblePluginMouseUpEvent,
+    CompatiblePluginInputEvent,
+    CompatiblePluginScrollEvent,
+    PluginScrollEventData,
+    PluginMouseUpEventData,
+    PluginContextMenuEventData,
 } from './PluginDomEvent';
 export { PluginEvent } from './PluginEvent';
 export {
@@ -31,5 +77,15 @@ export {
     PluginEventFromType,
     PluginEventFromTypeGeneric,
 } from './PluginEventData';
-export { EnterShadowEditEvent, LeaveShadowEditEvent } from './ShadowEditEvent';
-export { default as ZoomChangedEvent } from './ZoomChangedEvent';
+export {
+    EnterShadowEditEvent,
+    LeaveShadowEditEvent,
+    EnterShadowEditEventData,
+    CompatibleEnterShadowEditEvent,
+    CompatibleLeaveShadowEditEvent,
+} from './ShadowEditEvent';
+export {
+    default as ZoomChangedEvent,
+    ZoomChangedEventData,
+    CompatibleZoomChangedEvent,
+} from './ZoomChangedEvent';


### PR DESCRIPTION
When people wants to use CompatiblePluginEventType in their plugin code like:
```ts
onPluginEvent(e) {
  if (e.eventType == CompatiblePluginEventType.KeyDown) { ... }
}
```
They got compile error since our PluginEvent is not using CompatiblePluginEventType as the type value now. So we need to add it.

To make all other API works, such as IEditor.triggerPluginEvent, I need to create separate event types, for example:

```ts
interface ContentChangedEvent {
  type: PluginEventType.ContentChanged;
  ...
}

interface CompatibleContentChangedEvent {
  type: CompatiblePluginEventType.ContentChanged;
  ...
}
```

They are actually same type so we can use any one of them