### PR TITLE
Auto detect clear mode when clear format

### DIFF
--- a/packages-ui/roosterjs-react/lib/ribbon/component/buttons/clearFormat.ts
+++ b/packages-ui/roosterjs-react/lib/ribbon/component/buttons/clearFormat.ts
@@ -1,6 +1,7 @@
 import RibbonButton from '../../type/RibbonButton';
 import { clearFormat as clearFormatApi } from 'roosterjs-editor-api';
 import { ClearFormatButtonStringKey } from '../../type/RibbonButtonStringKeys';
+import { ClearFormatMode } from 'roosterjs-editor-types';
 
 /**
  * @internal
@@ -11,6 +12,6 @@ export const clearFormat: RibbonButton<ClearFormatButtonStringKey> = {
     unlocalizedText: 'Clear format',
     iconName: 'ClearFormatting',
     onClick: editor => {
-        clearFormatApi(editor);
+        clearFormatApi(editor, ClearFormatMode.AutoDetect);
     },
 };


### PR DESCRIPTION
Fix the behavior of clear format button in roosterjs-react, auto detect clear mode.

- If only part of a paragraph is selected, clear inline format only
- If a full paragraph or multiple paragraphs are selected, clear both inline format and block format