### PR TITLE
Fix #1163 Provide a friendly error message when uiUtilities is not set to react plugin

### DIFF
--- a/packages-ui/roosterjs-react/lib/common/utils/renderReactComponent.ts
+++ b/packages-ui/roosterjs-react/lib/common/utils/renderReactComponent.ts
@@ -1,0 +1,14 @@
+import UIUtilities from '../type/UIUtilities';
+
+/**
+ * @internal
+ */
+export function renderReactComponent(uiUtilities: UIUtilities | null, reactElement: JSX.Element) {
+    if (uiUtilities) {
+        return uiUtilities.renderComponent(reactElement);
+    } else {
+        throw new Error(
+            'UIUtilities is required but not provided. Please call ReactEditorPlugin.setUIUtilities() to set a valid uiUtilities object'
+        );
+    }
+}

--- a/packages-ui/roosterjs-react/lib/contextMenu/plugin/createContextMenuPlugin.tsx
+++ b/packages-ui/roosterjs-react/lib/contextMenu/plugin/createContextMenuPlugin.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ContextMenu } from 'roosterjs-editor-plugins';
 import { ContextualMenu, IContextualMenuItem } from '@fluentui/react/lib/ContextualMenu';
 import { ReactEditorPlugin, UIUtilities } from '../../common/index';
+import { renderReactComponent } from '../../common/utils/renderReactComponent';
 
 function normalizeItems(items: IContextualMenuItem[]) {
     let dividerKey = 0;
@@ -24,7 +25,8 @@ class ContextMenuPlugin extends ContextMenu<IContextualMenuItem> implements Reac
                 const normalizedITems = normalizeItems(items);
 
                 if (normalizedITems.length > 0) {
-                    this.disposer = this.uiUtilities.renderComponent(
+                    this.disposer = renderReactComponent(
+                        this.uiUtilities,
                         <ContextualMenu
                             target={container}
                             onDismiss={onDismiss}

--- a/packages-ui/roosterjs-react/lib/emoji/components/showEmojiCallout.tsx
+++ b/packages-ui/roosterjs-react/lib/emoji/components/showEmojiCallout.tsx
@@ -4,6 +4,7 @@ import { Emoji } from '../type/Emoji';
 import { EmojiPane, showEmojiPane } from './EmojiPane';
 import { EmojiStringKeys } from '../type/EmojiStringKeys';
 import { LocalizedStrings, UIUtilities } from '../../common/index';
+import { renderReactComponent } from '../../common/utils/renderReactComponent';
 
 /**
  * @internal
@@ -101,7 +102,8 @@ export default function showEmojiCallout(
         disposer = null;
     };
 
-    disposer = uiUtilities.renderComponent(
+    disposer = renderReactComponent(
+        uiUtilities,
         <EmojiICallout
             ref={emojiCalloutRef}
             cursorRect={cursorRect}

--- a/packages-ui/roosterjs-react/lib/inputDialog/utils/showInputDialog.tsx
+++ b/packages-ui/roosterjs-react/lib/inputDialog/utils/showInputDialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import DialogItem from '../type/DialogItem';
 import InputDialog from '../component/InputDialog';
+import { renderReactComponent } from '../../common/utils/renderReactComponent';
 import {
     CancelButtonStringKey,
     LocalizedStrings,
@@ -45,6 +46,6 @@ export default function showInputDialog<Strings extends string, ItemNames extend
             />
         );
 
-        disposer = uiUtilities.renderComponent(component);
+        disposer = renderReactComponent(uiUtilities, component);
     });
 }

--- a/packages-ui/roosterjs-react/lib/pasteOptions/component/showPasteOptionPane.tsx
+++ b/packages-ui/roosterjs-react/lib/pasteOptions/component/showPasteOptionPane.tsx
@@ -7,6 +7,7 @@ import { Icon } from '@fluentui/react/lib/Icon';
 import { IconButton } from '@fluentui/react/lib/Button';
 import { memoizeFunction } from '@fluentui/react/lib/Utilities';
 import { mergeStyleSets } from '@fluentui/react/lib/Styling';
+import { renderReactComponent } from '../../common/utils/renderReactComponent';
 import { Theme, useTheme } from '@fluentui/react/lib/Theme';
 import type { PasteOptionButtonKeys, PasteOptionStringKeys } from '../type/PasteOptionStringKeys';
 import type { NodePosition } from 'roosterjs-editor-types';
@@ -201,7 +202,8 @@ export default function showPasteOptionPane(
         disposer = null;
     };
 
-    disposer = uiUtilities.renderComponent(
+    disposer = renderReactComponent(
+        uiUtilities,
         <PasteOptionComponent
             ref={ref}
             position={position}


### PR DESCRIPTION
A uiUtilities object is required for those plugins that will render a react component. Today the `<Rooster />` component will initialize uiUtilities for us. However, if editor is not rendered using `<Rooster />` component, editor creator need to manually set uiUtilites to all React plugins. In this change I add an error message to let developer understand this issue.