### PR TITLE
Fix merge table cell behavior for ContentModel

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/table/normalizeTable.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/normalizeTable.ts
@@ -66,6 +66,11 @@ export function normalizeTable(table: ContentModelTable) {
 
         if (table.cells.every(row => row[colIndex]?.spanLeft)) {
             table.cells.forEach(row => row.splice(colIndex, 1));
+            table.widths.splice(
+                colIndex - 1,
+                2,
+                table.widths[colIndex - 1] + table.widths[colIndex]
+            );
         }
     }
 
@@ -81,6 +86,11 @@ export function normalizeTable(table: ContentModelTable) {
 
         if (row.every(cell => cell.spanAbove)) {
             table.cells.splice(rowIndex, 1);
+            table.heights.splice(
+                rowIndex - 1,
+                2,
+                table.heights[rowIndex - 1] + table.heights[rowIndex]
+            );
         }
     }
 }

--- a/packages/roosterjs-content-model/test/modelApi/table/normalizeTableTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/table/normalizeTableTest.ts
@@ -211,7 +211,7 @@ describe('normalizeTable', () => {
                 borderCollapse: true,
                 useBorderBox: true,
             },
-            widths: [120, 120, 120],
+            widths: [240, 120],
             heights: [22],
         });
     });
@@ -257,7 +257,7 @@ describe('normalizeTable', () => {
                 borderCollapse: true,
                 useBorderBox: true,
             },
-            widths: [120, 120],
+            widths: [240],
             heights: [22],
         });
     });
@@ -442,7 +442,7 @@ describe('normalizeTable', () => {
                 useBorderBox: true,
             },
             widths: [120, 120],
-            heights: [22, 22],
+            heights: [44],
         });
     });
 
@@ -532,8 +532,8 @@ describe('normalizeTable', () => {
                 borderCollapse: true,
                 useBorderBox: true,
             },
-            widths: [120, 120],
-            heights: [22, 22],
+            widths: [240],
+            heights: [44],
         });
     });
 });


### PR DESCRIPTION
When merge table cells, we should keep the merged cell has the same size with before, especially when whole column/row are merged.