### PR TITLE
Engineering improvement: Publish from release branch only

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -37,6 +37,3 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   BRANCH: gh-pages
                   FOLDER: dist/deploy
-
-            - name: Publish
-              run: node tools/build.js publish --token ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+on:
+    push:
+        branches:
+            - release
+jobs:
+    build-and-deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2.3.1
+              with:
+                  ref: release
+                  persist-credentials: false
+
+            - name: Set Node Version
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 'v14.18.2'
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Build
+              run: npm run-script build:ci
+
+            - name: Publish
+              run: node tools/build.js publish --token ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
After this change, check in to master branch will not publish new npm packages. To publish new npm package, we need to integrate code into release branch and bump up version. I'll investigate if we can automatically bump up version later. For now we still need to do it manually.