### PR TITLE
Add double long arrow bullet type

### DIFF
--- a/packages/roosterjs-editor-dom/lib/list/setBulletListMarkers.ts
+++ b/packages/roosterjs-editor-dom/lib/list/setBulletListMarkers.ts
@@ -22,6 +22,7 @@ const bulletListStyle: Record<string, string> = {
     [BulletListType.Square]: 'square',
     [BulletListType.Dash]: '- ',
     [BulletListType.LongArrow]: '→ ',
+    [BulletListType.DoubleLongArrow]: '→ ',
     [BulletListType.ShortArrow]: '➢ ',
     [BulletListType.UnfilledArrow]: '➪ ',
     [BulletListType.Hyphen]: '— ',

--- a/packages/roosterjs-editor-dom/test/list/setBulletListMarkersTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/setBulletListMarkersTest.ts
@@ -26,6 +26,10 @@ describe('setBulletListMarkers', () => {
         runTest(BulletListType.LongArrow, '"→ "');
     });
 
+    it('double long arrow', () => {
+        runTest(BulletListType.DoubleLongArrow, '"→ "');
+    });
+
     it('short arrow', () => {
         runTest(BulletListType.ShortArrow, '"➢ "');
     });

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/utils/getAutoBulletListStyle.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/utils/getAutoBulletListStyle.ts
@@ -5,7 +5,7 @@ const bulletListType: Record<string, number> = {
     '-': BulletListType.Dash,
     '--': BulletListType.Square,
     '->': BulletListType.LongArrow,
-    '-->': BulletListType.LongArrow,
+    '-->': BulletListType.DoubleLongArrow,
     '=>': BulletListType.UnfilledArrow,
     '>': BulletListType.ShortArrow,
     '—': BulletListType.Hyphen,

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/utils/getAutoBulletListStyleTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/utils/getAutoBulletListStyleTest.ts
@@ -12,7 +12,7 @@ describe('getAutoListStyle ', () => {
     });
 
     it('--> ', () => {
-        runTest('--> ', BulletListType.LongArrow);
+        runTest('--> ', BulletListType.DoubleLongArrow);
     });
 
     it('-> ', () => {

--- a/packages/roosterjs-editor-types/lib/enum/BulletListType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/BulletListType.ts
@@ -28,7 +28,7 @@ export const enum BulletListType {
     ShortArrow = 4,
 
     /**
-     * Bullet triggered by -> or -->
+     * Bullet triggered by ->
      */
     LongArrow = 5,
 
@@ -43,7 +43,12 @@ export const enum BulletListType {
     Hyphen = 7,
 
     /**
+     * Bullet triggered by -->
+     */
+    DoubleLongArrow = 8,
+
+    /**
      * Maximum value of the enum
      */
-    Max = 7,
+    Max = 9,
 }


### PR DESCRIPTION
Both --> and -> trigger a bullet list with the →  marker, then to identify the characters that triggered the list, a new list type called DoubleLong arrow was add. Then, when the unordered list style is DoubleLongArrow, the characters that triggered the list was -->