### PR TITLE
Stop propagation for HOME and other keys

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
@@ -209,7 +209,9 @@ export default class DOMEventPlugin implements PluginWithState<DOMEventPluginSta
     }
 
     private onKeyboardEvent = (event: KeyboardEvent) => {
-        if (isCharacterValue(event)) {
+        if (isCharacterValue(event) || (event.which >= Keys.PAGEUP && event.which <= Keys.DOWN)) {
+            // Stop propagation for Character keys and Up/Down/Left/Right/Home/End/PageUp/PageDown
+            // since editor already handles these keys and no need to propagate to parents
             event.stopPropagation();
         }
     };


### PR DESCRIPTION
We have code to stop propagation for character keys. We can expand this logic for the following keys as well:
- Home
- End
- PageUp
- PageDown
- Left
- Right
- Up
- Down

Because these keys are already handled by editor, so no need to expose them to parent containers.