### PR TITLE
Add buildmjs to export esmodules under lib-mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
         "builddemo": "node tools/build.js builddemo",
         "builddoc": "node tools/build.js builddoc",
         "build": "node tools/build.js clean checkdep normalize tslint buildcommonjs dts packprod builddemo",
-        "build:ci": "node tools/build.js --noProgressBar clean checkdep normalize tslint buildcommonjs buildamd dts pack packprod builddemo builddoc",
+        "build:ci": "node tools/build.js --noProgressBar clean checkdep normalize tslint buildcommonjs buildamd buildmjs dts pack packprod builddemo builddoc",
         "start": "node tools/start.js",
         "test": "node tools/build.js normalize & karma start",
         "test:chrome": "node tools/build.js normalize & karma start --chrome",
         "test:debug": "node tools/build.js normalize & karma start --no-single-run",
         "test:coverage": "node tools/build.js normalize & karma start --coverage",
-        "publish": "node tools/build.js clean normalize tslint buildcommonjs buildamd dts pack packprod builddemo builddoc publish"
+        "publish": "node tools/build.js clean normalize tslint buildcommonjs buildamd buildmjs dts pack packprod builddemo builddoc publish"
     },
     "devDependencies": {
         "@microsoft/loader-load-themed-styles": "1.8.11",

--- a/packages-ui/roosterjs-react/lib/emoji/plugin/createEmojiPlugin.ts
+++ b/packages-ui/roosterjs-react/lib/emoji/plugin/createEmojiPlugin.ts
@@ -20,7 +20,7 @@ import {
     EmojiFamilyStrings,
     EmojiKeywordStrings,
 } from '../type/EmojiStrings';
-import React = require('react');
+import * as React from 'react';
 
 const KEYCODE_COLON = 186;
 const KEYCODE_COLON_FIREFOX = 59;

--- a/tools/build.js
+++ b/tools/build.js
@@ -10,6 +10,7 @@ const checkDependencyStep = require('./buildTools/checkDependency');
 const cleanStep = require('./buildTools/clean');
 const normalizeStep = require('./buildTools/normalize');
 const buildAmdStep = require('./buildTools/buildAmd');
+const buildMjsStep = require('./buildTools/buildMjs');
 const buildCommonJsStep = require('./buildTools/buildCommonJs');
 const pack = require('./buildTools/pack');
 const dts = require('./buildTools/dts');
@@ -22,6 +23,7 @@ const allTasks = [
     normalizeStep,
     checkDependencyStep,
     buildAmdStep,
+    buildMjsStep,
     buildCommonJsStep,
     pack.commonJsDebug,
     pack.commonJsProduction,
@@ -47,6 +49,7 @@ const commands = [
     'clean', // Clean target folder
     'normalize', // Normalize package.json files
     'buildamd', // Build in AMD mode
+    'buildmjs', // Build in ESM/MJS mode
     'buildcommonjs', // Build in CommonJs mode
     'pack', // Run webpack to generate standalone .js files
     'packprod', // Run webpack to generate standalone .js files in production mode

--- a/tools/buildTools/buildMjs.js
+++ b/tools/buildTools/buildMjs.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const {
+    packagesPath,
+    packagesUiPath,
+    nodeModulesPath,
+    allPackages,
+    distPath,
+    runNode,
+} = require('./common');
+
+function buildMjs() {
+    const typescriptPath = path.join(nodeModulesPath, 'typescript/lib/tsc.js');
+
+    runNode(
+        typescriptPath +
+            ` -p ${path.join(
+                packagesPath,
+                'tsconfig.build.json'
+            )} -t es5 --moduleResolution node -m esnext`,
+        packagesPath
+    );
+    runNode(
+        typescriptPath +
+            ` -p ${path.join(
+                packagesUiPath,
+                'tsconfig.json'
+            )} -t es5 --moduleResolution node -m esnext`,
+        packagesPath
+    );
+
+    allPackages.forEach(packageName => {
+        const packagePath = path.join(distPath, packageName);
+        fs.renameSync(`${packagePath}/lib`, `${packagePath}/lib-mjs`);
+    });
+}
+
+module.exports = {
+    message: 'Building packages in ESNEXT mode...',
+    callback: buildMjs,
+    enabled: options => options.buildmjs,
+};

--- a/tools/buildTools/generateTargetWindow.js
+++ b/tools/buildTools/generateTargetWindow.js
@@ -51,5 +51,5 @@ function generateTargetWindow() {
 module.exports = {
     message: 'Generating TargetWindowBase.g.ts...',
     callback: generateTargetWindow,
-    enabled: options => options.buildcommonjs || options.buildamd,
+    enabled: options => options.buildcommonjs || options.buildamd || options.buildmjs,
 };


### PR DESCRIPTION
This change adds the buildmjs step which builds the esmodule version of rooster and puts the output in lib-mjs.