### PR TITLE
Customize api name

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
@@ -14,7 +14,7 @@ import type { CompatibleBulletListType } from 'roosterjs-editor-types/lib/compat
 export default function toggleBullet(
     editor: IEditor,
     listStyle?: BulletListType | CompatibleBulletListType,
-    autoFormat?: boolean
+    apiNameOverride?: string
 ) {
     toggleListType(
         editor,
@@ -23,6 +23,6 @@ export default function toggleBullet(
         false /* includeSiblingLists */,
         undefined /** orderedStyle  */,
         listStyle,
-        autoFormat
+        apiNameOverride
     );
 }

--- a/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleBullet.ts
@@ -10,6 +10,7 @@ import type { CompatibleBulletListType } from 'roosterjs-editor-types/lib/compat
  * browser execCommand API
  * @param editor The editor instance
  * @param listStyle (Optional) the style of the bullet list. If not defined, the style will be set to disc.
+ * @param apiNameOverride (Optional) Set a new api name, if empty the api name will be 'toggleListType'.
  */
 export default function toggleBullet(
     editor: IEditor,

--- a/packages/roosterjs-editor-api/lib/format/toggleNumbering.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleNumbering.ts
@@ -11,6 +11,7 @@ import type { CompatibleNumberingListType } from 'roosterjs-editor-types/lib/com
  * @param editor The editor instance
  * @param startNumber (Optional) Start number of the list
  * @param listStyle (Optional) The style of the numbering list. If not defined, the style will be set to decimal.
+ * @param apiNameOverride (Optional) Set a new api name, if empty the api name will be 'toggleListType'.
  */
 export default function toggleNumbering(
     editor: IEditor,

--- a/packages/roosterjs-editor-api/lib/format/toggleNumbering.ts
+++ b/packages/roosterjs-editor-api/lib/format/toggleNumbering.ts
@@ -16,7 +16,7 @@ export default function toggleNumbering(
     editor: IEditor,
     startNumber?: number,
     listStyle?: NumberingListType | CompatibleNumberingListType,
-    autoFormat?: boolean
+    apiNameOverride?: string
 ) {
     toggleListType(
         editor,
@@ -25,6 +25,6 @@ export default function toggleNumbering(
         undefined /* includeSiblingLists */,
         listStyle,
         undefined /* unorderedStyle */,
-        autoFormat
+        apiNameOverride
     );
 }

--- a/packages/roosterjs-editor-api/lib/utils/toggleListType.ts
+++ b/packages/roosterjs-editor-api/lib/utils/toggleListType.ts
@@ -31,6 +31,7 @@ import type {
  * @param includeSiblingLists Sets wether the operation should include Sibling Lists, by default true
  * @param orderedStyle (Optional) the style of an ordered. If not defined, the style will be set to decimal.
  * @param unorderedStyle (Optional) the style of an unordered list. If not defined, the style will be set to disc.
+ * @param apiNameOverride (Optional) Set a new api name, if empty the api name will be 'toggleListType'.
  */
 export default function toggleListType(
     editor: IEditor,
@@ -39,7 +40,7 @@ export default function toggleListType(
     includeSiblingLists: boolean = true,
     orderedStyle?: NumberingListType | CompatibleNumberingListType,
     unorderedStyle?: BulletListType | CompatibleBulletListType,
-    autoFormat?: boolean
+    apiNameOverride?: string
 ) {
     blockFormat(
         editor,
@@ -66,6 +67,6 @@ export default function toggleListType(
             }
         },
         undefined /* beforeRunCallback */,
-        autoFormat ? 'autoToggleListType' : 'toggleListType'
+        apiNameOverride || 'toggleListType'
     );
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/AutoFormat/AutoFormat.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/AutoFormat/AutoFormat.ts
@@ -16,8 +16,6 @@ export default class AutoFormat implements EditorPlugin {
     private editor: IEditor;
     private lastKeyTyped: string;
 
-    constructor() {}
-
     /**
      * Get a friendly name of this plugin
      */

--- a/packages/roosterjs-editor-plugins/lib/plugins/AutoFormat/AutoFormat.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/AutoFormat/AutoFormat.ts
@@ -16,7 +16,7 @@ export default class AutoFormat implements EditorPlugin {
     private editor: IEditor;
     private lastKeyTyped: string;
 
-    constructor(private enableAutoHyphen: boolean = true) {}
+    constructor() {}
 
     /**
      * Get a friendly name of this plugin
@@ -45,60 +45,58 @@ export default class AutoFormat implements EditorPlugin {
      * @param event PluginEvent object
      */
     onPluginEvent(event: PluginEvent) {
-        if (this.enableAutoHyphen) {
-            if (
-                event.eventType === PluginEventType.ContentChanged ||
-                event.eventType === PluginEventType.MouseDown ||
-                event.eventType === PluginEventType.MouseUp
-            ) {
+        if (
+            event.eventType === PluginEventType.ContentChanged ||
+            event.eventType === PluginEventType.MouseDown ||
+            event.eventType === PluginEventType.MouseUp
+        ) {
+            this.lastKeyTyped = '';
+        }
+
+        if (event.eventType === PluginEventType.KeyDown) {
+            const keyTyped = event.rawEvent.key;
+
+            if (keyTyped.length > 1) {
                 this.lastKeyTyped = '';
             }
 
-            if (event.eventType === PluginEventType.KeyDown) {
-                const keyTyped = event.rawEvent.key;
-
-                if (keyTyped.length > 1) {
-                    this.lastKeyTyped = '';
-                }
-
+            if (
+                this.lastKeyTyped === '-' &&
+                !specialCharacters.test(keyTyped) &&
+                keyTyped !== ' ' &&
+                keyTyped !== '-'
+            ) {
+                const searcher = this.editor.getContentSearcherOfCursor(event);
+                const textBeforeCursor = searcher.getSubStringBefore(3);
+                const dashes = searcher.getSubStringBefore(2);
+                const isPrecededByADash = textBeforeCursor[0] === '-';
+                const isPrecededByASpace = textBeforeCursor[0] === ' ';
                 if (
-                    this.lastKeyTyped === '-' &&
-                    !specialCharacters.test(keyTyped) &&
-                    keyTyped !== ' ' &&
-                    keyTyped !== '-'
+                    isPrecededByADash ||
+                    isPrecededByASpace ||
+                    specialCharacters.test(textBeforeCursor[0]) ||
+                    dashes !== '--'
                 ) {
-                    const searcher = this.editor.getContentSearcherOfCursor(event);
-                    const textBeforeCursor = searcher.getSubStringBefore(3);
-                    const dashes = searcher.getSubStringBefore(2);
-                    const isPrecededByADash = textBeforeCursor[0] === '-';
-                    const isPrecededByASpace = textBeforeCursor[0] === ' ';
-                    if (
-                        isPrecededByADash ||
-                        isPrecededByASpace ||
-                        specialCharacters.test(textBeforeCursor[0]) ||
-                        dashes !== '--'
-                    ) {
-                        return;
-                    }
-
-                    const textRange = searcher.getRangeFromText(dashes, true /* exactMatch */);
-                    const nodeHyphen = document.createTextNode('—');
-                    this.editor.addUndoSnapshot(
-                        () => {
-                            textRange.deleteContents();
-                            textRange.insertNode(nodeHyphen);
-                            this.editor.select(nodeHyphen, PositionType.End);
-                        },
-                        ChangeSource.Format /*changeSource*/,
-                        true /*canUndoByBackspace*/,
-                        { formatApiName: 'autoHyphen' }
-                    );
-
-                    //After the substitution the last key typed needs to be cleaned
-                    this.lastKeyTyped = '';
-                } else {
-                    this.lastKeyTyped = keyTyped;
+                    return;
                 }
+
+                const textRange = searcher.getRangeFromText(dashes, true /* exactMatch */);
+                const nodeHyphen = document.createTextNode('—');
+                this.editor.addUndoSnapshot(
+                    () => {
+                        textRange.deleteContents();
+                        textRange.insertNode(nodeHyphen);
+                        this.editor.select(nodeHyphen, PositionType.End);
+                    },
+                    ChangeSource.Format /*changeSource*/,
+                    true /*canUndoByBackspace*/,
+                    { formatApiName: 'autoHyphen' }
+                );
+
+                //After the substitution the last key typed needs to be cleaned
+                this.lastKeyTyped = '';
+            } else {
+                this.lastKeyTyped = keyTyped;
             }
         }
     }

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -231,7 +231,7 @@ const AutoBulletList: BuildInEditFeature<PluginKeyboardEvent> = {
 
                 if (textRange) {
                     prepareAutoBullet(editor, textRange);
-                    toggleBullet(editor, listStyle, true /** autoFormat */);
+                    toggleBullet(editor, listStyle, 'autoToggleList' /** apiNameOverride */);
                 }
                 searcher.getRangeFromText(textBeforeCursor, true /*exactMatch*/)?.deleteContents();
             },
@@ -271,14 +271,19 @@ const AutoNumberingList: BuildInEditFeature<PluginKeyboardEvent> = {
                 } else if ((regions = editor.getSelectedRegions()) && regions.length == 1) {
                     const num = parseInt(textBeforeCursor);
                     prepareAutoBullet(editor, textRange);
-                    toggleNumbering(editor, num, listStyle, true /** autoFormat */);
+                    toggleNumbering(
+                        editor,
+                        num,
+                        listStyle,
+                        'autoToggleList' /** apiNameOverride */
+                    );
                 } else {
                     prepareAutoBullet(editor, textRange);
                     toggleNumbering(
                         editor,
                         undefined /* startNumber*/,
                         listStyle,
-                        true /** autoFormat */
+                        'autoToggleList' /** apiNameOverride */
                     );
                 }
                 searcher.getRangeFromText(textBeforeCursor, true /*exactMatch*/)?.deleteContents();


### PR DESCRIPTION
Change autoFormat parameter to apiOverrideName, with this parameter the user can change the formatApiName of the toggleListType Api. 