### PR TITLE
Update getSelectionRangeEx typings to match desc

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -424,7 +424,7 @@ export default class Editor implements IEditor {
      * Default value is true
      * @returns current selection range, or null if editor never got focus before
      */
-    public getSelectionRangeEx(): SelectionRangeEx {
+    public getSelectionRangeEx(): SelectionRangeEx | null {
         const core = this.getCore();
         return core.api.getSelectionRangeEx(core);
     }
@@ -596,7 +596,7 @@ export default class Editor implements IEditor {
         const selection = this.getSelectionRangeEx();
         const result: Region[] = [];
         const contentDiv = this.getCore().contentDiv;
-        selection.ranges.forEach(range => {
+        selection?.ranges.forEach(range => {
             result.push(...(range ? getRegionsFromRange(contentDiv, range, type) : []));
         });
         return result.filter((value, index, self) => {

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -158,9 +158,9 @@ export type GetSelectionRange = (core: EditorCore, tryGetFromCache: boolean) => 
 /**
  * Get current selection range
  * @param core The EditorCore object
- * @returns A Range object of the selection range
+ * @returns A Range object of the selection range, or null if editor never got focus before
  */
-export type GetSelectionRangeEx = (core: EditorCore) => SelectionRangeEx;
+export type GetSelectionRangeEx = (core: EditorCore) => SelectionRangeEx | null;
 
 /**
  * Get style based format state from current selection, including font name/size and colors

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -229,7 +229,7 @@ export default interface IEditor {
      * It does a live pull on the selection.
      * @returns current selection range, or null if editor never got focus before
      */
-    getSelectionRangeEx(): SelectionRangeEx;
+    getSelectionRangeEx(): SelectionRangeEx | null;
 
     /**
      * Get current selection in a serializable format


### PR DESCRIPTION
`@returns current selection range, or null if editor never got focus before`

`getSelectionRangeEx` doesn't have the correct typings as `/coreApi` isn't strict yet. 

Update typings to match description & implementation in `IEditor.ts`