### PR TITLE
 Select merged cells

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -314,9 +314,7 @@ export default class TableEditor {
                 const rows = vTable.cells.length - 1;
                 let lastCellIndex: number = 0;
                 vTable.cells[rows].forEach((cell, index) => {
-                    if (cell.td) {
-                        lastCellIndex = index;
-                    }
+                    lastCellIndex = index;
                 });
 
                 const selection: TableSelection = {


### PR DESCRIPTION
On click in table selector, select all cells, even the merged ones. 
![selectWholeTable](https://user-images.githubusercontent.com/87443959/197608053-4d275349-74b9-4b50-abd7-f8e42b6acd19.gif)
