### PR TITLE
fix: toggling inner list type

### DIFF
--- a/packages/roosterjs-editor-dom/lib/list/VListItem.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VListItem.ts
@@ -318,7 +318,10 @@ export default class VListItem {
             //apply the styles of the current parent list to the new list
             if (this.getDeepChildIndex(originalRoot) == stackLength) {
                 const listStyleType = this.node.parentElement?.style.listStyleType;
-                if (listStyleType) {
+                if (
+                    listStyleType &&
+                    getTagOfNode(this.node.parentElement) === getTagOfNode(newList)
+                ) {
                     newList.style.listStyleType = listStyleType;
                 }
             }


### PR DESCRIPTION
fixing a bug where list style type was applied to inner lists even when the type was toggled

https://github.com/microsoft/roosterjs/issues/1256