### PR TITLE
Content Model: improve demo site, and minor bug fixes

### DIFF
--- a/demo/scripts/controls/contentModel/components/format/FormatView.tsx
+++ b/demo/scripts/controls/contentModel/components/format/FormatView.tsx
@@ -3,8 +3,12 @@ import { FormatRenderer } from './utils/FormatRenderer';
 
 const styles = require('./FormatView.scss');
 
-export function FormatView<T>(props: { format: T; renderers: FormatRenderer<T>[] }) {
-    const { format, renderers } = props;
+export function FormatView<T>(props: {
+    format: T;
+    renderers: FormatRenderer<T>[];
+    onUpdate?: () => void;
+}) {
+    const { format, renderers, onUpdate } = props;
 
-    return <div className={styles.formatTable}>{renderers.map(x => x(format))}</div>;
+    return <div className={styles.formatTable}>{renderers.map(x => x(format, onUpdate))}</div>;
 }

--- a/demo/scripts/controls/contentModel/components/format/utils/FormatRenderer.ts
+++ b/demo/scripts/controls/contentModel/components/format/utils/FormatRenderer.ts
@@ -1,1 +1,1 @@
-export type FormatRenderer<T> = (format: T) => JSX.Element;
+export type FormatRenderer<T> = (format: T, onUpdate?: () => void) => JSX.Element;

--- a/demo/scripts/controls/contentModel/components/format/utils/createCheckboxFormatRenderer.tsx
+++ b/demo/scripts/controls/contentModel/components/format/utils/createCheckboxFormatRenderer.tsx
@@ -9,8 +9,9 @@ function CheckboxFormatItem<TFormat>(props: {
     format: TFormat;
     getter: (format: TFormat) => boolean;
     setter?: (format: TFormat, newValue: boolean) => void;
+    onUpdate?: () => void;
 }) {
-    const { name, getter, setter, format } = props;
+    const { name, getter, setter, format, onUpdate } = props;
     const checkbox = React.useRef<HTMLInputElement>(null);
     const [value, setValue] = useProperty<boolean>(getter(format));
 
@@ -18,6 +19,7 @@ function CheckboxFormatItem<TFormat>(props: {
         const newValue = checkbox.current.checked;
         setValue(newValue);
         setter?.(format, newValue);
+        onUpdate?.();
     }, [format, setter, setValue]);
 
     return (
@@ -35,12 +37,13 @@ export function createCheckboxFormatRenderer<T>(
     getter: (format: T) => boolean,
     setter?: (format: T, newValue: boolean) => void
 ): FormatRenderer<T> {
-    return (format: T) => (
+    return (format: T, onUpdate?: () => void) => (
         <CheckboxFormatItem
             name={name}
             getter={getter}
             setter={setter}
             format={format}
+            onUpdate={onUpdate}
             key={name}
         />
     );

--- a/demo/scripts/controls/contentModel/components/format/utils/createColorFormatRender.tsx
+++ b/demo/scripts/controls/contentModel/components/format/utils/createColorFormatRender.tsx
@@ -11,8 +11,9 @@ function ColorFormatItem<T>(props: {
     format: T;
     getter: (format: T) => string;
     setter?: (format: T, newValue: string) => void;
+    onUpdate?: () => void;
 }) {
-    const { name, getter, setter, format } = props;
+    const { name, getter, setter, format, onUpdate } = props;
     const colorPickerBox = React.useRef<HTMLInputElement & HTMLTextAreaElement>(null);
     const colorValueBox = React.useRef<HTMLInputElement>(null);
     const transparentCheckBox = React.useRef<HTMLInputElement>(null);
@@ -39,6 +40,7 @@ function ColorFormatItem<T>(props: {
 
             setValue(newValue);
             setter?.(format, newValue);
+            onUpdate?.();
         },
         [setter, format]
     );
@@ -90,8 +92,15 @@ export function createColorFormatRenderer<T>(
     getter: (format: T) => string,
     setter?: (format: T, newValue: string) => void
 ): FormatRenderer<T> {
-    return (format: T) => (
-        <ColorFormatItem name={name} getter={getter} setter={setter} format={format} key={name} />
+    return (format: T, onUpdate?: () => void) => (
+        <ColorFormatItem
+            name={name}
+            getter={getter}
+            setter={setter}
+            format={format}
+            key={name}
+            onUpdate={onUpdate}
+        />
     );
 }
 
@@ -100,7 +109,7 @@ export function createColorFormatRendererGroup<T, V extends string>(
     getter: (format: T) => string[],
     setter?: (format: T, name: V, newValue: string) => void
 ): FormatRenderer<T> {
-    return (format: T) => {
+    return (format: T, onUpdate?: () => void) => {
         const initValues = getter(format);
 
         return (
@@ -111,6 +120,7 @@ export function createColorFormatRendererGroup<T, V extends string>(
                         getter={() => initValues[index]}
                         setter={(format, newValue) => setter?.(format, name, newValue)}
                         format={format}
+                        onUpdate={onUpdate}
                         key={name}
                     />
                 ))}

--- a/demo/scripts/controls/contentModel/components/format/utils/createDropDownFormatRenderer.tsx
+++ b/demo/scripts/controls/contentModel/components/format/utils/createDropDownFormatRenderer.tsx
@@ -10,8 +10,9 @@ function DropDownFormatItem<TFormat, TOption extends string>(props: {
     options: TOption[];
     getter: (format: TFormat) => TOption | undefined;
     setter?: (format: TFormat, newValue: TOption | undefined) => void;
+    onUpdate?: () => void;
 }) {
-    const { name, getter, setter, format, options } = props;
+    const { name, getter, setter, format, options, onUpdate } = props;
     const dropDown = React.useRef<HTMLSelectElement>(null);
     const [value, setValue] = useProperty(getter(format));
 
@@ -20,6 +21,7 @@ function DropDownFormatItem<TFormat, TOption extends string>(props: {
             dropDown.current.value == '' ? undefined : (dropDown.current.value as TOption);
         setValue(newValue);
         setter?.(format, newValue);
+        onUpdate?.();
     }, [format, setter]);
 
     return (
@@ -45,13 +47,14 @@ export function createDropDownFormatRenderer<T, O extends string>(
     getter: (format: T) => O,
     setter?: (format: T, newValue: O) => void
 ): FormatRenderer<T> {
-    return (format: T) => (
+    return (format: T, onUpdate?: () => void) => (
         <DropDownFormatItem
             name={name}
             getter={getter}
             setter={setter}
             format={format}
             options={options}
+            onUpdate={onUpdate}
             key={name}
         />
     );
@@ -63,7 +66,7 @@ export function createDropDownFormatRendererGroup<T, O extends string, V extends
     getter: (format: T) => O[],
     setter?: (format: T, name: V, newValue: O) => void
 ): FormatRenderer<T> {
-    return (format: T) => {
+    return (format: T, onUpdate?: () => void) => {
         const initValues = getter(format);
         return (
             <>
@@ -74,6 +77,7 @@ export function createDropDownFormatRendererGroup<T, O extends string, V extends
                         setter={(format, newValue) => setter?.(format, name, newValue)}
                         format={format}
                         options={options}
+                        onUpdate={onUpdate}
                         key={name}
                     />
                 ))}

--- a/demo/scripts/controls/contentModel/components/format/utils/createTextFormatRenderer.tsx
+++ b/demo/scripts/controls/contentModel/components/format/utils/createTextFormatRenderer.tsx
@@ -9,9 +9,10 @@ function TextFormatItem<T>(props: {
     format: T;
     getter: (format: T) => string;
     setter?: (format: T, newValue: string) => void;
+    onUpdate?: () => void;
     type: 'text' | 'number' | 'multiline';
 }) {
-    const { name, getter, setter, format, type } = props;
+    const { name, getter, setter, format, type, onUpdate } = props;
     const textBox = React.useRef<HTMLInputElement & HTMLTextAreaElement>(null);
     const [value, setValue] = useProperty(getter(format));
 
@@ -19,6 +20,7 @@ function TextFormatItem<T>(props: {
         (newValue: string) => {
             setValue(newValue);
             setter?.(format, newValue);
+            onUpdate();
         },
         [setter, format]
     );
@@ -78,13 +80,14 @@ export function createTextFormatRenderer<T>(
     setter?: (format: T, newValue: string) => void,
     type: 'text' | 'number' | 'multiline' = 'text'
 ): FormatRenderer<T> {
-    return (format: T) => (
+    return (format: T, onUpdate?: () => void) => (
         <TextFormatItem
             name={name}
             getter={getter}
             setter={setter}
             format={format}
             type={type}
+            onUpdate={onUpdate}
             key={name}
         />
     );
@@ -96,7 +99,7 @@ export function createTextFormatRendererGroup<T, V extends string>(
     setter?: (format: T, name: V, newValue: string) => void,
     type: 'text' | 'number' | 'multiline' = 'text'
 ): FormatRenderer<T> {
-    return (format: T) => {
+    return (format: T, onUpdate?: () => void) => {
         const initValues = getter(format);
 
         return (
@@ -108,6 +111,7 @@ export function createTextFormatRendererGroup<T, V extends string>(
                         setter={(format, newValue) => setter?.(format, name, newValue)}
                         format={format}
                         type={type}
+                        onUpdate={onUpdate}
                         key={name}
                     />
                 ))}

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBlockGroup.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBlockGroup.ts
@@ -25,7 +25,10 @@ export function handleBlockGroup(
             handleBlockGroupChildren(doc, newParent, group, context);
 
             if (isGeneralSegment(group) && isNodeOfType(newParent, NodeType.Element)) {
-                context.regularSelection.current.segment = newParent;
+                if (!group.element.firstChild) {
+                    context.regularSelection.current.segment = newParent;
+                }
+
                 applyFormat(newParent, SegmentFormatHandlers, group.format, context);
             }
 

--- a/packages/roosterjs-content-model/test/domToModel/processors/containerProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/containerProcessorTest.ts
@@ -228,7 +228,6 @@ describe('containerProcessor', () => {
         });
     });
 
-    // Skip this test for now, we will reenable it once we are ready to write e2e test case of creating model from dom
     it('Process a DIV with mixed selection', () => {
         const div = document.createElement('div');
         div.innerHTML = '<span>test1</span>test2test3';

--- a/packages/roosterjs-editor-core/test/coreApi/selectTableTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/selectTableTest.ts
@@ -232,7 +232,7 @@ describe('selectTable |', () => {
             expect(document.getElementById('tableStylecontentDiv_0')).toBeNull();
         });
 
-        it('Null last cell x coordinate', () => {
+        xit('Null last cell x coordinate', () => {
             selectTable(core, table, <TableSelection>{
                 firstCell: { x: 0, y: 0 },
                 lastCell: { x: null, y: 1 },

--- a/packages/roosterjs-editor-core/test/coreApi/selectTableTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/selectTableTest.ts
@@ -232,7 +232,7 @@ describe('selectTable |', () => {
             expect(document.getElementById('tableStylecontentDiv_0')).toBeNull();
         });
 
-        xit('Null last cell x coordinate', () => {
+        it('Null last cell x coordinate', () => {
             selectTable(core, table, <TableSelection>{
                 firstCell: { x: 0, y: 0 },
                 lastCell: { x: null, y: 1 },

--- a/packages/roosterjs-editor-dom/lib/metadata/validate.ts
+++ b/packages/roosterjs-editor-dom/lib/metadata/validate.ts
@@ -11,6 +11,11 @@ export default function validate<T>(input: any, def: Definition<T>): input is T 
     let result = false;
     if ((def.isOptional && typeof input === 'undefined') || (def.allowNull && input === null)) {
         result = true;
+    } else if (
+        (!def.isOptional && typeof input === 'undefined') ||
+        (!def.allowNull && input === null)
+    ) {
+        return false;
     } else {
         switch (def.type) {
             case DefinitionType.String:

--- a/packages/roosterjs-editor-types/lib/enum/BulletListType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/BulletListType.ts
@@ -48,7 +48,12 @@ export const enum BulletListType {
     DoubleLongArrow = 8,
 
     /**
+     * Bullet type circle
+     */
+    Circle = 9,
+
+    /**
      * Maximum value of the enum
      */
-    Max = 8,
+    Max = 9,
 }


### PR DESCRIPTION
This is a preparation step of Content Model List

Improve demo site to allow content model view know that a format item value is changed by adding an onUpdate callback.

Also fix bugs:
- Handle selection in general segment: no need to set current segment for selection if the segment is a general one and it has child nodes, since the selection will be finally handled by its child nodes.
- Metadata validation need to properly handle null and undefined value
- Bullet list type need to support "Circle" type
