### PR TITLE
Add effective background color value.

### DIFF
--- a/demo/scripts/controls/sidePane/formatState/FormatStatePane.tsx
+++ b/demo/scripts/controls/sidePane/formatState/FormatStatePane.tsx
@@ -54,6 +54,11 @@ export default class FormatStatePane extends React.Component<
                                     color: format.textColor,
                                     backgroundColor: format.backgroundColor,
                                 }}>{`${format.textColor} / ${format.backgroundColor}`}</span>
+                            <span
+                                style={{
+                                    color: format.textColor,
+                                    backgroundColor: format.effectiveBackgroundColor,
+                                }}>{`(${format.effectiveBackgroundColor})`}</span>
                         </td>
                     </tr>
                     <tr>

--- a/packages/roosterjs-editor-core/lib/coreApi/getStyleBasedFormatState.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getStyleBasedFormatState.ts
@@ -1,5 +1,9 @@
 import { DarkModeDatasetNames, EditorCore, GetStyleBasedFormatState } from 'roosterjs-editor-types';
-import { findClosestElementAncestor, getComputedStyles } from 'roosterjs-editor-dom';
+import {
+    findClosestElementAncestor,
+    getComputedStyles,
+    getEffectiveBackgroundColor,
+} from 'roosterjs-editor-dom';
 
 const ORIGINAL_STYLE_COLOR_SELECTOR = `[data-${DarkModeDatasetNames.OriginalStyleColor}],[data-${DarkModeDatasetNames.OriginalAttributeColor}]`;
 const ORIGINAL_STYLE_BACK_COLOR_SELECTOR = `[data-${DarkModeDatasetNames.OriginalStyleBackgroundColor}],[data-${DarkModeDatasetNames.OriginalAttributeBackgroundColor}]`;
@@ -31,6 +35,7 @@ export const getStyleBasedFormatState: GetStyleBasedFormatState = (
     }
 
     const styles = node ? getComputedStyles(node) : [];
+    const effectiveBackgroundColor = getEffectiveBackgroundColor(node, core.contentDiv);
     const isDarkMode = core.lifecycle.isDarkMode;
     const root = core.contentDiv;
     const ogTextColorNode =
@@ -49,6 +54,7 @@ export const getStyleBasedFormatState: GetStyleBasedFormatState = (
         fontSize: override[1] || styles[1],
         textColor: override[2] || styles[2],
         backgroundColor: override[3] || styles[3],
+        effectiveBackgroundColor: effectiveBackgroundColor,
         textColors: ogTextColorNode
             ? {
                   darkModeColor: override[2] || styles[2],

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -23,6 +23,7 @@ export { default as contains } from './utils/contains';
 export { default as findClosestElementAncestor } from './utils/findClosestElementAncestor';
 export { default as fromHtml } from './utils/fromHtml';
 export { default as getComputedStyles, getComputedStyle } from './utils/getComputedStyles';
+export { default as getEffectiveBackgroundColor } from './utils/getEffectiveBackgroundColor';
 export {
     default as getPendableFormatState,
     PendableFormatCommandMap,

--- a/packages/roosterjs-editor-dom/lib/utils/getEffectiveBackgroundColor.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/getEffectiveBackgroundColor.ts
@@ -1,0 +1,19 @@
+import findClosestElementAncestor from './findClosestElementAncestor';
+import getComputedStyles from './getComputedStyles';
+
+/**
+ * Get effective background value based on parent nodes
+ * @param node The node to get computed styles from
+ * @param rootNode Top most ancestor node to stop searching for inherited background value
+ * @returns An array of the computed styles
+ */
+export default function getEffectiveBackgroundColor(node: Node, rootNode: Node): string {
+    const value = getComputedStyles(node, 'background-color')[0];
+    if (value === 'rgba(0, 0, 0, 0)') {
+        const parentNode = findClosestElementAncestor(node.parentNode, rootNode);
+        if (parentNode) {
+            return getEffectiveBackgroundColor(parentNode, rootNode);
+        }
+    }
+    return value;
+}

--- a/packages/roosterjs-editor-dom/test/utils/getEffectiveBackgroundColorTest.ts
+++ b/packages/roosterjs-editor-dom/test/utils/getEffectiveBackgroundColorTest.ts
@@ -1,0 +1,39 @@
+import getEffectiveBackgroundColor from '../../lib/utils/getEffectiveBackgroundColor';
+
+describe('getEffectiveBackgroundColor()', () => {
+    let defaultResult = 'rgba(0, 0, 0, 0)';
+
+    it('getEffectiveBackgroundColor() case 0', () => {
+        runTest(1, '<div id=id1></div>', 'id1', defaultResult);
+    });
+    it('getEffectiveBackgroundColor() case 0', () => {
+        runTest(1, '<div id=id1 style="background-color:red"></div>', 'id1', 'rgb(255, 0, 0)');
+    });
+    it('getEffectiveBackgroundColor() case 0', () => {
+        runTest(1, '<div><div id=id1 ></div></div>', 'id1', defaultResult);
+    });
+    it('getEffectiveBackgroundColor() case 0', () => {
+        runTest(
+            1,
+            '<div><div id=id1 style="background-color:red"></div></div>',
+            'id1',
+            'rgb(255, 0, 0)'
+        );
+    });
+
+    function runTest(
+        caseIndex: number,
+        input: string,
+        id: string,
+        expectedEffectiveBackgroundColor: string
+    ) {
+        let div = document.createElement('div');
+        div.style.fontFamily = 'arial';
+        document.body.appendChild(div);
+        div.innerHTML = input;
+        let element = document.getElementById(id);
+        let result = getEffectiveBackgroundColor(element, div.parentNode);
+        expect(result).toEqual(expectedEffectiveBackgroundColor, `case index: ${caseIndex}`);
+        document.body.removeChild(div);
+    }
+});

--- a/packages/roosterjs-editor-types/lib/interface/FormatState.ts
+++ b/packages/roosterjs-editor-types/lib/interface/FormatState.ts
@@ -104,6 +104,11 @@ export interface StyleBasedFormatState {
     backgroundColor?: string;
 
     /**
+     * Effective background color based on ancestors styles
+     */
+    effectiveBackgroundColor?: string;
+
+    /**
      * Mode independent background color for dark mode
      */
     backgroundColors?: ModeIndependentColor;


### PR DESCRIPTION
Add `effectiveBackgroundColor` which is representing actual calculated background visible to the user.

When we click in the middle of element which has `bold`, `italic` and `background color` activated, `backgroundColor` value shows `rgba(0,0,0,0)` which is accurate from DOM, but not from user point of view. User should be able to see the actual background value obtained by traversing through the ancestors in the DOM tree and effectively show `rgb(0, 85, 0)`:
![image](https://user-images.githubusercontent.com/9194690/184433762-4ce5666d-a298-4101-9e66-7d05e5b8719d.png)
