### PR TITLE
Fix #1090 Remove debug info from SelectionBlockScoper .ts

### DIFF
--- a/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionBlockScoper.ts
+++ b/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionBlockScoper.ts
@@ -35,27 +35,12 @@ export default class SelectionBlockScoper implements TraversingScoper {
         position: NodePosition | Range,
         private startFrom: ContentPosition | CompatibleContentPosition
     ) {
-        // Debugging info, will be removed later
-        let isPosition = false;
-
         if (safeInstanceOf(position, 'Range')) {
             position = Position.getStart(position);
-        } else {
-            isPosition = true;
         }
 
-        try {
-            this.position = position.normalize();
-            this.block = getBlockElementAtNode(this.rootNode, this.position.node);
-        } catch (e) {
-            throw new Error(
-                `${
-                    (e as any)?.message
-                }; isPosition: ${isPosition}; actual type: ${typeof position}; String name: ${
-                    typeof position?.toString === 'function' ? position.toString() : 'No toString()'
-                }`
-            );
-        }
+        this.position = position.normalize();
+        this.block = getBlockElementAtNode(this.rootNode, this.position.node);
     }
 
     /**


### PR DESCRIPTION
We saw weird bug report from SelectionBlockScoper before (https://github.com/microsoft/roosterjs/issues/1045) which hard to repro. I added some debugging info and made a fix in https://github.com/microsoft/roosterjs/pull/1046. It seems after that fix the issue is gone. So we can safely remove the debugging info from SelectionBlockScoper now.