### PR TITLE
Content Model Table API improvement

### DIFF
--- a/demo/scripts/controls/MainPane.tsx
+++ b/demo/scripts/controls/MainPane.tsx
@@ -3,6 +3,7 @@ import * as ReactDOM from 'react-dom';
 import ApiPlaygroundPlugin from './sidePane/apiPlayground/ApiPlaygroundPlugin';
 import BuildInPluginState from './BuildInPluginState';
 import ContentModelPlugin from './sidePane/contentModel/ContentModelPlugin';
+import ContentModelRibbon from './ribbonButtons/contentModel/ContentModelRibbon';
 import EditorOptionsPlugin from './sidePane/editorOptions/EditorOptionsPlugin';
 import EventViewPlugin from './sidePane/eventViewer/EventViewPlugin';
 import ExperimentalContentModelEditor from './editor/ExperimentalContentModelEditor';
@@ -16,24 +17,13 @@ import { arrayPush } from 'roosterjs-editor-dom';
 import { darkMode, DarkModeButtonStringKey } from './ribbonButtons/darkMode';
 import { EditorOptions, EditorPlugin } from 'roosterjs-editor-types';
 import { ExportButtonStringKey, exportContent } from './ribbonButtons/export';
-import { formatTableButton } from './ribbonButtons/contentModel/formatTableButton';
 import { getDarkColor } from 'roosterjs-color-utils';
-import { insertTableButton } from './ribbonButtons/contentModel/insertTableButton';
 import { PartialTheme, ThemeProvider } from '@fluentui/react/lib/Theme';
 import { popout, PopoutButtonStringKey } from './ribbonButtons/popout';
 import { registerWindowForCss, unregisterWindowForCss } from '../utils/cssMonitor';
-import { setTableCellShadeButton } from './ribbonButtons/contentModel/setTableCellShadeButton';
 import { trustedHTMLHandler } from '../utils/trustedHTMLHandler';
 import { WindowProvider } from '@fluentui/react/lib/WindowProvider';
 import { zoom, ZoomButtonStringKey } from './ribbonButtons/zoom';
-import {
-    tableAlignCellButton,
-    tableAlignTableButton,
-    tableDeleteButton,
-    tableInsertButton,
-    tableMergeButton,
-    tableSplitButton,
-} from './ribbonButtons/contentModel/tableEditButtons';
 import {
     AllButtonStringKeys,
     createRibbonPlugin,
@@ -137,17 +127,6 @@ class MainPane extends MainPaneBase {
     private toggleablePlugins: EditorPlugin[] | null = null;
     private mainWindowButtons: RibbonButton<RibbonStringKeys>[];
     private popoutWindowButtons: RibbonButton<RibbonStringKeys>[];
-    private contentModelRibbonButtons: RibbonButton<any>[] = [
-        insertTableButton,
-        formatTableButton,
-        setTableCellShadeButton,
-        tableInsertButton,
-        tableDeleteButton,
-        tableMergeButton,
-        tableSplitButton,
-        tableAlignCellButton,
-        tableAlignTableButton,
-    ];
 
     private content: string = '';
 
@@ -327,10 +306,9 @@ class MainPane extends MainPaneBase {
 
     private renderContentModelRibbon() {
         return (
-            <Ribbon
-                buttons={this.contentModelRibbonButtons}
-                plugin={this.contentModelRibbonPlugin}
-                dir={this.state.isRtl ? 'rtl' : 'ltr'}
+            <ContentModelRibbon
+                ribbonPlugin={this.contentModelRibbonPlugin}
+                isRtl={this.state.isRtl}
             />
         );
     }

--- a/demo/scripts/controls/ribbonButtons/contentModel/ContentModelRibbon.tsx
+++ b/demo/scripts/controls/ribbonButtons/contentModel/ContentModelRibbon.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { formatTableButton } from './formatTableButton';
+import { insertTableButton } from './insertTableButton';
+import { Ribbon, RibbonPlugin } from 'roosterjs-react';
+import { setTableCellShadeButton } from './setTableCellShadeButton';
+import { setTableHeaderButton } from './setTableHeaderButton';
+import {
+    tableAlignCellButton,
+    tableAlignTableButton,
+    tableDeleteButton,
+    tableInsertButton,
+    tableMergeButton,
+    tableSplitButton,
+} from './tableEditButtons';
+
+const buttons = [
+    insertTableButton,
+    formatTableButton,
+    setTableCellShadeButton,
+    setTableHeaderButton,
+    tableInsertButton,
+    tableDeleteButton,
+    tableMergeButton,
+    tableSplitButton,
+    tableAlignCellButton,
+    tableAlignTableButton,
+];
+
+export default function ContentModelRibbon(props: { ribbonPlugin: RibbonPlugin; isRtl: boolean }) {
+    const { ribbonPlugin, isRtl } = props;
+
+    return <Ribbon buttons={buttons} plugin={ribbonPlugin} dir={isRtl ? 'rtl' : 'ltr'} />;
+}

--- a/demo/scripts/controls/ribbonButtons/contentModel/setTableHeaderButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/setTableHeaderButton.ts
@@ -1,0 +1,17 @@
+import isContentModelEditor from '../../editor/isContentModelEditor';
+import { formatTable } from 'roosterjs-content-model';
+import { getFormatState } from 'roosterjs-editor-api';
+import { RibbonButton } from 'roosterjs-react';
+
+export const setTableHeaderButton: RibbonButton<'ribbonButtonSetTableHeader'> = {
+    key: 'ribbonButtonSetTableHeader',
+    unlocalizedText: 'Toggle table header',
+    iconName: 'Header',
+    isDisabled: formatState => !formatState.isInTable,
+    onClick: editor => {
+        if (isContentModelEditor(editor)) {
+            const format = getFormatState(editor);
+            formatTable(editor, { hasHeaderRow: !format.tableHasHeader }, true /*keepCellShade*/);
+        }
+    },
+};

--- a/demo/scripts/controls/sidePane/formatState/FormatStatePane.tsx
+++ b/demo/scripts/controls/sidePane/formatState/FormatStatePane.tsx
@@ -80,6 +80,7 @@ export default class FormatStatePane extends React.Component<
                             {this.renderSpan(format.canUnlink, 'In Link')}
                             {this.renderSpan(format.canAddImageAltText, 'In Image')}
                             {this.renderSpan(format.isInTable, 'In Table')}
+                            {this.renderSpan(format.tableHasHeader, 'Table Has Header')}
                             <span
                                 className={
                                     format.headerLevel == 0 && styles.inactive

--- a/packages/roosterjs-content-model/lib/modelApi/table/applyTableFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/applyTableFormat.ts
@@ -1,6 +1,7 @@
 import { BorderIndex, combineBorderValue, extractBorderValues } from '../../domUtils/borderValues';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { ContentModelTableCell } from '../../publicTypes/block/group/ContentModelTableCell';
+import { ContentModelTableCellFormat } from '../../publicTypes/format/ContentModelTableCellFormat';
 import { TableBorderFormat } from 'roosterjs-editor-types';
 import { TableMetadataFormat } from '../../publicTypes/format/formatParts/TableMetadataFormat';
 
@@ -36,7 +37,7 @@ export function applyTableFormat(
     Object.assign(format, effectiveMetadata);
 
     if (!keepCellShade) {
-        deleteCellBackgroundColorOverride(cells, effectiveMetadata);
+        deleteCellBackgroundColorOverride(cells);
     }
 
     formatBorders(cells, effectiveMetadata);
@@ -45,10 +46,7 @@ export function applyTableFormat(
     setHeaderRowFormat(cells, effectiveMetadata);
 }
 
-function deleteCellBackgroundColorOverride(
-    cells: ContentModelTableCell[][],
-    format: TableMetadataFormat
-) {
+function deleteCellBackgroundColorOverride(cells: ContentModelTableCell[][]) {
     cells.forEach(row => {
         row.forEach(cell => {
             delete cell.format.bgColorOverride;
@@ -166,13 +164,7 @@ function formatBackgroundColors(cells: ContentModelTableCell[][], format: TableM
                     ? format.bgColorOdd
                     : null;
 
-                if (color && !cell.format.bgColorOverride) {
-                    cell.format.backgroundColor = color;
-
-                    // TODO: format text color
-                } else {
-                    delete cell.format.backgroundColor;
-                }
+                setBackgroundColor(cell.format, color);
             }
         });
     });
@@ -190,8 +182,8 @@ function setFirstColumnFormat(
 
                 if (rowIndex !== 0 && !cell.format.bgColorOverride) {
                     borders[BorderIndex.Top] = 'transparent';
-                    delete cell.format.backgroundColor;
-                    // TODO: Set text color
+
+                    setBackgroundColor(cell.format, null /*color*/);
                 }
 
                 if (rowIndex !== cells.length - 1 && rowIndex !== 0) {
@@ -211,11 +203,7 @@ function setHeaderRowFormat(cells: ContentModelTableCell[][], format: TableMetad
         cell.isHeader = format.hasHeaderRow;
 
         if (format.hasHeaderRow && format.headerRowColor) {
-            if (!cell.format.bgColorOverride) {
-                cell.format.backgroundColor = format.headerRowColor;
-
-                // TODO: Set text color
-            }
+            setBackgroundColor(cell.format, format.headerRowColor);
 
             const borders = extractBorderValues(cell.format.borderColor!);
 
@@ -226,4 +214,14 @@ function setHeaderRowFormat(cells: ContentModelTableCell[][], format: TableMetad
             cell.format.borderColor = combineBorderValue(borders, 'transparent');
         }
     });
+}
+
+function setBackgroundColor(format: ContentModelTableCellFormat, color: string | null | undefined) {
+    if (color && !format.bgColorOverride) {
+        format.backgroundColor = color;
+
+        // TODO: Handle text color when background color is dark
+    } else {
+        delete format.backgroundColor;
+    }
 }

--- a/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellHorizontally.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellHorizontally.ts
@@ -2,6 +2,8 @@ import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { createTableCell } from '../creators/createTableCell';
 import { getSelectedCells } from './getSelectedCells';
 
+const MIN_WIDTH = 30;
+
 /**
  * @internal
  */
@@ -26,8 +28,9 @@ export function splitTableCellHorizontally(table: ContentModelTable) {
                         rightCell.spanLeft = false;
 
                         if (cell.format.width) {
-                            rightCell.format.width = cell.format.width / 2;
-                            cell.format.width = cell.format.width / 2;
+                            // Delete existing width to let other cell determine the width
+                            delete rightCell.format.width;
+                            delete cell.format.width;
                         }
                     }
                 });
@@ -49,8 +52,9 @@ export function splitTableCellHorizontally(table: ContentModelTable) {
                                 newCell.format.width = 0;
                             }
                         } else {
-                            cell.format.width! /= 2;
-                            newCell.format.width! /= 2;
+                            const newWidth = Math.max(cell.format.width! / 2, MIN_WIDTH);
+                            cell.format.width = newWidth;
+                            newCell.format.width = newWidth;
                             newCell.isSelected = cell.isSelected;
                         }
                         row.splice(colIndex + 1, 0, newCell);

--- a/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellVertically.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellVertically.ts
@@ -2,6 +2,8 @@ import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { createTableCell } from '../creators/createTableCell';
 import { getSelectedCells } from './getSelectedCells';
 
+const MIN_HEIGHT = 22;
+
 /**
  * @internal
  */
@@ -26,8 +28,9 @@ export function splitTableCellVertically(table: ContentModelTable) {
                         belowCell.spanAbove = false;
 
                         if (cell.format.height) {
-                            belowCell.format.height = cell.format.height / 2;
-                            cell.format.height = cell.format.height / 2;
+                            // Delete existing height to let other cells determine the height
+                            delete belowCell.format.height;
+                            delete cell.format.height;
                         }
                     }
                 });
@@ -46,8 +49,9 @@ export function splitTableCellVertically(table: ContentModelTable) {
                             newCell.format.height = 0;
                         }
                     } else {
-                        cell.format.height! /= 2;
-                        newCell.format.height! /= 2;
+                        const newHeight = Math.max((cell.format.height! /= 2), MIN_HEIGHT);
+                        cell.format.height = newHeight;
+                        newCell.format.height = newHeight;
                         newCell.isSelected = cell.isSelected;
                     }
 

--- a/packages/roosterjs-content-model/lib/publicApi/table/editTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/editTable.ts
@@ -19,15 +19,15 @@ import { splitTableCellVertically } from '../../modelApi/table/splitTableCellVer
 /**
  * Format current focused table with the given format
  * @param editor The editor instance
- * @param format The table format to apply
+ * @param operation The table operation to apply
  */
 export default function editTable(
     editor: IExperimentalContentModelEditor,
     operation: TableOperation
 ) {
     const table = editor.getElementAtCursor('TABLE');
-    const model = editor.createContentModel(table);
-    const tableModel = model.blocks[0];
+    const model = table && editor.createContentModel(table);
+    const tableModel = model?.blocks[0];
 
     if (tableModel?.blockType == ContentModelBlockType.Table) {
         switch (operation) {

--- a/packages/roosterjs-content-model/lib/publicApi/table/formatTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/formatTable.ts
@@ -8,17 +8,19 @@ import { TableMetadataFormat } from '../../publicTypes/format/formatParts/TableM
  * Format current focused table with the given format
  * @param editor The editor instance
  * @param format The table format to apply
+ * @param keepCellShade Whether keep existing shade color when apply format if there is a manually set shade color
  */
 export default function formatTable(
     editor: IExperimentalContentModelEditor,
-    format: TableMetadataFormat
+    format: TableMetadataFormat,
+    keepCellShade?: boolean
 ) {
     const table = editor.getElementAtCursor('TABLE');
-    const model = editor.createContentModel(table);
-    const tableModel = model.blocks[0];
+    const model = table && editor.createContentModel(table);
+    const tableModel = model?.blocks[0];
 
     if (tableModel?.blockType == ContentModelBlockType.Table) {
-        applyTableFormat(tableModel, format);
+        applyTableFormat(tableModel, format, keepCellShade);
 
         editor.addUndoSnapshot(
             () => {

--- a/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
@@ -11,8 +11,8 @@ import { setTableCellBackgroundColor } from '../../modelApi/table/setTableCellBa
  */
 export default function setTableCellShade(editor: IExperimentalContentModelEditor, color: string) {
     const table = editor.getElementAtCursor('TABLE');
-    const model = editor.createContentModel(table);
-    const tableModel = model.blocks[0];
+    const model = table && editor.createContentModel(table);
+    const tableModel = model?.blocks[0];
 
     if (tableModel?.blockType == ContentModelBlockType.Table) {
         normalizeTable(tableModel);

--- a/packages/roosterjs-editor-api/lib/format/getFormatState.ts
+++ b/packages/roosterjs-editor-api/lib/format/getFormatState.ts
@@ -1,4 +1,4 @@
-import { getTagOfNode } from 'roosterjs-editor-dom';
+import { getTableFormatInfo, getTagOfNode, toArray } from 'roosterjs-editor-dom';
 import {
     ElementBasedFormatState,
     FormatState,
@@ -19,20 +19,26 @@ export function getElementBasedFormatState(
     editor: IEditor,
     event?: PluginEvent
 ): ElementBasedFormatState {
-    let listTag = getTagOfNode(editor.getElementAtCursor('OL,UL', null /*startFrom*/, event));
+    const listTag = getTagOfNode(editor.getElementAtCursor('OL,UL', null /*startFrom*/, event));
 
     // Check if selection is multiline, spans more than one block
-    let range = editor.getSelectionRange();
+    const range = editor.getSelectionRange();
     let multiline = false;
+
     if (range && !range.collapsed) {
-        let startingBlock = editor.getBlockElementAtNode(range.startContainer);
-        let endingBlock = editor.getBlockElementAtNode(range.endContainer);
+        const startingBlock = editor.getBlockElementAtNode(range.startContainer);
+        const endingBlock = editor.getBlockElementAtNode(range.endContainer);
         multiline = endingBlock ? !endingBlock.equals(startingBlock) : false;
     }
 
-    let headerTag = getTagOfNode(
+    const headerTag = getTagOfNode(
         editor.getElementAtCursor('H1,H2,H3,H4,H5,H6', null /*startFrom*/, event)
     );
+    const table = editor.queryElements('table', QueryScope.OnSelection)[0];
+    const tableFormat = table ? getTableFormatInfo(table) : undefined;
+    const hasHeader = table?.rows[0]
+        ? toArray(table.rows[0].cells).every(cell => getTagOfNode(cell) == 'TH')
+        : undefined;
 
     return {
         isBullet: listTag == 'UL',
@@ -42,7 +48,9 @@ export function getElementBasedFormatState(
         canUnlink: !!editor.queryElements('a[href]', QueryScope.OnSelection)[0],
         canAddImageAltText: !!editor.queryElements('img', QueryScope.OnSelection)[0],
         isBlockQuote: !!editor.queryElements('blockquote', QueryScope.OnSelection)[0],
-        isInTable: !!editor.queryElements('table', QueryScope.OnSelection)[0],
+        isInTable: !!table,
+        tableFormat: tableFormat,
+        tableHasHeader: hasHeader,
     };
 }
 

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -56,6 +56,7 @@ export { default as VListItem } from './list/VListItem';
 export { default as createVListFromRegion } from './list/createVListFromRegion';
 export { default as VListChain } from './list/VListChain';
 export { default as setListItemStyle } from './list/setListItemStyle';
+export { getTableFormatInfo } from './table/tableFormatInfo';
 
 export { default as getRegionsFromRange } from './region/getRegionsFromRange';
 export { default as getSelectedBlockElementsInRegion } from './region/getSelectedBlockElementsInRegion';

--- a/packages/roosterjs-editor-dom/lib/table/tableFormatInfo.ts
+++ b/packages/roosterjs-editor-dom/lib/table/tableFormatInfo.ts
@@ -40,7 +40,6 @@ const TableFormatMetadata = createObjectDefinition<Required<TableFormat>>(
 );
 
 /**
- * @internal
  * Get the format info of a table
  * If the table does not have a info saved, it will be retrieved from the css styles
  * @param table The table that has the info

--- a/packages/roosterjs-editor-types/lib/interface/FormatState.ts
+++ b/packages/roosterjs-editor-types/lib/interface/FormatState.ts
@@ -1,4 +1,5 @@
 import ModeIndependentColor from './ModeIndependentColor';
+import TableFormat from './TableFormat';
 
 /**
  * Format states that can have pending state.
@@ -82,6 +83,16 @@ export interface ElementBasedFormatState {
      * Whether the cursor is in table
      */
     isInTable?: boolean;
+
+    /**
+     * Format of table, if there is table at cursor position
+     */
+    tableFormat?: TableFormat;
+
+    /**
+     * If there is a table, whether the table has header row
+     */
+    tableHasHeader?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Change to major package
1. Add "tableHasHeader" and "tableFormat" to ElementBasedFormatState and FormatState to easily get table format
2. Export getTableFormatInfo funtion from roosterjs-editor-dom

## Change to Content Model package
1. Improve applyTableFormat() to get prepared for text color adjustment
2. Fix bug in split table cell API that can cause table size changed incorrectly

## Change to demo site
1. Create a dedicate component for ContentModel ribbon in demo site
2. Add a toggle table header button
3. Show table header state in format state pane

#1093 