### PR TITLE
Fix empty line bug for content model

### DIFF
--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleSegment.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleSegment.ts
@@ -36,8 +36,12 @@ export const handleSegment: ContentModelHandler<ContentModelSegment> = (
             break;
 
         case 'Br':
-            element = doc.createElement('br');
-            regularSelection.current.segment = element;
+            const br = doc.createElement('br');
+            element = doc.createElement('span');
+            element.appendChild(br);
+            regularSelection.current.segment = br;
+
+            applyFormat(element, context.formatAppliers.segment, segment.format, context);
             break;
 
         case 'General':

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleSegmentTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleSegmentTest.ts
@@ -50,7 +50,7 @@ describe('handleSegment', () => {
                 segmentType: 'Br',
                 format: {},
             },
-            '<br>',
+            '<span><br></span>',
             0
         );
     });

--- a/packages/roosterjs-editor-api/lib/format/changeFontSize.ts
+++ b/packages/roosterjs-editor-api/lib/format/changeFontSize.ts
@@ -29,7 +29,7 @@ export default function changeFontSize(
             let pt = parseFloat(getComputedStyle(element, 'font-size') || element.style.fontSize);
             element.style.fontSize = getNewFontSize(pt, changeBase, fontSizes) + 'pt';
             let lineHeight = getComputedStyle(element, 'line-height');
-            if (lineHeight != 'normal') {
+            if (lineHeight && lineHeight != 'normal') {
                 element.style.lineHeight = 'normal';
             }
         },

--- a/packages/roosterjs-editor-api/lib/format/setFontSize.ts
+++ b/packages/roosterjs-editor-api/lib/format/setFontSize.ts
@@ -17,7 +17,7 @@ export default function setFontSize(editor: IEditor, fontSize: string) {
         (element, isInnerNode) => {
             element.style.fontSize = isInnerNode ? '' : fontSize;
             let lineHeight = getComputedStyle(element, 'line-height');
-            if (lineHeight != 'normal') {
+            if (lineHeight && lineHeight != 'normal') {
                 element.style.lineHeight = 'normal';
             }
         },

--- a/packages/roosterjs-editor-core/lib/corePlugins/PendingFormatStatePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/PendingFormatStatePlugin.ts
@@ -94,6 +94,7 @@ export default class PendingFormatStatePlugin
                     isCharacterValue(event.rawEvent) &&
                     this.state.pendableFormatSpan
                 ) {
+                    this.state.pendableFormatSpan.removeAttribute('contentEditable');
                     this.editor.insertNode(this.state.pendableFormatSpan);
                     this.editor.select(
                         this.state.pendableFormatSpan,


### PR DESCRIPTION
Repro step:
1. Type some text
2. Select all, and apply some format such as font, color
3. Add some new empty lines after the text
4. Open content model side pane, click "Create DOM tree" button
5. focus to the empty lines, type text
Expect: typed text is still in the applied format
Actual: format is lost

This is because when create DOM tree, those empty lines doesn't have a SPAN tag to hold its format, so format got lost

Fix:
Create SPAN tag for BR tag as well. So the SPAN tag can hold the format.

Also fix bugs:
1. When apply pending format, remove "content editable" attribute since we don't need it in the body, in order to make the SPAN tag clean so that it can be recognized correctly by Content Model.
2. When apply font size, no need to apply line-height format if there it was not set to other values, in order to make the SPAN tag clean so that it can be recognized correctly by Content Model.