### PR TITLE
Modify the Check in normalizeRect

### DIFF
--- a/packages/roosterjs-editor-dom/lib/utils/normalizeRect.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/normalizeRect.ts
@@ -7,12 +7,12 @@ import { Rect } from 'roosterjs-editor-types';
 export default function normalizeRect(clientRect: DOMRect): Rect | null {
     let { left, right, top, bottom } =
         clientRect || <DOMRect>{ left: 0, right: 0, top: 0, bottom: 0 };
-    return left + right + top + bottom > 0
-        ? {
+    return left === 0 && right === 0 && top === 0 && bottom === 0
+        ? null
+        : {
               left: Math.round(left),
               right: Math.round(right),
               top: Math.round(top),
               bottom: Math.round(bottom),
-          }
-        : null;
+          };
 }


### PR DESCRIPTION
 A ClientRect of all 0 is possible. i.e. chrome returns a ClientRect of 0 when the cursor is on an empty p.

Currently we check that the sum of all the properties of the Rect are more than 0, but There are scenarios where the sum of all the properties is negative and still is a valid Rect

Changing the validation to verify that all the properties are not 0.