### PR TITLE
Content Model step 0: Preparation

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreApi/attachDomEvent.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/attachDomEvent.ts
@@ -1,4 +1,4 @@
-import { getObjectKeys } from 'roosterjs-editor-dom/lib';
+import { getObjectKeys } from 'roosterjs-editor-dom';
 import {
     AttachDomEvent,
     DOMEventHandler,

--- a/packages/roosterjs-editor-plugins/lib/pluginUtils/DragAndDropHelper.ts
+++ b/packages/roosterjs-editor-plugins/lib/pluginUtils/DragAndDropHelper.ts
@@ -1,6 +1,6 @@
-import { Browser } from 'roosterjs-editor-dom/lib';
 import Disposable from './Disposable';
 import DragAndDropHandler from './DragAndDropHandler';
+import { Browser } from 'roosterjs-editor-dom';
 
 /**
  * @internal

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/ContentEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/ContentEdit.ts
@@ -1,5 +1,5 @@
 import getAllFeatures from './getAllFeatures';
-import { getObjectKeys } from 'roosterjs-editor-dom/lib';
+import { getObjectKeys } from 'roosterjs-editor-dom';
 import {
     ContentEditFeatureSettings,
     EditorPlugin,

--- a/packages/roosterjs-editor-types/lib/corePluginState/EditPluginState.ts
+++ b/packages/roosterjs-editor-types/lib/corePluginState/EditPluginState.ts
@@ -1,4 +1,4 @@
-import { GenericContentEditFeature } from '../interface/IEditor';
+import { GenericContentEditFeature } from '../interface/ContentEditFeature';
 import { PluginEvent } from '../event/PluginEvent';
 
 /**

--- a/packages/roosterjs-editor-types/lib/enum/NodeType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/NodeType.ts
@@ -10,6 +10,11 @@ export const enum NodeType {
     Element = 1,
 
     /**
+     * An Attribute node such as name="value".
+     */
+    Attribute = 2,
+
+    /**
      * The actual Text of Element or Attr.
      */
     Text = 3,

--- a/packages/roosterjs-editor-types/lib/interface/ContentEditFeature.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ContentEditFeature.ts
@@ -1,0 +1,52 @@
+import IEditor from './IEditor';
+import { CompatiblePluginKeyboardEvent, PluginKeyboardEvent } from '../event/PluginDomEvent';
+import { PluginEvent } from '../event/PluginEvent';
+
+/**
+ * Generic ContentEditFeature interface
+ */
+export interface GenericContentEditFeature<TEvent extends PluginEvent> {
+    /**
+     * Keys of this edit feature to handle
+     */
+    keys: number[];
+
+    /**
+     * Check if the event should be handled by this edit feature
+     * @param event The plugin event to check
+     * @param editor The editor object
+     * @param ctrlOrMeta If Ctrl key (for Windows) or Meta key (for Mac) is pressed
+     */
+    shouldHandleEvent: (event: TEvent, editor: IEditor, ctrlOrMeta: boolean) => any;
+
+    /**
+     * Handle this event
+     * @param event The event to handle
+     * @param editor The editor object
+     */
+    handleEvent: (event: TEvent, editor: IEditor) => any;
+
+    /**
+     * Whether function keys (Ctrl/Meta or Alt) is allowed for this edit feature, default value is false.
+     * When set to false, this edit feature won't be triggered if user has pressed Ctrl/Meta/Alt key
+     */
+    allowFunctionKeys?: boolean;
+}
+
+/**
+ * ContentEditFeature interface that handles keyboard event
+ */
+export type ContentEditFeature = GenericContentEditFeature<
+    PluginKeyboardEvent | CompatiblePluginKeyboardEvent
+>;
+
+/**
+ * RoosterJs build in content edit feature
+ */
+export interface BuildInEditFeature<TEvent extends PluginEvent>
+    extends GenericContentEditFeature<TEvent> {
+    /**
+     * Whether this edit feature is disabled by default
+     */
+    defaultDisabled?: boolean;
+}

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -13,12 +13,12 @@ import { ContentPosition } from '../enum/ContentPosition';
 import { DOMEventHandler } from '../type/domEventHandler';
 import { EditorUndoState, PendableFormatState, StyleBasedFormatState } from './FormatState';
 import { ExperimentalFeatures } from '../enum/ExperimentalFeatures';
+import { GenericContentEditFeature } from './ContentEditFeature';
 import { GetContentMode } from '../enum/GetContentMode';
 import { InsertOption } from './InsertOption';
 import { PluginEvent } from '../event/PluginEvent';
 import { PluginEventData, PluginEventFromType } from '../event/PluginEventData';
 import { PluginEventType } from '../enum/PluginEventType';
-import { PluginKeyboardEvent } from '../event/PluginDomEvent';
 import { PositionType } from '../enum/PositionType';
 import { QueryScope } from '../enum/QueryScope';
 import { RegionType } from '../enum/RegionType';
@@ -625,50 +625,3 @@ export default interface IEditor {
 
 // Temporarily put these interfaces here to workaround circular dependency issue
 // Need to revisit these interfaces later.
-
-/**
- * Generic ContentEditFeature interface
- */
-export interface GenericContentEditFeature<TEvent extends PluginEvent> {
-    /**
-     * Keys of this edit feature to handle
-     */
-    keys: number[];
-
-    /**
-     * Check if the event should be handled by this edit feature
-     * @param event The plugin event to check
-     * @param editor The editor object
-     * @param ctrlOrMeta If Ctrl key (for Windows) or Meta key (for Mac) is pressed
-     */
-    shouldHandleEvent: (event: TEvent, editor: IEditor, ctrlOrMeta: boolean) => any;
-
-    /**
-     * Handle this event
-     * @param event The event to handle
-     * @param editor The editor object
-     */
-    handleEvent: (event: TEvent, editor: IEditor) => any;
-
-    /**
-     * Whether function keys (Ctrl/Meta or Alt) is allowed for this edit feature, default value is false.
-     * When set to false, this edit feature won't be triggered if user has pressed Ctrl/Meta/Alt key
-     */
-    allowFunctionKeys?: boolean;
-}
-
-/**
- * ContentEditFeature interface that handles keyboard event
- */
-export type ContentEditFeature = GenericContentEditFeature<PluginKeyboardEvent>;
-
-/**
- * RoosterJs build in content edit feature
- */
-export interface BuildInEditFeature<TEvent extends PluginEvent>
-    extends GenericContentEditFeature<TEvent> {
-    /**
-     * Whether this edit feature is disabled by default
-     */
-    defaultDisabled?: boolean;
-}

--- a/packages/roosterjs-editor-types/lib/interface/index.ts
+++ b/packages/roosterjs-editor-types/lib/interface/index.ts
@@ -48,12 +48,12 @@ export { default as HtmlSanitizerOptions } from './HtmlSanitizerOptions';
 export { default as SanitizeHtmlOptions } from './SanitizeHtmlOptions';
 export { default as TargetWindowBase } from './TargetWindowBase';
 export { default as TargetWindow } from './TargetWindow';
+export { default as IEditor } from './IEditor';
 export {
-    default as IEditor,
     ContentEditFeature,
     GenericContentEditFeature,
     BuildInEditFeature,
-} from './IEditor';
+} from './ContentEditFeature';
 export { default as EditorPlugin } from './EditorPlugin';
 export { default as PluginWithState } from './PluginWithState';
 export {


### PR DESCRIPTION
#1093 

This is the 0th step of Content Model, do some preparation work.

1. Fix checkDependency.js to allow in-package circular dependency. We didn't allow file level circular dependency before, but that was too strict. Now circular dependency within the same package is allowed. Cross package circular dependency is still disallowed.
2. Fix some existing importing violations
3. Move ContentEditFeatures declaration to a new file since circular dependency is allowed.