### PR TITLE
Revert "Update getSelectionRangeEx typings to match desc"

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreApi/addUndoSnapshot.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/addUndoSnapshot.ts
@@ -94,7 +94,7 @@ function addUndoSnapshotInternal(core: EditorCore, canUndoByBackspace: boolean) 
                       isDarkMode,
                       start: [],
                       end: [],
-                      ...(getSelectionPath(core.contentDiv, rangeEx?.ranges[0] ?? null) || {}),
+                      ...(getSelectionPath(core.contentDiv, rangeEx.ranges[0]) || {}),
                   };
 
         core.undo.snapshotsService.addSnapshot(

--- a/packages/roosterjs-editor-core/lib/coreApi/switchShadowEdit.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/switchShadowEdit.ts
@@ -41,12 +41,12 @@ export const switchShadowEdit: SwitchShadowEdit = (core: EditorCore, isOn: boole
             shadowEditSelectionPath = range && getSelectionPath(contentDiv, range);
             shadowEditTableSelectionPath = getShadowEditSelectionPath(
                 SelectionRangeTypes.TableSelection,
-                selection ?? undefined
+                selection
             );
             shadowEditFragment = core.contentDiv.ownerDocument.createDocumentFragment();
             shadowEditImageSelectionPath = getShadowEditSelectionPath(
                 SelectionRangeTypes.ImageSelection,
-                selection ?? undefined
+                selection
             );
 
             moveChildNodes(shadowEditFragment, contentDiv);

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -424,7 +424,7 @@ export default class Editor implements IEditor {
      * Default value is true
      * @returns current selection range, or null if editor never got focus before
      */
-    public getSelectionRangeEx(): SelectionRangeEx | null {
+    public getSelectionRangeEx(): SelectionRangeEx {
         const core = this.getCore();
         return core.api.getSelectionRangeEx(core);
     }
@@ -596,7 +596,7 @@ export default class Editor implements IEditor {
         const selection = this.getSelectionRangeEx();
         const result: Region[] = [];
         const contentDiv = this.getCore().contentDiv;
-        selection?.ranges.forEach(range => {
+        selection.ranges.forEach(range => {
             result.push(...(range ? getRegionsFromRange(contentDiv, range, type) : []));
         });
         return result.filter((value, index, self) => {

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -158,9 +158,9 @@ export type GetSelectionRange = (core: EditorCore, tryGetFromCache: boolean) => 
 /**
  * Get current selection range
  * @param core The EditorCore object
- * @returns A Range object of the selection range, or null if editor never got focus before
+ * @returns A Range object of the selection range
  */
-export type GetSelectionRangeEx = (core: EditorCore) => SelectionRangeEx | null;
+export type GetSelectionRangeEx = (core: EditorCore) => SelectionRangeEx;
 
 /**
  * Get style based format state from current selection, including font name/size and colors

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -229,7 +229,7 @@ export default interface IEditor {
      * It does a live pull on the selection.
      * @returns current selection range, or null if editor never got focus before
      */
-    getSelectionRangeEx(): SelectionRangeEx | null;
+    getSelectionRangeEx(): SelectionRangeEx;
 
     /**
      * Get current selection in a serializable format


### PR DESCRIPTION
We should always return a selectionRangeEx object. When there is no selection, we can just return it with an empty ranges[] array so that we don't need to check null for this result everywhere.