### PR TITLE
Add module field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "8.27.1",
+    "version": "8.27.2",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",

--- a/packages-ui/roosterjs-react/package.json
+++ b/packages-ui/roosterjs-react/package.json
@@ -15,5 +15,6 @@
         "react-dom": ">=16.0.0",
         "@fluentui/react": ">=8.0.0"
     },
-    "main": "./lib/index.ts"
+    "main": "./lib/index.ts",
+    "module": "./lib-mjs/index.ts"
 }

--- a/packages/roosterjs-color-utils/package.json
+++ b/packages/roosterjs-color-utils/package.json
@@ -5,5 +5,6 @@
         "color": "^3.0.0"
     },
     "main": "./lib/index.ts",
+    "module": "./lib-mjs/index.ts",
     "version": "1.0.1"
 }

--- a/packages/roosterjs-content-model/package.json
+++ b/packages/roosterjs-content-model/package.json
@@ -6,5 +6,6 @@
         "roosterjs-editor-dom": ""
     },
     "main": "./lib/index.ts",
+    "module": "./lib-mjs/index.ts",
     "version": "0.0.0"
 }

--- a/packages/roosterjs-editor-api/package.json
+++ b/packages/roosterjs-editor-api/package.json
@@ -5,5 +5,6 @@
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": ""
     },
-    "main": "./lib/index.ts"
+    "main": "./lib/index.ts",
+    "module": "./lib-mjs/index.ts"
 }

--- a/packages/roosterjs-editor-core/package.json
+++ b/packages/roosterjs-editor-core/package.json
@@ -5,5 +5,6 @@
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": ""
     },
-    "main": "./lib/index.ts"
+    "main": "./lib/index.ts",
+    "module": "./lib-mjs/index.ts"
 }

--- a/packages/roosterjs-editor-dom/package.json
+++ b/packages/roosterjs-editor-dom/package.json
@@ -4,5 +4,6 @@
     "dependencies": {
         "roosterjs-editor-types": ""
     },
-    "main": "./lib/index.ts"
+    "main": "./lib/index.ts",
+    "module": "./lib-mjs/index.ts"
 }

--- a/packages/roosterjs-editor-plugins/package.json
+++ b/packages/roosterjs-editor-plugins/package.json
@@ -6,5 +6,6 @@
         "roosterjs-editor-dom": "",
         "roosterjs-editor-api": ""
     },
-    "main": "./lib/index.ts"
+    "main": "./lib/index.ts",
+    "module": "./lib-mjs/index.ts"
 }

--- a/packages/roosterjs-editor-types-compatible/package.json
+++ b/packages/roosterjs-editor-types-compatible/package.json
@@ -5,5 +5,6 @@
         "roosterjs-editor-types": "",
         "@types/dom-inputevent": "^1.0.3"
     },
-    "main": "./lib/index.ts"
+    "main": "./lib/index.ts",
+    "module": "./lib-mjs/index.ts"
 }

--- a/packages/roosterjs-editor-types/package.json
+++ b/packages/roosterjs-editor-types/package.json
@@ -4,5 +4,6 @@
     "dependencies": {
         "@types/dom-inputevent": "^1.0.3"
     },
-    "main": "./lib/index.ts"
+    "main": "./lib/index.ts",
+    "module": "./lib-mjs/index.ts"
 }

--- a/packages/roosterjs/package.json
+++ b/packages/roosterjs/package.json
@@ -10,5 +10,6 @@
         "roosterjs-editor-plugins": "",
         "roosterjs-color-utils": ""
     },
-    "main": "./lib/index.ts"
+    "main": "./lib/index.ts",
+    "module": "./lib-mjs/index.ts"
 }

--- a/tools/buildTools/buildMjs.js
+++ b/tools/buildTools/buildMjs.js
@@ -19,7 +19,7 @@ function buildMjs() {
             ` -p ${path.join(
                 packagesPath,
                 'tsconfig.build.json'
-            )} -t es5 --moduleResolution node -m esnext`,
+            )} -t es5 --moduleResolution node -m esnext --preserveConstEnums`,
         packagesPath
     );
     runNode(
@@ -27,7 +27,7 @@ function buildMjs() {
             ` -p ${path.join(
                 packagesUiPath,
                 'tsconfig.json'
-            )} -t es5 --moduleResolution node -m esnext`,
+            )} -t es5 --moduleResolution node -m esnext --preserveConstEnums`,
         packagesPath
     );
 

--- a/tools/buildTools/normalize.js
+++ b/tools/buildTools/normalize.js
@@ -41,6 +41,7 @@ function normalize() {
 
         packageJson.typings = './lib/index.d.ts';
         packageJson.main = './lib/index.js';
+        packageJson.module = './lib-mjs/index.js';
         packageJson.license = 'MIT';
         packageJson.repository = {
             type: 'git',


### PR DESCRIPTION
This will help with esm usage/tree shaking. In Planner's usage, this change gave us another ~100kb stat size savings in our bundle.

In the future, we also need to add exports similar to how FluentUI does it: https://github.com/microsoft/fluentui/blob/master/packages/react/package.json

More info on exports: https://webpack.js.org/guides/package-exports/