### PR TITLE
Change the order of karma plugins

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,9 +13,8 @@ module.exports = function (config) {
     ];
     const launcher = [];
 
-    if (runFirefox) {
-        plugins.push('karma-firefox-launcher');
-        launcher.push('Firefox');
+    if (runCoverage) {
+        plugins.push('karma-coverage-istanbul-reporter');
     }
 
     if (runChrome) {
@@ -23,8 +22,9 @@ module.exports = function (config) {
         launcher.push('Chrome');
     }
 
-    if (runCoverage) {
-        plugins.push('karma-coverage-istanbul-reporter');
+    if (runFirefox) {
+        plugins.push('karma-firefox-launcher');
+        launcher.push('Firefox');
     }
 
     const rules = runCoverage


### PR DESCRIPTION
Change the order of karma plugins in order to get consistent test coverage result between web page report and command line