### PR TITLE
Publish the first version of content model

### DIFF
--- a/packages/roosterjs-content-model/package.json
+++ b/packages/roosterjs-content-model/package.json
@@ -6,5 +6,5 @@
         "roosterjs-editor-dom": ""
     },
     "main": "./lib/index.ts",
-    "version": "0.0.0"
+    "version": "0.0.1-dev.0"
 }


### PR DESCRIPTION
Allow publishing roosterjs-content-model@0.0.1-dev.0 to npm