### PR TITLE
Handle CSS variable when sanitize

### DIFF
--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/processCssVariable.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/processCssVariable.ts
@@ -1,0 +1,18 @@
+const VARIABLE_REGEX = /^\s*var\(\s*[a-zA-Z0-9-_]+\s*(,\s*(.*))?\)\s*$/;
+const VARIABLE_PREFIX = 'var(';
+
+/**
+ * @internal
+ * Handle CSS variable format. e.g.: var(--name, fallbackValue)
+ */
+export function processCssVariable(value: string): string {
+    const match = VARIABLE_REGEX.exec(value);
+    return match?.[2] || ''; // Without fallback value, we don't know what does the original value mean, so ignore it
+}
+
+/**
+ * @internal
+ */
+export function isCssVariable(value: string): boolean {
+    return value.indexOf(VARIABLE_PREFIX) == 0;
+}

--- a/packages/roosterjs-editor-dom/test/htmlSanitizer/processCssVariableTest.ts
+++ b/packages/roosterjs-editor-dom/test/htmlSanitizer/processCssVariableTest.ts
@@ -1,0 +1,40 @@
+import { isCssVariable, processCssVariable } from '../../lib/htmlSanitizer/processCssVariable';
+
+describe('processCssVariable', () => {
+    it('no var', () => {
+        const result = processCssVariable('test');
+        expect(result).toBe('');
+    });
+
+    it('var without fallback', () => {
+        const result = processCssVariable('var(--test)');
+        expect(result).toBe('');
+    });
+
+    it('var with fallback', () => {
+        const result = processCssVariable('var(--test, fallback)');
+        expect(result).toBe('fallback');
+    });
+
+    it('var with fallback that has complex value', () => {
+        const result = processCssVariable('var(--test, rgb(1, 2, 3))');
+        expect(result).toBe('rgb(1, 2, 3');
+    });
+
+    it('var with fallback and more spaces', () => {
+        const result = processCssVariable('var(    --test    ,   aa bb  cc   )');
+        expect(result).toBe('aa bb  cc   ');
+    });
+});
+
+describe('isCssVariable', () => {
+    it('no var', () => {
+        const result = isCssVariable('test');
+        expect(result).toBeFalse();
+    });
+
+    it('var', () => {
+        const result = isCssVariable('var(');
+        expect(result).toBeTrue();
+    });
+});


### PR DESCRIPTION
when use CSS variable such as var(--my-color, #123456), we need to parse the var value and retrieve its fallback value if any, and use its fallback value as its real value since the variable may not really work when doing some calculation such as dark mode.