### PR TITLE
Fix #1071 Replace highlighted text not working

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/TypeInContainerPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/TypeInContainerPlugin.ts
@@ -1,5 +1,5 @@
+import { Browser, findClosestElementAncestor, getTagOfNode, Position } from 'roosterjs-editor-dom';
 import { EditorPlugin, IEditor, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
-import { findClosestElementAncestor, getTagOfNode, Position } from 'roosterjs-editor-dom';
 
 /**
  * @internal
@@ -70,9 +70,20 @@ export default class TypeInContainerPlugin implements EditorPlugin {
             if (range.collapsed) {
                 this.editor.ensureTypeInContainer(Position.getStart(range), event.rawEvent);
             } else {
-                this.editor.runAsync(editor => {
-                    editor.ensureTypeInContainer(editor.getFocusedPosition(), event.rawEvent);
-                });
+                const callback = () => {
+                    if (this.editor) {
+                        this.editor.ensureTypeInContainer(
+                            this.editor.getFocusedPosition(),
+                            event.rawEvent
+                        );
+                    }
+                };
+
+                if (Browser.isMobileOrTablet) {
+                    this.editor.getDocument().defaultView.setTimeout(callback, 100);
+                } else {
+                    this.editor.runAsync(callback);
+                }
             }
         }
     }


### PR DESCRIPTION
#1071 Replace highlighted text not working

From what I can tell, this is caused by iOS has different executing order of async call (and very likely related to CPU speed).

We have a call to editor.runAsync() which is using window.requestAnimationFrame(). On desktop browser, the callback of runAsync() will be called after current execution flow and event is handled by browser. But in iOS Safari (on higher speed CPU), it seems the callback is called before event is handled by browser.

So the fix here is to set a longer time delay for mobile device to make sure current event is handled by browser first, then let the callback handle it.

Using async call to handle event is a very tricky way and can somehow cause problems. So we should consider removing it as a long term goal. Opened #1128 to track.