### PR TITLE
Content Model List: Support "type" attribute of OL element

### DIFF
--- a/packages/roosterjs-content-model/lib/formatHandlers/list/listLevelMetadataFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/list/listLevelMetadataFormatHandler.ts
@@ -7,6 +7,7 @@ import {
     createObjectDefinition,
     getObjectKeys,
     getTagOfNode,
+    safeInstanceOf,
 } from 'roosterjs-editor-dom';
 
 /**
@@ -21,7 +22,7 @@ export const OrderedMap: Record<NumberingListType, string> = {
     [NumberingListType.LowerAlphaDash]: '"${LowerAlpha}- "',
     [NumberingListType.LowerAlphaParenthesis]: '"${LowerAlpha}) "',
     [NumberingListType.LowerAlphaDoubleParenthesis]: '"(${LowerAlpha}) "',
-    [NumberingListType.UpperAlpha]: '"${UpperAlpha}. "',
+    [NumberingListType.UpperAlpha]: 'upper-alpha',
     [NumberingListType.UpperAlphaDash]: '"${UpperAlpha}- "',
     [NumberingListType.UpperAlphaParenthesis]: '"${UpperAlpha}) "',
     [NumberingListType.UpperAlphaDoubleParenthesis]: '"(${UpperAlpha}) "',
@@ -29,7 +30,7 @@ export const OrderedMap: Record<NumberingListType, string> = {
     [NumberingListType.LowerRomanDash]: '"${LowerRoman}- "',
     [NumberingListType.LowerRomanParenthesis]: '"${LowerRoman}) "',
     [NumberingListType.LowerRomanDoubleParenthesis]: '"(${LowerRoman}) "',
-    [NumberingListType.UpperRoman]: '"${UpperRoman}. "',
+    [NumberingListType.UpperRoman]: 'upper-roman',
     [NumberingListType.UpperRomanDash]: '"${UpperRoman}- "',
     [NumberingListType.UpperRomanParenthesis]: '"${UpperRoman}) "',
     [NumberingListType.UpperRomanDoubleParenthesis]: '"(${UpperRoman}) "',
@@ -76,12 +77,22 @@ const listMetadataFormatHandlerInternal = createMetadataFormatHandler<ListMetada
     })
 );
 
+const OLTypeToStyleMap: Record<string, string> = {
+    '1': 'decimal',
+    a: 'lower-alpha',
+    A: 'upper-alpha',
+    i: 'lower-roman',
+    I: 'upper-roman',
+};
+
 /**
  * @internal
  */
 export const listLevelMetadataFormatHandler: FormatHandler<ListMetadataFormat> = {
     parse: (format, element, context, defaultStyle) => {
-        const listStyle = element.style.listStyleType;
+        const listStyle =
+            element.style.listStyleType ||
+            (safeInstanceOf(element, 'HTMLOListElement') && OLTypeToStyleMap[element.type]);
         const tag = getTagOfNode(element);
 
         listMetadataFormatHandlerInternal.parse(format, element, context, defaultStyle);

--- a/packages/roosterjs-content-model/test/formatHandlers/list/listLevelMetadataFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/list/listLevelMetadataFormatHandlerTest.ts
@@ -130,6 +130,37 @@ describe('listLevelMetadataFormatHandler.parse', () => {
         });
     });
 
+    it('OL with type attribute', () => {
+        const ol = document.createElement('ol');
+
+        ol.type = 'I';
+
+        listLevelMetadataFormatHandler.parse(format, ol, context, {});
+
+        expect(format.orderedStyleType).toBe(NumberingListType.UpperRoman);
+        expect(format.unorderedStyleType).toBeUndefined();
+        expect(context.listFormat).toEqual({
+            threadItemCounts: [],
+            levels: [],
+        });
+    });
+
+    it('OL with type attribute and list-style-type', () => {
+        const ol = document.createElement('ol');
+
+        ol.style.listStyleType = 'lower-roman';
+        ol.type = 'I';
+
+        listLevelMetadataFormatHandler.parse(format, ol, context, {});
+
+        expect(format.orderedStyleType).toBe(NumberingListType.LowerRoman);
+        expect(format.unorderedStyleType).toBeUndefined();
+        expect(context.listFormat).toEqual({
+            threadItemCounts: [],
+            levels: [],
+        });
+    });
+
     it('OL with conflict metadata and list type', () => {
         const ol = document.createElement('ol');
 
@@ -189,7 +220,7 @@ describe('listLevelMetadataFormatHandler.parse', () => {
         listLevelMetadataFormatHandler.apply(format, ol, context);
 
         expect(ol.outerHTML).toBe(
-            '<ol data-editing-info="{&quot;orderedStyleType&quot;:9,&quot;unorderedStyleType&quot;:9}"></ol>'
+            '<ol data-editing-info="{&quot;orderedStyleType&quot;:9,&quot;unorderedStyleType&quot;:9}" style="list-style-type: upper-alpha;"></ol>'
         );
     });
 


### PR DESCRIPTION
It is supported to use "type" attribute in OL to specify list style type. So we need to support it in Content Model