### PR TITLE
Remove bgColor on insert table

### DIFF
--- a/packages/roosterjs-editor-api/lib/table/insertTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/insertTable.ts
@@ -1,4 +1,5 @@
 import formatUndoSnapshot from '../utils/formatUndoSnapshot';
+import setBackgroundColor from '../format/setBackgroundColor';
 import { IEditor, PositionType, TableFormat } from 'roosterjs-editor-types';
 import { Position, VTable } from 'roosterjs-editor-dom';
 
@@ -38,6 +39,10 @@ export default function insertTable(
     formatUndoSnapshot(
         editor,
         () => {
+            const element = editor.getElementAtCursor();
+            if (element.style.backgroundColor) {
+                setBackgroundColor(editor, 'transparent');
+            }
             let vtable = new VTable(table);
             vtable.applyFormat(format);
             vtable.writeBack();

--- a/packages/roosterjs-editor-api/test/table/insertTableTest.ts
+++ b/packages/roosterjs-editor-api/test/table/insertTableTest.ts
@@ -29,4 +29,15 @@ describe('InsertTable', () => {
             expect(table.isContentEditable).toBe(true);
         });
     });
+
+    it('Remove background color on insert table', () => {
+        editor.setContent(`<span id="${testElementId}" style='background-color: purple'></span>`);
+        const target = document.getElementById(testElementId);
+        const range = new Range();
+        range.setStart(target!, 0);
+        editor.select(range);
+        insertTable(editor, 1, 1);
+
+        expect(target?.style.backgroundColor).toBe('transparent');
+    });
 });

--- a/packages/roosterjs-editor-dom/lib/utils/setColor.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/setColor.ts
@@ -14,6 +14,7 @@ const enum ColorTones {
 const DARK_COLORS_LIGHTNESS = 20;
 //If the value of the lightness is more than 80, the color is bright
 const BRIGHT_COLORS_LIGHTNESS = 80;
+const TRANSPARENT_COLOR = 'transparent';
 
 /**
  * Set text color or background color to the given element
@@ -46,7 +47,7 @@ export default function setColor(
             const dataSetName = isBackgroundColor
                 ? DarkModeDatasetNames.OriginalStyleBackgroundColor
                 : DarkModeDatasetNames.OriginalStyleColor;
-            if (!isDarkMode) {
+            if (!isDarkMode || color == TRANSPARENT_COLOR) {
                 delete element.dataset[dataSetName];
             } else if (modeIndependentColor) {
                 element.dataset[dataSetName] = modeIndependentColor.lightModeColor;


### PR DESCRIPTION
https://github.com/microsoft/roosterjs/issues/1159

When the format contains background color and we insert a table, the table is wrapped by a span with the background color style. When pasting text inside of the table, the pasted content gets formatted to have the same background color as the span wrapping the table.

Code Change:
Remove background color when inserting a table, so the issue stops happening


![After1](https://user-images.githubusercontent.com/8291124/183769751-59e89d71-3a13-4300-b0bc-c0cef6ad9bae.gif)

