### PR TITLE
8.28.1 Stop using pinned version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "roosterjs",
-    "version": "8.28.0",
+    "version": "8.28.1",
     "description": "Framework-independent javascript editor",
     "repository": {
         "type": "git",
@@ -30,7 +30,6 @@
     "devDependencies": {
         "@microsoft/loader-load-themed-styles": "1.8.11",
         "@types/color": "3.0.0",
-        "@types/dom-inputevent": "1.0.5",
         "@types/dompurify": "2.2.3",
         "@types/jasmine": "3.5.10",
         "@types/node": "13.13.4",

--- a/packages/roosterjs-editor-types-compatible/package.json
+++ b/packages/roosterjs-editor-types-compatible/package.json
@@ -2,8 +2,7 @@
     "name": "roosterjs-editor-types-compatible",
     "description": "Type definition for roosterjs with enums that can be compatible with isolatedModules",
     "dependencies": {
-        "roosterjs-editor-types": "",
-        "@types/dom-inputevent": "^1.0.3"
+        "roosterjs-editor-types": ""
     },
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-types/package.json
+++ b/packages/roosterjs-editor-types/package.json
@@ -1,8 +1,6 @@
 {
     "name": "roosterjs-editor-types",
     "description": "Type definition for roosterjs",
-    "dependencies": {
-        "@types/dom-inputevent": "^1.0.3"
-    },
+    "dependencies": {},
     "main": "./lib/index.ts"
 }

--- a/tools/buildTools/normalize.js
+++ b/tools/buildTools/normalize.js
@@ -23,9 +23,9 @@ function normalize() {
             if (packageJson.dependencies[dep]) {
                 // No op, keep the specified value
             } else if (knownCustomizedPackages[dep]) {
-                packageJson.dependencies[dep] = knownCustomizedPackages[dep];
+                packageJson.dependencies[dep] = '^' + knownCustomizedPackages[dep];
             } else if (packages.indexOf(dep) > -1) {
-                packageJson.dependencies[dep] = mainPackageJson.version;
+                packageJson.dependencies[dep] = '^' + mainPackageJson.version;
             } else if (mainPackageJson.dependencies && mainPackageJson.dependencies[dep]) {
                 packageJson.dependencies[dep] = mainPackageJson.dependencies[dep];
             } else if (!packageJson.dependencies[dep]) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -411,11 +411,6 @@
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
   integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
 
-"@types/dom-inputevent@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@types/dom-inputevent/-/dom-inputevent-1.0.5.tgz#c880fa9b4482b49accc107e4a950117a1af7a61b"
-  integrity sha512-oL8NzIAn1J8vsIigjEM2qip6PUBRkb1kE+3gbM+NvSCzrScgz+Ixymuv9Z9jmktVjeHWMJc9zhP49YBUBeCTaQ==
-
 "@types/dompurify@2.2.3":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-2.2.3.tgz#6e89677a07902ac1b6821c345f34bd85da239b08"


### PR DESCRIPTION
#1145 

- Bump version to 8.28.1:
- Use caret version dependency between packages
- Remove an unused dependency "@types/dom-inputevent"
