### PR TITLE
Fix clear format not handling heading and blockquote wrappers

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -4,6 +4,7 @@ import formatUndoSnapshot from '../utils/formatUndoSnapshot';
 import setBackgroundColor from './setBackgroundColor';
 import setFontName from './setFontName';
 import setFontSize from './setFontSize';
+import setFontWeight from './setFontWeight';
 import setTextColor from './setTextColor';
 import toggleBold from './toggleBold';
 import toggleItalic from './toggleItalic';
@@ -25,6 +26,7 @@ import {
     isNodeInRegion,
     isVoidHtmlElement,
     PartialInlineElement,
+    Position,
     safeInstanceOf,
     setStyles,
     splitBalancedNodeRange,
@@ -38,7 +40,7 @@ const STYLES_TO_REMOVE = ['font', 'text-decoration', 'color', 'background'];
 const TAGS_TO_UNWRAP = 'B,I,U,STRONG,EM,SUB,SUP,STRIKE,FONT,CENTER,H1,H2,H3,H4,H5,H6,UL,OL,LI,SPAN,P,BLOCKQUOTE,CODE,S,PRE'.split(
     ','
 );
-const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6';
+const WRAPPER_SELECTOR = 'h1, h2, h3, h4, h5, h6, blockquote';
 const ATTRIBUTES_TO_PRESERVE = ['href', 'src', 'cellpadding', 'cellspacing'];
 const TAGS_TO_STOP_UNWRAP = ['TD', 'TH', 'TR', 'TABLE', 'TBODY', 'THEAD'];
 
@@ -196,6 +198,15 @@ function clearBlockFormat(editor: IEditor) {
     );
 }
 
+function isRangeContainingAll(range: Range) {
+    return (
+        range.startContainer === range.startContainer.parentElement.firstChild &&
+        range.endContainer === range.endContainer.parentElement.lastChild &&
+        range.startOffset === 0 &&
+        Position.getEnd(range).isAtEnd
+    );
+}
+
 function clearInlineFormat(editor: IEditor) {
     editor.focus();
     editor.addUndoSnapshot(() => {
@@ -204,11 +215,17 @@ function clearInlineFormat(editor: IEditor) {
             node.removeAttribute('class')
         );
 
+        let selection = editor.getSelectionRange();
+
         /**
-         * Manually unwrap headings as they're not covered by the `removeFormat` command spec
+         * Manually unwrap headings and blockquotes as they're not covered by the `removeFormat` command spec
          * https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#the-removeformat-command
          */
-        editor.queryElements(HEADING_SELECTOR, QueryScope.OnSelection, unwrap);
+        if (isRangeContainingAll(selection)) {
+            editor.queryElements(WRAPPER_SELECTOR, QueryScope.OnSelection, unwrap);
+        } else {
+            editor.queryElements(WRAPPER_SELECTOR, QueryScope.InSelection, unwrap);
+        }
 
         setDefaultFormat(editor);
 

--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -275,6 +275,8 @@ function setDefaultFormat(editor: IEditor) {
         if (defaultFormat.underline) {
             toggleUnderline(editor);
         }
+
+        setFontWeight(editor, '400');
     }
 }
 

--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -285,6 +285,8 @@ function setDefaultFormat(editor: IEditor) {
         }
         if (defaultFormat.bold) {
             toggleBold(editor);
+        } else {
+            setFontWeight(editor, '400');
         }
         if (defaultFormat.italic) {
             toggleItalic(editor);
@@ -292,8 +294,6 @@ function setDefaultFormat(editor: IEditor) {
         if (defaultFormat.underline) {
             toggleUnderline(editor);
         }
-
-        setFontWeight(editor, '400');
     }
 }
 

--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -38,6 +38,7 @@ const STYLES_TO_REMOVE = ['font', 'text-decoration', 'color', 'background'];
 const TAGS_TO_UNWRAP = 'B,I,U,STRONG,EM,SUB,SUP,STRIKE,FONT,CENTER,H1,H2,H3,H4,H5,H6,UL,OL,LI,SPAN,P,BLOCKQUOTE,CODE,S,PRE'.split(
     ','
 );
+const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6';
 const ATTRIBUTES_TO_PRESERVE = ['href', 'src', 'cellpadding', 'cellspacing'];
 const TAGS_TO_STOP_UNWRAP = ['TD', 'TH', 'TR', 'TABLE', 'TBODY', 'THEAD'];
 
@@ -202,6 +203,12 @@ function clearInlineFormat(editor: IEditor) {
         editor.queryElements('[class]', QueryScope.OnSelection, node =>
             node.removeAttribute('class')
         );
+
+        /**
+         * Manually unwrap headings as they're not covered by the `removeFormat` command spec
+         * https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#the-removeformat-command
+         */
+        editor.queryElements(HEADING_SELECTOR, QueryScope.OnSelection, unwrap);
 
         setDefaultFormat(editor);
 

--- a/packages/roosterjs-editor-api/lib/format/setFontWeight.ts
+++ b/packages/roosterjs-editor-api/lib/format/setFontWeight.ts
@@ -1,0 +1,24 @@
+import applyListItemStyleWrap from '../utils/applyListItemWrap';
+import { getComputedStyle } from 'roosterjs-editor-dom';
+import { IEditor } from 'roosterjs-editor-types';
+
+/**
+ * Set font weight at selection
+ * Only sets the value if the computed weight is different
+ * @param editor The editor instance
+ * @param fontWeight The fontWight string, should be a valid CSS font-weight style.
+ * Currently there's no validation to the string, if the passed string is invalid, it won't take affect
+ */
+export default function setFontWeight(editor: IEditor, fontWeight: string) {
+    applyListItemStyleWrap(
+        editor,
+        'font-weight',
+        element => {
+            let computedFontWeight = getComputedStyle(element, 'font-weight');
+            if (computedFontWeight !== fontWeight) {
+                element.style.fontWeight = '400';
+            }
+        },
+        'setFontWeight'
+    );
+}

--- a/packages/roosterjs-editor-api/test/format/clearFormatTest.ts
+++ b/packages/roosterjs-editor-api/test/format/clearFormatTest.ts
@@ -280,7 +280,7 @@ describe('clearAutodetectFormat Partial Tests', () => {
         const originalText =
             '<h1 id="testHeader" style="margin-right:0in;margin-left:0in;font-size:24pt;font-family:&quot;Times New Roman&quot;, serif"><span style="font-size: 24pt; font-family: Arial, sans-serif;">Header middle text 1</span></h1>';
         const expectedFormat =
-            '<span style="font-size: 24pt; font-family: Arial, sans-serif;">Header </span><span style="font-family: arial; font-size: 12pt; color: black;">middle</span><span style="font-size: 24pt; font-family: Arial, sans-serif;"> text 1</span>';
+            '<span style="font-size: 24pt; font-family: Arial, sans-serif;">Header </span><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">middle</span><span style="font-size: 24pt; font-family: Arial, sans-serif;"> text 1</span>';
         editor.setContent(originalText);
 
         let header = doc.getElementById('testHeader');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const devServerPort = 3000;
+const devServerPort = 3001;
 
 const externalMap = new Map([
     ['react', 'React'],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const devServerPort = 3001;
+const devServerPort = 3000;
 
 const externalMap = new Map([
     ['react', 'React'],


### PR DESCRIPTION
Selects all `<hX>` and `<blockquote>` elements under selection and unwraps them as they are not removed by `removeFormat` command.
https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#the-removeformat-command

Initial
<img height="203" alt="image" src="https://user-images.githubusercontent.com/44042957/196546440-f1e86fae-36c7-408d-975a-e63e3762da73.png">
Current clearFormat impl
<img height="200" alt="image" src="https://user-images.githubusercontent.com/44042957/196546504-a513edb3-f9cd-42e8-805c-33a29192bddb.png">
Fixed clearFormat impl
<img height="200" alt="image" src="https://user-images.githubusercontent.com/44042957/196546568-99d6d083-14fa-4d2c-8ff7-195034e8038b.png">

Additionally set a default font weight so partial clear format under `<h1>` tags isn't bold
![image](https://user-images.githubusercontent.com/44042957/197619409-3868c541-654f-42d7-887b-f74cb384aefe.png)
