### PR TITLE
Fix a regression in TableCellSelection

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -22,6 +22,7 @@ import {
     VTable,
     Position,
     contains,
+    isCtrlOrMetaPressed,
 } from 'roosterjs-editor-dom';
 
 const TABLE_CELL_SELECTOR = 'td,th';
@@ -210,7 +211,10 @@ export default class TableCellSelection implements EditorPlugin {
                     this.tableSelection = false;
                 }
             });
-        } else if (this.editor.getSelectionRangeEx()?.type == SelectionRangeTypes.TableSelection) {
+        } else if (
+            this.editor.getSelectionRangeEx()?.type == SelectionRangeTypes.TableSelection &&
+            !isCtrlOrMetaPressed(event.rawEvent)
+        ) {
             this.editor.select(null);
         }
     }

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -213,7 +213,7 @@ export default class TableCellSelection implements EditorPlugin {
             });
         } else if (
             this.editor.getSelectionRangeEx()?.type == SelectionRangeTypes.TableSelection &&
-            !isCtrlOrMetaPressed(event.rawEvent)
+            (!isCtrlOrMetaPressed(event.rawEvent) || which == Keys.HOME || which == Keys.END)
         ) {
             this.editor.select(null);
         }

--- a/packages/roosterjs-editor-types/lib/enum/Keys.ts
+++ b/packages/roosterjs-editor-types/lib/enum/Keys.ts
@@ -12,6 +12,8 @@ export const enum Keys {
     ESCAPE = 27,
     SPACE = 32,
     PAGEUP = 33,
+    END = 35,
+    HOME = 36,
     LEFT = 37,
     UP = 38,
     RIGHT = 39,


### PR DESCRIPTION
Fix #1356 

Add a check to Ctrl/Meta key when handle key down event with table selection. Also allow Home/End key to dismiss table selection.