### PR TITLE
Fix #1189 list item not showing correctly in Win32 Outlook

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
@@ -22,6 +22,8 @@ const FeatureNames: Partial<Record<ExperimentalFeatures, string>> = {
         'Trigger formatting by a especial characters. Ex: (A), 1. i).',
     [ExperimentalFeatures.PendingStyleBasedFormat]:
         'Use pending style format to do formatting when selection is collapsed',
+    [ExperimentalFeatures.NormalizeList]:
+        'Normalize list to make sure it can be displayed correctly in other client',
 };
 
 export default class ExperimentalFeaturesPane extends React.Component<

--- a/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
@@ -95,4 +95,10 @@ export const enum ExperimentalFeatures {
      * when selection is collapsed. Instead, we will hold the pending format in memory and only apply it when type something
      */
     PendingStyleBasedFormat = 'PendingStyleBasedFormat',
+
+    /**
+     * Normalize list to make sure it can be displayed correctly in other client
+     * e.g. We will move list items with "display: block" into previous list item and change tag to be DIV
+     */
+    NormalizeList = 'NormalizeList',
 }


### PR DESCRIPTION
Fix #1189 

Add an experimental feature to move `<LI style="display:block">... </LI>` into previous list item and change tag to DIV when export HTML. 