### PR TITLE
Rename experimentCommitListChains to commitListChains

### DIFF
--- a/packages/roosterjs-editor-api/lib/index.ts
+++ b/packages/roosterjs-editor-api/lib/index.ts
@@ -36,4 +36,4 @@ export { default as applyCellShading } from './table/applyCellShading';
 
 export { default as toggleListType } from './utils/toggleListType';
 export { default as blockFormat } from './utils/blockFormat';
-export { default as experimentCommitListChains } from './experiment/experimentCommitListChains';
+export { default as commitListChains, experimentCommitListChains } from './utils/commitListChains';

--- a/packages/roosterjs-editor-api/lib/utils/blockFormat.ts
+++ b/packages/roosterjs-editor-api/lib/utils/blockFormat.ts
@@ -1,4 +1,4 @@
-import experimentCommitListChains from '../experiment/experimentCommitListChains';
+import commitListChains from '../utils/commitListChains';
 import formatUndoSnapshot from './formatUndoSnapshot';
 import { IEditor, NodePosition, Region, SelectionRangeTypes } from 'roosterjs-editor-types';
 import { VListChain } from 'roosterjs-editor-dom';
@@ -27,7 +27,7 @@ export default function blockFormat(
                 const regions = editor.getSelectedRegions();
                 const chains = VListChain.createListChains(regions, start?.node);
                 regions.forEach(region => callback(region, start, end, chains));
-                experimentCommitListChains(editor, chains);
+                commitListChains(editor, chains);
             }
             if (selection.type == SelectionRangeTypes.Normal) {
                 editor.select(start, end);

--- a/packages/roosterjs-editor-api/lib/utils/commitListChains.ts
+++ b/packages/roosterjs-editor-api/lib/utils/commitListChains.ts
@@ -6,7 +6,7 @@ import { Position, VListChain } from 'roosterjs-editor-dom';
  * @param editor The Editor object
  * @param chains List chains to commit
  */
-export default function experimentCommitListChains(editor: IEditor, chains: VListChain[]) {
+export default function commitListChains(editor: IEditor, chains: VListChain[]) {
     if (chains?.length > 0) {
         const range = editor.getSelectionRange();
         const start = range && Position.getStart(range);
@@ -15,3 +15,9 @@ export default function experimentCommitListChains(editor: IEditor, chains: VLis
         editor.select(start, end);
     }
 }
+
+/**
+ * @deprecated
+ * Same with commitListChains, keep this export just for backward compatibility
+ */
+export const experimentCommitListChains = commitListChains;

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -2,7 +2,7 @@ import getAutoBulletListStyle from '../utils/getAutoBulletListStyle';
 import getAutoNumberingListStyle from '../utils/getAutoNumberingListStyle';
 import {
     blockFormat,
-    experimentCommitListChains,
+    commitListChains,
     setIndentation,
     toggleBullet,
     toggleNumbering,
@@ -116,7 +116,7 @@ const MaintainListChainWhenDelete: BuildInEditFeature<PluginKeyboardEvent> = {
     },
     handleEvent: (event, editor) => {
         const chains = getListChains(editor);
-        editor.runAsync(editor => experimentCommitListChains(editor, chains));
+        editor.runAsync(editor => commitListChains(editor, chains));
     },
 };
 
@@ -309,7 +309,7 @@ const MaintainListChain: BuildInEditFeature<PluginKeyboardEvent> = {
         editor.queryElements('li', QueryScope.OnSelection).length > 0,
     handleEvent: (event, editor) => {
         const chains = getListChains(editor);
-        editor.runAsync(editor => experimentCommitListChains(editor, chains));
+        editor.runAsync(editor => commitListChains(editor, chains));
     },
 };
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/CutPasteListChain/CutPasteListChain.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/CutPasteListChain/CutPasteListChain.ts
@@ -1,4 +1,4 @@
-import { experimentCommitListChains } from 'roosterjs-editor-api';
+import { commitListChains } from 'roosterjs-editor-api';
 import { VListChain } from 'roosterjs-editor-dom';
 import {
     ChangeSource,
@@ -61,7 +61,7 @@ export default class CutPasteListChain implements EditorPlugin {
 
             case PluginEventType.ContentChanged:
                 if (this.chains?.length > 0 && this.expectedChangeSource == event.source) {
-                    experimentCommitListChains(this.editor, this.chains);
+                    commitListChains(this.editor, this.chains);
                     this.chains = null;
                     this.expectedChangeSource = null;
                 }

--- a/packages/roosterjs-editor-plugins/test/CutPasteListChain/cutPasteListChainTest.ts
+++ b/packages/roosterjs-editor-plugins/test/CutPasteListChain/cutPasteListChainTest.ts
@@ -1,6 +1,7 @@
-import * as experimentCommitListChains from 'roosterjs-editor-api/lib/experiment/experimentCommitListChains';
-import { Position, VListChain } from 'roosterjs-editor-dom';
+import * as commitListChains from 'roosterjs-editor-api/lib/utils/commitListChains';
 import * as DomTestHelper from 'roosterjs-editor-dom/test/DomTestHelper';
+import { CutPasteListChain } from '../../lib/CutPasteListChain';
+import { Position, VListChain } from 'roosterjs-editor-dom';
 import {
     ClipboardData,
     IEditor,
@@ -9,7 +10,6 @@ import {
     PluginEventType,
     SelectionRangeTypes,
 } from 'roosterjs-editor-types';
-import { CutPasteListChain } from '../../lib/CutPasteListChain';
 
 describe('cutPasteListChain tests', () => {
     let editor: IEditor;
@@ -18,7 +18,7 @@ describe('cutPasteListChain tests', () => {
 
     beforeEach(() => {
         spyOn(VListChain, 'createListChains').and.callThrough();
-        spyOn(experimentCommitListChains, 'default').and.callFake(() => {});
+        spyOn(commitListChains, 'default').and.callFake(() => {});
 
         plugin = new CutPasteListChain();
 
@@ -165,7 +165,7 @@ describe('cutPasteListChain tests', () => {
         expect(contentDiv.innerHTML).toBe(expectedText);
     });
 
-    it('not call experimentCommitListChains with non-list element', () => {
+    it('not call commitListChains with non-list element', () => {
         const testString: string = 'this is a test';
         const contentDiv = createStringElement(testString);
         const pasteEvent = createPluginEventBeforePaste(testString);
@@ -180,10 +180,10 @@ describe('cutPasteListChain tests', () => {
         };
         plugin.onPluginEvent(contentChangedEvent);
 
-        expect(experimentCommitListChains.default).not.toHaveBeenCalled();
+        expect(commitListChains.default).not.toHaveBeenCalled();
     });
 
-    it('calls experimentCommitListChains with list element', () => {
+    it('calls commitListChains with list element', () => {
         const contentDiv = createListElement();
 
         setGetSelectedRegions(contentDiv);
@@ -198,6 +198,6 @@ describe('cutPasteListChain tests', () => {
         };
         plugin.onPluginEvent(contentChangedEvent);
 
-        expect(experimentCommitListChains.default).toHaveBeenCalled();
+        expect(commitListChains.default).toHaveBeenCalled();
     });
 });

--- a/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
@@ -43,7 +43,7 @@ export const enum ExperimentalFeatures {
     ImageRotate = 'ImageRotate',
 
     /**
-     * Crop an inline image (requires ImageEdit plugin)
+     * @deprecated This feature is always enabled
      */
     ImageCrop = 'ImageCrop',
 


### PR DESCRIPTION
List Chain, as an experimental feature, has been graduated for long time. So we should not keep the word "experiment" in its function name. So rename to `commitListChains`.

Still keep exporting experimentCommitListChains  for backward compatibility.