### PR TITLE
Improve image selection and table selection

### DIFF
--- a/demo/scripts/controls/editor/ExperimentalContentModelEditor.ts
+++ b/demo/scripts/controls/editor/ExperimentalContentModelEditor.ts
@@ -72,23 +72,18 @@ export default class ExperimentalContentModelEditor extends Editor
         );
         const mergingCallback = option?.mergingCallback || mergeFragmentWithEntity;
 
-        switch (range?.type) {
-            case SelectionRangeTypes.Normal:
+        if (range) {
+            if (range.type == SelectionRangeTypes.Normal) {
+                // Need to get start and end from range position before merge because range can be changed during merging
                 const start = Position.getStart(range.ranges[0]);
                 const end = Position.getEnd(range.ranges[0]);
 
                 mergingCallback(fragment, this.contentDiv, entityPairs);
                 this.select(start, end);
-                break;
-
-            case SelectionRangeTypes.TableSelection:
+            } else {
                 mergingCallback(fragment, this.contentDiv, entityPairs);
-                this.select(range.table, range.coordinates);
-                break;
-
-            case undefined:
-                mergingCallback(fragment, this.contentDiv, entityPairs);
-                break;
+                this.select(range);
+            }
         }
     }
 }

--- a/packages/roosterjs-editor-api/lib/utils/blockFormat.ts
+++ b/packages/roosterjs-editor-api/lib/utils/blockFormat.ts
@@ -31,8 +31,8 @@ export default function blockFormat(
             }
             if (selection.type == SelectionRangeTypes.Normal) {
                 editor.select(start, end);
-            } else if (selection.type == SelectionRangeTypes.TableSelection) {
-                editor.select(selection.table, selection.coordinates);
+            } else {
+                editor.select(selection);
             }
         },
         apiName

--- a/packages/roosterjs-editor-api/lib/utils/execCommand.ts
+++ b/packages/roosterjs-editor-api/lib/utils/execCommand.ts
@@ -1,11 +1,11 @@
 import formatUndoSnapshot from './formatUndoSnapshot';
-import { getObjectKeys, PendableFormatCommandMap, PendableFormatNames } from 'roosterjs-editor-dom';
 import {
     DocumentCommand,
     IEditor,
     PluginEventType,
     SelectionRangeTypes,
 } from 'roosterjs-editor-types';
+import { getObjectKeys, PendableFormatCommandMap, PendableFormatNames } from 'roosterjs-editor-dom';
 import type { CompatibleDocumentCommand } from 'roosterjs-editor-types/lib/compatibleTypes';
 
 /**
@@ -46,19 +46,17 @@ export default function execCommand(
         formatUndoSnapshot(
             editor,
             () => {
-                let tempRange: Range;
+                const needToSwitchSelection = selection.type != SelectionRangeTypes.Normal;
+
                 selection.ranges.forEach(range => {
-                    if (selection.type == SelectionRangeTypes.TableSelection) {
+                    if (needToSwitchSelection) {
                         editor.select(range);
                     }
-
                     formatter();
-
-                    tempRange = range;
                 });
 
-                if (tempRange && selection.type == SelectionRangeTypes.TableSelection) {
-                    editor.select(selection.table, selection.coordinates);
+                if (needToSwitchSelection) {
+                    editor.select(selection);
                 }
             },
             apiName

--- a/packages/roosterjs-editor-core/lib/coreApi/addUndoSnapshot.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/addUndoSnapshot.ts
@@ -1,15 +1,16 @@
-import { getSelectionPath, Position } from 'roosterjs-editor-dom';
 import {
     AddUndoSnapshot,
     ChangeSource,
+    ContentChangedData,
     ContentChangedEvent,
+    ContentMetadata,
     EditorCore,
     NodePosition,
     PluginEventType,
+    SelectionRangeEx,
     SelectionRangeTypes,
-    ContentMetadata,
-    ContentChangedData,
 } from 'roosterjs-editor-types';
+import { getSelectionPath, Position } from 'roosterjs-editor-dom';
 import type { CompatibleChangeSource } from 'roosterjs-editor-types/lib/compatibleTypes';
 
 /**
@@ -81,21 +82,7 @@ function addUndoSnapshotInternal(core: EditorCore, canUndoByBackspace: boolean) 
     if (!core.lifecycle.shadowEditFragment) {
         const rangeEx = core.api.getSelectionRangeEx(core);
         const isDarkMode = core.lifecycle.isDarkMode;
-        const metadata: ContentMetadata =
-            rangeEx?.type == SelectionRangeTypes.TableSelection
-                ? {
-                      type: SelectionRangeTypes.TableSelection,
-                      tableId: rangeEx.table.id,
-                      isDarkMode,
-                      ...rangeEx.coordinates!,
-                  }
-                : {
-                      type: SelectionRangeTypes.Normal,
-                      isDarkMode,
-                      start: [],
-                      end: [],
-                      ...(getSelectionPath(core.contentDiv, rangeEx.ranges[0]) || {}),
-                  };
+        const metadata = createContentMetadata(core.contentDiv, rangeEx, isDarkMode) || null;
 
         core.undo.snapshotsService.addSnapshot(
             {
@@ -105,5 +92,35 @@ function addUndoSnapshotInternal(core: EditorCore, canUndoByBackspace: boolean) 
             canUndoByBackspace
         );
         core.undo.hasNewContent = false;
+    }
+}
+
+function createContentMetadata(
+    root: HTMLElement,
+    rangeEx: SelectionRangeEx,
+    isDarkMode: boolean
+): ContentMetadata | undefined {
+    switch (rangeEx?.type) {
+        case SelectionRangeTypes.TableSelection:
+            return {
+                type: SelectionRangeTypes.TableSelection,
+                tableId: rangeEx.table.id,
+                isDarkMode: !!isDarkMode,
+                ...rangeEx.coordinates!,
+            };
+        case SelectionRangeTypes.ImageSelection:
+            return {
+                type: SelectionRangeTypes.ImageSelection,
+                imageId: rangeEx.image.id,
+                isDarkMode: !!isDarkMode,
+            };
+        case SelectionRangeTypes.Normal:
+            return {
+                type: SelectionRangeTypes.Normal,
+                isDarkMode: !!isDarkMode,
+                start: [],
+                end: [],
+                ...(getSelectionPath(root, rangeEx.ranges[0]) || {}),
+            };
     }
 }

--- a/packages/roosterjs-editor-core/lib/coreApi/selectImage.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/selectImage.ts
@@ -12,6 +12,8 @@ import {
 const IMAGE_ID = 'imageSelected';
 const CONTENT_DIV_ID = 'contentDiv_';
 const STYLE_ID = 'imageStyle';
+const DEFAULT_SELECTION_BORDER_COLOR = '#DB626C';
+
 /**
  * @internal
  * Select a image and save data of the selected range
@@ -20,6 +22,9 @@ const STYLE_ID = 'imageStyle';
  */
 export const selectImage: SelectImage = (core: EditorCore, image: HTMLImageElement | null) => {
     unselect(core);
+
+    let selection: ImageSelectionRange | null = null;
+
     if (image) {
         const range = createRange(image);
 
@@ -30,20 +35,15 @@ export const selectImage: SelectImage = (core: EditorCore, image: HTMLImageEleme
 
         select(core, image);
 
-        const selection: ImageSelectionRange = {
+        selection = {
             type: SelectionRangeTypes.ImageSelection,
             ranges: [range],
             image: image,
             areAllCollapsed: range.collapsed,
         };
-
-        core.domEvent.imageSelectionRange = selection;
-
-        return selection;
     }
 
-    core.domEvent.imageSelectionRange = null;
-    return null;
+    return selection;
 };
 
 const select = (core: EditorCore, image: HTMLImageElement) => {
@@ -53,16 +53,10 @@ const select = (core: EditorCore, image: HTMLImageElement) => {
 };
 
 const buildBorderCSS = (core: EditorCore, imageId: string): string => {
-    const borderColor = core.imageSelectionBorderColor || '#DB626C';
-    return (
-        '#' +
-        core.contentDiv.id +
-        ' #' +
-        imageId +
-        ' { margin: -2px !important; border: 2px solid' +
-        borderColor +
-        ' !important; }'
-    );
+    const divId = core.contentDiv.id;
+    const color = core.imageSelectionBorderColor || DEFAULT_SELECTION_BORDER_COLOR;
+
+    return `#${divId} #${imageId} {outline-style: auto!important;outline-color: ${color}!important;caret-color: transparent!important;}`;
 };
 
 const unselect = (core: EditorCore) => {

--- a/packages/roosterjs-editor-core/lib/coreApi/selectTable.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/selectTable.ts
@@ -80,8 +80,7 @@ function buildCss(
 
     let firstSelected: HTMLTableCellElement | null = null;
     let lastSelected: HTMLTableCellElement | null = null;
-    let css = '';
-    let isFirst = true;
+    const selectors: string[] = [];
 
     const vTable = new VTable(table);
 
@@ -89,7 +88,7 @@ function buildCss(
     const tableChildren = toArray(table.childNodes).filter(
         node => ['THEAD', 'TBODY', 'TFOOT'].indexOf(getTagOfNode(node)) > -1
     );
-    // Set the start and end of each of the table childs, so we can build the selector according the element between the table and the row.
+    // Set the start and end of each of the table children, so we can build the selector according the element between the table and the row.
     let cont = 0;
     const indexes = tableChildren.map(node => {
         const result = {
@@ -123,12 +122,6 @@ function buildCss(
                 tdCount++;
 
                 if (rowIndex >= tr1 && rowIndex <= tr2 && cellIndex >= td1 && cellIndex <= td2) {
-                    if (isFirst) {
-                        isFirst = false;
-                    } else if (!css.endsWith(',')) {
-                        css += ',';
-                    }
-
                     removeImportant(cell);
 
                     const selector = generateCssFromCell(
@@ -139,9 +132,10 @@ function buildCss(
                         tag,
                         tdCount
                     );
-                    css += selector;
+
+                    selectors.push(selector);
                     firstSelected = firstSelected || table.querySelector(selector);
-                    lastSelected = table.querySelector(selector)!;
+                    lastSelected = table.querySelector(selector);
                 }
             }
         }
@@ -154,7 +148,9 @@ function buildCss(
         }
     });
 
-    css += '{background-color: rgba(198,198,198,0.7) !important;}';
+    const css = `${selectors.join(
+        ','
+    )} {background-color: rgba(198,198,198,0.7) !important; caret-color: transparent}`;
 
     return { css, ranges };
 }

--- a/packages/roosterjs-editor-core/lib/coreApi/setContent.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/setContent.ts
@@ -73,20 +73,39 @@ export const setContent: SetContent = (
 };
 
 function selectContentMetadata(core: EditorCore, metadata: ContentMetadata | undefined) {
-    switch (metadata?.type) {
-        case SelectionRangeTypes.Normal:
-            const range = createRange(core.contentDiv, metadata.start, metadata.end);
-            core.api.selectRange(core, range);
-            break;
-        case SelectionRangeTypes.TableSelection:
-            const table = queryElements(
-                core.contentDiv,
-                '#' + metadata.tableId
-            )[0] as HTMLTableElement;
+    if (!core.lifecycle.shadowEditSelectionPath && metadata) {
+        core.domEvent.tableSelectionRange = null;
+        core.domEvent.imageSelectionRange = null;
+        core.domEvent.selectionRange = null;
 
-            if (table) {
-                core.api.selectTable(core, table, metadata);
-            }
-            break;
+        switch (metadata.type) {
+            case SelectionRangeTypes.Normal:
+                core.api.selectTable(core, null);
+                core.api.selectImage(core, null);
+
+                const range = createRange(core.contentDiv, metadata.start, metadata.end);
+                core.api.selectRange(core, range);
+                break;
+            case SelectionRangeTypes.TableSelection:
+                const table = queryElements(
+                    core.contentDiv,
+                    '#' + metadata.tableId
+                )[0] as HTMLTableElement;
+
+                if (table) {
+                    core.domEvent.tableSelectionRange = core.api.selectTable(core, table, metadata);
+                }
+                break;
+            case SelectionRangeTypes.ImageSelection:
+                const image = queryElements(
+                    core.contentDiv,
+                    '#' + metadata.imageId
+                )[0] as HTMLImageElement;
+
+                if (image) {
+                    core.domEvent.imageSelectionRange = core.api.selectImage(core, image);
+                }
+                break;
+        }
     }
 }

--- a/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/CopyPastePlugin.ts
@@ -95,7 +95,7 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
                     html,
                     this.editor.getTrustedHTMLHandler()
                 );
-                let newRange: Range | null;
+                let newRange: Range | null = null;
 
                 if (
                     selection.type === SelectionRangeTypes.TableSelection &&
@@ -111,6 +111,12 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
                             selection.table,
                             selection.coordinates
                         );
+                    }
+                } else if (selection.type === SelectionRangeTypes.ImageSelection) {
+                    const image = tempDiv.querySelector('#' + selection.image.id);
+
+                    if (image) {
+                        newRange = createRange(image);
                     }
                 } else {
                     newRange =
@@ -210,9 +216,8 @@ export default class CopyPastePlugin implements PluginWithState<CopyPastePluginS
             const selection = <SelectionRangeEx>range;
             switch (selection.type) {
                 case SelectionRangeTypes.TableSelection:
-                    if (this.editor && selection.table && selection.coordinates) {
-                        this.editor.select(selection.table, selection.coordinates);
-                    }
+                case SelectionRangeTypes.ImageSelection:
+                    this.editor?.select(selection);
                     break;
                 case SelectionRangeTypes.Normal:
                     const range = selection.ranges?.[0];

--- a/packages/roosterjs-editor-core/test/coreApi/selectImageTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/selectImageTest.ts
@@ -27,10 +27,9 @@ describe('selectImage |', () => {
     });
 
     it('selectImage', () => {
-        selectImage(core, image);
+        const selectedInfo = selectImage(core, image);
         const range = new Range();
         range.selectNode(image!);
-        const selectedInfo = core.domEvent.imageSelectionRange;
 
         expect(selectedInfo).toEqual({
             type: SelectionRangeTypes.ImageSelection,

--- a/packages/roosterjs-editor-dom/lib/selection/setHtmlWithSelectionPath.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/setHtmlWithSelectionPath.ts
@@ -12,11 +12,11 @@ import {
     ContentMetadata,
     SelectionRangeTypes,
     TrustedHTMLHandler,
+    ImageContentMetadata,
     NormalContentMetadata,
     TableContentMetadata,
     Coordinates,
 } from 'roosterjs-editor-types';
-
 const NumberArrayDefinition = createArrayDefinition<number>(createNumberDefinition());
 
 const CoordinatesDefinition = createObjectDefinition<Coordinates>({
@@ -39,6 +39,12 @@ const TableContentMetadataDefinition = createObjectDefinition<TableContentMetada
     tableId: createStringDefinition(),
     firstCell: CoordinatesDefinition,
     lastCell: CoordinatesDefinition,
+});
+
+const ImageContentMetadataDefinition = createObjectDefinition<ImageContentMetadata>({
+    type: createNumberDefinition(false /*isOptional*/, SelectionRangeTypes.ImageSelection),
+    isDarkMode: IsDarkModeDefinition,
+    imageId: createStringDefinition(),
 });
 
 /**
@@ -89,7 +95,8 @@ export function setHtmlWithMetadata(
 
             if (
                 validate(obj, NormalContentMetadataDefinition) ||
-                validate(obj, TableContentMetadataDefinition)
+                validate(obj, TableContentMetadataDefinition) ||
+                validate(obj, ImageContentMetadataDefinition)
             ) {
                 rootNode.removeChild(potentialMetadataComment);
                 obj.type = typeof obj.type === 'undefined' ? SelectionRangeTypes.Normal : obj.type;

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -210,6 +210,8 @@ export default class TableCellSelection implements EditorPlugin {
                     this.tableSelection = false;
                 }
             });
+        } else if (this.editor.getSelectionRangeEx()?.type == SelectionRangeTypes.TableSelection) {
+            this.editor.select(null);
         }
     }
 

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/tableFeaturesTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/tableFeaturesTest.ts
@@ -111,7 +111,15 @@ describe('TableFeature', () => {
                 runTest(true, 1, 0);
             });
             it('Shift + Tab in 1st cell', () => {
-                runTest(true, 0, 0);
+                const event = shiftKeyboardEvent;
+                let cells = table?.querySelectorAll('td,th')!;
+                const target = cells[0]!;
+
+                editor.select(target, 0);
+                feature.handleEvent(event, editor);
+
+                const focusedPos = editor.getFocusedPosition();
+                expect(focusedPos.node).toBe(table?.parentNode);
             });
             it('Tab in last cell to create new row', () => {
                 runTest(false, 3, 4);

--- a/packages/roosterjs-editor-types/lib/interface/ContentMetadata.ts
+++ b/packages/roosterjs-editor-types/lib/interface/ContentMetadata.ts
@@ -41,5 +41,19 @@ export interface TableContentMetadata
 /**
  * A content metadata is a data structure storing information other than HTML content,
  * such as dark mode info, selection info, ...
+ *
+ * ImageContentMetadata is content metadata for image selection with image id
+ *
+ * When do any change to this type, also need to fix function isUndoMetadata to make sure
+ * the check is correct
  */
-export type ContentMetadata = NormalContentMetadata | TableContentMetadata;
+export interface ImageContentMetadata
+    extends ContentMetadataBase<SelectionRangeTypes.ImageSelection> {
+    imageId: string;
+}
+
+/**
+ * A content metadata is a data structure storing information other than HTML content,
+ * such as dark mode info, selection info, ...
+ */
+export type ContentMetadata = NormalContentMetadata | TableContentMetadata | ImageContentMetadata;

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -316,6 +316,12 @@ export default interface IEditor {
     select(table: HTMLTableElement, coordinates: TableSelection): boolean;
 
     /**
+     * Select content SelectionRangeEx
+     * @param rangeEx SelectionRangeEx object to specify what to select
+     */
+    select(rangeEx: SelectionRangeEx): boolean;
+
+    /**
      * Get current focused position. Return null if editor doesn't have focus at this time.
      */
     getFocusedPosition(): NodePosition | null;
@@ -644,6 +650,3 @@ export default interface IEditor {
     getVisibleViewport(): Rect | null;
     //#endregion
 }
-
-// Temporarily put these interfaces here to workaround circular dependency issue
-// Need to revisit these interfaces later.

--- a/packages/roosterjs-editor-types/lib/interface/index.ts
+++ b/packages/roosterjs-editor-types/lib/interface/index.ts
@@ -38,6 +38,7 @@ export {
     ContentMetadataBase,
     NormalContentMetadata,
     TableContentMetadata,
+    ImageContentMetadata,
     ContentMetadata,
 } from './ContentMetadata';
 export { default as Snapshot } from './Snapshot';


### PR DESCRIPTION
To prepare the support for image selection in Content Model, do some refactoring for selection code. This includes:
1. Hide cursor when image selection/table selection happens
2. Support passing in SelectionRangeEx into editor.select()
3. Better support image selection/table selection when do inline format and block format
4. Better support image selection/table selection when restore selection