### PR TITLE
Content Model List bug fix

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/listProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/listProcessor.ts
@@ -22,6 +22,8 @@ export const listProcessor: ElementProcessor = (group, element, context) => {
             parseFormat(element, ListLevelFormatHandlers, level, context);
             parseFormat(element, SegmentFormatHandlers, context.segmentFormat, context);
 
+            const originalListParent = listFormat.listParent;
+
             listFormat.listParent = listFormat.listParent || group;
             listFormat.levels.push(level);
 
@@ -29,6 +31,7 @@ export const listProcessor: ElementProcessor = (group, element, context) => {
                 containerProcessor(group, element, context);
             } finally {
                 listFormat.levels.pop();
+                listFormat.listParent = originalListParent;
             }
         }
     );

--- a/packages/roosterjs-content-model/test/domToModel/processors/containerProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/containerProcessorTest.ts
@@ -4,6 +4,7 @@ import { ContentModelDocument } from '../../../lib/publicTypes/block/group/Conte
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
 import { DomToModelContext } from '../../../lib/publicTypes/context/DomToModelContext';
+import { generalProcessor } from '../../../lib/domToModel/processors/generalProcessor';
 
 describe('containerProcessor', () => {
     let doc: ContentModelDocument;
@@ -288,6 +289,94 @@ describe('containerProcessor', () => {
                 { segmentType: 'SelectionMarker', format: { a: 'b' } as any, isSelected: true },
             ],
             isImplicit: true,
+        });
+    });
+
+    it('Process lists that are under different container', () => {
+        const div = document.createElement('div');
+        div.innerHTML =
+            '<div id="div1"><ol><li>test1</li></ol></div><div id="div2">test2</div><div id="div3"><ol><li>test3</li></ol></div>';
+
+        context.elementProcessors.DIV = generalProcessor;
+
+        containerProcessor(doc, div, context);
+
+        expect(doc.blocks.length).toBe(3);
+        expect(doc.blocks[0]).toEqual({
+            blockType: 'BlockGroup',
+            blockGroupType: 'General',
+            element: div.querySelector('#div1') as HTMLElement,
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    levels: [{ listType: 'OL' }],
+                    formatHolder: { segmentType: 'SelectionMarker', isSelected: true, format: {} },
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            isImplicit: true,
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test1',
+                                    format: {},
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(doc.blocks[1]).toEqual({
+            blockType: 'BlockGroup',
+            blockGroupType: 'General',
+            element: div.querySelector('#div2') as HTMLElement,
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    isImplicit: true,
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test2',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(doc.blocks[2]).toEqual({
+            blockType: 'BlockGroup',
+            blockGroupType: 'General',
+            element: div.querySelector('#div3') as HTMLElement,
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    levels: [{ listType: 'OL', startNumberOverride: 1 }],
+                    formatHolder: { segmentType: 'SelectionMarker', isSelected: true, format: {} },
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            isImplicit: true,
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test3',
+                                    format: {},
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+
+        expect(context.listFormat).toEqual({
+            levels: [],
+            listParent: undefined,
+            threadItemCounts: [1],
         });
     });
 });

--- a/packages/roosterjs-content-model/test/domToModel/processors/listProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/listProcessorTest.ts
@@ -36,7 +36,7 @@ describe('listProcessor', () => {
             blocks: [],
         });
 
-        expect(context.listFormat.listParent).toBe(group);
+        expect(context.listFormat.listParent).toBeUndefined();
         expect(context.listFormat.levels).toEqual([]);
         expect(context.listFormat.threadItemCounts).toEqual([]);
         expect(context.segmentFormat).toEqual({});
@@ -61,7 +61,7 @@ describe('listProcessor', () => {
             blocks: [],
         });
 
-        expect(context.listFormat.listParent).toBe(group);
+        expect(context.listFormat.listParent).toBeUndefined();
         expect(context.listFormat.levels).toEqual([]);
         expect(context.listFormat.threadItemCounts).toEqual([0]);
         expect(context.segmentFormat).toEqual({});
@@ -94,7 +94,7 @@ describe('listProcessor', () => {
             blocks: [],
         });
 
-        expect(context.listFormat.listParent).toBe(group);
+        expect(context.listFormat.listParent).toBeUndefined();
         expect(context.listFormat.levels).toEqual([]);
         expect(context.listFormat.threadItemCounts).toEqual([0]);
         expect(context.segmentFormat).toEqual({});
@@ -116,7 +116,7 @@ describe('listProcessor', () => {
             blocks: [],
         });
 
-        expect(context.listFormat.listParent).toBe(group);
+        expect(context.listFormat.listParent).toBeUndefined();
         expect(context.listFormat.levels).toEqual([]);
         expect(context.listFormat.threadItemCounts).toEqual([]);
         expect(context.segmentFormat).toEqual({});
@@ -153,7 +153,7 @@ describe('listProcessor', () => {
             blocks: [],
         });
 
-        expect(context.listFormat.listParent).toBe(group);
+        expect(context.listFormat.listParent).toBeUndefined();
         expect(context.listFormat.threadItemCounts).toEqual([]);
         expect(context.segmentFormat).toEqual({});
 
@@ -200,7 +200,7 @@ describe('listProcessor without format handlers', () => {
             blocks: [],
         });
 
-        expect(context.listFormat.listParent).toBe(group);
+        expect(context.listFormat.listParent).toBeUndefined();
         expect(context.listFormat.levels).toEqual([]);
         expect(context.listFormat.threadItemCounts).toEqual([]);
         expect(context.segmentFormat).toEqual({});
@@ -225,7 +225,7 @@ describe('listProcessor without format handlers', () => {
             blocks: [],
         });
 
-        expect(context.listFormat.listParent).toBe(group);
+        expect(context.listFormat.listParent).toBeUndefined();
         expect(context.listFormat.levels).toEqual([]);
         expect(context.listFormat.threadItemCounts).toEqual([]);
         expect(context.segmentFormat).toEqual({});
@@ -258,7 +258,7 @@ describe('listProcessor without format handlers', () => {
             blocks: [],
         });
 
-        expect(context.listFormat.listParent).toBe(group);
+        expect(context.listFormat.listParent).toBeUndefined();
         expect(context.listFormat.levels).toEqual([]);
         expect(context.listFormat.threadItemCounts).toEqual([]);
         expect(context.segmentFormat).toEqual({});
@@ -280,7 +280,7 @@ describe('listProcessor without format handlers', () => {
             blocks: [],
         });
 
-        expect(context.listFormat.listParent).toBe(group);
+        expect(context.listFormat.listParent).toBeUndefined();
         expect(context.listFormat.levels).toEqual([]);
         expect(context.listFormat.threadItemCounts).toEqual([]);
         expect(context.segmentFormat).toEqual({});
@@ -317,7 +317,7 @@ describe('listProcessor without format handlers', () => {
             blocks: [],
         });
 
-        expect(context.listFormat.listParent).toBe(group);
+        expect(context.listFormat.listParent).toBeUndefined();
         expect(context.listFormat.threadItemCounts).toEqual([]);
         expect(context.segmentFormat).toEqual({});
 


### PR DESCRIPTION
When two lists that belong to different container, and there is other block between them, e.g.
```html
<div><ol>...</ol></div>
<div>other block</div>
<div><ol>...</ol></div>
```

Content Model will incorrectly append the second list into the same parent of the first one. This is because after processing the OL/UL element, we didn't clean up the list parent from context, so next time when we hit another list, the previous list parent is reused. The fixed is to clean up list parent after OL/UL element is processed.