### PR TITLE
Temporarily hide version from doc

### DIFF
--- a/tools/tsconfig.doc.json
+++ b/tools/tsconfig.doc.json
@@ -36,7 +36,7 @@
         "excludeExternals": true,
         "exclude": "../**/*.d.ts",
         "excludePrivate": true,
-        "includeVersion": true,
+        "includeVersion": false,
         "external-modulemap": ".*\\/(roosterjs[a-zA-Z0-9\\-]*)\\/lib\\/"
     }
 }


### PR DESCRIPTION
Since we have set version to be "0.0.0" in master branch, we also need to hide version from the reference doc to avoid it to be "0.0.0"