### PR TITLE
Graduate some features

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -28,10 +28,6 @@ const initialState: BuildInPluginState = {
     watermarkText: 'Type content here ...',
     forcePreserveRatio: false,
     experimentalFeatures: [
-        ExperimentalFeatures.PasteWithLinkPreview,
-        ExperimentalFeatures.SingleDirectionResize,
-        ExperimentalFeatures.ImageRotate,
-        ExperimentalFeatures.ImageCrop,
         ExperimentalFeatures.ConvertSingleImageBody,
         ExperimentalFeatures.TableAlignment,
         ExperimentalFeatures.AdaptiveHandlesResizer,

--- a/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
@@ -9,10 +9,6 @@ export interface ExperimentalFeaturesProps {
 }
 
 const FeatureNames: Partial<Record<ExperimentalFeatures, string>> = {
-    [ExperimentalFeatures.SingleDirectionResize]: 'Resize an image horizontally or vertically',
-    [ExperimentalFeatures.PasteWithLinkPreview]: 'Try retrieve link preview information when paste',
-    [ExperimentalFeatures.ImageRotate]: 'Rotate an inline image',
-    [ExperimentalFeatures.ImageCrop]: 'Crop an inline image',
     [ExperimentalFeatures.ConvertSingleImageBody]:
         'Paste Html instead of image when Html have one Img Children (Animated Image Paste)',
     [ExperimentalFeatures.TableAlignment]:

--- a/packages-ui/roosterjs-react/lib/contextMenu/menus/createImageEditMenuProvider.tsx
+++ b/packages-ui/roosterjs-react/lib/contextMenu/menus/createImageEditMenuProvider.tsx
@@ -1,6 +1,7 @@
 import ContextMenuItem from '../types/ContextMenuItem';
 import createContextMenuProvider from '../utils/createContextMenuProvider';
 import showInputDialog from '../../inputDialog/utils/showInputDialog';
+import { EditorPlugin, IEditor, ImageEditOperation } from 'roosterjs-editor-types';
 import { ImageEditMenuItemStringKey } from '../types/ContextMenuItemStringKeys';
 import { LocalizedStrings } from '../../common/type/LocalizedStrings';
 import { safeInstanceOf } from 'roosterjs-editor-dom';
@@ -11,12 +12,6 @@ import {
     resetImage,
     resizeByPercentage,
 } from 'roosterjs-editor-plugins';
-import {
-    ExperimentalFeatures,
-    IEditor,
-    ImageEditOperation,
-    EditorPlugin,
-} from 'roosterjs-editor-types';
 
 const ImageAltTextMenuItem: ContextMenuItem<ImageEditMenuItemStringKey> = {
     key: 'menuNameImageAltText',
@@ -90,9 +85,9 @@ const ImageResizeMenuItem: ContextMenuItem<ImageEditMenuItemStringKey> = {
 const ImageCropMenuItem: ContextMenuItem<ImageEditMenuItemStringKey, ImageEdit> = {
     key: 'menuNameImageCrop',
     unlocalizedText: 'Crop image',
-    shouldShow: (editor, node) => {
+    shouldShow: (_, node, imageEdit) => {
         return (
-            editor.isFeatureEnabled(ExperimentalFeatures.ImageCrop) &&
+            imageEdit.isOperationAllowed(ImageEditOperation.Crop) &&
             canRegenerateImage(node as HTMLImageElement)
         );
     },

--- a/packages-ui/roosterjs-react/lib/contextMenu/types/ContextMenuItem.ts
+++ b/packages-ui/roosterjs-react/lib/contextMenu/types/ContextMenuItem.ts
@@ -38,8 +38,9 @@ export default interface ContextMenuItem<TString extends string, TContext = neve
      * A callback function to check whether this menu item should show now
      * @param editor The editor object that triggers this event
      * @param targetNode The node that user is clicking onto
+     * @param context A context object that passed in from context menu provider, can be anything
      */
-    shouldShow?: (editor: IEditor, targetNode: Node) => boolean;
+    shouldShow?: (editor: IEditor, targetNode: Node, context: TContext) => boolean;
 
     /**
      * A key-value map for sub menu items, key is the key of menu item, value is unlocalized string

--- a/packages-ui/roosterjs-react/lib/contextMenu/utils/createContextMenuProvider.ts
+++ b/packages-ui/roosterjs-react/lib/contextMenu/utils/createContextMenuProvider.ts
@@ -55,7 +55,9 @@ class ContextMenuProviderImpl<TString extends string, TContext>
 
         return this.shouldAddMenuItems(this.editor, node)
             ? this.items
-                  .filter(item => !item.shouldShow || item.shouldShow(this.editor, node))
+                  .filter(
+                      item => !item.shouldShow || item.shouldShow(this.editor, node, this.context)
+                  )
                   .map(item => this.convertMenuItems(item))
             : [];
     }

--- a/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
@@ -14,7 +14,6 @@ import {
     GetContentMode,
     IEditor,
     PluginEventType,
-    ExperimentalFeatures,
     PluginWithState,
     KnownCreateElementDataIndex,
     SelectionRangeEx,
@@ -119,9 +118,6 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
             event as ClipboardEvent,
             clipboardData => this.editor?.paste(clipboardData),
             {
-                allowLinkPreview: this.editor?.isFeatureEnabled(
-                    ExperimentalFeatures.PasteWithLinkPreview
-                ),
                 allowedCustomPasteType: this.state.allowedCustomPasteType,
                 getTempDiv: () => {
                     range = this.editor?.getSelectionRange();

--- a/packages/roosterjs-editor-dom/lib/clipboard/extractClipboardItems.ts
+++ b/packages/roosterjs-editor-dom/lib/clipboard/extractClipboardItems.ts
@@ -27,6 +27,7 @@ const ContentHandlers: {
         (data.rawHtml = Browser.isEdge ? workaroundForEdge(value) : value),
     [ContentType.PlainText]: (data, value) => (data.text = value),
     [OTHER_TEXT_TYPE]: (data, value, type?) => !!type && (data.customValues[type] = value),
+    [ContentTypePrefix.Text + EDGE_LINK_PREVIEW]: tryParseLinkPreview,
 };
 
 /**
@@ -53,12 +54,6 @@ export default function extractClipboardItems(
         rawHtml: null,
         customValues: {},
     };
-
-    const contentHandlers = { ...ContentHandlers };
-
-    if (options?.allowLinkPreview) {
-        contentHandlers[ContentTypePrefix.Text + EDGE_LINK_PREVIEW] = tryParseLinkPreview;
-    }
 
     return Promise.all(
         (items || []).map(item => {
@@ -89,7 +84,7 @@ export default function extractClipboardItems(
             } else {
                 const customType = getAllowedCustomType(type, options?.allowedCustomPasteType);
                 const handler =
-                    contentHandlers[type] || (customType ? contentHandlers[OTHER_TEXT_TYPE] : null);
+                    ContentHandlers[type] || (customType ? ContentHandlers[OTHER_TEXT_TYPE] : null);
                 return new Promise<void>(resolve =>
                     handler
                         ? item.getAsString(value => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -60,15 +60,6 @@ const DirectionRad = (Math.PI * 2) / DIRECTIONS;
 const DirectionOrder = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
 
 /**
- * Map the experimental features to image edit operations to help determine which operation is allowed
- */
-const FeatureToOperationMap = {
-    [ExperimentalFeatures.SingleDirectionResize]: ImageEditOperation.SideResize,
-    [ExperimentalFeatures.ImageRotate]: ImageEditOperation.Rotate,
-    [ExperimentalFeatures.ImageCrop]: ImageEditOperation.Crop,
-};
-
-/**
  * Default image edit options
  */
 const DefaultOptions: Required<ImageEditOptions> = {
@@ -79,6 +70,9 @@ const DefaultOptions: Required<ImageEditOptions> = {
     minRotateDeg: 5,
     imageSelector: 'img',
     rotateIconHTML: null,
+    disableCrop: false,
+    disableRotate: false,
+    disableSideResize: false,
 };
 
 /**
@@ -117,7 +111,7 @@ export default class ImageEdit implements EditorPlugin {
     private disposer: () => void;
 
     // Allowed editing operations
-    private allowedOperations: ImageEditOperation = ImageEditOperation.CornerResize;
+    private allowedOperations: ImageEditOperation;
 
     // Current editing image
     private image: HTMLImageElement;
@@ -150,6 +144,12 @@ export default class ImageEdit implements EditorPlugin {
             ...DefaultOptions,
             ...(options || {}),
         };
+
+        this.allowedOperations =
+            ImageEditOperation.CornerResize |
+            (this.options.disableCrop ? 0 : ImageEditOperation.Crop) |
+            (this.options.disableRotate ? 0 : ImageEditOperation.Rotate) |
+            (this.options.disableSideResize ? 0 : ImageEditOperation.SideResize);
     }
 
     /**
@@ -166,13 +166,6 @@ export default class ImageEdit implements EditorPlugin {
     initialize(editor: IEditor) {
         this.editor = editor;
         this.disposer = editor.addDomEventHandler('blur', this.onBlur);
-
-        // Read current enabled features from editor to determine which editing operations are allowed
-        getObjectKeys(FeatureToOperationMap).forEach(key => {
-            this.allowedOperations |= this.editor.isFeatureEnabled(key)
-                ? FeatureToOperationMap[key]
-                : 0;
-        });
     }
 
     /**
@@ -257,6 +250,15 @@ export default class ImageEdit implements EditorPlugin {
                 });
                 break;
         }
+    }
+
+    /**
+     * Check if the given image edit operation is allowed by this pluign
+     * @param operation The image edit operation to check
+     * @returns True means it is allowed, otherwise false
+     */
+    isOperationAllowed(operation: ImageEditOperation): boolean {
+        return !!(this.allowedOperations & operation);
     }
 
     /**
@@ -365,9 +367,11 @@ export default class ImageEdit implements EditorPlugin {
         wrapper.style.position = 'relative';
         wrapper.style.maxWidth = '100%';
         // keep the same vertical align
-        const originalVerticalAlign = this.image.ownerDocument.defaultView.getComputedStyle(this.image).getPropertyValue('vertical-align');
+        const originalVerticalAlign = this.image.ownerDocument.defaultView
+            .getComputedStyle(this.image)
+            .getPropertyValue('vertical-align');
         if (originalVerticalAlign) {
-          wrapper.style.verticalAlign = originalVerticalAlign;
+            wrapper.style.verticalAlign = originalVerticalAlign;
         }
         wrapper.style.display = Browser.isSafari ? 'inline-block' : 'inline-flex';
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
@@ -68,20 +68,8 @@ export default function applyChange(
     // Write back the change to image, and set its new size
     const { targetWidth, targetHeight } = getGeneratedImageSize(editInfo);
     image.src = newSrc;
-    setImageSize(image, wasResized, targetWidth, targetHeight);
-}
 
-/**
- * @param img The current image.
- * @param wasResized the current resize state of the image
- */
-function setImageSize(
-    image: HTMLImageElement,
-    wasResized: boolean,
-    targetWidth: number,
-    targetHeight: number
-) {
-    if (wasResized) {
+    if (wasResized || state == ImageEditInfoState.FullyChanged) {
         image.style.maxWidth = 'initial';
         image.width = targetWidth;
         image.height = targetHeight;

--- a/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
@@ -28,17 +28,17 @@ export const enum ExperimentalFeatures {
     MergePastedLine = 'MergePastedLine',
 
     /**
-     * Resize an image horizontally or vertically
+     * @deprecated This feature is always enabled
      */
     SingleDirectionResize = 'SingleDirectionResize',
 
     /**
-     * Try retrieve link preview information when paste
+     * @deprecated This feature is always enabled
      */
     PasteWithLinkPreview = 'PasteWithLinkPreview',
 
     /**
-     * Rotate an inline image (requires ImageEdit plugin)
+     * @deprecated This feature is always enabled
      */
     ImageRotate = 'ImageRotate',
 

--- a/packages/roosterjs-editor-types/lib/interface/ExtractClipboardEventOption.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ExtractClipboardEventOption.ts
@@ -3,7 +3,7 @@
  */
 export interface ExtractClipboardItemsOption {
     /**
-     * Whether retrieving value of text/link-preview is allowed
+     * @deprecated This feature is always enabled
      */
     allowLinkPreview?: boolean;
 

--- a/packages/roosterjs-editor-types/lib/interface/ImageEditOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ImageEditOptions.ts
@@ -48,4 +48,19 @@ export default interface ImageEditOptions {
      * @default A predefined SVG icon
      */
     rotateIconHTML?: string;
+
+    /**
+     * Whether side resizing (single direction resizing) is disabled. @default false
+     */
+    disableSideResize?: boolean;
+
+    /**
+     * Whether image rotate is disabled. @default false
+     */
+    disableRotate?: boolean;
+
+    /**
+     * Whether image crop is disabled. @default false
+     */
+    disableCrop?: boolean;
 }


### PR DESCRIPTION
1. Graduate the following featrues:
      - ExperimentalFeatures.PasteWithLinkPreview,
      - ExperimentalFeatures.SingleDirectionResize,
      - ExperimentalFeatures.ImageRotate,
      - ExperimentalFeatures.ImageCrop,
2. Add parameter to ImageEdit plugin to still allow disable image side resize/crop/rotate functionalities
