### PR TITLE
Fix broken paste option plugin in demo app

### DIFF
--- a/packages-ui/roosterjs-react/lib/pasteOptions/component/showPasteOptionPane.tsx
+++ b/packages-ui/roosterjs-react/lib/pasteOptions/component/showPasteOptionPane.tsx
@@ -54,7 +54,7 @@ interface PasteOptionButtonProps {
     buttonName: PasteOptionButtonKeys;
     className: string;
     paste: (key: PasteOptionButtonKeys) => void;
-    strings: LocalizedStrings<PasteOptionStringKeys>;
+    strings?: LocalizedStrings<PasteOptionStringKeys>;
 }
 
 function PasteOptionButton(props: PasteOptionButtonProps) {
@@ -78,7 +78,7 @@ function PasteOptionButton(props: PasteOptionButtonProps) {
 }
 
 interface PasteOptionProps {
-    strings: LocalizedStrings<PasteOptionStringKeys>;
+    strings?: LocalizedStrings<PasteOptionStringKeys>;
     position: NodePosition;
     isRtl: boolean;
     paste: (key: PasteOptionButtonKeys) => void;
@@ -192,9 +192,9 @@ const PasteOptionComponent = React.forwardRef(function PasteOptionFunc(
 export default function showPasteOptionPane(
     uiUtilities: UIUtilities,
     position: NodePosition,
-    strings: LocalizedStrings<PasteOptionStringKeys>,
     onPaste: (key: PasteOptionButtonKeys) => void,
-    ref: React.RefObject<PasteOptionPane>
+    ref: React.RefObject<PasteOptionPane>,
+    strings?: LocalizedStrings<PasteOptionStringKeys>
 ) {
     let disposer: (() => void) | null = null;
     const onDismiss = () => {

--- a/packages-ui/roosterjs-react/lib/pasteOptions/plugin/createPasteOptionPlugin.ts
+++ b/packages-ui/roosterjs-react/lib/pasteOptions/plugin/createPasteOptionPlugin.ts
@@ -153,13 +153,13 @@ class PasteOptionPlugin implements ReactEditorPlugin {
 
         const focusedPosition = this.editor?.getFocusedPosition();
 
-        if (focusedPosition && this.uiUtilities && this.strings) {
+        if (focusedPosition && this.uiUtilities) {
             showPasteOptionPane(
                 this.uiUtilities,
                 focusedPosition,
-                this.strings,
                 this.onPaste,
-                this.pasteOptionRef
+                this.pasteOptionRef,
+                this.strings
             );
         }
     }


### PR DESCRIPTION
This PR fixes a regression introduced in #1285, we never expected strings in `showPasteOptionPane` to be required.

To fix it we should either:
- Make the parameter optional and remove the check, or
- Provide localized strings when creating the pane

This PR goes with option 1, feel free to close if you think there's a better option.

> It should be OK in production since we will likely provide localized strings.