### PR TITLE
Comment Removal, remove style attribute instead of removing whole element

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/commentsRemoval.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/commentsRemoval.ts
@@ -39,10 +39,7 @@ export default function commentsRemoval(
     //      </span>
     chainSanitizerCallback(elementCallbacks, 'SPAN', element => {
         const styles = getStyles(element);
-        if (
-            styles[MSO_SPECIAL_CHARACTER] == MSO_SPECIAL_CHARACTER_COMMENT ||
-            !!styles[MSO_COMMENT_CONTINUATION]
-        ) {
+        if (styles[MSO_SPECIAL_CHARACTER] == MSO_SPECIAL_CHARACTER_COMMENT) {
             element.parentElement?.removeChild(element);
         }
         return true;
@@ -89,7 +86,10 @@ export default function commentsRemoval(
      * Remove styles related to Office Comments that can cause unwanted behaviors
      * depending on the user client
      */
-    chainSanitizerCallback(styleCallbacks, MSO_COMMENT_REFERENCE, () => false);
-    chainSanitizerCallback(styleCallbacks, MSO_COMMENT_DATE, () => false);
-    chainSanitizerCallback(styleCallbacks, MSO_COMMENT_PARENT, () => false);
+    [
+        MSO_COMMENT_REFERENCE,
+        MSO_COMMENT_DATE,
+        MSO_COMMENT_PARENT,
+        MSO_COMMENT_CONTINUATION,
+    ].forEach(style => chainSanitizerCallback(styleCallbacks, style, () => false));
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/commentsRemoval.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/commentsRemoval.ts
@@ -15,6 +15,7 @@ const MSO_SPECIAL_CHARACTER_COMMENT = 'comment';
 const MSO_COMMENT_CONTINUATION = 'mso-comment-continuation';
 const MSO_ELEMENT = 'mso-element';
 const MSO_ELEMENT_COMMENT_LIST = 'comment-list';
+const MSO_COMMENT_DONE = 'mso-comment-done';
 
 /**
  * @internal
@@ -91,5 +92,6 @@ export default function commentsRemoval(
         MSO_COMMENT_DATE,
         MSO_COMMENT_PARENT,
         MSO_COMMENT_CONTINUATION,
+        MSO_COMMENT_DONE,
     ].forEach(style => chainSanitizerCallback(styleCallbacks, style, () => false));
 }

--- a/packages/roosterjs-editor-plugins/test/paste/word/convertPastedContentFromWordTest.ts
+++ b/packages/roosterjs-editor-plugins/test/paste/word/convertPastedContentFromWordTest.ts
@@ -63,6 +63,11 @@ describe('convertPastedContentFromWord', () => {
         runTest(source, '<span></span>');
     });
 
+    it('Remove Comment | mso-comment-done, remove style', () => {
+        let source = '<span style="mso-comment-done:yes"></span>';
+        runTest(source, '<span></span>');
+    });
+
     it('Remove Comment | mso-special-character:comment', () => {
         let source = '<span><span style="mso-special-character:comment">&nbsp;</span></span>';
         runTest(source, '<span></span>');

--- a/packages/roosterjs-editor-plugins/test/paste/word/convertPastedContentFromWordTest.ts
+++ b/packages/roosterjs-editor-plugins/test/paste/word/convertPastedContentFromWordTest.ts
@@ -53,14 +53,14 @@ describe('convertPastedContentFromWord', () => {
         runTest(source, '<p><a></a><a></a></p>');
     });
 
-    it('Remove Comment | mso-comment-continuation', () => {
+    it('Remove Comment | mso-comment-continuation, remove style 1', () => {
         let source = '<span><span style="mso-comment-continuation:3"></span></span>';
-        runTest(source, '<span></span>');
+        runTest(source, '<span><span></span></span>');
     });
 
-    it('Remove Comment | mso-comment-continuation, no parent so no remove', () => {
+    it('Remove Comment | mso-comment-continuation, remove style 2', () => {
         let source = '<span style="mso-comment-continuation:3"></span>';
-        runTest(source, '<span style="mso-comment-continuation:3"></span>');
+        runTest(source, '<span></span>');
     });
 
     it('Remove Comment | mso-special-character:comment', () => {


### PR DESCRIPTION
Copied elements mso-comment-continuation, should not be removed as they contain text in some scenarios. Instead just remove the style property.