### PR TITLE
Content Model: Support BR segment

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/creators/createBr.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/creators/createBr.ts
@@ -1,0 +1,18 @@
+import { ContentModelBr } from '../../publicTypes/segment/ContentModelBr';
+import { ContentModelSegmentType } from '../../publicTypes/enum/SegmentType';
+import { FormatContext } from '../../formatHandlers/FormatContext';
+
+/**
+ * @internal
+ */
+export function createBr(context: FormatContext): ContentModelBr {
+    const result: ContentModelBr = {
+        segmentType: ContentModelSegmentType.Br,
+    };
+
+    if (context.isInSelection) {
+        result.isSelected = true;
+    }
+
+    return result;
+}

--- a/packages/roosterjs-content-model/lib/domToModel/processors/brProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/brProcessor.ts
@@ -1,0 +1,10 @@
+import { addSegment } from '../utils/addSegment';
+import { createBr } from '../creators/createBr';
+import { ElementProcessor } from './ElementProcessor';
+
+/**
+ * @internal
+ */
+export const brProcessor: ElementProcessor = (group, element, context) => {
+    addSegment(group, createBr(context));
+};

--- a/packages/roosterjs-content-model/lib/domToModel/processors/containerProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/containerProcessor.ts
@@ -2,12 +2,9 @@ import { addSegment } from '../utils/addSegment';
 import { ContentModelBlockGroup } from '../../publicTypes/block/group/ContentModelBlockGroup';
 import { createSelectionMarker } from '../creators/createSelectionMarker';
 import { FormatContext } from '../../formatHandlers/FormatContext';
-import { generalBlockProcessor } from './generalBlockProcessor';
-import { generalSegmentProcessor } from './generalSegmentProcessor';
-import { getProcessor } from './getProcessor';
-import { isBlockElement } from 'roosterjs-editor-dom';
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import { NodeType } from 'roosterjs-editor-types';
+import { singleElementProcessor } from './singleElementProcessor';
 import { textProcessor } from './textProcessor';
 
 /**
@@ -36,28 +33,16 @@ export function containerProcessor(
         }
 
         if (isNodeOfType(child, NodeType.Element)) {
-            processElement(group, child, context);
+            singleElementProcessor(group, child, context);
         } else if (isNodeOfType(child, NodeType.Text)) {
-            processText(group, child, context);
+            textNodeProcessor(group, child, context);
         }
 
         index++;
     }
 }
 
-function processElement(
-    group: ContentModelBlockGroup,
-    element: HTMLElement,
-    context: FormatContext
-) {
-    const processor =
-        getProcessor(element.tagName) ||
-        (isBlockElement(element) ? generalBlockProcessor : generalSegmentProcessor);
-
-    processor(group, element, context);
-}
-
-function processText(group: ContentModelBlockGroup, textNode: Text, context: FormatContext) {
+function textNodeProcessor(group: ContentModelBlockGroup, textNode: Text, context: FormatContext) {
     let txt = textNode.nodeValue || '';
     let [txtStartOffset, txtEndOffset] = getRegularSelectionOffsets(context, textNode);
 

--- a/packages/roosterjs-content-model/lib/domToModel/processors/getProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/getProcessor.ts
@@ -1,7 +1,9 @@
+import { brProcessor } from './brProcessor';
 import { ElementProcessor } from './ElementProcessor';
 import { tableProcessor } from './tableProcessor';
 
 const ProcessorMap: Record<string, ElementProcessor> = {
+    BR: brProcessor,
     TABLE: tableProcessor,
 };
 

--- a/packages/roosterjs-content-model/lib/domToModel/processors/singleElementProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/singleElementProcessor.ts
@@ -1,0 +1,19 @@
+import { ElementProcessor } from './ElementProcessor';
+import { generalBlockProcessor } from './generalBlockProcessor';
+import { generalSegmentProcessor } from './generalSegmentProcessor';
+import { getProcessor } from './getProcessor';
+import { isBlockElement } from 'roosterjs-editor-dom';
+
+/**
+ * @internal
+ * @param group
+ * @param element
+ * @param context
+ */
+export const singleElementProcessor: ElementProcessor = (group, element, context) => {
+    const processor =
+        getProcessor(element.tagName) ||
+        (isBlockElement(element) ? generalBlockProcessor : generalSegmentProcessor);
+
+    processor(group, element, context);
+};

--- a/packages/roosterjs-content-model/lib/formatHandlers/table/tableMetadataFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/table/tableMetadataFormatHandler.ts
@@ -1,10 +1,6 @@
-import { FormatHandler } from '../FormatHandler';
-import { MetadataFormat } from '../../publicTypes/format/formatParts/MetadataFormat';
+import { createMetadataFormatHandler } from '../utils/createMetadataFormatHandler';
 import { TableFormat } from 'roosterjs-editor-types';
 import {
-    getMetadata,
-    setMetadata,
-    removeMetadata,
     createBooleanDefinition,
     createNumberDefinition,
     createObjectDefinition,
@@ -19,7 +15,7 @@ const NullStringDefinition = createStringDefinition(
 
 const BooleanDefinition = createBooleanDefinition(false /** isOptional */);
 
-const TableFormatMetadata = createObjectDefinition<Required<TableFormat>>(
+const TableFormatDefinition = createObjectDefinition<Required<TableFormat>>(
     {
         topBorderColor: NullStringDefinition,
         bottomBorderColor: NullStringDefinition,
@@ -46,19 +42,6 @@ const TableFormatMetadata = createObjectDefinition<Required<TableFormat>>(
 /**
  * @internal
  */
-export const tableMetadataFormatHandler: FormatHandler<MetadataFormat<TableFormat>> = {
-    parse: (format, element) => {
-        const metadata = getMetadata(element, TableFormatMetadata);
-
-        if (metadata) {
-            format.metadata = metadata;
-        }
-    },
-    apply: (format, element) => {
-        if (format.metadata) {
-            setMetadata(element, format.metadata, TableFormatMetadata);
-        } else {
-            removeMetadata(element);
-        }
-    },
-};
+export const tableMetadataFormatHandler = createMetadataFormatHandler<TableFormat>(
+    TableFormatDefinition
+);

--- a/packages/roosterjs-content-model/lib/formatHandlers/utils/createMetadataFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/utils/createMetadataFormatHandler.ts
@@ -1,0 +1,28 @@
+import { Definition } from 'roosterjs-editor-types';
+import { FormatHandler } from '../FormatHandler';
+import { getMetadata, removeMetadata, setMetadata } from 'roosterjs-editor-dom';
+import { MetadataFormat } from '../../publicTypes/format/formatParts/MetadataFormat';
+
+/**
+ * @internal
+ */
+export function createMetadataFormatHandler<T>(
+    definition: Definition<T>
+): FormatHandler<MetadataFormat<T>> {
+    return {
+        parse: (format, element) => {
+            const metadata = getMetadata(element, definition);
+
+            if (metadata) {
+                format.metadata = metadata;
+            }
+        },
+        apply: (format, element) => {
+            if (format.metadata) {
+                setMetadata(element, format.metadata, definition);
+            } else {
+                removeMetadata(element);
+            }
+        },
+    };
+}

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleSegment.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleSegment.ts
@@ -22,6 +22,10 @@ export function handleSegment(
             element.appendChild(txt);
             break;
 
+        case ContentModelSegmentType.Br:
+            element = doc.createElement('br');
+            break;
+
         case ContentModelSegmentType.General:
             handleBlock(doc, parent, segment, context);
             break;

--- a/packages/roosterjs-content-model/lib/publicTypes/enum/SegmentType.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/enum/SegmentType.ts
@@ -8,6 +8,11 @@ export const enum ContentModelSegmentType {
     Text,
 
     /**
+     * Represents a BR element
+     */
+    Br,
+
+    /**
      * Represents a selection marker. A selection marker is an empty segment that mark the start/end of selection
      */
     SelectionMarker,

--- a/packages/roosterjs-content-model/lib/publicTypes/index.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/index.ts
@@ -10,6 +10,7 @@ export { ContentModelParagraph } from './block/ContentModelParagraph';
 export { ContentModelSegmentBase } from './segment/ContentModelSegmentBase';
 export { ContentModelSelectionMarker } from './segment/ContentModelSelectionMarker';
 export { ContentModelText } from './segment/ContentModelText';
+export { ContentModelBr } from './segment/ContentModelBr';
 export { ContentModelGeneralSegment } from './segment/ContentModelGeneralSegment';
 export { ContentModelSegment } from './segment/ContentModelSegment';
 

--- a/packages/roosterjs-content-model/lib/publicTypes/segment/ContentModelBr.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/segment/ContentModelBr.ts
@@ -1,0 +1,11 @@
+import { ContentModelSegmentBase } from './ContentModelSegmentBase';
+import { ContentModelSegmentType } from '../enum/SegmentType';
+import type { CompatibleContentModelSegmentType } from '../compatibleEnum/SegmentType';
+
+/**
+ * Content Model of BR
+ */
+export interface ContentModelBr
+    extends ContentModelSegmentBase<
+        ContentModelSegmentType.Br | CompatibleContentModelSegmentType.Br
+    > {}

--- a/packages/roosterjs-content-model/lib/publicTypes/segment/ContentModelSegment.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/segment/ContentModelSegment.ts
@@ -1,3 +1,4 @@
+import { ContentModelBr } from './ContentModelBr';
 import { ContentModelGeneralSegment } from './ContentModelGeneralSegment';
 import { ContentModelSelectionMarker } from './ContentModelSelectionMarker';
 import { ContentModelText } from './ContentModelText';
@@ -8,4 +9,5 @@ import { ContentModelText } from './ContentModelText';
 export type ContentModelSegment =
     | ContentModelSelectionMarker
     | ContentModelText
+    | ContentModelBr
     | ContentModelGeneralSegment;

--- a/packages/roosterjs-content-model/test/domToModel/creators/creatorsTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/creators/creatorsTest.ts
@@ -1,6 +1,7 @@
 import { ContentModelBlockGroupType } from '../../../lib/publicTypes/enum/BlockGroupType';
 import { ContentModelBlockType } from '../../../lib/publicTypes/enum/BlockType';
 import { ContentModelSegmentType } from '../../../lib/publicTypes/enum/SegmentType';
+import { createBr } from '../../../lib/domToModel/creators/createBr';
 import { createContentModelDocument } from '../../../lib/domToModel/creators/createContentModelDocument';
 import { createFormatContext } from '../../../lib/formatHandlers/createFormatContext';
 import { createGeneralBlock } from '../../../lib/domToModel/creators/createGeneralBlock';
@@ -27,6 +28,18 @@ describe('Creators', () => {
             blockGroupType: ContentModelBlockGroupType.Document,
             blocks: [],
             document: document,
+        });
+    });
+
+    it('createContentModelDocument with different document', () => {
+        const anotherDoc = ({} as any) as Document;
+        const result = createContentModelDocument(anotherDoc);
+
+        expect(result).toEqual({
+            blockType: ContentModelBlockType.BlockGroup,
+            blockGroupType: ContentModelBlockGroupType.Document,
+            blocks: [],
+            document: anotherDoc,
         });
     });
 
@@ -197,6 +210,25 @@ describe('Creators', () => {
 
         expect(marker).toEqual({
             segmentType: ContentModelSegmentType.SelectionMarker,
+            isSelected: true,
+        });
+    });
+
+    it('createBr', () => {
+        const br = createBr(context);
+
+        expect(br).toEqual({
+            segmentType: ContentModelSegmentType.Br,
+        });
+    });
+
+    it('createBr with selection', () => {
+        context.isInSelection = true;
+
+        const br = createBr(context);
+
+        expect(br).toEqual({
+            segmentType: ContentModelSegmentType.Br,
             isSelected: true,
         });
     });

--- a/packages/roosterjs-content-model/test/domToModel/processors/brProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/brProcessorTest.ts
@@ -1,0 +1,39 @@
+import { brProcessor } from '../../../lib/domToModel/processors/brProcessor';
+import { ContentModelBlockGroupType } from '../../../lib/publicTypes/enum/BlockGroupType';
+import { ContentModelBlockType } from '../../../lib/publicTypes/enum/BlockType';
+import { ContentModelSegmentType } from '../../../lib/publicTypes/enum/SegmentType';
+import { createContentModelDocument } from '../../../lib/domToModel/creators/createContentModelDocument';
+import { createFormatContext } from '../../../lib/formatHandlers/createFormatContext';
+import { FormatContext } from '../../../lib/formatHandlers/FormatContext';
+
+describe('brProcessor', () => {
+    let context: FormatContext;
+
+    beforeEach(() => {
+        context = createFormatContext();
+    });
+
+    it('Regular Br', () => {
+        const doc = createContentModelDocument(document);
+        const br = document.createElement('br');
+
+        brProcessor(doc, br, context);
+
+        expect(doc).toEqual({
+            blockType: ContentModelBlockType.BlockGroup,
+            blockGroupType: ContentModelBlockGroupType.Document,
+            blocks: [
+                {
+                    blockType: ContentModelBlockType.Paragraph,
+                    isImplicit: true,
+                    segments: [
+                        {
+                            segmentType: ContentModelSegmentType.Br,
+                        },
+                    ],
+                },
+            ],
+            document: document,
+        });
+    });
+});

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleSegmentTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleSegmentTest.ts
@@ -42,6 +42,16 @@ describe('handleSegment', () => {
         );
     });
 
+    it('Br segment', () => {
+        runTest(
+            {
+                segmentType: ContentModelSegmentType.Br,
+            },
+            '<br>',
+            0
+        );
+    });
+
     it('general segment', () => {
         const segment: ContentModelSegment = {
             segmentType: ContentModelSegmentType.General,


### PR DESCRIPTION
#1093 

1. Support BR segment
2. Create a comment format handler for Metadata
3. Split out "processElement" from containerProcesser.ts to be singleElementProcessor, used for processing an element itself and its child nodes, while containerProcess process child nodes only,

These are preparation steps for table format api.