### PR TITLE
Return the Table Operation in the editTable API and store it in the Content Edit Event Data

### DIFF
--- a/demo/scripts/controls/sidePane/eventViewer/EventViewPane.tsx
+++ b/demo/scripts/controls/sidePane/eventViewer/EventViewPane.tsx
@@ -174,6 +174,8 @@ export default class EventViewPane extends React.Component<
                         Source=
                         {event.source}, Data=
                         {event.data && event.data.toString && event.data.toString()}
+                        {event.additionalData?.formatApiName &&
+                            ',Format API = "' + event.additionalData?.formatApiName + '"'}
                     </span>
                 );
 

--- a/packages/roosterjs-content-model/lib/publicApi/table/editTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/editTable.ts
@@ -105,6 +105,8 @@ export default function editTable(
                         },
                     });
                 }
+
+                return operation;
             },
             ChangeSource.Format,
             false /*canUndoByBackspace*/,

--- a/packages/roosterjs-editor-api/lib/table/editTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/editTable.ts
@@ -30,6 +30,8 @@ export default function editTable(
                     vtable.getCell(cellToSelect.newRow, cellToSelect.newCol).td,
                     PositionType.Begin
                 );
+
+                return operation;
             },
             'editTable'
         );


### PR DESCRIPTION
Store the content edit data when editing a table, so this information can be used during the content changed event.

