### PR TITLE
Content Model: Fix the check of block group empty

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/common/isEmpty.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/isEmpty.ts
@@ -25,7 +25,19 @@ export function isBlockEmpty(block: ContentModelBlock): boolean {
  * @internal
  */
 export function isBlockGroupEmpty(group: ContentModelBlockGroup): boolean {
-    return group.blocks.every(isBlockEmpty);
+    switch (group.blockGroupType) {
+        case 'Document':
+        case 'Quote':
+            return group.blocks.every(isBlockEmpty);
+
+        case 'General':
+        case 'ListItem':
+        case 'TableCell':
+            return false;
+
+        default:
+            return true;
+    }
 }
 
 /**

--- a/packages/roosterjs-content-model/lib/modelApi/common/isEmpty.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/isEmpty.ts
@@ -16,6 +16,9 @@ export function isBlockEmpty(block: ContentModelBlock): boolean {
         case 'BlockGroup':
             return isBlockGroupEmpty(block);
 
+        case 'Entity':
+            return false;
+
         default:
             return false;
     }
@@ -46,7 +49,7 @@ export function isBlockGroupEmpty(group: ContentModelBlockGroup): boolean {
 export function isSegmentEmpty(segment: ContentModelSegment): boolean {
     switch (segment.segmentType) {
         case 'Text':
-            return !segment.text || /^[\r\n]*$/.test(segment.text);
+            return !segment.text || /^[\r\n\s\t]*$/.test(segment.text);
 
         default:
             return false;

--- a/packages/roosterjs-content-model/lib/modelApi/common/isEmpty.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/isEmpty.ts
@@ -29,10 +29,10 @@ export function isBlockEmpty(block: ContentModelBlock): boolean {
  */
 export function isBlockGroupEmpty(group: ContentModelBlockGroup): boolean {
     switch (group.blockGroupType) {
-        case 'Document':
         case 'Quote':
             return group.blocks.every(isBlockEmpty);
 
+        case 'Document':
         case 'General':
         case 'ListItem':
         case 'TableCell':

--- a/packages/roosterjs-content-model/test/modelApi/common/isEmptyTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/isEmptyTest.ts
@@ -190,7 +190,7 @@ describe('isEmpty', () => {
             blocks: [],
         });
 
-        expect(result).toBeTrue();
+        expect(result).toBeFalse();
     });
 
     it('Document with empty block', () => {
@@ -206,7 +206,7 @@ describe('isEmpty', () => {
             ],
         });
 
-        expect(result).toBeTrue();
+        expect(result).toBeFalse();
     });
 
     it('Document with content', () => {

--- a/packages/roosterjs-content-model/test/modelApi/common/isEmptyTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/isEmptyTest.ts
@@ -1,0 +1,304 @@
+import { isEmpty } from '../../../lib/modelApi/common/isEmpty';
+
+describe('isEmpty', () => {
+    it('Empty paragraph', () => {
+        const result = isEmpty({
+            blockType: 'Paragraph',
+            format: {},
+            segments: [],
+        });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Paragraph has text', () => {
+        const result = isEmpty({
+            blockType: 'Paragraph',
+            format: {},
+            segments: [
+                {
+                    segmentType: 'Text',
+                    format: {},
+                    text: 'test',
+                },
+            ],
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Paragraph has selection marker', () => {
+        const result = isEmpty({
+            blockType: 'Paragraph',
+            format: {},
+            segments: [
+                {
+                    segmentType: 'SelectionMarker',
+                    format: {},
+                    isSelected: true,
+                },
+            ],
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Empty table 1', () => {
+        const result = isEmpty({
+            blockType: 'Table',
+            format: {},
+            cells: [],
+            widths: [],
+            heights: [],
+        });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Empty table 2', () => {
+        const result = isEmpty({
+            blockType: 'Table',
+            format: {},
+            cells: [[], [], []],
+            widths: [],
+            heights: [],
+        });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Table has cell', () => {
+        const result = isEmpty({
+            blockType: 'Table',
+            format: {},
+            cells: [
+                [
+                    {
+                        blockGroupType: 'TableCell',
+                        format: {},
+                        spanAbove: false,
+                        spanLeft: false,
+                        blocks: [],
+                    },
+                ],
+            ],
+            widths: [],
+            heights: [],
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Empty quote', () => {
+        const result = isEmpty({
+            blockType: 'BlockGroup',
+            blockGroupType: 'Quote',
+            format: {},
+            blocks: [],
+        });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Quote has empty block', () => {
+        const result = isEmpty({
+            blockType: 'BlockGroup',
+            blockGroupType: 'Quote',
+            format: {},
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [],
+                },
+            ],
+        });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Empty list item', () => {
+        const result = isEmpty({
+            blockType: 'BlockGroup',
+            blockGroupType: 'ListItem',
+            format: {},
+            blocks: [],
+            levels: [],
+            formatHolder: {
+                segmentType: 'SelectionMarker',
+                format: {},
+                isSelected: true,
+            },
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('List item has empty block', () => {
+        const result = isEmpty({
+            blockType: 'BlockGroup',
+            blockGroupType: 'ListItem',
+            format: {},
+            levels: [],
+            formatHolder: {
+                segmentType: 'SelectionMarker',
+                format: {},
+                isSelected: true,
+            },
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [],
+                },
+            ],
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Empty general node', () => {
+        const result = isEmpty({
+            blockType: 'BlockGroup',
+            blockGroupType: 'General',
+            element: document.createElement('div'),
+            format: {},
+            blocks: [],
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Empty entity node', () => {
+        const result = isEmpty({
+            blockType: 'Entity',
+            segmentType: 'Entity',
+            format: {},
+            type: 'Test',
+            id: 'Test',
+            wrapper: document.createElement('div'),
+            isReadonly: false,
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Empty document', () => {
+        const result = isEmpty({
+            blockGroupType: 'Document',
+            document: document,
+            blocks: [],
+        });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Document with empty block', () => {
+        const result = isEmpty({
+            blockGroupType: 'Document',
+            document: document,
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [],
+                },
+            ],
+        });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Document with content', () => {
+        const result = isEmpty({
+            blockGroupType: 'Document',
+            document: document,
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Empty table cell', () => {
+        const result = isEmpty({
+            blockGroupType: 'TableCell',
+            format: {},
+            spanAbove: false,
+            spanLeft: false,
+            blocks: [],
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Empty text', () => {
+        const result = isEmpty({
+            segmentType: 'Text',
+            format: {},
+            text: '',
+        });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Text has only spaces', () => {
+        const result = isEmpty({
+            segmentType: 'Text',
+            format: {},
+            text: ' \t \r \n ',
+        });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Text has content', () => {
+        const result = isEmpty({
+            segmentType: 'Text',
+            format: {},
+            text: '  aa  ',
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Text has content and CR', () => {
+        const result = isEmpty({
+            segmentType: 'Text',
+            format: {},
+            text: '  aa  \r\n  bb  ',
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Selection marker', () => {
+        const result = isEmpty({
+            segmentType: 'SelectionMarker',
+            format: {},
+            isSelected: true,
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Br', () => {
+        const result = isEmpty({
+            segmentType: 'Br',
+            format: {},
+            isSelected: true,
+        });
+
+        expect(result).toBeFalse();
+    });
+});


### PR DESCRIPTION
For block group, when we check if it is empty, we need to check according to its type.

For example, a General block group or a TableCell should never be treated as empty.