### PR TITLE
Allow setting custom classname to Watermark entities for easy querying

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/Watermark/Watermark.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Watermark/Watermark.ts
@@ -111,7 +111,9 @@ export default class Watermark implements EditorPlugin {
                 false /*isReadonly*/,
                 ContentPosition.Begin
             );
-            newEntity.wrapper.classList.add(this.customClass);
+            if (this.customClass) {
+                newEntity.wrapper.classList.add(this.customClass);
+            }
         }
     };
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/Watermark/Watermark.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Watermark/Watermark.ts
@@ -24,7 +24,11 @@ export default class Watermark implements EditorPlugin {
      * Create an instance of Watermark plugin
      * @param watermark The watermark string
      */
-    constructor(private watermark: string, private format?: DefaultFormat) {
+    constructor(
+        private watermark: string,
+        private format?: DefaultFormat,
+        private customClass?: string
+    ) {
         this.format = this.format || {
             fontSize: '14px',
             textColors: {
@@ -99,7 +103,7 @@ export default class Watermark implements EditorPlugin {
             watermarks.forEach(this.removeWatermark);
             this.editor.focus();
         } else if (!hasFocus && !isShowing && this.editor.isEmpty()) {
-            insertEntity(
+            const newEntity = insertEntity(
                 this.editor,
                 ENTITY_TYPE,
                 this.editor.getDocument().createTextNode(this.watermark),
@@ -107,6 +111,7 @@ export default class Watermark implements EditorPlugin {
                 false /*isReadonly*/,
                 ContentPosition.Begin
             );
+            newEntity.wrapper.classList.add(this.customClass);
         }
     };
 


### PR DESCRIPTION
As requested by https://github.com/microsoft/roosterjs/issues/1079, there's no easy way to query for watermark elements without reverse-engineering Rooster a little. 

Given that the current class name (`_EId_WATERMARK_WRAPPER`) is also used for the entity system, overriding is not an option. As such, an optional extra class can be added to these entities specifically. This is done when constructing the Watermark plugin by adding a `string` as a third parameter. 