### PR TITLE
Improve building speed

### DIFF
--- a/tools/buildTools/checkDependency.js
+++ b/tools/buildTools/checkDependency.js
@@ -33,10 +33,9 @@ function processFile(dir, filename, files, externalDependencies) {
 
     const index = files.indexOf(thisFilename);
 
-    if (index >= 0) {
-        files = files.slice(index);
-        files.push(thisFilename);
+    files.push(thisFilename);
 
+    if (index >= 0) {
         const packageNames = files.map(findPackageName).sort();
 
         if (packageNames[0] == packageNames[packageNames.length - 1]) {
@@ -48,7 +47,6 @@ function processFile(dir, filename, files, externalDependencies) {
 
     var match;
     try {
-        files.push(thisFilename);
         var dir = path.dirname(thisFilename);
         var content = fs.readFileSync(thisFilename).toString();
         var reg = /from\s+'([^']+)';$/gm;
@@ -56,9 +54,11 @@ function processFile(dir, filename, files, externalDependencies) {
         while ((match = reg.exec(content))) {
             var nextFile = match[1];
             if (nextFile) {
-                processFile(dir, nextFile, files.slice(), externalDependencies);
+                processFile(dir, nextFile, files, externalDependencies);
             }
         }
+
+        files.pop();
     } catch (e) {
         err(
             'Found dependency issue when processing file ' +
@@ -105,7 +105,7 @@ function checkDependency() {
 }
 
 module.exports = {
-    message: 'Checking circular dependency...',
+    message: 'Checking dependency...',
     callback: checkDependency,
     enabled: options => options.checkdep,
 };


### PR DESCRIPTION
The check dependency tool in our build system has some bug that it will always check to the same files so many times. This change fix this issue to improve the building speed.