### PR TITLE
[Hot fix] Add null check to list metadata

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -339,12 +339,9 @@ const getPreviousList = (editor: IEditor, textRange: Range) => {
 const getPreviousListType = (editor: IEditor, textRange: Range, listType: ListType) => {
     const type = listType === ListType.Ordered ? 'orderedStyleType' : 'unorderedStyleType';
     const previousNode = getPreviousList(editor, textRange);
+    const metadata = getMetadata(previousNode.parentElement, ListStyleDefinitionMetadata);
 
-    return previousNode &&
-        getTagOfNode(previousNode) === 'LI' &&
-        getMetadata(previousNode.parentElement, ListStyleDefinitionMetadata)
-        ? getMetadata(previousNode.parentElement, ListStyleDefinitionMetadata)[type]
-        : null;
+    return previousNode && getTagOfNode(previousNode) === 'LI' && metadata ? metadata[type] : null;
 };
 
 const isFirstItemOfAList = (item: string) => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -340,7 +340,9 @@ const getPreviousListType = (editor: IEditor, textRange: Range, listType: ListTy
     const type = listType === ListType.Ordered ? 'orderedStyleType' : 'unorderedStyleType';
     const previousNode = getPreviousList(editor, textRange);
 
-    return previousNode && getTagOfNode(previousNode) === 'LI'
+    return previousNode &&
+        getTagOfNode(previousNode) === 'LI' &&
+        getMetadata(previousNode.parentElement, ListStyleDefinitionMetadata)
         ? getMetadata(previousNode.parentElement, ListStyleDefinitionMetadata)[type]
         : null;
 };


### PR DESCRIPTION
When the list does not have metadata, return previous list style as null. 