### PR TITLE
Demo: Fix typo in Add alt text prompt

### DIFF
--- a/packages-ui/roosterjs-react/lib/contextMenu/menus/createImageEditMenuProvider.tsx
+++ b/packages-ui/roosterjs-react/lib/contextMenu/menus/createImageEditMenuProvider.tsx
@@ -23,7 +23,7 @@ const ImageAltTextMenuItem: ContextMenuItem<ImageEditMenuItemStringKey> = {
         showInputDialog(
             uiUtilities,
             'menuNameImageAltText',
-            'Set numbering value',
+            'Add alternate text',
             {
                 altText: {
                     labelKey: null,


### PR DESCRIPTION
Steps to repro:
1. Paste an image
2. Right click
3. "Add alternate text"

Current:
![image](https://user-images.githubusercontent.com/44042957/187335073-80d3f29b-a12a-49be-b449-0cea0c478e85.png)

Fix:
![image](https://user-images.githubusercontent.com/44042957/187335115-01768b95-23a4-42ec-a89c-a190ce812191.png)
