### PR TITLE
Fix clear format not handling heading and blockquote wrappers - v2

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -4,6 +4,7 @@ import formatUndoSnapshot from '../utils/formatUndoSnapshot';
 import setBackgroundColor from './setBackgroundColor';
 import setFontName from './setFontName';
 import setFontSize from './setFontSize';
+import setFontWeight from './setFontWeight';
 import setTextColor from './setTextColor';
 import toggleBold from './toggleBold';
 import toggleItalic from './toggleItalic';

--- a/packages/roosterjs-editor-api/lib/format/setFontWeight.ts
+++ b/packages/roosterjs-editor-api/lib/format/setFontWeight.ts
@@ -1,5 +1,4 @@
 import applyListItemStyleWrap from '../utils/applyListItemWrap';
-import { getComputedStyle } from 'roosterjs-editor-dom';
 import { IEditor } from 'roosterjs-editor-types';
 
 /**
@@ -13,12 +12,7 @@ export default function setFontWeight(editor: IEditor, fontWeight: string) {
     applyListItemStyleWrap(
         editor,
         'font-weight',
-        element => {
-            let computedFontWeight = getComputedStyle(element, 'font-weight');
-            if (computedFontWeight !== fontWeight) {
-                element.style.fontWeight = '400';
-            }
-        },
+        element => (element.style.fontWeight = fontWeight),
         'setFontWeight'
     );
 }

--- a/packages/roosterjs-editor-api/lib/format/setFontWeight.ts
+++ b/packages/roosterjs-editor-api/lib/format/setFontWeight.ts
@@ -1,0 +1,24 @@
+import applyListItemStyleWrap from '../utils/applyListItemWrap';
+import { getComputedStyle } from 'roosterjs-editor-dom';
+import { IEditor } from 'roosterjs-editor-types';
+
+/**
+ * Set font weight at selection
+ * Only sets the value if the computed weight is different
+ * @param editor The editor instance
+ * @param fontWeight The fontWight string, should be a valid CSS font-weight style.
+ * Currently there's no validation to the string, if the passed string is invalid, it won't take affect
+ */
+export default function setFontWeight(editor: IEditor, fontWeight: string) {
+    applyListItemStyleWrap(
+        editor,
+        'font-weight',
+        element => {
+            let computedFontWeight = getComputedStyle(element, 'font-weight');
+            if (computedFontWeight !== fontWeight) {
+                element.style.fontWeight = '400';
+            }
+        },
+        'setFontWeight'
+    );
+}

--- a/packages/roosterjs-editor-api/test/format/clearFormatTest.ts
+++ b/packages/roosterjs-editor-api/test/format/clearFormatTest.ts
@@ -39,7 +39,7 @@ describe('clearFormat()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div id="text" style=""><span style="font-family: arial; font-size: 12pt; color: black;">text</span></div>'
+            '<div id="text" style=""><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">text</span></div>'
         );
     });
 
@@ -63,7 +63,7 @@ describe('clearFormat()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div id="text"><span style="font-family: arial; font-size: 12pt; color: black;">This is a </span><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">link</span></a><span style="font-family: arial; font-size: 12pt; color: black;">.</span></div>'
+            '<div id="text"><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">This is a </span><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt; font-weight: 400;">link</span></a><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">.</span></div>'
         );
     });
 
@@ -79,7 +79,7 @@ describe('clearFormat()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div id="text"><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">link</span></a></div>'
+            '<div id="text"><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt; font-weight: 400;">link</span></a></div>'
         );
     });
 
@@ -97,7 +97,7 @@ describe('clearFormat()', () => {
 
             // Assert
             expect(editor.getContent()).toBe(
-                '<div id="text" style=""><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">hello</span></a><span style="font-family: arial; font-size: 12pt; color: black;"> World!</span></div>'
+                '<div id="text" style=""><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt; font-weight: 400;">hello</span></a><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;"> World!</span></div>'
             );
         }
     );
@@ -116,7 +116,7 @@ describe('clearFormat()', () => {
 
             // Assert
             expect(editor.getContent()).toBe(
-                '<span style="font-family: arial; font-size: 12pt; color: black;">This is a test text with </span><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">Hyperlink.</span></a>'
+                '<span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">This is a test text with </span><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt; font-weight: 400;">Hyperlink.</span></a>'
             );
         }
     );
@@ -300,7 +300,7 @@ describe('clearAutodetectFormat Partial Tests', () => {
         const originalContent =
             '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul type="disc" style="margin-bottom:0in"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">item 1</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Item 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
         const expectedFormat =
-            '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul style="margin-bottom:0in" type="disc"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">item 1</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-family: arial; font-size: 12pt; color: black;">Item</span><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif"> 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
+            '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul style="margin-bottom:0in" type="disc"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">item 1</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">Item</span><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif"> 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
         editor.setContent(originalContent);
 
         const ul = doc.getElementsByTagName('ul')[0];

--- a/packages/roosterjs-editor-api/test/format/clearFormatTest.ts
+++ b/packages/roosterjs-editor-api/test/format/clearFormatTest.ts
@@ -280,7 +280,7 @@ describe('clearAutodetectFormat Partial Tests', () => {
         const originalText =
             '<h1 id="testHeader" style="margin-right:0in;margin-left:0in;font-size:24pt;font-family:&quot;Times New Roman&quot;, serif"><span style="font-size: 24pt; font-family: Arial, sans-serif;">Header middle text 1</span></h1>';
         const expectedFormat =
-            '<span style="font-size: 24pt; font-family: Arial, sans-serif;">Header </span><span style="font-family: arial; font-size: 12pt; color: black;">middle</span><span style="font-size: 24pt; font-family: Arial, sans-serif;"> text 1</span>';
+            '<span style="font-size: 24pt; font-family: Arial, sans-serif;">Header </span><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">middle</span><span style="font-size: 24pt; font-family: Arial, sans-serif;"> text 1</span>';
         editor.setContent(originalText);
 
         let header = doc.getElementById('testHeader');


### PR DESCRIPTION
Selects all `<hX>` and `<blockquote>` elements under selection and unwraps them as they are not removed by `removeFormat` command.
https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html#the-removeformat-command

Initial
<img height="203" alt="image" src="https://user-images.githubusercontent.com/44042957/196546440-f1e86fae-36c7-408d-975a-e63e3762da73.png">
Current clearFormat impl
<img height="200" alt="image" src="https://user-images.githubusercontent.com/44042957/196546504-a513edb3-f9cd-42e8-805c-33a29192bddb.png">
Fixed clearFormat impl
<img height="200" alt="image" src="https://user-images.githubusercontent.com/44042957/196546568-99d6d083-14fa-4d2c-8ff7-195034e8038b.png">

Additionally set a default font weight so partial clear format under `<h1>` tags isn't bold
![image](https://user-images.githubusercontent.com/44042957/197619409-3868c541-654f-42d7-887b-f74cb384aefe.png)
