### PR TITLE
Fix(#1103): Delete the whole table if the table is empty after deletion

### DIFF
--- a/packages/roosterjs-editor-dom/lib/table/VTable.ts
+++ b/packages/roosterjs-editor-dom/lib/table/VTable.ts
@@ -271,6 +271,9 @@ export default class VTable {
                     ? this.selection.lastCell.y - this.selection.firstCell.y
                     : 0;
                 this.cells.splice(firstRow, removedRows + 1);
+                if (this.cells.length === 0) {
+                    this.cells = null;
+                }
 
                 break;
             case TableOperation.DeleteColumn:
@@ -287,6 +290,9 @@ export default class VTable {
                         row.splice(removedColumns, 1);
                     });
                     deletedColumns++;
+                }
+                if (this.cells?.length === 0 || this.cells?.every(row => row.length === 0)) {
+                    this.cells = null;
                 }
                 break;
 


### PR DESCRIPTION
After Deleting rows or columns, see if the table is empty. If so, set cells to null.