### PR TITLE
Content Model Bug fix: part 1

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/generalProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/generalProcessor.ts
@@ -29,6 +29,8 @@ const generalSegmentProcessor: ElementProcessor<HTMLElement> = (group, element, 
         segment.isSelected = true;
     }
 
+    addSegment(group, segment);
+
     stackFormat(
         context,
         {
@@ -36,7 +38,6 @@ const generalSegmentProcessor: ElementProcessor<HTMLElement> = (group, element, 
                 'empty' /*clearFormat, General segment will include all properties and styles when generate back to HTML, so no need to carry over existing segment format*/,
         },
         () => {
-            addSegment(group, segment);
             context.elementProcessors.child(segment, element, context);
         }
     );

--- a/packages/roosterjs-content-model/lib/modelApi/selection/getSelectedParagraphs.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/selection/getSelectedParagraphs.ts
@@ -18,7 +18,32 @@ export function getSelectedParagraphs(group: ContentModelBlockGroup): SelectedPa
 
     getSelectedParagraphsInternal([group], result);
 
+    // Remove tail paragraph if first selection marker is the only selection
+    if (result.length > 1 && isOnlySelectionMarkerSelected(result, false /*checkFirstParagraph*/)) {
+        result.pop();
+    }
+
+    // Remove head paragraph if first selection marker is the only selection
+    if (result.length > 1 && isOnlySelectionMarkerSelected(result, true /*checkFirstParagraph*/)) {
+        result.shift();
+    }
+
     return result;
+}
+
+function isOnlySelectionMarkerSelected(
+    paragraphs: SelectedParagraphWithPath[],
+    checkFirstParagraph: boolean
+): boolean {
+    const paragraph = paragraphs[checkFirstParagraph ? 0 : paragraphs.length - 1].paragraph;
+    const selectedSegments = paragraph.segments.filter(s => s.isSelected);
+
+    return (
+        selectedSegments.length == 1 &&
+        selectedSegments[0].segmentType == 'SelectionMarker' &&
+        selectedSegments[0] ==
+            paragraph.segments[checkFirstParagraph ? paragraph.segments.length - 1 : 0]
+    );
 }
 
 function getSelectedParagraphsInternal(

--- a/packages/roosterjs-content-model/lib/modelToDom/context/defaultContentModelHandlers.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/context/defaultContentModelHandlers.ts
@@ -2,7 +2,9 @@ import { ContentModelHandlerMap } from '../../publicTypes/context/ModelToDomSett
 import { handleBlock } from '../handlers/handleBlock';
 import { handleBlockGroup } from '../handlers/handleBlockGroup';
 import { handleBlockGroupChildren } from '../handlers/handleBlockGroupChildren';
+import { handleBr } from '../handlers/handleBr';
 import { handleEntity } from '../handlers/handleEntity';
+import { handleGeneralModel } from '../handlers/handleGeneralModel';
 import { handleHR } from '../handlers/handleHr';
 import { handleImage } from '../handlers/handleImage';
 import { handleList } from '../handlers/handleList';
@@ -11,6 +13,7 @@ import { handleParagraph } from '../handlers/handleParagraph';
 import { handleQuote } from '../handlers/handleQuote';
 import { handleSegment } from '../handlers/handleSegment';
 import { handleTable } from '../handlers/handleTable';
+import { handleText } from '../handlers/handleText';
 
 /**
  * @internal
@@ -19,7 +22,9 @@ export const defaultContentModelHandlers: ContentModelHandlerMap = {
     block: handleBlock,
     blockGroup: handleBlockGroup,
     blockGroupChildren: handleBlockGroupChildren,
+    br: handleBr,
     entity: handleEntity,
+    general: handleGeneralModel,
     hr: handleHR,
     image: handleImage,
     list: handleList,
@@ -28,4 +33,5 @@ export const defaultContentModelHandlers: ContentModelHandlerMap = {
     quote: handleQuote,
     segment: handleSegment,
     table: handleTable,
+    text: handleText,
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBlockGroup.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBlockGroup.ts
@@ -1,4 +1,3 @@
-import { applyFormat } from '../utils/applyFormat';
 import { ContentModelBlockGroup } from '../../publicTypes/block/group/ContentModelBlockGroup';
 import { ContentModelGeneralBlock } from '../../publicTypes/block/group/ContentModelGeneralBlock';
 import { ContentModelGeneralSegment } from '../../publicTypes/segment/ContentModelGeneralSegment';
@@ -23,12 +22,12 @@ export const handleBlockGroup: ContentModelHandler<ContentModelBlockGroup> = (
 
             context.modelHandlers.blockGroupChildren(doc, newParent, group, context);
 
-            if (isGeneralSegment(group) && isNodeOfType(newParent, NodeType.Element)) {
-                if (!group.element.firstChild) {
-                    context.regularSelection.current.segment = newParent;
-                }
-
-                applyFormat(newParent, context.formatAppliers.segment, group.format, context);
+            if (
+                isGeneralSegment(group) &&
+                isNodeOfType(newParent, NodeType.Element) &&
+                !group.element.firstChild
+            ) {
+                context.regularSelection.current.segment = newParent;
             }
 
             break;

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBlockGroup.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBlockGroup.ts
@@ -1,10 +1,6 @@
 import { ContentModelBlockGroup } from '../../publicTypes/block/group/ContentModelBlockGroup';
-import { ContentModelGeneralBlock } from '../../publicTypes/block/group/ContentModelGeneralBlock';
-import { ContentModelGeneralSegment } from '../../publicTypes/segment/ContentModelGeneralSegment';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
-import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
-import { NodeType } from 'roosterjs-editor-types';
 
 /**
  * @internal
@@ -17,19 +13,7 @@ export const handleBlockGroup: ContentModelHandler<ContentModelBlockGroup> = (
 ) => {
     switch (group.blockGroupType) {
         case 'General':
-            const newParent = group.element.cloneNode();
-            parent.appendChild(newParent);
-
-            context.modelHandlers.blockGroupChildren(doc, newParent, group, context);
-
-            if (
-                isGeneralSegment(group) &&
-                isNodeOfType(newParent, NodeType.Element) &&
-                !group.element.firstChild
-            ) {
-                context.regularSelection.current.segment = newParent;
-            }
-
+            context.modelHandlers.general(doc, parent, group, context);
             break;
 
         case 'Quote':
@@ -45,7 +29,3 @@ export const handleBlockGroup: ContentModelHandler<ContentModelBlockGroup> = (
             break;
     }
 };
-
-function isGeneralSegment(block: ContentModelGeneralBlock): block is ContentModelGeneralSegment {
-    return (block as ContentModelGeneralSegment).segmentType == 'General';
-}

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBr.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBr.ts
@@ -1,0 +1,22 @@
+import { applyFormat } from '../utils/applyFormat';
+import { ContentModelBr } from '../../publicTypes/segment/ContentModelBr';
+import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
+import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+
+/**
+ * @internal
+ */
+export const handleBr: ContentModelHandler<ContentModelBr> = (
+    doc: Document,
+    parent: Node,
+    segment: ContentModelBr,
+    context: ModelToDomContext
+) => {
+    const br = doc.createElement('br');
+    const element = doc.createElement('span');
+    element.appendChild(br);
+    parent.appendChild(element);
+
+    context.regularSelection.current.segment = br;
+    applyFormat(element, context.formatAppliers.segment, segment.format, context);
+};

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleGeneralModel.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleGeneralModel.ts
@@ -1,0 +1,34 @@
+import { applyFormat } from '../utils/applyFormat';
+import { ContentModelGeneralBlock } from '../../publicTypes/block/group/ContentModelGeneralBlock';
+import { ContentModelGeneralSegment } from '../../publicTypes/segment/ContentModelGeneralSegment';
+import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
+import { isNodeOfType } from '../../domUtils/isNodeOfType';
+import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+import { NodeType } from 'roosterjs-editor-types';
+
+/**
+ * @internal
+ */
+export const handleGeneralModel: ContentModelHandler<ContentModelGeneralBlock> = (
+    doc: Document,
+    parent: Node,
+    group: ContentModelGeneralBlock,
+    context: ModelToDomContext
+) => {
+    const newParent = group.element.cloneNode();
+    parent.appendChild(newParent);
+
+    context.modelHandlers.blockGroupChildren(doc, newParent, group, context);
+
+    if (isGeneralSegment(group) && isNodeOfType(newParent, NodeType.Element)) {
+        if (!group.element.firstChild) {
+            context.regularSelection.current.segment = newParent;
+        }
+
+        applyFormat(newParent, context.formatAppliers.segment, group.format, context);
+    }
+};
+
+function isGeneralSegment(block: ContentModelGeneralBlock): block is ContentModelGeneralSegment {
+    return (block as ContentModelGeneralSegment).segmentType == 'General';
+}

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleSegment.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleSegment.ts
@@ -1,4 +1,3 @@
-import { applyFormat } from '../utils/applyFormat';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
 import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
@@ -21,27 +20,13 @@ export const handleSegment: ContentModelHandler<ContentModelSegment> = (
         };
     }
 
-    let element: HTMLElement | null = null;
-
     switch (segment.segmentType) {
         case 'Text':
-            const txt = doc.createTextNode(segment.text);
-
-            element = doc.createElement('span');
-            element.appendChild(txt);
-            regularSelection.current.segment = txt;
-
-            applyFormat(element, context.formatAppliers.segment, segment.format, context);
-
+            context.modelHandlers.text(doc, parent, segment, context);
             break;
 
         case 'Br':
-            const br = doc.createElement('br');
-            element = doc.createElement('span');
-            element.appendChild(br);
-            regularSelection.current.segment = br;
-
-            applyFormat(element, context.formatAppliers.segment, segment.format, context);
+            context.modelHandlers.br(doc, parent, segment, context);
             break;
 
         case 'Image':
@@ -49,16 +34,12 @@ export const handleSegment: ContentModelHandler<ContentModelSegment> = (
             break;
 
         case 'General':
-            context.modelHandlers.block(doc, parent, segment, context);
+            context.modelHandlers.general(doc, parent, segment, context);
             break;
 
         case 'Entity':
             context.modelHandlers.entity(doc, parent, segment, context);
             break;
-    }
-
-    if (element) {
-        parent.appendChild(element);
     }
 
     // If end position is not set, or it is not finalized, and current segment is still in selection, set end position

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleText.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleText.ts
@@ -1,0 +1,23 @@
+import { applyFormat } from '../utils/applyFormat';
+import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
+import { ContentModelText } from '../../publicTypes/segment/ContentModelText';
+import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+
+/**
+ * @internal
+ */
+export const handleText: ContentModelHandler<ContentModelText> = (
+    doc: Document,
+    parent: Node,
+    segment: ContentModelText,
+    context: ModelToDomContext
+) => {
+    const txt = doc.createTextNode(segment.text);
+    const element = doc.createElement('span');
+
+    element.appendChild(txt);
+    parent.appendChild(element);
+
+    context.regularSelection.current.segment = txt;
+    applyFormat(element, context.formatAppliers.segment, segment.format, context);
+};

--- a/packages/roosterjs-content-model/lib/publicTypes/context/ModelToDomSettings.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/ModelToDomSettings.ts
@@ -1,8 +1,10 @@
 import { ContentModelBlock } from '../block/ContentModelBlock';
 import { ContentModelBlockGroup } from '../block/group/ContentModelBlockGroup';
+import { ContentModelBr } from '../segment/ContentModelBr';
 import { ContentModelEntity } from '../entity/ContentModelEntity';
 import { ContentModelFormatBase } from '../format/ContentModelFormatBase';
 import { ContentModelFormatMap } from '../format/ContentModelFormatMap';
+import { ContentModelGeneralBlock } from '../block/group/ContentModelGeneralBlock';
 import { ContentModelHandler } from './ContentModelHandler';
 import { ContentModelHR } from '../block/ContentModelHR';
 import { ContentModelImage } from '../segment/ContentModelImage';
@@ -11,6 +13,7 @@ import { ContentModelParagraph } from '../block/ContentModelParagraph';
 import { ContentModelQuote } from '../block/group/ContentModelQuote';
 import { ContentModelSegment } from '../segment/ContentModelSegment';
 import { ContentModelTable } from '../block/ContentModelTable';
+import { ContentModelText } from '../segment/ContentModelText';
 import { FormatHandlerTypeMap, FormatKey } from '../format/FormatHandlerTypeMap';
 import { ModelToDomContext } from './ModelToDomContext';
 
@@ -60,9 +63,19 @@ export interface ContentModelHandlerTypeMap {
     blockGroupChildren: ContentModelBlockGroup;
 
     /**
+     * Content Model type for ContentModelBr
+     */
+    br: ContentModelBr;
+
+    /**
      * Content Model type for child models of ContentModelEntity
      */
     entity: ContentModelEntity;
+
+    /**
+     * Content Model type for ContentModelGeneralBlock
+     */
+    general: ContentModelGeneralBlock;
 
     /**
      * Content Model type for ContentModelHR
@@ -103,6 +116,11 @@ export interface ContentModelHandlerTypeMap {
      * Content Model type for ContentModelTable
      */
     table: ContentModelTable;
+
+    /**
+     * Content Model type for ContentModelText
+     */
+    text: ContentModelText;
 }
 
 /**

--- a/packages/roosterjs-content-model/test/modelApi/selection/getSelectedParagraphsTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/selection/getSelectedParagraphsTest.ts
@@ -2,6 +2,7 @@ import { createContentModelDocument } from '../../../lib/modelApi/creators/creat
 import { createListItem } from '../../../lib/modelApi/creators/createListItem';
 import { createParagraph } from '../../../lib/modelApi/creators/createParagraph';
 import { createQuote } from '../../../lib/modelApi/creators/createQuote';
+import { createSelectionMarker } from '../../../lib/modelApi/creators/createSelectionMarker';
 import { createTable } from '../../../lib/modelApi/creators/createTable';
 import { createTableCell } from '../../../lib/modelApi/creators/createTableCell';
 import { createText } from '../../../lib/modelApi/creators/createText';
@@ -236,6 +237,120 @@ describe('getSelectedParagraphs', () => {
             {
                 paragraph: para2,
                 path: [cell1, group],
+            },
+        ]);
+    });
+
+    it('Select from the end of paragraph', () => {
+        const group = createContentModelDocument(document);
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const marker = createSelectionMarker();
+        const text = createText('test');
+
+        text.isSelected = true;
+        para1.segments.push(marker);
+        para2.segments.push(text);
+        group.blocks.push(para1);
+        group.blocks.push(para2);
+
+        const result = getSelectedParagraphs(group);
+
+        expect(result).toEqual([
+            {
+                paragraph: para2,
+                path: [group],
+            },
+        ]);
+    });
+
+    it('Select to the start of paragraph', () => {
+        const group = createContentModelDocument(document);
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const marker = createSelectionMarker();
+        const text = createText('test');
+
+        text.isSelected = true;
+        para1.segments.push(text);
+        para2.segments.push(marker);
+        group.blocks.push(para1);
+        group.blocks.push(para2);
+
+        const result = getSelectedParagraphs(group);
+
+        expect(result).toEqual([
+            {
+                paragraph: para1,
+                path: [group],
+            },
+        ]);
+    });
+
+    it('Select from the end to the start of paragraph', () => {
+        const group = createContentModelDocument(document);
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const para3 = createParagraph();
+        const marker1 = createSelectionMarker();
+        const marker2 = createSelectionMarker();
+        const text = createText('test');
+
+        text.isSelected = true;
+        para1.segments.push(marker1);
+        para2.segments.push(text);
+        para3.segments.push(marker2);
+        group.blocks.push(para1);
+        group.blocks.push(para2);
+        group.blocks.push(para3);
+
+        const result = getSelectedParagraphs(group);
+
+        expect(result).toEqual([
+            {
+                paragraph: para2,
+                path: [group],
+            },
+        ]);
+    });
+
+    it('Select not from the end, and not to the start of paragraph', () => {
+        const group = createContentModelDocument(document);
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const para3 = createParagraph();
+        const marker1 = createSelectionMarker();
+        const marker2 = createSelectionMarker();
+        const text1 = createText('test1');
+        const text2 = createText('test2');
+        const text3 = createText('test3');
+
+        text1.isSelected = true;
+        text2.isSelected = true;
+        text3.isSelected = true;
+        para1.segments.push(marker1);
+        para1.segments.push(text1);
+        para2.segments.push(text2);
+        para3.segments.push(text3);
+        para3.segments.push(marker2);
+        group.blocks.push(para1);
+        group.blocks.push(para2);
+        group.blocks.push(para3);
+
+        const result = getSelectedParagraphs(group);
+
+        expect(result).toEqual([
+            {
+                paragraph: para1,
+                path: [group],
+            },
+            {
+                paragraph: para2,
+                path: [group],
+            },
+            {
+                paragraph: para3,
+                path: [group],
             },
         ]);
     });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockGroupTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockGroupTest.ts
@@ -92,13 +92,7 @@ describe('handleBlockGroup', () => {
             group,
             context
         );
-        expect(applyFormat.applyFormat).toHaveBeenCalledTimes(1);
-        expect(applyFormat.applyFormat).toHaveBeenCalledWith(
-            clonedChild,
-            context.formatAppliers.segment,
-            group.format,
-            context
-        );
+        expect(applyFormat.applyFormat).not.toHaveBeenCalled();
     });
 
     it('General segment: element with child', () => {
@@ -125,13 +119,7 @@ describe('handleBlockGroup', () => {
             group,
             context
         );
-        expect(applyFormat.applyFormat).toHaveBeenCalledTimes(1);
-        expect(applyFormat.applyFormat).toHaveBeenCalledWith(
-            clonedChild,
-            context.formatAppliers.segment,
-            group.format,
-            context
-        );
+        expect(applyFormat.applyFormat).not.toHaveBeenCalled();
     });
 
     it('Quote', () => {

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockGroupTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockGroupTest.ts
@@ -1,11 +1,10 @@
-import * as applyFormat from '../../../lib/modelToDom/utils/applyFormat';
 import { ContentModelBlockGroup } from '../../../lib/publicTypes/block/group/ContentModelBlockGroup';
+import { ContentModelGeneralBlock } from '../../../lib/publicTypes/block/group/ContentModelGeneralBlock';
 import { ContentModelHandler } from '../../../lib/publicTypes/context/ContentModelHandler';
 import { ContentModelListItem } from '../../../lib/publicTypes/block/group/ContentModelListItem';
 import { ContentModelQuote } from '../../../lib/publicTypes/block/group/ContentModelQuote';
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
 import { createGeneralBlock } from '../../../lib/modelApi/creators/createGeneralBlock';
-import { createGeneralSegment } from '../../../lib/modelApi/creators/createGeneralSegment';
 import { createListItem } from '../../../lib/modelApi/creators/createListItem';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { createQuote } from '../../../lib/modelApi/creators/createQuote';
@@ -18,17 +17,20 @@ describe('handleBlockGroup', () => {
     let handleBlockGroupChildren: jasmine.Spy<ContentModelHandler<ContentModelBlockGroup>>;
     let handleListItem: jasmine.Spy<ContentModelHandler<ContentModelListItem>>;
     let handleQuote: jasmine.Spy<ContentModelHandler<ContentModelQuote>>;
+    let handleGeneralModel: jasmine.Spy<ContentModelHandler<ContentModelGeneralBlock>>;
 
     beforeEach(() => {
         handleBlockGroupChildren = jasmine.createSpy('handleBlockGroupChildren');
         handleListItem = jasmine.createSpy('handleListItem');
         handleQuote = jasmine.createSpy('handleQuote');
+        handleGeneralModel = jasmine.createSpy('handleGeneralModel');
 
         context = createModelToDomContext(undefined, {
             modelHandlerOverride: {
                 blockGroupChildren: handleBlockGroupChildren,
                 listItem: handleListItem,
                 quote: handleQuote,
+                general: handleGeneralModel,
             },
         });
         parent = document.createElement('div');
@@ -51,75 +53,11 @@ describe('handleBlockGroup', () => {
         } as any) as HTMLElement;
         const group = createGeneralBlock(childMock);
 
-        spyOn(applyFormat, 'applyFormat');
-
         handleBlockGroup(document, parent, group, context);
 
-        expect(parent.outerHTML).toBe('<div><span></span></div>');
-        expect(typeof parent.firstChild).toBe('object');
-        expect(parent.firstChild).toBe(clonedChild);
-        expect(context.listFormat.nodeStack).toEqual([]);
-        expect(handleBlockGroupChildren).toHaveBeenCalledTimes(1);
-        expect(handleBlockGroupChildren).toHaveBeenCalledWith(
-            document,
-            clonedChild,
-            group,
-            context
-        );
-        expect(applyFormat.applyFormat).not.toHaveBeenCalled();
-    });
-
-    it('General segment: empty element', () => {
-        const clonedChild = document.createElement('span');
-        const childMock = ({
-            cloneNode: () => clonedChild,
-        } as any) as HTMLElement;
-        const group = createGeneralSegment(childMock);
-
-        spyOn(applyFormat, 'applyFormat');
-
-        handleBlockGroup(document, parent, group, context);
-
-        expect(parent.outerHTML).toBe('<div><span></span></div>');
-        expect(context.regularSelection.current.segment).toBe(clonedChild);
-        expect(typeof parent.firstChild).toBe('object');
-        expect(parent.firstChild).toBe(clonedChild);
-        expect(context.listFormat.nodeStack).toEqual([]);
-        expect(handleBlockGroupChildren).toHaveBeenCalledTimes(1);
-        expect(handleBlockGroupChildren).toHaveBeenCalledWith(
-            document,
-            clonedChild,
-            group,
-            context
-        );
-        expect(applyFormat.applyFormat).not.toHaveBeenCalled();
-    });
-
-    it('General segment: element with child', () => {
-        const clonedChild = document.createElement('span');
-        const childMock = ({
-            cloneNode: () => clonedChild,
-            firstChild: true,
-        } as any) as HTMLElement;
-        const group = createGeneralSegment(childMock);
-
-        spyOn(applyFormat, 'applyFormat');
-
-        handleBlockGroup(document, parent, group, context);
-
-        expect(parent.outerHTML).toBe('<div><span></span></div>');
-        expect(context.regularSelection.current.segment).toBeNull();
-        expect(typeof parent.firstChild).toBe('object');
-        expect(parent.firstChild).toBe(clonedChild);
-        expect(context.listFormat.nodeStack).toEqual([]);
-        expect(handleBlockGroupChildren).toHaveBeenCalledTimes(1);
-        expect(handleBlockGroupChildren).toHaveBeenCalledWith(
-            document,
-            clonedChild,
-            group,
-            context
-        );
-        expect(applyFormat.applyFormat).not.toHaveBeenCalled();
+        expect(parent.outerHTML).toBe('<div></div>');
+        expect(handleGeneralModel).toHaveBeenCalledTimes(1);
+        expect(handleGeneralModel).toHaveBeenCalledWith(document, parent, group, context);
     });
 
     it('Quote', () => {

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockTest.ts
@@ -106,12 +106,7 @@ describe('handleBlock', () => {
         expect(parent.innerHTML).toBe('<span></span>');
         expect(parent.firstChild).not.toBe(element);
         expect(context.regularSelection.current.segment).toBe(parent.firstChild);
-        expect(applyFormat.applyFormat).toHaveBeenCalledWith(
-            parent.firstChild as HTMLElement,
-            context.formatAppliers.segment,
-            block.format,
-            context
-        );
+        expect(applyFormat.applyFormat).not.toHaveBeenCalled();
     });
 
     it('Entity block', () => {

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockTest.ts
@@ -106,7 +106,7 @@ describe('handleBlock', () => {
         expect(parent.innerHTML).toBe('<span></span>');
         expect(parent.firstChild).not.toBe(element);
         expect(context.regularSelection.current.segment).toBe(parent.firstChild);
-        expect(applyFormat.applyFormat).not.toHaveBeenCalled();
+        expect(applyFormat.applyFormat).toHaveBeenCalled();
     });
 
     it('Entity block', () => {

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleBrTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleBrTest.ts
@@ -1,0 +1,36 @@
+import { ContentModelBr } from '../../../lib/publicTypes/segment/ContentModelBr';
+import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { handleBr } from '../../../lib/modelToDom/handlers/handleBr';
+import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
+
+describe('handleSegment', () => {
+    let parent: HTMLElement;
+    let context: ModelToDomContext;
+
+    beforeEach(() => {
+        parent = document.createElement('div');
+        context = createModelToDomContext();
+    });
+
+    it('Br segment', () => {
+        const br: ContentModelBr = {
+            segmentType: 'Br',
+            format: {},
+        };
+
+        handleBr(document, parent, br, context);
+
+        expect(parent.innerHTML).toBe('<span><br></span>');
+    });
+
+    it('Br segment with format', () => {
+        const br: ContentModelBr = {
+            segmentType: 'Br',
+            format: { textColor: 'red' },
+        };
+
+        handleBr(document, parent, br, context);
+
+        expect(parent.innerHTML).toBe('<span style="color: red;"><br></span>');
+    });
+});

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleEntityTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleEntityTest.ts
@@ -33,5 +33,8 @@ describe('handleEntity', () => {
                 placeholder: parent.firstChild as Comment,
             },
         ]);
+        expect(div.outerHTML).toBe(
+            '<div class="_Entity _EType_entity _EId_entity_1 _EReadonly_1" contenteditable="false"></div>'
+        );
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleGeneralModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleGeneralModelTest.ts
@@ -1,0 +1,111 @@
+import * as applyFormat from '../../../lib/modelToDom/utils/applyFormat';
+import { ContentModelBlockGroup } from '../../../lib/publicTypes/block/group/ContentModelBlockGroup';
+import { ContentModelHandler } from '../../../lib/publicTypes/context/ContentModelHandler';
+import { ContentModelListItem } from '../../../lib/publicTypes/block/group/ContentModelListItem';
+import { ContentModelQuote } from '../../../lib/publicTypes/block/group/ContentModelQuote';
+import { createGeneralBlock } from '../../../lib/modelApi/creators/createGeneralBlock';
+import { createGeneralSegment } from '../../../lib/modelApi/creators/createGeneralSegment';
+import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { handleGeneralModel } from '../../../lib/modelToDom/handlers/handleGeneralModel';
+import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
+
+describe('handleBlockGroup', () => {
+    let context: ModelToDomContext;
+    let parent: HTMLDivElement;
+    let handleBlockGroupChildren: jasmine.Spy<ContentModelHandler<ContentModelBlockGroup>>;
+    let handleListItem: jasmine.Spy<ContentModelHandler<ContentModelListItem>>;
+    let handleQuote: jasmine.Spy<ContentModelHandler<ContentModelQuote>>;
+
+    beforeEach(() => {
+        handleBlockGroupChildren = jasmine.createSpy('handleBlockGroupChildren');
+        handleListItem = jasmine.createSpy('handleListItem');
+        handleQuote = jasmine.createSpy('handleQuote');
+
+        context = createModelToDomContext(undefined, {
+            modelHandlerOverride: {
+                blockGroupChildren: handleBlockGroupChildren,
+                listItem: handleListItem,
+                quote: handleQuote,
+            },
+        });
+        parent = document.createElement('div');
+    });
+
+    it('General block', () => {
+        const clonedChild = document.createElement('span');
+        const childMock = ({
+            cloneNode: () => clonedChild,
+        } as any) as HTMLElement;
+        const group = createGeneralBlock(childMock);
+
+        spyOn(applyFormat, 'applyFormat');
+
+        handleGeneralModel(document, parent, group, context);
+
+        expect(parent.outerHTML).toBe('<div><span></span></div>');
+        expect(typeof parent.firstChild).toBe('object');
+        expect(parent.firstChild).toBe(clonedChild);
+        expect(context.listFormat.nodeStack).toEqual([]);
+        expect(handleBlockGroupChildren).toHaveBeenCalledTimes(1);
+        expect(handleBlockGroupChildren).toHaveBeenCalledWith(
+            document,
+            clonedChild,
+            group,
+            context
+        );
+        expect(applyFormat.applyFormat).not.toHaveBeenCalled();
+    });
+
+    it('General segment: empty element', () => {
+        const clonedChild = document.createElement('span');
+        const childMock = ({
+            cloneNode: () => clonedChild,
+        } as any) as HTMLElement;
+        const group = createGeneralSegment(childMock);
+
+        spyOn(applyFormat, 'applyFormat');
+
+        handleGeneralModel(document, parent, group, context);
+
+        expect(parent.outerHTML).toBe('<div><span></span></div>');
+        expect(context.regularSelection.current.segment).toBe(clonedChild);
+        expect(typeof parent.firstChild).toBe('object');
+        expect(parent.firstChild).toBe(clonedChild);
+        expect(context.listFormat.nodeStack).toEqual([]);
+        expect(handleBlockGroupChildren).toHaveBeenCalledTimes(1);
+        expect(handleBlockGroupChildren).toHaveBeenCalledWith(
+            document,
+            clonedChild,
+            group,
+            context
+        );
+        expect(applyFormat.applyFormat).toHaveBeenCalled();
+    });
+
+    it('General segment: element with child', () => {
+        const clonedChild = document.createElement('span');
+        const childMock = ({
+            cloneNode: () => clonedChild,
+            firstChild: true,
+        } as any) as HTMLElement;
+        const group = createGeneralSegment(childMock);
+
+        spyOn(applyFormat, 'applyFormat');
+
+        handleGeneralModel(document, parent, group, context);
+
+        expect(parent.outerHTML).toBe('<div><span></span></div>');
+        expect(context.regularSelection.current.segment).toBeNull();
+        expect(typeof parent.firstChild).toBe('object');
+        expect(parent.firstChild).toBe(clonedChild);
+        expect(context.listFormat.nodeStack).toEqual([]);
+        expect(handleBlockGroupChildren).toHaveBeenCalledTimes(1);
+        expect(handleBlockGroupChildren).toHaveBeenCalledWith(
+            document,
+            clonedChild,
+            group,
+            context
+        );
+        expect(applyFormat.applyFormat).toHaveBeenCalled();
+    });
+});

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleSegmentTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleSegmentTest.ts
@@ -1,6 +1,10 @@
-import { ContentModelBlock } from '../../../lib/publicTypes/block/ContentModelBlock';
+import { ContentModelBr } from '../../../lib/publicTypes/segment/ContentModelBr';
+import { ContentModelEntity } from '../../../lib/publicTypes/entity/ContentModelEntity';
+import { ContentModelGeneralBlock } from '../../../lib/publicTypes/block/group/ContentModelGeneralBlock';
 import { ContentModelHandler } from '../../../lib/publicTypes/context/ContentModelHandler';
+import { ContentModelImage } from '../../../lib/publicTypes/segment/ContentModelImage';
 import { ContentModelSegment } from '../../../lib/publicTypes/segment/ContentModelSegment';
+import { ContentModelText } from '../../../lib/publicTypes/segment/ContentModelText';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { handleSegment } from '../../../lib/modelToDom/handlers/handleSegment';
 import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
@@ -8,51 +12,53 @@ import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomCo
 describe('handleSegment', () => {
     let parent: HTMLElement;
     let context: ModelToDomContext;
-    let handleBlock: jasmine.Spy<ContentModelHandler<ContentModelBlock>>;
+    let handleBr: jasmine.Spy<ContentModelHandler<ContentModelBr>>;
+    let handleText: jasmine.Spy<ContentModelHandler<ContentModelText>>;
+    let handleGeneralModel: jasmine.Spy<ContentModelHandler<ContentModelGeneralBlock>>;
+    let handleEntity: jasmine.Spy<ContentModelHandler<ContentModelEntity>>;
+    let handleImage: jasmine.Spy<ContentModelHandler<ContentModelImage>>;
 
     beforeEach(() => {
-        handleBlock = jasmine.createSpy('handleBlock');
+        parent = document.createElement('div');
+        handleBr = jasmine.createSpy('handleBr');
+        handleText = jasmine.createSpy('handleText');
+        handleGeneralModel = jasmine.createSpy('handleGeneralModel');
+        handleEntity = jasmine.createSpy('handleEntity');
+        handleImage = jasmine.createSpy('handleImage');
+
         context = createModelToDomContext(undefined, {
             modelHandlerOverride: {
-                block: handleBlock,
+                br: handleBr,
+                text: handleText,
+                general: handleGeneralModel,
+                entity: handleEntity,
+                image: handleImage,
             },
         });
     });
 
-    function runTest(
-        segment: ContentModelSegment,
-        expectedInnerHTML: string,
-        expectedCreateBlockFromContentModelCalledTimes: number
-    ) {
-        parent = document.createElement('div');
-
-        handleSegment(document, parent, segment, context);
-
-        expect(parent.innerHTML).toBe(expectedInnerHTML);
-        expect(handleBlock).toHaveBeenCalledTimes(expectedCreateBlockFromContentModelCalledTimes);
-    }
-
     it('Text segment', () => {
-        runTest(
-            {
-                segmentType: 'Text',
-                text: 'test',
-                format: {},
-            },
-            '<span>test</span>',
-            0
-        );
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'test',
+            format: {},
+        };
+
+        handleSegment(document, parent, text, context);
+
+        expect(handleText).toHaveBeenCalledWith(document, parent, text, context);
+        expect(parent.innerHTML).toBe('');
     });
 
     it('Br segment', () => {
-        runTest(
-            {
-                segmentType: 'Br',
-                format: {},
-            },
-            '<span><br></span>',
-            0
-        );
+        const br: ContentModelBr = {
+            segmentType: 'Br',
+            format: {},
+        };
+        handleSegment(document, parent, br, context);
+
+        expect(parent.innerHTML).toBe('');
+        expect(handleBr).toHaveBeenCalledWith(document, parent, br, context);
     });
 
     it('general segment', () => {
@@ -64,8 +70,10 @@ describe('handleSegment', () => {
             element: null!,
             format: {},
         };
-        runTest(segment, '', 1);
-        expect(handleBlock).toHaveBeenCalledWith(document, parent, segment, context);
+
+        handleSegment(document, parent, segment, context);
+        expect(parent.innerHTML).toBe('');
+        expect(handleGeneralModel).toHaveBeenCalledWith(document, parent, segment, context);
     });
 
     it('entity segment', () => {
@@ -79,17 +87,21 @@ describe('handleSegment', () => {
             wrapper: div,
             isReadonly: true,
         };
-        runTest(segment, '<!--Entity:entity_1-->', 0);
 
-        expect(context.entityPairs).toEqual([
-            {
-                entityWrapper: div,
-                placeholder: document.createComment('Entity:entity_1'),
-            },
-        ]);
+        handleSegment(document, parent, segment, context);
+        expect(parent.innerHTML).toBe('');
+        expect(handleEntity).toHaveBeenCalledWith(document, parent, segment, context);
+    });
 
-        expect(div.outerHTML).toBe(
-            '<div class="_Entity _EType_entity _EId_entity_1 _EReadonly_1" contenteditable="false"></div>'
-        );
+    it('image segment', () => {
+        const segment: ContentModelSegment = {
+            segmentType: 'Image',
+            src: 'test',
+            format: {},
+        };
+
+        handleSegment(document, parent, segment, context);
+        expect(parent.innerHTML).toBe('');
+        expect(handleImage).toHaveBeenCalledWith(document, parent, segment, context);
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleTextTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleTextTest.ts
@@ -1,0 +1,38 @@
+import { ContentModelText } from '../../../lib/publicTypes/segment/ContentModelText';
+import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { handleText } from '../../../lib/modelToDom/handlers/handleText';
+import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
+
+describe('handleSegment', () => {
+    let parent: HTMLElement;
+    let context: ModelToDomContext;
+
+    beforeEach(() => {
+        parent = document.createElement('div');
+        context = createModelToDomContext();
+    });
+
+    it('Text segment', () => {
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'test',
+            format: {},
+        };
+
+        handleText(document, parent, text, context);
+
+        expect(parent.innerHTML).toBe('<span>test</span>');
+    });
+
+    it('Text segment', () => {
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'test',
+            format: { textColor: 'red' },
+        };
+
+        handleText(document, parent, text, context);
+
+        expect(parent.innerHTML).toBe('<span style="color: red;">test</span>');
+    });
+});


### PR DESCRIPTION
Content Model Bug Fix  part 1. Select lines and apply list change, the next line is also impacted
![image](https://user-images.githubusercontent.com/23065085/198701872-e26f2d36-b48d-44f1-9886-7c3fb85f7369.png)

This is because there is a selection marker added in the next line to indicate end of line is selected. To fix it, we check if there is only selection marker selected in the line, then remove it from selected paragraphs

Also refactor handleSegment() function to split it into separate files, and update test.