### PR TITLE
Change content model version to 0.0.1

### DIFF
--- a/packages/roosterjs-content-model/package.json
+++ b/packages/roosterjs-content-model/package.json
@@ -6,5 +6,5 @@
         "roosterjs-editor-dom": ""
     },
     "main": "./lib/index.ts",
-    "version": "0.0.1-dev.0"
+    "version": "0.0.1"
 }


### PR DESCRIPTION
I realize that OWA doesn't allow tagged version now, so change content model version to 0.0.1