### PR TITLE
Content Model Table bug fixes

### DIFF
--- a/demo/scripts/controls/contentModel/components/format/formatPart/BorderBoxFormatRenderer.ts
+++ b/demo/scripts/controls/contentModel/components/format/formatPart/BorderBoxFormatRenderer.ts
@@ -1,0 +1,11 @@
+import { BorderBoxFormat } from 'roosterjs-content-model';
+import { createCheckboxFormatRenderer } from '../utils/createCheckboxFormatRenderer';
+import { FormatRenderer } from '../utils/FormatRenderer';
+
+export const BorderBoxFormatRenderer: FormatRenderer<BorderBoxFormat> = createCheckboxFormatRenderer<
+    BorderBoxFormat
+>(
+    'UseBorderBox',
+    format => format.useBorderBox,
+    (format, value) => (format.useBorderBox = value)
+);

--- a/demo/scripts/controls/contentModel/components/format/formatPart/BorderFormatRenderers.ts
+++ b/demo/scripts/controls/contentModel/components/format/formatPart/BorderFormatRenderers.ts
@@ -1,77 +1,68 @@
 import { BorderFormat, combineBorderValue, extractBorderValues } from 'roosterjs-content-model';
-import { createCheckboxFormatRenderer } from '../utils/createCheckboxFormatRenderer';
-import { createColorFormatRendererGroup } from '../utils/createColorFormatRender';
-import { createDropDownFormatRendererGroup } from '../utils/createDropDownFormatRenderer';
-import { createTextFormatRendererGroup } from '../utils/createTextFormatRenderer';
+import { createDropDownFormatRenderer } from '../utils/createDropDownFormatRenderer';
+import { createTextFormatRenderer } from '../utils/createTextFormatRenderer';
 import { FormatRenderer } from '../utils/FormatRenderer';
 
-type BorderStyle = 'dashed' | 'dotted' | 'double' | 'groove' | 'none' | 'outset' | 'solid';
-const BorderStyleValues: BorderStyle[] = [
-    'dashed',
+type BorderStyle =
+    | 'dashed'
+    | 'dotted'
+    | 'double'
+    | 'groove'
+    | 'none'
+    | 'outset'
+    | 'solid'
+    | 'hidden'
+    | 'ridge'
+    | 'inset';
+const BorderStyles: BorderStyle[] = [
+    'none',
+    'hidden',
     'dotted',
+    'dashed',
+    'solid',
     'double',
     'groove',
-    'none',
+    'ridge',
+    'inset',
     'outset',
-    'solid',
 ];
 
-type BorderWidthName = 'Width-top' | 'Width-right' | 'Width-Bottom' | 'Width-Left';
-type BorderStyleName = 'Style-top' | 'Style-right' | 'Style-Bottom' | 'Style-Left';
-type BorderColorName = 'Color-top' | 'Color-right' | 'Color-Bottom' | 'Color-Left';
-
-const BorderWidthNames: BorderWidthName[] = [
-    'Width-top',
-    'Width-right',
-    'Width-Bottom',
-    'Width-Left',
-];
-const BorderStyleNames: BorderStyleName[] = [
-    'Style-top',
-    'Style-right',
-    'Style-Bottom',
-    'Style-Left',
-];
-const BorderColorNames: BorderColorName[] = [
-    'Color-top',
-    'Color-right',
-    'Color-Bottom',
-    'Color-Left',
-];
+function createBorderRenderer(position: keyof BorderFormat): FormatRenderer<BorderFormat>[] {
+    return [
+        createTextFormatRenderer<BorderFormat>(
+            position + 'Width',
+            format => extractBorderValues(format[position]).width,
+            (format, newValue) => {
+                const border = extractBorderValues(format[position]);
+                border.width = newValue;
+                format[position] = combineBorderValue(border);
+            }
+        ),
+        createDropDownFormatRenderer<BorderFormat, BorderStyle>(
+            position + 'Style',
+            BorderStyles,
+            format => extractBorderValues(format[position]).style as BorderStyle,
+            (format, newValue) => {
+                const border = extractBorderValues(format[position]);
+                border.style = newValue;
+                format[position] = combineBorderValue(border);
+            }
+        ),
+        createTextFormatRenderer<BorderFormat>(
+            position + 'Color',
+            format => extractBorderValues(format[position]).color,
+            (format, newValue) => {
+                const border = extractBorderValues(format[position]);
+                border.color = newValue;
+                format[position] = combineBorderValue(border);
+            }
+        ),
+    ];
+}
 
 export const BorderFormatRenderers: FormatRenderer<BorderFormat>[] = [
-    createTextFormatRendererGroup<BorderFormat, BorderWidthName>(
-        BorderWidthNames,
-        format => extractBorderValues(format.borderWidth),
-        (format, name, value) => {
-            const values = extractBorderValues(format.borderWidth);
-            values[BorderWidthNames.indexOf(name)] = value;
-            format.borderWidth = combineBorderValue(values, '0');
-        }
-    ),
-    createDropDownFormatRendererGroup<BorderFormat, BorderStyle, BorderStyleName>(
-        BorderStyleNames,
-        BorderStyleValues,
-        format => extractBorderValues(format.borderStyle) as BorderStyle[],
-        (format, name, value) => {
-            const values = extractBorderValues(format.borderStyle);
-            values[BorderStyleNames.indexOf(name)] = value;
-            format.borderStyle = combineBorderValue(values, 'none');
-        }
-    ),
-    createColorFormatRendererGroup<BorderFormat, BorderColorName>(
-        BorderColorNames,
-        format => extractBorderValues(format.borderColor),
-        (format, name, value) => {
-            const values = extractBorderValues(format.borderColor);
-            values[BorderColorNames.indexOf(name)] = value;
-            format.borderColor = combineBorderValue(values, 'transparent');
-        }
-    ),
-
-    createCheckboxFormatRenderer<BorderFormat>(
-        'UseBorderBox',
-        format => format.useBorderBox,
-        (format, value) => (format.useBorderBox = value)
-    ),
+    ...createBorderRenderer('borderTop'),
+    ...createBorderRenderer('borderRight'),
+    ...createBorderRenderer('borderBottom'),
+    ...createBorderRenderer('borderLeft'),
 ];

--- a/demo/scripts/controls/contentModel/components/format/formatPart/MarginFormatRenderer.ts
+++ b/demo/scripts/controls/contentModel/components/format/formatPart/MarginFormatRenderer.ts
@@ -1,19 +1,17 @@
-import { combineBorderValue, extractBorderValues, MarginFormat } from 'roosterjs-content-model';
 import { createTextFormatRendererGroup } from '../utils/createTextFormatRenderer';
 import { FormatRenderer } from '../utils/FormatRenderer';
+import { MarginFormat } from 'roosterjs-content-model';
 
-type MarginName = 'Margin-top' | 'Margin-right' | 'Margin-bottom' | 'Margin-left';
-const MarginNames: MarginName[] = ['Margin-top', 'Margin-right', 'Margin-bottom', 'Margin-left'];
+type MarginName = keyof MarginFormat;
+const MarginNames: MarginName[] = ['marginTop', 'marginRight', 'marginBottom', 'marginLeft'];
 
 export const MarginFormatRenderer: FormatRenderer<MarginFormat> = createTextFormatRendererGroup<
     MarginFormat,
     MarginName
 >(
     MarginNames,
-    format => extractBorderValues(format.margin),
+    format => MarginNames.map(name => format[name]),
     (format, name, value) => {
-        const values = extractBorderValues(format.margin);
-        values[MarginNames.indexOf(name)] = value;
-        format.margin = combineBorderValue(values, '0');
+        format[name] = value;
     }
 );

--- a/demo/scripts/controls/contentModel/components/format/formatPart/PaddingFormatRenderer.ts
+++ b/demo/scripts/controls/contentModel/components/format/formatPart/PaddingFormatRenderer.ts
@@ -1,0 +1,17 @@
+import { createTextFormatRendererGroup } from '../utils/createTextFormatRenderer';
+import { FormatRenderer } from '../utils/FormatRenderer';
+import { PaddingFormat } from 'roosterjs-content-model';
+
+type PaddingName = keyof PaddingFormat;
+const PaddingNames: PaddingName[] = ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'];
+
+export const PaddingFormatRenderer: FormatRenderer<PaddingFormat> = createTextFormatRendererGroup<
+    PaddingFormat,
+    PaddingName
+>(
+    PaddingNames,
+    format => PaddingNames.map(name => format[name]),
+    (format, name, value) => {
+        format[name] = value;
+    }
+);

--- a/demo/scripts/controls/contentModel/components/model/ContentModelTableCellView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelTableCellView.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { BackgroundColorFormatRenderer } from '../format/formatPart/BackgroundColorFormatRenderer';
 import { BlockGroupContentView } from './BlockGroupContentView';
+import { BorderBoxFormatRenderer } from '../format/formatPart/BorderBoxFormatRenderer';
 import { BorderFormatRenderers } from '../format/formatPart/BorderFormatRenderers';
 import { ContentModelView } from '../ContentModelView';
 import { FormatRenderer } from '../format/utils/FormatRenderer';
 import { FormatView } from '../format/FormatView';
+import { PaddingFormatRenderer } from '../format/formatPart/PaddingFormatRenderer';
 import { TableCellMetadataFormatRender } from '../format/formatPart/TableCellMetadataFormatRender';
 import { TextAlignFormatRenderer } from '../format/formatPart/TextAlignFormatRenderer';
 import { useProperty } from '../../hooks/useProperty';
@@ -19,7 +21,9 @@ const styles = require('./ContentModelTableCellView.scss');
 
 const TableCellFormatRenderers: FormatRenderer<ContentModelTableCellFormat>[] = [
     ...BorderFormatRenderers,
+    BorderBoxFormatRenderer,
     BackgroundColorFormatRenderer,
+    PaddingFormatRenderer,
     TextAlignFormatRenderer,
     VerticalAlignFormatRenderer,
     TableCellMetadataFormatRender,

--- a/demo/scripts/controls/contentModel/components/model/ContentModelTableView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelTableView.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { applyTableFormat } from 'roosterjs-content-model/lib/modelApi/table/applyTableFormat';
 import { BackgroundColorFormatRenderer } from '../format/formatPart/BackgroundColorFormatRenderer';
+import { BorderBoxFormatRenderer } from '../format/formatPart/BorderBoxFormatRenderer';
 import { BorderFormatRenderers } from '../format/formatPart/BorderFormatRenderers';
 import { ContentModelBlockGroupView } from './ContentModelBlockGroupView';
 import { ContentModelView } from '../ContentModelView';
@@ -25,6 +26,7 @@ const TableFormatRenderers: FormatRenderer<ContentModelTableFormat>[] = [
     BackgroundColorFormatRenderer,
     MarginFormatRenderer,
     ...BorderFormatRenderers,
+    BorderBoxFormatRenderer,
     ...TableMetadataFormatRenders,
 ];
 

--- a/demo/scripts/controls/editor/ExperimentalContentModelEditor.ts
+++ b/demo/scripts/controls/editor/ExperimentalContentModelEditor.ts
@@ -52,6 +52,7 @@ export default class ExperimentalContentModelEditor extends Editor
         return domToContentModel(startNode || this.contentDiv, this.createEditorContext(), {
             includeRoot: !!startNode,
             selectionRange: this.getSelectionRangeEx(),
+            alwaysNormalizeTable: true,
             ...(option || {}),
         });
     }

--- a/packages/roosterjs-content-model/lib/domToModel/context/createDomToModelContext.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/context/createDomToModelContext.ts
@@ -42,6 +42,10 @@ export function createDomToModelContext(
         formatParsers: getFormatParsers(options?.formatParserOverride),
     };
 
+    if (options?.alwaysNormalizeTable) {
+        context.alwaysNormalizeTable = true;
+    }
+
     const range = options?.selectionRange;
 
     switch (range?.type) {

--- a/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
@@ -3,6 +3,7 @@ import { containerProcessor } from './containerProcessor';
 import { createTable } from '../../modelApi/creators/createTable';
 import { createTableCell } from '../../modelApi/creators/createTableCell';
 import { ElementProcessor } from '../../publicTypes/context/ElementProcessor';
+import { normalizeTable } from '../../modelApi/table/normalizeTable';
 import { parseFormat } from '../utils/parseFormat';
 import { SegmentFormatHandlers } from '../../formatHandlers/SegmentFormatHandlers';
 import { stackFormat } from '../utils/stackFormat';
@@ -109,6 +110,10 @@ export const tableProcessor: ElementProcessor = (group, element, context) => {
 
         table.widths = calcSizes(columnPositions);
         table.heights = calcSizes(rowPositions);
+
+        if (context.alwaysNormalizeTable) {
+            normalizeTable(table);
+        }
     });
 };
 

--- a/packages/roosterjs-content-model/lib/domUtils/borderValues.ts
+++ b/packages/roosterjs-content-model/lib/domUtils/borderValues.ts
@@ -1,40 +1,58 @@
-// Match a word or word with "(...)" that may have space inside
-// e.g.
-//   test
-//   test(1, 2, 3)
-const BorderValuesRegex = /(\w*\([^\)]*\)\w*|[^\s]+)/g;
-
 /**
- * Index of border values
+ * A combination of CSS border value.
+ * See https://developer.mozilla.org/en-US/docs/Web/CSS/border for more information
  */
-export const BorderIndex = {
-    Top: 0,
-    Right: 1,
-    Bottom: 2,
-    Left: 3,
-};
+export interface Border {
+    /**
+     * Width of the border
+     */
+    width?: string;
+
+    /**
+     * Style of the border
+     */
+    style?: string;
+
+    /**
+     * Color of the border
+     */
+    color?: string;
+}
+
+const BorderStyles = [
+    'none',
+    'hidden',
+    'dotted',
+    'dashed',
+    'solid',
+    'double',
+    'groove',
+    'ridge',
+    'inset',
+    'outset',
+];
+const BorderSizeRegex = /^(thin|medium|thick|[\d\.]+\w*)$/;
 
 /**
- * Extract an integrated border string (something like 'top right bottom left') to value array
+ * Extract an integrated border string with border width, style, color to value tuple
  * @param combinedBorder The integrated border style string
  * @returns An array with the splitted values
  */
-export function extractBorderValues(combinedBorder?: string): string[] {
-    combinedBorder = combinedBorder || '';
-    let match = BorderValuesRegex.exec(combinedBorder);
-    const result: string[] = [];
+export function extractBorderValues(combinedBorder?: string): Border {
+    const result: Border = {};
+    const values = (combinedBorder || '').replace(/, /g, ',').split(' ');
 
-    while (match) {
-        result.push(match[0]);
-        match = BorderValuesRegex.exec(combinedBorder);
-    }
+    values.forEach(v => {
+        if (BorderStyles.indexOf(v) >= 0 && !result.style) {
+            result.style = v;
+        } else if (BorderSizeRegex.test(v) && !result.width) {
+            result.width = v;
+        } else if (v && !result.color) {
+            result.color = v; // TODO: Do we need to use a regex to match all possible colors?
+        }
+    });
 
-    result[0] = result[0] || '';
-    result[1] = result[1] || result[0];
-    result[2] = result[2] || result[0];
-    result[3] = result[3] || result[1];
-
-    return result.slice(0, 4);
+    return result;
 }
 
 /**
@@ -42,9 +60,6 @@ export function extractBorderValues(combinedBorder?: string): string[] {
  * @param values Input string values
  * @param initialValue Initial value for those items without valid value
  */
-export function combineBorderValue(values: string[], initialValue: string): string {
-    return values
-        .slice(0, 4)
-        .map(v => v || initialValue)
-        .join(' ');
+export function combineBorderValue(value: Border): string {
+    return [value.width || '', value.style || '', value.color || ''].join(' ').trim() || 'none';
 }

--- a/packages/roosterjs-content-model/lib/formatHandlers/TableCellFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/TableCellFormatHandler.ts
@@ -5,7 +5,9 @@ import { FormatKey } from '../publicTypes/format/FormatHandlerTypeMap';
  */
 export const TableCellFormatHandlers: FormatKey[] = [
     'border',
+    'borderBox',
     'backgroundColor',
+    'padding',
     'textAlign',
     'verticalAlign',
     'tableCellMetadata',

--- a/packages/roosterjs-content-model/lib/formatHandlers/TableFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/TableFormatHandlers.ts
@@ -6,6 +6,7 @@ import { FormatKey } from '../publicTypes/format/FormatHandlerTypeMap';
 export const TableFormatHandlers: FormatKey[] = [
     'id',
     'border',
+    'borderBox',
     'tableMetadata',
     'tableSpacing',
     'margin',

--- a/packages/roosterjs-content-model/lib/formatHandlers/common/borderBoxFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/common/borderBoxFormatHandler.ts
@@ -1,0 +1,18 @@
+import { BorderBoxFormat } from '../../publicTypes/format/formatParts/BorderBoxFormat';
+import { FormatHandler } from '../FormatHandler';
+
+/**
+ * @internal
+ */
+export const borderBoxFormatHandler: FormatHandler<BorderBoxFormat> = {
+    parse: (format, element) => {
+        if (element.style?.boxSizing == 'border-box') {
+            format.useBorderBox = true;
+        }
+    },
+    apply: (format, element) => {
+        if (format.useBorderBox) {
+            element.style.boxSizing = 'border-box';
+        }
+    },
+};

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -1,5 +1,6 @@
 import { backgroundColorFormatHandler } from './common/backgroundColorFormatHandler';
 import { boldFormatHandler } from './segment/boldFormatHandler';
+import { borderBoxFormatHandler } from './common/borderBoxFormatHandler';
 import { borderFormatHandler } from './common/borderFormatHandler';
 import { fontFamilyFormatHandler } from './segment/fontFamilyFormatHandler';
 import { fontSizeFormatHandler } from './segment/fontSizeFormatHandler';
@@ -16,6 +17,7 @@ import { listLevelMetadataFormatHandler } from './list/listLevelMetadataFormatHa
 import { listLevelThreadFormatHandler } from './list/listLevelThreadFormatHandler';
 import { listTypeFormatHandler } from './list/listTypeFormatHandler';
 import { marginFormatHandler } from './paragraph/marginFormatHandler';
+import { paddingFormatHandler } from './paragraph/paddingFormatHandler';
 import { strikeFormatHandler } from './segment/strikeFormatHandler';
 import { superOrSubScriptFormatHandler } from './segment/superOrSubScriptFormatHandler';
 import { tableCellMetadataFormatHandler } from './table/tableCellMetadataFormatHandler';
@@ -34,6 +36,7 @@ const defaultFormatHandlerMap: FormatHandlers = {
     backgroundColor: backgroundColorFormatHandler,
     bold: boldFormatHandler,
     border: borderFormatHandler,
+    borderBox: borderBoxFormatHandler,
     fontFamily: fontFamilyFormatHandler,
     fontSize: fontSizeFormatHandler,
     id: idFormatHandler,
@@ -44,6 +47,7 @@ const defaultFormatHandlerMap: FormatHandlers = {
     listLevelThread: listLevelThreadFormatHandler,
     listType: listTypeFormatHandler,
     margin: marginFormatHandler,
+    padding: paddingFormatHandler,
     strike: strikeFormatHandler,
     superOrSubScript: superOrSubScriptFormatHandler,
     tableCellMetadata: tableCellMetadataFormatHandler,

--- a/packages/roosterjs-content-model/lib/formatHandlers/paragraph/marginFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/paragraph/marginFormatHandler.ts
@@ -1,20 +1,33 @@
 import { FormatHandler } from '../FormatHandler';
 import { MarginFormat } from '../../publicTypes/format/formatParts/MarginFormat';
 
+const MarginKeys: (keyof MarginFormat & keyof CSSStyleDeclaration)[] = [
+    'marginTop',
+    'marginRight',
+    'marginBottom',
+    'marginLeft',
+];
+
 /**
  * @internal
  */
 export const marginFormatHandler: FormatHandler<MarginFormat> = {
     parse: (format, element) => {
-        const margin = element.style.margin;
+        MarginKeys.forEach(key => {
+            const value = element.style[key];
 
-        if (margin) {
-            format.margin = element.style.margin;
-        }
+            if (value) {
+                format[key] = value;
+            }
+        });
     },
     apply: (format, element) => {
-        if (format.margin) {
-            element.style.margin = format.margin;
-        }
+        MarginKeys.forEach(key => {
+            const value = format[key];
+
+            if (value) {
+                element.style[key] = value;
+            }
+        });
     },
 };

--- a/packages/roosterjs-content-model/lib/formatHandlers/paragraph/paddingFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/paragraph/paddingFormatHandler.ts
@@ -1,22 +1,19 @@
-import { BorderFormat } from '../../publicTypes/format/formatParts/BorderFormat';
 import { FormatHandler } from '../FormatHandler';
+import { PaddingFormat } from '../../publicTypes/format/formatParts/PaddingFormat';
 
-/**
- * @internal
- */
-export const BorderKeys: (keyof BorderFormat & keyof CSSStyleDeclaration)[] = [
-    'borderTop',
-    'borderRight',
-    'borderBottom',
-    'borderLeft',
+const PaddingKeys: (keyof PaddingFormat & keyof CSSStyleDeclaration)[] = [
+    'paddingTop',
+    'paddingRight',
+    'paddingBottom',
+    'paddingLeft',
 ];
 
 /**
  * @internal
  */
-export const borderFormatHandler: FormatHandler<BorderFormat> = {
+export const paddingFormatHandler: FormatHandler<PaddingFormat> = {
     parse: (format, element) => {
-        BorderKeys.forEach(key => {
+        PaddingKeys.forEach(key => {
             const value = element.style[key];
 
             if (value) {
@@ -25,9 +22,8 @@ export const borderFormatHandler: FormatHandler<BorderFormat> = {
         });
     },
     apply: (format, element) => {
-        BorderKeys.forEach(key => {
+        PaddingKeys.forEach(key => {
             const value = format[key];
-
             if (value) {
                 element.style[key] = value;
             }

--- a/packages/roosterjs-content-model/lib/index.ts
+++ b/packages/roosterjs-content-model/lib/index.ts
@@ -8,7 +8,7 @@ export { default as hasSelectionInBlock } from './publicApi/selection/hasSelecti
 export { default as hasSelectionInSegment } from './publicApi/selection/hasSelectionInSegment';
 export { default as hasSelectionInBlockGroup } from './publicApi/selection/hasSelectionInBlockGroup';
 
-export { extractBorderValues, combineBorderValue, BorderIndex } from './domUtils/borderValues';
+export { combineBorderValue, extractBorderValues } from './domUtils/borderValues';
 
 export { ContentModelBlockGroupType } from './publicTypes/enum/BlockGroupType';
 export { ContentModelBlockType } from './publicTypes/enum/BlockType';
@@ -43,6 +43,7 @@ export { TextAlignFormat } from './publicTypes/format/formatParts/TextAlignForma
 export { VerticalAlignFormat } from './publicTypes/format/formatParts/VerticalAlignFormat';
 export { BackgroundColorFormat } from './publicTypes/format/formatParts/BackgroundColorFormat';
 export { BorderFormat } from './publicTypes/format/formatParts/BorderFormat';
+export { BorderBoxFormat } from './publicTypes/format/formatParts/BorderBoxFormat';
 export { IdFormat } from './publicTypes/format/formatParts/IdFormat';
 export { SizeFormat } from './publicTypes/format/formatParts/SizeFormat';
 export { SpacingFormat } from './publicTypes/format/formatParts/SpacingFormat';
@@ -57,6 +58,7 @@ export { SuperOrSubScriptFormat } from './publicTypes/format/formatParts/SuperOr
 export { TableMetadataFormat } from './publicTypes/format/formatParts/TableMetadataFormat';
 export { ContentModelFormatBase } from './publicTypes/format/ContentModelFormatBase';
 export { MarginFormat } from './publicTypes/format/formatParts/MarginFormat';
+export { PaddingFormat } from './publicTypes/format/formatParts/PaddingFormat';
 export { ListTypeFormat } from './publicTypes/format/formatParts/ListTypeFormat';
 export { ListThreadFormat } from './publicTypes/format/formatParts/ListThreadFormat';
 export { ListMetadataFormat } from './publicTypes/format/formatParts/ListMetadataFormat';

--- a/packages/roosterjs-content-model/lib/modelApi/table/alignTable.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/alignTable.ts
@@ -1,4 +1,3 @@
-import { BorderIndex, combineBorderValue, extractBorderValues } from '../../domUtils/borderValues';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { TableOperation } from 'roosterjs-editor-types';
 import type { CompatibleTableOperation } from 'roosterjs-editor-types/lib/compatibleTypes';
@@ -16,10 +15,6 @@ export function alignTable(
         | CompatibleTableOperation.AlignLeft
         | CompatibleTableOperation.AlignRight
 ) {
-    const values = extractBorderValues(table.format.margin || '');
-
-    values[BorderIndex.Left] = operation == TableOperation.AlignLeft ? '' : 'auto';
-    values[BorderIndex.Right] = operation == TableOperation.AlignRight ? '' : 'auto';
-
-    table.format.margin = combineBorderValue(values, '0');
+    table.format.marginLeft = operation == TableOperation.AlignLeft ? '' : 'auto';
+    table.format.marginRight = operation == TableOperation.AlignRight ? '' : 'auto';
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/IExperimentalContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/IExperimentalContentModelEditor.ts
@@ -33,6 +33,13 @@ export interface DomToModelOption {
      * Overrides default format handlers
      */
     formatParserOverride?: Partial<FormatParsers>;
+
+    /**
+     * When process table, whether we should always normalize it.
+     * This can help persist the size of table that is not created from Content Model
+     * @default false
+     */
+    alwaysNormalizeTable?: boolean;
 }
 
 /**

--- a/packages/roosterjs-content-model/lib/publicTypes/context/DomToModelFormatContext.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/DomToModelFormatContext.ts
@@ -35,4 +35,11 @@ export interface DomToModelFormatContext {
      * Context of list that is currently processing
      */
     listFormat: DomToModelListFormat;
+
+    /**
+     * When process table, whether we should always normalize it.
+     * This can help persist the size of table that is not created from Content Model
+     * @default false
+     */
+    alwaysNormalizeTable?: boolean;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatBase.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatBase.ts
@@ -3,6 +3,13 @@
  * All content model format should only have simple value type (string, number, boolean).
  * So that we can use a single level copy ({...object}) to easily clone a format object
  */
-export type ContentModelFormatBase = {
-    [key: string]: string | number | boolean | undefined | null;
+export type ContentModelFormatBase<
+    V extends string | number | boolean | undefined | null =
+        | string
+        | number
+        | boolean
+        | undefined
+        | null
+> = {
+    [key: string]: V;
 };

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelTableCellFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelTableCellFormat.ts
@@ -1,5 +1,7 @@
 import { BackgroundColorFormat } from './formatParts/BackgroundColorFormat';
+import { BorderBoxFormat } from './formatParts/BorderBoxFormat';
 import { BorderFormat } from './formatParts/BorderFormat';
+import { PaddingFormat } from './formatParts/PaddingFormat';
 import { TableCellMetadataFormat } from 'roosterjs-editor-types';
 import { TextAlignFormat } from './formatParts/TextAlignFormat';
 import { VerticalAlignFormat } from './formatParts/VerticalAlignFormat';
@@ -8,7 +10,9 @@ import { VerticalAlignFormat } from './formatParts/VerticalAlignFormat';
  * Format of table cell
  */
 export type ContentModelTableCellFormat = BorderFormat &
+    BorderBoxFormat &
     BackgroundColorFormat &
+    PaddingFormat &
     TextAlignFormat &
     VerticalAlignFormat &
     TableCellMetadataFormat;

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelTableFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelTableFormat.ts
@@ -1,4 +1,5 @@
 import { BackgroundColorFormat } from './formatParts/BackgroundColorFormat';
+import { BorderBoxFormat } from './formatParts/BorderBoxFormat';
 import { BorderFormat } from './formatParts/BorderFormat';
 import { IdFormat } from './formatParts/IdFormat';
 import { MarginFormat } from './formatParts/MarginFormat';
@@ -10,6 +11,7 @@ import { TableMetadataFormat } from './formatParts/TableMetadataFormat';
  */
 export type ContentModelTableFormat = IdFormat &
     BorderFormat &
+    BorderBoxFormat &
     SpacingFormat &
     BackgroundColorFormat &
     MarginFormat &

--- a/packages/roosterjs-content-model/lib/publicTypes/format/FormatHandlerTypeMap.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/FormatHandlerTypeMap.ts
@@ -1,5 +1,6 @@
 import { BackgroundColorFormat } from './formatParts/BackgroundColorFormat';
 import { BoldFormat } from './formatParts/BoldFormat';
+import { BorderBoxFormat } from './formatParts/BorderBoxFormat';
 import { BorderFormat } from './formatParts/BorderFormat';
 import { FontFamilyFormat } from './formatParts/FontFamilyFormat';
 import { FontSizeFormat } from './formatParts/FontSizeFormat';
@@ -9,6 +10,7 @@ import { ListMetadataFormat } from './formatParts/ListMetadataFormat';
 import { ListThreadFormat } from './formatParts/ListThreadFormat';
 import { ListTypeFormat } from './formatParts/ListTypeFormat';
 import { MarginFormat } from './formatParts/MarginFormat';
+import { PaddingFormat } from './formatParts/PaddingFormat';
 import { SpacingFormat } from './formatParts/SpacingFormat';
 import { StrikeFormat } from './formatParts/StrikeFormat';
 import { SuperOrSubScriptFormat } from './formatParts/SuperOrSubScriptFormat';
@@ -37,6 +39,11 @@ export interface FormatHandlerTypeMap {
      * Format for BorderFormat
      */
     border: BorderFormat;
+
+    /**
+     * Format for BorderBoxFormat
+     */
+    borderBox: BorderBoxFormat;
 
     /**
      * Format for FontFamilyFormat
@@ -87,6 +94,11 @@ export interface FormatHandlerTypeMap {
      * Format for MarginFormat
      */
     margin: MarginFormat;
+
+    /**
+     * Format for PaddingFormat
+     */
+    padding: PaddingFormat;
 
     /**
      * Format for StrikeFormat

--- a/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/BorderBoxFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/BorderBoxFormat.ts
@@ -1,0 +1,9 @@
+/**
+ * Format of border box
+ */
+export type BorderBoxFormat = {
+    /**
+     * Whether use border-box for this element
+     */
+    useBorderBox?: boolean;
+};

--- a/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/BorderFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/BorderFormat.ts
@@ -3,22 +3,22 @@
  */
 export type BorderFormat = {
     /**
-     * Border width in order: "top right bottom left"
+     * Top border in format 'width style color'
      */
-    borderWidth?: string;
+    borderTop?: string;
 
     /**
-     * Border style in order: "top right bottom left"
+     * Right border in format 'width style color'
      */
-    borderStyle?: string;
+    borderRight?: string;
 
     /**
-     * Border color in order: "top right bottom left"
+     * Bottom border in format 'width style color'
      */
-    borderColor?: string;
+    borderBottom?: string;
 
     /**
-     * Whether use border-box for this element
+     * Left border in format 'width style color'
      */
-    useBorderBox?: boolean;
+    borderLeft?: string;
 };

--- a/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/MarginFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/MarginFormat.ts
@@ -3,7 +3,22 @@
  */
 export type MarginFormat = {
     /**
-     * Margin value in order of "top right bottom left"
+     * Margin top value
      */
-    margin?: string;
+    marginTop?: string;
+
+    /**
+     * Margin right value
+     */
+    marginRight?: string;
+
+    /**
+     * Margin bottom value
+     */
+    marginBottom?: string;
+
+    /**
+     * Margin left value
+     */
+    marginLeft?: string;
 };

--- a/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/PaddingFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/PaddingFormat.ts
@@ -1,0 +1,24 @@
+/**
+ * Format of padding
+ */
+export type PaddingFormat = {
+    /**
+     * Padding top value
+     */
+    paddingTop?: string;
+
+    /**
+     * Padding right value
+     */
+    paddingRight?: string;
+
+    /**
+     * Padding bottom value
+     */
+    paddingBottom?: string;
+
+    /**
+     * Padding left value
+     */
+    paddingLeft?: string;
+};

--- a/packages/roosterjs-content-model/test/domUtils/borderValuesTest.ts
+++ b/packages/roosterjs-content-model/test/domUtils/borderValuesTest.ts
@@ -2,81 +2,86 @@ import { combineBorderValue, extractBorderValues } from '../../lib/domUtils/bord
 
 describe('extractBorderValues', () => {
     it('undefined string', () => {
-        expect(extractBorderValues(undefined)).toEqual(['', '', '', '']);
+        expect(extractBorderValues(undefined)).toEqual({});
     });
 
     it('empty string', () => {
-        expect(extractBorderValues('')).toEqual(['', '', '', '']);
+        expect(extractBorderValues('')).toEqual({});
     });
 
     it('Single value', () => {
-        expect(extractBorderValues('test1')).toEqual(['test1', 'test1', 'test1', 'test1']);
+        expect(extractBorderValues('test1')).toEqual({
+            color: 'test1',
+        });
     });
 
     it('Two values', () => {
-        expect(extractBorderValues('test1 test2')).toEqual(['test1', 'test2', 'test1', 'test2']);
+        expect(extractBorderValues('test1 test2')).toEqual({
+            color: 'test1',
+        });
     });
 
-    it('Three values', () => {
-        expect(extractBorderValues('test1 test2 test3')).toEqual([
-            'test1',
-            'test2',
-            'test3',
-            'test2',
-        ]);
+    it('value with rgb color', () => {
+        expect(extractBorderValues('rgb(1, 2, 3)')).toEqual({
+            color: 'rgb(1,2,3)',
+        });
     });
 
-    it('Four values', () => {
-        expect(extractBorderValues('test1 test2 test3 test4')).toEqual([
-            'test1',
-            'test2',
-            'test3',
-            'test4',
-        ]);
+    it('value with style', () => {
+        expect(extractBorderValues('none')).toEqual({
+            style: 'none',
+        });
     });
 
-    it('Five values', () => {
-        expect(extractBorderValues('test1 test2 test3 test4 test5')).toEqual([
-            'test1',
-            'test2',
-            'test3',
-            'test4',
-        ]);
+    it('value with width 1', () => {
+        expect(extractBorderValues('thin')).toEqual({
+            width: 'thin',
+        });
     });
 
-    it('value with ()', () => {
-        expect(extractBorderValues('test1 ( ) test2 (test 3)')).toEqual([
-            'test1',
-            '( )',
-            'test2',
-            '(test 3)',
-        ]);
+    it('value with width 2', () => {
+        expect(extractBorderValues('2px')).toEqual({
+            width: '2px',
+        });
     });
 
-    it('value rgb', () => {
-        expect(extractBorderValues('rgb(1, 2, 3) transparent')).toEqual([
-            'rgb(1, 2, 3)',
-            'transparent',
-            'rgb(1, 2, 3)',
-            'transparent',
-        ]);
+    it('full value 1', () => {
+        expect(extractBorderValues('red 2px solid')).toEqual({
+            color: 'red',
+            width: '2px',
+            style: 'solid',
+        });
+    });
+
+    it('full value 2', () => {
+        expect(extractBorderValues('rgb(1, 2, 3) thick solid')).toEqual({
+            color: 'rgb(1,2,3)',
+            width: 'thick',
+            style: 'solid',
+        });
     });
 });
 
 describe('combineBorderValue', () => {
     it('empty array', () => {
-        expect(combineBorderValue([], 'default')).toEqual('');
+        expect(combineBorderValue({})).toEqual('none');
     });
 
     it('array with partial values', () => {
-        expect(combineBorderValue(['a', undefined!, 'b'], 'default')).toEqual('a default b');
+        expect(
+            combineBorderValue({
+                color: 'red',
+            })
+        ).toEqual('red');
     });
 
     it('array with full values', () => {
-        expect(combineBorderValue(['a', 'b', 'c', 'd'], 'default')).toEqual('a b c d');
-    });
-
-    it('array with extract values', () => {
-        expect(combineBorderValue(['a', 'b', 'c', 'd', 'e'], 'default')).toEqual('a b c d');
+        expect(
+            combineBorderValue({
+                color: 'rgb(1,2,3)',
+                style: 'solid',
+                width: 'thick',
+            })
+        ).toEqual('thick solid rgb(1,2,3)');
     });
 });

--- a/packages/roosterjs-content-model/test/formatHandlers/common/borderBoxFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/common/borderBoxFormatHandlerTest.ts
@@ -1,0 +1,48 @@
+import { BorderBoxFormat } from '../../../lib/publicTypes/format/formatParts/BorderBoxFormat';
+import { borderBoxFormatHandler } from '../../../lib/formatHandlers/common/borderBoxFormatHandler';
+import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
+import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { DomToModelContext } from '../../../lib/publicTypes/context/DomToModelContext';
+import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
+
+describe('borderBoxFormat.parse', () => {
+    let format: BorderBoxFormat;
+    let context: DomToModelContext;
+
+    beforeEach(() => {
+        format = {};
+        context = createDomToModelContext();
+    });
+
+    it('UseBorderBox', () => {
+        const fake = ({
+            getBoundingClientRect: () => ({
+                width: 0,
+                height: 0,
+            }),
+            style: {
+                boxSizing: 'border-box',
+            },
+        } as any) as HTMLElement;
+        borderBoxFormatHandler.parse(format, fake, context, {});
+        expect(format).toEqual({ useBorderBox: true });
+    });
+});
+
+describe('borderBoxFormatHandler.apply', () => {
+    let div: HTMLElement;
+    let format: BorderBoxFormat;
+    let context: ModelToDomContext;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+        format = {};
+        context = createModelToDomContext();
+    });
+
+    it('UseBorderBox', () => {
+        format.useBorderBox = true;
+        borderBoxFormatHandler.apply(format, div, context);
+        expect(div.outerHTML).toBe('<div style="box-sizing: border-box;"></div>');
+    });
+});

--- a/packages/roosterjs-content-model/test/formatHandlers/common/borderFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/common/borderFormatHandlerTest.ts
@@ -22,80 +22,34 @@ describe('borderFormatHandler.parse', () => {
         expect(format).toEqual({});
     });
 
-    it('Has border color', () => {
+    it('Has border values', () => {
         div.style.borderColor = 'red';
-
-        borderFormatHandler.parse(format, div, context, {});
-
-        expect(format).toEqual({
-            borderColor: 'red',
-        });
-    });
-
-    it('Has border width', () => {
+        div.style.borderStyle = 'solid';
         div.style.borderWidth = '1px';
 
         borderFormatHandler.parse(format, div, context, {});
 
         expect(format).toEqual({
-            borderWidth: '1px',
+            borderTop: '1px solid red',
+            borderRight: '1px solid red',
+            borderBottom: '1px solid red',
+            borderLeft: '1px solid red',
         });
     });
 
-    it('Has border style', () => {
+    it('Has border width with different values', () => {
+        div.style.borderWidth = '1px 2px 3px 4px';
         div.style.borderStyle = 'solid';
+        div.style.borderColor = 'red';
 
         borderFormatHandler.parse(format, div, context, {});
 
         expect(format).toEqual({
-            borderStyle: 'solid',
+            borderTop: '1px solid red',
+            borderRight: '2px solid red',
+            borderBottom: '3px solid red',
+            borderLeft: '4px solid red',
         });
-    });
-
-    it('Has border width with different values', () => {
-        div.style.borderWidth = '1px 2px 3px 4px';
-
-        borderFormatHandler.parse(format, div, context, {});
-
-        expect(format).toEqual({
-            borderWidth: '1px 2px 3px 4px',
-        });
-    });
-
-    it('Has border width with different values', () => {
-        div.style.borderWidth = '1px 2px 3px 4px';
-
-        borderFormatHandler.parse(format, div, context, {});
-
-        expect(format).toEqual({
-            borderWidth: '1px 2px 3px 4px',
-        });
-    });
-
-    it('Has every thing', () => {
-        div.style.border = 'solid 1px black';
-
-        borderFormatHandler.parse(format, div, context, {});
-
-        expect(format).toEqual({
-            borderWidth: '1px',
-            borderColor: 'black',
-            borderStyle: 'solid',
-        });
-    });
-
-    it('UseBorderBox', () => {
-        const fake = ({
-            getBoundingClientRect: () => ({
-                width: 0,
-                height: 0,
-            }),
-            style: {
-                boxSizing: 'border-box',
-            },
-        } as any) as HTMLElement;
-        borderFormatHandler.parse(format, fake, context, {});
-        expect(format).toEqual({ useBorderBox: true });
     });
 });
 
@@ -116,141 +70,19 @@ describe('borderFormatHandler.apply', () => {
         expect(div.outerHTML).toEqual('<div></div>');
     });
 
-    it('Has border color - empty array', () => {
-        format.borderColor = '';
+    it('Has top border', () => {
+        format.borderTop = '1px solid red';
 
         borderFormatHandler.apply(format, div, context);
 
-        expect(div.outerHTML).toEqual('<div></div>');
+        expect(div.outerHTML).toEqual('<div style="border-top: 1px solid red;"></div>');
     });
 
     it('Has border color - empty values', () => {
-        format.borderColor = '';
+        format.borderTop = 'red';
 
         borderFormatHandler.apply(format, div, context);
 
-        expect(div.outerHTML).toEqual('<div></div>');
-    });
-
-    it('Has border color - with initial, transparent and inherit values', () => {
-        format.borderColor = 'inherit initial';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div></div>');
-    });
-
-    it('Has border color - one value', () => {
-        format.borderColor = 'red';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-color: red;"></div>');
-    });
-
-    it('Has border color - two values', () => {
-        format.borderColor = 'red green';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-color: red green;"></div>');
-    });
-
-    it('Has border color - three values', () => {
-        format.borderColor = 'red green blue';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-color: red green blue;"></div>');
-    });
-
-    it('Has border color - four values - same value', () => {
-        format.borderColor = 'red red red red';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-color: red;"></div>');
-    });
-
-    it('Has border color - four values - different values 1', () => {
-        format.borderColor = 'red red red green';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-color: red red red green;"></div>');
-    });
-
-    it('Has border color - four values - different values 2', () => {
-        format.borderColor = 'red red green green';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-color: red red green green;"></div>');
-    });
-
-    it('Has border color - four values - different values 3', () => {
-        format.borderColor = 'red red green red';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-color: red red green;"></div>');
-    });
-
-    it('Has border color - four values - different values 4', () => {
-        format.borderColor = 'red green red red';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-color: red green red red;"></div>');
-    });
-
-    it('Has border color - four values - different values 5', () => {
-        format.borderColor = 'red green red green';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-color: red green;"></div>');
-    });
-
-    it('Has border color - four values - different values 6', () => {
-        format.borderColor = 'red green blue yellow';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-color: red green blue yellow;"></div>');
-    });
-
-    it('Has border style', () => {
-        format.borderStyle = 'solid solid solid solid';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-style: solid;"></div>');
-    });
-
-    it('Has border width', () => {
-        format.borderWidth = '1px 2px 3px 4px';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual('<div style="border-width: 1px 2px 3px 4px;"></div>');
-    });
-
-    it('Has everything', () => {
-        format.borderColor = 'red blue green yellow';
-        format.borderStyle = 'solid none dashed dotted';
-        format.borderWidth = '1px 2px 3px 4px';
-
-        borderFormatHandler.apply(format, div, context);
-
-        expect(div.outerHTML).toEqual(
-            '<div style="border-color: red blue green yellow; border-width: 1px 2px 3px 4px; border-style: solid none dashed dotted;"></div>'
-        );
-    });
-
-    it('UseBorderBox', () => {
-        format.useBorderBox = true;
-        borderFormatHandler.apply(format, div, context);
-        expect(div.outerHTML).toBe('<div style="box-sizing: border-box;"></div>');
+        expect(div.outerHTML).toEqual('<div style="border-top: red;"></div>');
     });
 });

--- a/packages/roosterjs-content-model/test/formatHandlers/common/borderFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/common/borderFormatHandlerTest.ts
@@ -3,6 +3,7 @@ import { borderFormatHandler } from '../../../lib/formatHandlers/common/borderFo
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { DomToModelContext } from '../../../lib/publicTypes/context/DomToModelContext';
+import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
 import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
 
 describe('borderFormatHandler.parse', () => {
@@ -78,7 +79,7 @@ describe('borderFormatHandler.apply', () => {
         expect(div.outerHTML).toEqual('<div style="border-top: 1px solid red;"></div>');
     });
 
-    it('Has border color - empty values', () => {
+    itChromeOnly('Has border color - empty values', () => {
         format.borderTop = 'red';
 
         borderFormatHandler.apply(format, div, context);

--- a/packages/roosterjs-content-model/test/modelApi/table/alignTableTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/table/alignTableTest.ts
@@ -9,7 +9,8 @@ describe('alignTable', () => {
         alignTable(table, TableOperation.AlignLeft);
 
         expect(table.format).toEqual({
-            margin: '0 auto 0 0',
+            marginRight: 'auto',
+            marginLeft: '',
         });
     });
 
@@ -19,7 +20,8 @@ describe('alignTable', () => {
         alignTable(table, TableOperation.AlignCenter);
 
         expect(table.format).toEqual({
-            margin: '0 auto 0 auto',
+            marginLeft: 'auto',
+            marginRight: 'auto',
         });
     });
 
@@ -29,18 +31,25 @@ describe('alignTable', () => {
         alignTable(table, TableOperation.AlignRight);
 
         expect(table.format).toEqual({
-            margin: '0 0 0 auto',
+            marginLeft: 'auto',
+            marginRight: '',
         });
     });
 
     it('Align table to left to a table already has margin', () => {
         const table = createTable(1);
-        table.format.margin = '10px';
+        table.format.marginTop = '10px';
+        table.format.marginRight = '10px';
+        table.format.marginBottom = '10px';
+        table.format.marginLeft = '10px';
 
         alignTable(table, TableOperation.AlignRight);
 
         expect(table.format).toEqual({
-            margin: '10px 0 10px auto',
+            marginTop: '10px',
+            marginRight: '',
+            marginBottom: '10px',
+            marginLeft: 'auto',
         });
     });
 });

--- a/packages/roosterjs-content-model/test/modelApi/table/applyTableFormatTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/table/applyTableFormatTest.ts
@@ -1,5 +1,4 @@
 import { applyTableFormat } from '../../../lib/modelApi/table/applyTableFormat';
-import { combineBorderValue } from '../../../lib/domUtils/borderValues';
 import { ContentModelTable } from '../../../lib/publicTypes/block/ContentModelTable';
 import { ContentModelTableCell } from '../../../lib/publicTypes/block/group/ContentModelTableCell';
 import { TableBorderFormat } from 'roosterjs-editor-types';
@@ -65,10 +64,15 @@ describe('applyTableFormat', () => {
                     `BackgroundColor Row=${row} Col=${col}`
                 );
 
-                expect(table.cells[row][col].format.borderColor).toEqual(
-                    combineBorderValue(expectedBorderColors[row][col], ''),
-                    `BorderColor Row=${row} Col=${col}`
-                );
+                const { borderTop, borderRight, borderLeft, borderBottom } = table.cells[row][
+                    col
+                ].format;
+                const colors = expectedBorderColors[row][col];
+
+                expect(borderTop).toBe('1px solid ' + colors[0]);
+                expect(borderRight).toBe('1px solid ' + colors[1]);
+                expect(borderBottom).toBe('1px solid ' + colors[2]);
+                expect(borderLeft).toBe('1px solid ' + colors[3]);
             }
         }
     }


### PR DESCRIPTION
Fix #1304 

When create table that is not using insertTable() API from Content Model (e.g. original insertTable API), there is no useBorderBox property set for table cells. So when read and write table cell size, it will also include border width then rewrite will increase table size. 
Fix: always set useBorderBox when parse table by adding an option in createContentModel() API

When border contains "initial" value for its style value, browser doesn't accept border value such as "solid solid initial solid" then it causes the all borders are missing.
Fix: Redesign BorderFormat to split the border info into top/right/bottom/left, so we can set each border separately.

Also add padding format and handler in case TD cell has padding style.

Fix related test cases