### PR TITLE
Fix content model table bugs

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
@@ -18,7 +18,12 @@ export const knownElementProcessor: ElementProcessor<HTMLElement> = (group, elem
             },
             () => {
                 parseFormat(element, context.formatParsers.block, context.blockFormat, context);
-                parseFormat(element, context.formatParsers.segment, context.segmentFormat, context);
+                parseFormat(
+                    element,
+                    context.formatParsers.segmentOnBlock,
+                    context.segmentFormat,
+                    context
+                );
 
                 addBlock(group, createParagraph(false /*isImplicit*/, context.blockFormat));
 

--- a/packages/roosterjs-content-model/lib/domToModel/processors/listItemProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/listItemProcessor.ts
@@ -22,7 +22,12 @@ export const listItemProcessor: ElementProcessor<HTMLLIElement> = (group, elemen
                 segment: 'shallowClone',
             },
             () => {
-                parseFormat(element, context.formatParsers.segment, context.segmentFormat, context);
+                parseFormat(
+                    element,
+                    context.formatParsers.segmentOnBlock,
+                    context.segmentFormat,
+                    context
+                );
 
                 const listItem = createListItem(listFormat.levels, context.segmentFormat);
                 listFormat.listParent!.blocks.push(listItem);

--- a/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
@@ -31,7 +31,12 @@ export const tableProcessor: ElementProcessor<HTMLTableElement> = (
 
     stackFormat(context, { segment: 'shallowClone' }, () => {
         parseFormat(tableElement, context.formatParsers.table, table.format, context);
-        parseFormat(tableElement, context.formatParsers.segment, context.segmentFormat, context);
+        parseFormat(
+            tableElement,
+            context.formatParsers.segmentOnBlock,
+            context.segmentFormat,
+            context
+        );
         addBlock(group, table);
 
         const columnPositions: number[] = [0];
@@ -89,7 +94,7 @@ export const tableProcessor: ElementProcessor<HTMLTableElement> = (
                                 );
                                 parseFormat(
                                     td,
-                                    context.formatParsers.segment,
+                                    context.formatParsers.segmentOnBlock,
                                     context.segmentFormat,
                                     context
                                 );

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -85,6 +85,7 @@ const defaultFormatKeysPerCategory: {
         'textColor',
         'backgroundColor',
     ],
+    segmentOnBlock: ['fontFamily', 'fontSize', 'underline', 'italic', 'bold', 'textColor'],
     tableCell: [
         'border',
         'borderBox',

--- a/packages/roosterjs-content-model/lib/publicApi/table/editTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/editTable.ts
@@ -99,7 +99,7 @@ export default function editTable(
                 editor.focus();
                 if (model && table) {
                     editor.setContentModel(model, {
-                        mergingCallback: (target, fragment, entityPairs) => {
+                        mergingCallback: (fragment, _, entityPairs) => {
                             preprocessEntitiesFromContentModel(entityPairs);
                             editor.replaceNode(table, fragment);
                         },

--- a/packages/roosterjs-content-model/lib/publicApi/table/formatTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/formatTable.ts
@@ -27,7 +27,7 @@ export default function formatTable(
                 editor.focus();
                 if (model && table) {
                     editor.setContentModel(model, {
-                        mergingCallback: (target, fragment, entityPairs) => {
+                        mergingCallback: (fragment, _, entityPairs) => {
                             preprocessEntitiesFromContentModel(entityPairs);
                             editor.replaceNode(table, fragment);
                         },

--- a/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
@@ -38,7 +38,7 @@ export default function insertTable(
     editor.addUndoSnapshot(
         () => {
             editor.setContentModel(doc, {
-                mergingCallback: (target, fragment, entityPairs) => {
+                mergingCallback: (fragment, _, entityPairs) => {
                     preprocessEntitiesFromContentModel(entityPairs);
                     editor.insertNode(fragment);
                 },

--- a/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
@@ -22,7 +22,7 @@ export default function setTableCellShade(editor: IExperimentalContentModelEdito
                 editor.focus();
                 if (model && table) {
                     editor.setContentModel(model, {
-                        mergingCallback: (target, fragment, entityPairs) => {
+                        mergingCallback: (fragment, _, entityPairs) => {
                             preprocessEntitiesFromContentModel(entityPairs);
                             editor.replaceNode(table, fragment);
                         },

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
@@ -19,6 +19,13 @@ export interface ContentModelFormatMap {
     segment: ContentModelSegmentFormat;
 
     /**
+     * Format type for segment on block.
+     * Block can have format that can impact segment, such as font and color.
+     * But some segment format should not be read from block, like background color.
+     */
+    segmentOnBlock: ContentModelSegmentFormat;
+
+    /**
      * Format type for table
      */
     table: ContentModelTableFormat;

--- a/packages/roosterjs-content-model/test/domToModel/processors/tableProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/tableProcessorTest.ts
@@ -210,13 +210,13 @@ describe('tableProcessor with format', () => {
             if (element == table) {
                 if (handlers == context.formatParsers.table) {
                     (<any>format).format1 = 'table';
-                } else if (handlers == context.formatParsers.segment) {
+                } else if (handlers == context.formatParsers.segmentOnBlock) {
                     (<any>format).format2 = 'tableSegment';
                 }
             } else if (element == td) {
                 if (handlers == context.formatParsers.tableCell) {
                     (<any>format).format3 = 'td';
-                } else if (handlers == context.formatParsers.segment) {
+                } else if (handlers == context.formatParsers.segmentOnBlock) {
                     (<any>format).format4 = 'tdSegment';
                 }
             }


### PR DESCRIPTION
1. Insert table using content model is broken. This is because I changed mergeCallback format but I didn't update the table code to adopt the change
2. Applying table cell shade also impact segment background color, so that when apply table shade color again, the previous color is applied to segment. Fix by adding a new format category "segmentOnBlock" to only parse/apply segmentOnBlock format from block.