### PR TITLE
Fix Option+Backspace behavior on Mac

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/shortcutFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/shortcutFeatures.ts
@@ -22,7 +22,6 @@ interface ShortcutCommand {
     winKey: number;
     macKey: number;
     action: (editor: IEditor) => any;
-    disabled: boolean;
 }
 
 function createCommand(
@@ -31,11 +30,13 @@ function createCommand(
     action: (editor: IEditor) => any,
     disabled: boolean = false
 ) {
+    if (disabled) {
+        return null;
+    }
     return {
         winKey,
         macKey,
         action,
-        disabled,
     };
 }
 
@@ -49,7 +50,7 @@ const commands: ShortcutCommand[] = [
         Keys.ALT | Keys.BACKSPACE,
         Keys.ALT | Keys.BACKSPACE,
         editor => editor.undo(),
-        Browser.isMac /* Disabled for Mac */
+        Browser.isMac /* Option+Backspace to be handled by browsers on Mac */
     ),
     createCommand(Keys.Ctrl | Keys.Y, Keys.Meta | Keys.Shift | Keys.Z, editor => editor.redo()),
     createCommand(Keys.Ctrl | Keys.PERIOD, Keys.Meta | Keys.PERIOD, toggleBullet),
@@ -64,7 +65,7 @@ const commands: ShortcutCommand[] = [
         Keys.Meta | Keys.Shift | Keys.COMMA,
         editor => changeFontSize(editor, FontSizeChange.Decrease)
     ),
-];
+].filter((command): command is ShortcutCommand => !!command);
 
 /**
  * DefaultShortcut edit feature, provides shortcuts for the following features:
@@ -97,7 +98,7 @@ const DefaultShortcut: BuildInEditFeature<PluginKeyboardEvent> = {
     shouldHandleEvent: cacheGetCommand,
     handleEvent: (event, editor) => {
         let command = cacheGetCommand(event);
-        if (command && !command.disabled) {
+        if (command) {
             command.action(editor);
             event.rawEvent.preventDefault();
             event.rawEvent.stopPropagation();

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/shortcutFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/shortcutFeatures.ts
@@ -22,13 +22,20 @@ interface ShortcutCommand {
     winKey: number;
     macKey: number;
     action: (editor: IEditor) => any;
+    disabled: boolean;
 }
 
-function createCommand(winKey: number, macKey: number, action: (editor: IEditor) => any) {
+function createCommand(
+    winKey: number,
+    macKey: number,
+    action: (editor: IEditor) => any,
+    disabled: boolean = false
+) {
     return {
         winKey,
         macKey,
         action,
+        disabled,
     };
 }
 
@@ -38,7 +45,12 @@ const commands: ShortcutCommand[] = [
     createCommand(Keys.Ctrl | Keys.U, Keys.Meta | Keys.U, toggleUnderline),
     createCommand(Keys.Ctrl | Keys.SPACE, Keys.Meta | Keys.SPACE, clearFormat),
     createCommand(Keys.Ctrl | Keys.Z, Keys.Meta | Keys.Z, editor => editor.undo()),
-    createCommand(Keys.ALT | Keys.BACKSPACE, Keys.ALT | Keys.BACKSPACE, editor => editor.undo()),
+    createCommand(
+        Keys.ALT | Keys.BACKSPACE,
+        Keys.ALT | Keys.BACKSPACE,
+        editor => editor.undo(),
+        Browser.isMac /* Disabled for Mac */
+    ),
     createCommand(Keys.Ctrl | Keys.Y, Keys.Meta | Keys.Shift | Keys.Z, editor => editor.redo()),
     createCommand(Keys.Ctrl | Keys.PERIOD, Keys.Meta | Keys.PERIOD, toggleBullet),
     createCommand(Keys.Ctrl | Keys.FORWARD_SLASH, Keys.Meta | Keys.FORWARD_SLASH, toggleNumbering),
@@ -85,7 +97,7 @@ const DefaultShortcut: BuildInEditFeature<PluginKeyboardEvent> = {
     shouldHandleEvent: cacheGetCommand,
     handleEvent: (event, editor) => {
         let command = cacheGetCommand(event);
-        if (command) {
+        if (command && !command.disabled) {
             command.action(editor);
             event.rawEvent.preventDefault();
             event.rawEvent.stopPropagation();


### PR DESCRIPTION
Conditionally disable Alt+Backspace shortcut as it's not required on Mac