### PR TITLE
Stop Table Resizer disposal while editing

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -55,7 +55,7 @@ export default class TableResize implements EditorPlugin {
     dispose() {
         this.onMouseMoveDisposer();
         this.invalidateTableRects();
-        this.setTableEditor(null);
+        this.disposeTableEditor();
         this.editor = null;
     }
 
@@ -106,13 +106,8 @@ export default class TableResize implements EditorPlugin {
     };
 
     private setTableEditor(table: HTMLTableElement, e?: MouseEvent) {
-        if (
-            this.tableEditor &&
-            this.tableEditor.isDisposable() &&
-            table != this.tableEditor.table
-        ) {
-            this.tableEditor.dispose();
-            this.tableEditor = null;
+        if (this.tableEditor && !this.tableEditor.isEditing() && table != this.tableEditor.table) {
+            this.disposeTableEditor();
         }
 
         if (!this.tableEditor && table) {
@@ -129,6 +124,11 @@ export default class TableResize implements EditorPlugin {
     private invalidateTableRects = () => {
         this.tableRectMap = null;
     };
+
+    private disposeTableEditor() {
+        this.tableEditor?.dispose();
+        this.tableEditor = null;
+    }
 
     private ensureTableRects() {
         if (!this.tableRectMap) {

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -106,7 +106,11 @@ export default class TableResize implements EditorPlugin {
     };
 
     private setTableEditor(table: HTMLTableElement, e?: MouseEvent) {
-        if (this.tableEditor && table != this.tableEditor.table) {
+        if (
+            this.tableEditor &&
+            this.tableEditor.isDisposable() &&
+            table != this.tableEditor.table
+        ) {
             this.tableEditor.dispose();
             this.tableEditor = null;
         }

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -68,6 +68,7 @@ export default class TableEditor {
     private isRTL: boolean;
     private start: NodePosition;
     private end: NodePosition;
+    private isEditing: boolean;
 
     constructor(
         private editor: IEditor,
@@ -95,6 +96,7 @@ export default class TableEditor {
             this.onShowHelperElement,
             this.getShouldShowTableSelectorHandler(this.editor.getScrollContainer(), eventTarget)
         );
+        this.isEditing = false;
     }
 
     dispose() {
@@ -102,6 +104,10 @@ export default class TableEditor {
         this.disposeCellResizers();
         this.disposeTableInserter();
         this.disposeTableSelector();
+    }
+
+    isDisposable(): boolean {
+        return !this.isEditing;
     }
 
     onMouseMove(x: number, y: number) {
@@ -251,19 +257,24 @@ export default class TableEditor {
         this.editor.select(this.start, this.end);
         this.editor.addUndoSnapshot(null /*callback*/, ChangeSource.Format);
         this.onChanged();
+        this.isEditing = false;
+
         return false;
     };
 
     private onStartTableResize = () => {
+        this.isEditing = true;
         this.onStartResize();
     };
 
     private onStartCellResize = () => {
+        this.isEditing = true;
         this.disposeTableResizer();
         this.onStartResize();
     };
 
     private onStartResize() {
+        this.isEditing = true;
         const range = this.editor.getSelectionRange();
 
         if (range) {

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -68,7 +68,7 @@ export default class TableEditor {
     private isRTL: boolean;
     private start: NodePosition;
     private end: NodePosition;
-    private isEditing: boolean;
+    private isCurrentlyEditing: boolean;
 
     constructor(
         private editor: IEditor,
@@ -96,7 +96,7 @@ export default class TableEditor {
             this.onShowHelperElement,
             this.getShouldShowTableSelectorHandler(this.editor.getScrollContainer(), eventTarget)
         );
-        this.isEditing = false;
+        this.isCurrentlyEditing = false;
     }
 
     dispose() {
@@ -106,8 +106,8 @@ export default class TableEditor {
         this.disposeTableSelector();
     }
 
-    isDisposable(): boolean {
-        return !this.isEditing;
+    isEditing(): boolean {
+        return this.isCurrentlyEditing;
     }
 
     onMouseMove(x: number, y: number) {
@@ -257,24 +257,24 @@ export default class TableEditor {
         this.editor.select(this.start, this.end);
         this.editor.addUndoSnapshot(null /*callback*/, ChangeSource.Format);
         this.onChanged();
-        this.isEditing = false;
+        this.isCurrentlyEditing = false;
 
         return false;
     };
 
     private onStartTableResize = () => {
-        this.isEditing = true;
+        this.isCurrentlyEditing = true;
         this.onStartResize();
     };
 
     private onStartCellResize = () => {
-        this.isEditing = true;
+        this.isCurrentlyEditing = true;
         this.disposeTableResizer();
         this.onStartResize();
     };
 
     private onStartResize() {
-        this.isEditing = true;
+        this.isCurrentlyEditing = true;
         const range = this.editor.getSelectionRange();
 
         if (range) {


### PR DESCRIPTION
**Describe the bug**
When resizing a big table where the top of the table is not visible, the Table Editors are getting disposed on the middle of the edit.

**Code change**
When the TableEditors are editing prevent the dispose function to be called

**Before**
![TableResizerBug1](https://user-images.githubusercontent.com/8291124/181060777-880c3470-8aee-4060-afdd-d075e07a89f9.gif)
  
**After**
![TableResizerBug2](https://user-images.githubusercontent.com/8291124/181126204-858dd186-2fb2-4679-9c54-68d6bd7fcc95.gif)

