### PR TITLE
Fix(#1073): Order in ensureUniqueId

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreApi/selectTable.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/selectTable.ts
@@ -201,8 +201,8 @@ function ensureUniqueId(el: HTMLElement, idPrefix: string) {
         //Ensure that there are no elements with the same ID
         let element = getElement();
         while (element) {
-            element = getElement();
             cont++;
+            element = getElement();
         }
 
         el.id = idPrefix + cont;


### PR DESCRIPTION
The while loop in ensureUniqueId caused mistake generating id. If we do ``getElement`` before ``cont++``, we will get **2** if id0 is used, while **1** should be the right one.