### PR TITLE
Fix for case where endingBlock is null

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/getFormatState.ts
+++ b/packages/roosterjs-editor-api/lib/format/getFormatState.ts
@@ -27,7 +27,7 @@ export function getElementBasedFormatState(
     if (range && !range.collapsed) {
         let startingBlock = editor.getBlockElementAtNode(range.startContainer);
         let endingBlock = editor.getBlockElementAtNode(range.endContainer);
-        multiline = !endingBlock.equals(startingBlock);
+        multiline = endingBlock ? !endingBlock.equals(startingBlock) : false;
     }
 
     let headerTag = getTagOfNode(


### PR DESCRIPTION
Modified a line to guarantee multiline is always boolean and calls are not made if endingBlock is null.