### PR TITLE
Run test coverage for both browsers

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,22 +2,30 @@ const argv = require('minimist')(process.argv.slice(2));
 const components = argv.components !== true && argv.components;
 const runCoverage = typeof argv.coverage !== 'undefined';
 const runFirefox = typeof argv.firefox !== 'undefined';
+const runChrome = typeof argv.chrome !== 'undefined';
 
 module.exports = function (config) {
     const plugins = [
         'karma-webpack',
-        runFirefox ? 'karma-firefox-launcher' : 'karma-chrome-launcher',
         'karma-phantomjs-launcher',
         'karma-jasmine',
         'karma-sourcemap-loader',
     ];
+    const launcher = [];
+
+    if (runFirefox) {
+        plugins.push('karma-firefox-launcher');
+        launcher.push('Firefox');
+    }
+
+    if (runChrome) {
+        plugins.push('karma-chrome-launcher');
+        launcher.push('Chrome');
+    }
 
     if (runCoverage) {
         plugins.push('karma-coverage-istanbul-reporter');
     }
-
-    const browser = runFirefox ? 'Firefox' : 'Chrome';
-    const launcher = runFirefox ? ['Firefox'] : ['Chrome'];
 
     const rules = runCoverage
         ? [
@@ -43,7 +51,6 @@ module.exports = function (config) {
         client: {
             components: components,
             clearContext: false,
-            browser: browser,
         },
         browsers: launcher,
         files: ['karma.tests.js'],

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
         "build": "node tools/build.js clean checkdep normalize tslint buildcommonjs dts packprod builddemo",
         "build:ci": "node tools/build.js --noProgressBar clean checkdep normalize tslint buildcommonjs buildamd buildmjs dts pack packprod builddemo builddoc",
         "start": "node tools/start.js",
-        "test": "node tools/build.js normalize & karma start",
-        "test:chrome": "node tools/build.js normalize & karma start",
+        "test": "node tools/build.js normalize & karma start --chrome",
+        "test:chrome": "node tools/build.js normalize & karma start --chrome",
         "test:firefox": "node tools/build.js normalize & karma start --firefox",
-        "test:debug": "node tools/build.js normalize & karma start --no-single-run",
-        "test:coverage": "node tools/build.js normalize & karma start --coverage",
+        "test:debug": "node tools/build.js normalize & karma start --no-single-run --chrome",
+        "test:coverage": "node tools/build.js normalize & karma start --coverage --firefox --chrome",
         "publish": "node tools/build.js clean normalize tslint buildcommonjs buildamd buildmjs dts pack packprod builddemo builddoc publish"
     },
     "devDependencies": {

--- a/packages/roosterjs-editor-dom/test/DomTestHelper.ts
+++ b/packages/roosterjs-editor-dom/test/DomTestHelper.ts
@@ -2,6 +2,7 @@ import createRange from '../lib/selection/createRange';
 import getInlineElementAtNode from '../lib/inlineElements/getInlineElementAtNode';
 import NodeBlockElement from '../lib/blockElements/NodeBlockElement';
 import StartEndBlockElement from '../lib/blockElements/StartEndBlockElement';
+import { Browser } from '../lib/utils/Browser';
 import { InlineElement, NodePosition } from 'roosterjs-editor-types';
 
 // Create element with content and id and insert the element in the DOM
@@ -103,14 +104,12 @@ export function htmlToDom(html: string): Node[] {
     return [].slice.call(element.childNodes);
 }
 
-declare var __karma__: any;
-
 export function itFirefoxOnly(
     expectation: string,
     assertion?: jasmine.ImplementationCallback,
     timeout?: number
 ) {
-    const func = __karma__.config.browser == 'Chrome' ? xit : it;
+    const func = Browser.isFirefox ? it : xit;
     return func(expectation, assertion, timeout);
 }
 
@@ -119,6 +118,6 @@ export function itChromeOnly(
     assertion?: jasmine.ImplementationCallback,
     timeout?: number
 ) {
-    const func = __karma__.config.browser == 'Chrome' ? it : xit;
+    const func = Browser.isChrome ? it : xit;
     return func(expectation, assertion, timeout);
 }


### PR DESCRIPTION
From #1121, I have switched to use Chrome as default test browser. However, I realized that there are more than 100 test cases are marked as for Firefox only. So that this causes our coverage reduced. 
In this change I'll enable both Chrome and Firefox for test code coverage. With this change our code coverage is increased from 78.16% to 79.4%