### PR TITLE
Add null check in AdjustInsertPosition

### DIFF
--- a/packages/roosterjs-editor-dom/lib/edit/adjustInsertPosition.ts
+++ b/packages/roosterjs-editor-dom/lib/edit/adjustInsertPosition.ts
@@ -253,7 +253,7 @@ function adjustInsertPositionForNotEditableNode(
     position: NodePosition,
     range: Range
 ): NodePosition {
-    if (!position.element.isContentEditable) {
+    if (!position.element?.isContentEditable) {
         let nonEditableElement: HTMLElement | undefined;
         let lastNonEditableElement: HTMLElement | null = findClosestElementAncestor(
             position.node,


### PR DESCRIPTION
In some scenarios when adjusting the Position that was created based on a document fragment, the element property of the Position is going to be null. So, adding a null check to prevent code to crash