### PR TITLE
Modify the editor.addUndoSnapshot to add formatApiName to the request

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -5,6 +5,7 @@ import {
     ChangeSource,
     ClipboardData,
     ColorTransformDirection,
+    ContentChangedData,
     ContentPosition,
     DefaultFormat,
     DOMEventHandler,
@@ -602,9 +603,16 @@ export default class Editor implements IEditor {
     public addUndoSnapshot(
         callback?: (start: NodePosition, end: NodePosition) => any,
         changeSource?: ChangeSource | CompatibleChangeSource | string,
-        canUndoByBackspace?: boolean
+        canUndoByBackspace?: boolean,
+        additionalData?: ContentChangedData
     ) {
-        this.core.api.addUndoSnapshot(this.core, callback, changeSource, canUndoByBackspace);
+        this.core.api.addUndoSnapshot(
+            this.core,
+            callback,
+            changeSource,
+            canUndoByBackspace,
+            additionalData
+        );
     }
 
     /**


### PR DESCRIPTION
In a previous change (#1044 ) we added the format api name that was executed to the EditorApi Interfaces, but did not modify the editor api itself, so the editorApi Invoked was not being provided to the ContentChanged event.

In this PR we add the parameter added to the EditorApi interface to the editor API