### PR TITLE
[Rooster-react]: Emoji plugin fixes

### DIFF
--- a/packages-ui/roosterjs-react/lib/emoji/components/EmojiNavBar.tsx
+++ b/packages-ui/roosterjs-react/lib/emoji/components/EmojiNavBar.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { css } from '@fluentui/react/lib/Utilities';
-import { EmojiFabricIconCharacterMap, EmojiFamilyKeys, EmojiList } from '../utils/emojiList';
+import { EmojiFabricIconCharacterMap, EmojiList } from '../utils/emojiList';
 import { EmojiPaneStyle } from '../type/EmojiPaneStyles';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react/lib/FocusZone';
+import { getObjectKeys } from 'roosterjs-editor-dom';
 import { Icon } from '@fluentui/react/lib/Icon';
 import { IProcessedStyleSet, IStyleSet } from '@fluentui/react/lib/Styling';
 import { TooltipHost } from '@fluentui/react/lib/Tooltip';
@@ -24,7 +25,7 @@ export interface EmojiNavBarProps {
  */
 export default function EmojiNavBar(props: EmojiNavBarProps) {
     const { currentSelected, getTabId, strings = {}, classNames } = props;
-    const keys = Object.keys(EmojiList) as EmojiFamilyKeys[];
+    const keys = getObjectKeys(EmojiList);
     const onFamilyClick = (key: string) => {
         if (props.onClick) {
             props.onClick(key);
@@ -38,13 +39,14 @@ export default function EmojiNavBar(props: EmojiNavBarProps) {
                 {keys.map((key, index) => {
                     const selected = key === currentSelected;
                     const friendlyName = strings[key];
+
                     return (
                         <TooltipHost
                             hostClassName={classNames.navBarTooltip}
                             content={friendlyName}
                             key={key}>
                             <button
-                                className={css(classNames.navBarButton, 'emoji-nav-bar-button', {
+                                className={css(classNames.navBarButton, {
                                     [classNames.selected]: selected,
                                 })}
                                 key={key}
@@ -55,6 +57,7 @@ export default function EmojiNavBar(props: EmojiNavBarProps) {
                                 aria-label={friendlyName}
                                 data-is-focusable="true"
                                 aria-posinset={index + 1}
+                                tabIndex={0}
                                 aria-setsize={keys.length}>
                                 <Icon iconName={EmojiFabricIconCharacterMap[key]} />
                             </button>

--- a/packages-ui/roosterjs-react/lib/emoji/components/EmojiPane.tsx
+++ b/packages-ui/roosterjs-react/lib/emoji/components/EmojiPane.tsx
@@ -271,21 +271,19 @@ const EmojiPane = React.forwardRef(function EmojiPaneFunc(
         return (
             <div id={listId} role="listbox">
                 {emojiList}
-                {emojiList && (
-                    <div
-                        id={listId}
-                        role="listbox"
-                        className={css(classNames.quickPicker, classNames.roosterEmojiPane)}>
-                        <Callout
-                            {...TooltipCalloutProps}
-                            role="tooltip"
-                            target={target}
-                            hidden={!content}
-                            className={classNames.tooltip}>
-                            {content}
-                        </Callout>
-                    </div>
-                )}
+                <div
+                    id={listId}
+                    role="listbox"
+                    className={css(classNames.quickPicker, classNames.roosterEmojiPane)}>
+                    <Callout
+                        {...TooltipCalloutProps}
+                        role="tooltip"
+                        target={target}
+                        hidden={!content || !emojiList}
+                        className={classNames.tooltip}>
+                        {content}
+                    </Callout>
+                </div>
             </div>
         );
     };

--- a/packages-ui/roosterjs-react/lib/emoji/components/EmojiPane.tsx
+++ b/packages-ui/roosterjs-react/lib/emoji/components/EmojiPane.tsx
@@ -269,26 +269,24 @@ const EmojiPane = React.forwardRef(function EmojiPaneFunc(
         // note: we're using a callout since TooltipHost does not support manual trigger, and we need to show the tooltip since quick picker is shown
         // as an autocomplete menu (false focus based on transferring navigation keyboard event)
         return (
-            <>
-                <div id={listId} role="listbox">
-                    {emojiList}
-                    {emojiList && (
-                        <div
-                            id={listId}
-                            role="listbox"
-                            className={css(classNames.quickPicker, classNames.roosterEmojiPane)}>
-                            <Callout
-                                {...TooltipCalloutProps}
-                                role="tooltip"
-                                target={target}
-                                hidden={!content}
-                                className={classNames.tooltip}>
-                                {content}
-                            </Callout>
-                        </div>
-                    )}
-                </div>
-            </>
+            <div id={listId} role="listbox">
+                {emojiList}
+                {emojiList && (
+                    <div
+                        id={listId}
+                        role="listbox"
+                        className={css(classNames.quickPicker, classNames.roosterEmojiPane)}>
+                        <Callout
+                            {...TooltipCalloutProps}
+                            role="tooltip"
+                            target={target}
+                            hidden={!content}
+                            className={classNames.tooltip}>
+                            {content}
+                        </Callout>
+                    </div>
+                )}
+            </div>
         );
     };
 

--- a/packages-ui/roosterjs-react/lib/emoji/components/EmojiPane.tsx
+++ b/packages-ui/roosterjs-react/lib/emoji/components/EmojiPane.tsx
@@ -120,7 +120,6 @@ const EmojiPane = React.forwardRef(function EmojiPaneFunc(
     ref: React.Ref<EmojiPane>
 ) {
     let searchBox: ITextField;
-
     let emojiBody: HTMLElement;
     let input: HTMLInputElement;
 
@@ -182,12 +181,12 @@ const EmojiPane = React.forwardRef(function EmojiPaneFunc(
 
             return null;
         },
-        [index]
+        [currentEmojiList]
     );
 
     const getSelectedEmoji = React.useCallback((): Emoji => {
         return currentEmojiList[index];
-    }, [index]);
+    }, [currentEmojiList, index]);
 
     const showFullPicker = React.useCallback(
         (fullSearchText: string): void => {
@@ -230,7 +229,7 @@ const EmojiPane = React.forwardRef(function EmojiPaneFunc(
         (emoji: Emoji): string => {
             return emoji ? `${listId}-${emoji.key}` : undefined;
         },
-        [index]
+        [listId]
     );
 
     React.useImperativeHandle(
@@ -266,30 +265,30 @@ const EmojiPane = React.forwardRef(function EmojiPaneFunc(
         const selectedEmoji = getSelectedEmoji();
         const target = selectedEmoji ? `#${getEmojiIconId(selectedEmoji)}` : undefined;
         const content = selectedEmoji ? strings[selectedEmoji.description] : undefined;
-
+        const emojiList = renderCurrentEmojiIcons(index, currentEmojiList);
         // note: we're using a callout since TooltipHost does not support manual trigger, and we need to show the tooltip since quick picker is shown
         // as an autocomplete menu (false focus based on transferring navigation keyboard event)
         return (
-            <div id={listId} role="listbox">
-                {renderCurrentEmojiIcons(index, currentEmojiList)}
-                <div
-                    id={listId}
-                    role="listbox"
-                    className={css(
-                        classNames.quickPicker,
-                        classNames.roosterEmojiPane,
-                        'quick-picker'
-                    )}>
-                    <Callout
-                        {...TooltipCalloutProps}
-                        role="tooltip"
-                        target={target}
-                        hidden={!content}
-                        className={classNames.tooltip}>
-                        {content}
-                    </Callout>
+            <>
+                <div id={listId} role="listbox">
+                    {emojiList}
+                    {emojiList && (
+                        <div
+                            id={listId}
+                            role="listbox"
+                            className={css(classNames.quickPicker, classNames.roosterEmojiPane)}>
+                            <Callout
+                                {...TooltipCalloutProps}
+                                role="tooltip"
+                                target={target}
+                                hidden={!content}
+                                className={classNames.tooltip}>
+                                {content}
+                            </Callout>
+                        </div>
+                    )}
                 </div>
-            </div>
+            </>
         );
     };
 
@@ -403,7 +402,6 @@ const EmojiPane = React.forwardRef(function EmojiPaneFunc(
 
     const renderCurrentEmojiIcons = (index: number, currentEmojiList: Emoji[]): JSX.Element[] => {
         const { strings } = props;
-
         return currentEmojiList.map((emoji, emojiIndex) => (
             <EmojiIcon
                 strings={strings}
@@ -624,6 +622,20 @@ const getEmojiPaneClassName = memoizeFunction((theme: Theme) => {
     return mergeStyleSets({
         quickPicker: {
             overflowY: 'hidden',
+            ':after': {
+                content: '',
+                position: 'absolute',
+                left: '0px',
+                top: '0px',
+                bottom: '0px',
+                right: '0px',
+                zIndex: 1,
+                borderWidth: '1px',
+                borderStyle: 'solid',
+                borderColor: 'rgb(255, 255, 255)',
+                borderImage: 'initial',
+                outline: 'rgb(102, 102, 102) solid 1px',
+            },
         },
 
         tooltip: {
@@ -658,11 +670,6 @@ const getEmojiPaneClassName = memoizeFunction((theme: Theme) => {
         roosterEmojiPane: {
             padding: '1px',
             background: palette.white,
-
-            button: {
-                outline: 0,
-                position: 'relative',
-            },
         },
 
         emoji: {
@@ -670,16 +677,9 @@ const getEmojiPaneClassName = memoizeFunction((theme: Theme) => {
             width: '40px',
             height: '40px',
             border: '0',
-            outline: 0,
             position: 'relative',
             background: palette.white,
             transition: 'backgorund 0.5s ease-in-out',
-            '&::-moz-focus-inner': {
-                border: '0',
-            },
-            ':focus': {
-                background: palette.themeLight,
-            },
         },
 
         emojiSelected: {
@@ -687,32 +687,30 @@ const getEmojiPaneClassName = memoizeFunction((theme: Theme) => {
         },
 
         navBar: {
-            position: 'absolute',
-            top: '-0.5px',
+            top: '-1px',
             zIndex: 10,
+            position: 'sticky',
         },
+
         navBarTooltip: {
             display: 'inline-block',
         },
+
         navBarButton: {
             height: '40px',
             width: '40px',
             border: '0',
             borderBottom: 'solid 1px',
+            padding: 0,
+            marginBottom: 0,
             display: 'inline-block',
-            padding: '0',
-            margin: '0',
             color: palette.themeDark,
             background: palette.white,
-
-            '&::-moz-focus-inner': {
-                border: 0,
-            },
-
             '&:hover': {
                 cursor: 'default',
             },
         },
+
         selected: {
             borderBottom: '2px solid',
             borderBottomColor: palette.themeDark,

--- a/packages-ui/roosterjs-react/lib/emoji/plugin/createEmojiPlugin.ts
+++ b/packages-ui/roosterjs-react/lib/emoji/plugin/createEmojiPlugin.ts
@@ -161,6 +161,7 @@ class EmojiPlugin implements ReactEditorPlugin {
         ) {
             this.editor.getDocument().defaultView.clearTimeout(this.timer);
             this.timer = null;
+            this.emojiCalloutRef.current?.dismiss();
         }
 
         const wordBeforeCursor = this.getWordBeforeCursor(event);
@@ -245,6 +246,8 @@ class EmojiPlugin implements ReactEditorPlugin {
             null /*changeSource*/,
             true /*canUndoByBackspace*/
         );
+
+        this.emojiCalloutRef.current?.dismiss();
     }
 
     private getWordBeforeCursor(event: PluginEvent): string {


### PR DESCRIPTION
1. Fix emoji navigation tab focus
2. Show the callout quick picker callout, only after quick picker render
3. Dismiss callout after keydown or inserted emoji

![emojiPluginFixes](https://user-images.githubusercontent.com/87443959/176518781-7c9c5592-63e6-4db6-9be4-45bb19928bbe.gif)
