### PR TITLE
Fix: Horizontal table inserter not disposing

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -140,7 +140,8 @@ export default class TableEditor {
                             true /*isHorizontal*/
                         );
                     } else {
-                        this.setInserterTd(null);
+                        this.setInserterTd(null, true);
+                        this.setInserterTd(null, false);
                     }
 
                     this.setResizingTd(td);


### PR DESCRIPTION
In TableResizePlugin, the horizontal TableInserter should be disposed when the mouse leaves the leftmost cells, but it doesn't.

https://user-images.githubusercontent.com/20739682/179770217-74d3531d-3c27-41a1-85b4-206244d8e022.mov

This is because in this [line](https://github.com/microsoft/roosterjs/blob/cc152f0e4282b51c39070282c032712b6e450a29/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts#L143) we passed ``isHorizontal = undefined`` to ``setInserterTd ``. So in [here](https://github.com/microsoft/roosterjs/blob/cc152f0e4282b51c39070282c032712b6e450a29/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts#L187) the inserter will always be the ``verticalInserter``.

