### PR TITLE
Allow unknown protocol in demo site

### DIFF
--- a/demo/scripts/utils/trustedHTMLHandler.ts
+++ b/demo/scripts/utils/trustedHTMLHandler.ts
@@ -6,6 +6,7 @@ export function trustedHTMLHandler(html: string): string {
         ADD_ATTR: ['name', 'content'],
         WHOLE_DOCUMENT: true,
         RETURN_TRUSTED_TYPE: true,
+        ALLOW_UNKNOWN_PROTOCOLS: true,
     });
     return <string>(<any>result);
 }


### PR DESCRIPTION
By default the trustHTMLHandler function of demo site is using DOMPurify and it will remove blob:// and other unknown protocols. This causes some issue when copy/paste content in MacOS. So let's set ALLOW_UNKNOWN_PROTOCOLS to true to allow those protocols.

This will only impact demo site, no impact to roosterjs dev code.