### PR TITLE
Resize cropped image

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/api/resizeByPercentage.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/api/resizeByPercentage.ts
@@ -23,7 +23,7 @@ export default function resizeByPercentage(
     const editInfo = getEditInfoFromImage(image);
 
     if (!isResizedTo(image, percentage)) {
-        loadImage(image, editInfo.src, () => {
+        loadImage(image, image.src, () => {
             if (!editor.isDisposed() && editor.contains(image)) {
                 const lastSrc = image.getAttribute('src');
                 const { width, height } = getTargetSizeByPercentage(editInfo, percentage);


### PR DESCRIPTION
When resize by percentage get the image src, so the cropped images can be resized and not reseted. 

![imageResizeBug](https://user-images.githubusercontent.com/87443959/197584265-daef3d20-c819-4a44-9a11-7dfc93c5d0e4.gif)
