### PR TITLE
Fix content model ribbon button issue in demo site

### DIFF
--- a/demo/scripts/controls/MainPane.tsx
+++ b/demo/scripts/controls/MainPane.tsx
@@ -429,6 +429,7 @@ class MainPane extends MainPaneBase {
             ...this.toggleablePlugins,
             this.ribbonPlugin,
             this.contentModelRibbonPlugin,
+            this.contentModelPlugin.getInnerRibbonPlugin(),
             this.pasteOptionPlugin,
             this.emojiPlugin,
         ];

--- a/demo/scripts/controls/sidePane/contentModel/ContentModelPlugin.ts
+++ b/demo/scripts/controls/sidePane/contentModel/ContentModelPlugin.ts
@@ -41,6 +41,10 @@ export default class ContentModelPlugin extends SidePanePluginImpl<
         this.contentModelRibbon.onPluginEvent(e);
     }
 
+    getInnerRibbonPlugin() {
+        return this.contentModelRibbon;
+    }
+
     protected getComponentProps(baseProps: SidePaneElementProps): ContentModelPaneProps {
         return {
             ...baseProps,


### PR DESCRIPTION
Thanks @BryanValverdeU for finding the ribbon button not working issue. It is because the related plugin was not added into editor so after a strict mode fix, there is a check for uiUtilities which has never been set so the button is not working.

Fix it by adding the plugin into editor.