### PR TITLE
Apply default format on SPAN instead of DIV

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -34,6 +34,7 @@ const initialState: BuildInPluginState = {
         ExperimentalFeatures.AdaptiveHandlesResizer,
         ExperimentalFeatures.ListItemAlignment,
         ExperimentalFeatures.PendingStyleBasedFormat,
+        ExperimentalFeatures.DefaultFormatInSpan,
     ],
     isRtl: false,
 };

--- a/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
@@ -26,6 +26,8 @@ const FeatureNames: Partial<Record<ExperimentalFeatures, string>> = {
         'Normalize list to make sure it can be displayed correctly in other client',
     [ExperimentalFeatures.ReuseAllAncestorListElements]:
         "Reuse ancestor list elements even if they don't match the types from the list item.",
+    [ExperimentalFeatures.DefaultFormatInSpan]:
+        'When apply default format when initialize or user type, apply the format on a SPAN element.',
 };
 
 export default class ExperimentalFeaturesPane extends React.Component<

--- a/packages/roosterjs-editor-api/test/format/toggleBlockQuoteTest.ts
+++ b/packages/roosterjs-editor-api/test/format/toggleBlockQuoteTest.ts
@@ -33,7 +33,7 @@ describe('toggleBlockQuote', () => {
     TestHelper.itFirefoxOnly('Empty DIV', () => {
         runTest(
             '<div></div><!--{"start":[0],"end":[0]}-->',
-            '<blockquote><div><br></div></blockquote>'
+            '<blockquote><div><span><br></span></div></blockquote>'
         );
     });
 

--- a/packages/roosterjs-editor-api/test/format/toggleBlockQuoteTest.ts
+++ b/packages/roosterjs-editor-api/test/format/toggleBlockQuoteTest.ts
@@ -24,7 +24,10 @@ describe('toggleBlockQuote', () => {
     }
 
     it('Empty input', () => {
-        runTest('<!--{"start":[0],"end":[0]}-->', '<blockquote><div><br></div></blockquote>');
+        runTest(
+            '<!--{"start":[0],"end":[0]}-->',
+            '<blockquote><div><span><br></span></div></blockquote>'
+        );
     });
 
     TestHelper.itFirefoxOnly('Empty DIV', () => {

--- a/packages/roosterjs-editor-core/lib/coreApi/ensureTypeInContainer.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/ensureTypeInContainer.ts
@@ -15,6 +15,8 @@ import {
     isNodeEmpty,
     Position,
     safeInstanceOf,
+    toArray,
+    wrap,
 } from 'roosterjs-editor-dom';
 
 /**
@@ -25,7 +27,8 @@ import {
 export const ensureTypeInContainer: EnsureTypeInContainer = (
     core: EditorCore,
     position: NodePosition,
-    keyboardEvent?: KeyboardEvent
+    keyboardEvent?: KeyboardEvent,
+    applyFormatToSpan?: boolean
 ) => {
     const table = findClosestElementAncestor(position.node, core.contentDiv, 'table');
     let td: HTMLElement | null;
@@ -51,23 +54,34 @@ export const ensureTypeInContainer: EnsureTypeInContainer = (
             isNodeEmpty(formatNode) ||
             (keyboardEvent && wasNodeJustCreatedByKeyboardEvent(keyboardEvent, formatNode));
         formatNode = formatNode && shouldSetNodeStyles ? formatNode : null;
+
+        if (formatNode && core.lifecycle.defaultFormat && applyFormatToSpan) {
+            const firstChild = formatNode.firstChild;
+            formatNode = safeInstanceOf(firstChild, 'HTMLSpanElement')
+                ? firstChild
+                : wrap(toArray(formatNode.childNodes), 'span');
+
+            position = new Position(formatNode, PositionType.Begin);
+        }
     } else {
         // Only reason we don't get the selection block is that we have an empty content div
         // which can happen when users removes everything (i.e. select all and DEL, or backspace from very end to begin)
         // The fix is to add a DIV wrapping, apply default format and move cursor over
-        formatNode = createElement(
+        const newNode = createElement(
             KnownCreateElementDataIndex.EmptyLine,
             core.contentDiv.ownerDocument
         ) as HTMLElement;
-        core.api.insertNode(core, formatNode, {
+        core.api.insertNode(core, newNode, {
             position: ContentPosition.End,
             updateCursor: false,
             replaceSelection: false,
             insertOnNewLine: false,
         });
 
+        formatNode = newNode.firstChild as HTMLElement;
+
         // element points to a wrapping node we added "<div><br></div>". We should move the selection left to <br>
-        position = new Position(formatNode.firstChild!, PositionType.Begin);
+        position = new Position(formatNode, PositionType.Begin);
     }
 
     if (formatNode && core.lifecycle.defaultFormat) {

--- a/packages/roosterjs-editor-core/test/coreApi/ensureTypeInContainerTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/ensureTypeInContainerTest.ts
@@ -1,0 +1,177 @@
+import * as createRange from 'roosterjs-editor-dom/lib/selection/createRange';
+import createEditorCore from './createMockEditorCore';
+import { DefaultFormat, NodePosition, PositionType } from 'roosterjs-editor-types';
+import { ensureTypeInContainer } from '../../lib/coreApi/ensureTypeInContainer';
+import { Position } from 'roosterjs-editor-dom';
+
+describe('ensureTypeInContainer', () => {
+    let div: HTMLDivElement;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+        document.body.appendChild(div);
+        spyOn(createRange, 'default').and.callFake(pos => (pos as any) as Range);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(div!);
+        div = null!;
+    });
+
+    function runTest(
+        content: string,
+        defaultFormat: DefaultFormat | undefined,
+        event: KeyboardEvent | undefined,
+        applyFormatToSpan: boolean,
+        expectedHtml: string,
+        expectedPos?: () => NodePosition
+    ) {
+        const position = new Position(div, PositionType.Begin);
+        const selectRange = jasmine.createSpy('selectRange');
+        const core = createEditorCore(div, {
+            coreApiOverride: {
+                selectRange: selectRange,
+            },
+            defaultFormat: defaultFormat,
+        });
+        core.api.setContent(core, content, true);
+
+        ensureTypeInContainer(core, position, event, applyFormatToSpan);
+
+        expect(div.innerHTML).toBe(expectedHtml);
+
+        if (expectedPos) {
+            expect(selectRange).toHaveBeenCalledWith(core, expectedPos());
+        } else {
+            expect(selectRange).not.toHaveBeenCalled();
+        }
+    }
+
+    it('empty', () => {
+        runTest('', undefined, undefined, false, '<div><span><br></span></div>');
+    });
+
+    it('pure text', () => {
+        runTest('text', undefined, undefined, false, '<div>text</div>');
+    });
+
+    it('div with text', () => {
+        runTest('<div>text</div>', undefined, undefined, false, '<div>text</div>');
+    });
+
+    it('empty editor with format', () => {
+        runTest(
+            '',
+            {
+                fontSize: '10pt',
+            },
+            undefined,
+            false,
+            '<div><span style="font-size: 10pt;"><br></span></div>'
+        );
+    });
+
+    it('pure text with format', () => {
+        runTest(
+            'text',
+            {
+                fontSize: '10pt',
+            },
+            undefined,
+            false,
+            '<div>text</div>'
+        );
+    });
+
+    it('div with text and format', () => {
+        runTest(
+            '<div>text</div>',
+            {
+                fontSize: '10pt',
+            },
+            undefined,
+            false,
+            '<div>text</div>'
+        );
+    });
+
+    it('div with format and event', () => {
+        runTest(
+            '<div>a</div>',
+            {
+                fontSize: '10pt',
+            },
+            ({
+                target: div,
+                key: 'a',
+            } as any) as KeyboardEvent,
+            false,
+            '<div style="font-size: 10pt;">a</div>',
+            () => new Position(div.firstChild?.firstChild, PositionType.Begin)
+        );
+    });
+
+    it('div with format and event and use span', () => {
+        runTest(
+            '<div>a</div>',
+            {
+                fontSize: '10pt',
+            },
+            ({
+                target: div,
+                key: 'a',
+            } as any) as KeyboardEvent,
+            true,
+            '<div><span style="font-size: 10pt;">a</span></div>',
+            () => new Position(div.firstChild?.firstChild, PositionType.Begin)
+        );
+    });
+
+    it('div with format and event and use span, div is not created from the event', () => {
+        runTest(
+            '<div>a</div>',
+            {
+                fontSize: '10pt',
+            },
+            ({
+                target: div,
+                key: 'b',
+            } as any) as KeyboardEvent,
+            true,
+            '<div>a</div>',
+            () => new Position(div.firstChild!.firstChild, PositionType.Begin)
+        );
+    });
+
+    it('table with format and event and not use span', () => {
+        runTest(
+            '<table><tr><td id="td"></td></tr></table>',
+            {
+                fontSize: '10pt',
+            },
+            ({
+                target: div,
+                key: 'a',
+            } as any) as KeyboardEvent,
+            false,
+            '<table><tbody><tr><td id="td" style="font-size: 10pt;"><br></td></tr></tbody></table>',
+            () => new Position(div.querySelector('#td'), PositionType.Begin)
+        );
+    });
+
+    it('table with format and event and use span', () => {
+        runTest(
+            '<table><tr><td id="td"></td></tr></table>',
+            {
+                fontSize: '10pt',
+            },
+            ({
+                target: div,
+                key: 'a',
+            } as any) as KeyboardEvent,
+            true,
+            '<table><tbody><tr><td id="td"><span style="font-size: 10pt;"><br></span></td></tr></tbody></table>',
+            () => new Position(div.querySelector('#td')!.firstChild, PositionType.Begin)
+        );
+    });
+});

--- a/packages/roosterjs-editor-dom/lib/utils/createElement.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/createElement.ts
@@ -1,6 +1,5 @@
 import getObjectKeys from '../jsUtils/getObjectKeys';
 import safeInstanceOf from './safeInstanceOf';
-import { Browser } from './Browser';
 import { CreateElementData, KnownCreateElementDataIndex } from 'roosterjs-editor-types';
 import type { CompatibleKnownCreateElementDataIndex } from 'roosterjs-editor-types/lib/compatibleTypes';
 
@@ -12,9 +11,10 @@ export const KnownCreateElementData: Record<KnownCreateElementDataIndex, CreateE
 
     // Edge can sometimes lose current format when Enter to new line.
     // So here we add an extra SPAN for Edge to workaround this bug
-    [KnownCreateElementDataIndex.EmptyLine]: Browser.isEdge
-        ? { tag: 'div', children: [{ tag: 'span', children: [{ tag: 'br' }] }] }
-        : { tag: 'div', children: [{ tag: 'br' }] },
+    [KnownCreateElementDataIndex.EmptyLine]: {
+        tag: 'div',
+        children: [{ tag: 'span', children: [{ tag: 'br' }] }],
+    },
     [KnownCreateElementDataIndex.BlockquoteWrapper]: {
         tag: 'blockquote',
         style: 'margin-top:0;margin-bottom:0',

--- a/packages/roosterjs-editor-dom/test/list/createVListFromRegionTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/createVListFromRegionTest.ts
@@ -57,7 +57,7 @@ describe('createVListFromRegion from selection, no sibling list', () => {
         runTest(`<div id="${FocusNode}"></div>`, [
             {
                 listTypes: [ListType.None],
-                outerHTML: '<li><br></li>',
+                outerHTML: '<li><span><br></span></li>',
             },
         ]);
     });

--- a/packages/roosterjs-editor-dom/test/utils/createElementTest.ts
+++ b/packages/roosterjs-editor-dom/test/utils/createElementTest.ts
@@ -13,7 +13,7 @@ describe('createElement', () => {
     });
 
     it('create by index', () => {
-        runTest(KnownCreateElementDataIndex.EmptyLine, '<div><br></div>');
+        runTest(KnownCreateElementDataIndex.EmptyLine, '<div><span><br></span></div>');
     });
 
     it('create by tag', () => {

--- a/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
@@ -115,4 +115,10 @@ export const enum ExperimentalFeatures {
      * is the one closest to the item.
      */
     ReuseAllAncestorListElements = 'ReuseAllAncestorListElements',
+
+    /**
+     * When apply default format when initialize or user type, apply the format on a SPAN element rather than
+     * the block element (In most case, the DIV element) so keep the block element clean.
+     */
+    DefaultFormatInSpan = 'DefaultFormatInSpan',
 }

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -123,11 +123,14 @@ export type CreatePasteFragment = (
  * @param core The EditorCore object.
  * @param position The position that user is about to type to
  * @param keyboardEvent Optional keyboard event object
+ * @param applyFormatToSpan Optional When set to true, default format (if any) will be applied to
+ * a SPAN element inside the block element instead of the block element itself.
  */
 export type EnsureTypeInContainer = (
     core: EditorCore,
     position: NodePosition,
-    keyboardEvent?: KeyboardEvent
+    keyboardEvent?: KeyboardEvent,
+    applyFormatToSpan?: boolean
 ) => void;
 
 /**
@@ -327,6 +330,8 @@ export interface CoreApiMap {
      * @param core The EditorCore object.
      * @param position The position that user is about to type to
      * @param keyboardEvent Optional keyboard event object
+     * @param applyFormatToSpan Optional When set to true, default format (if any) will be applied to
+     * a SPAN element inside the block element instead of the block element itself.
      */
     ensureTypeInContainer: EnsureTypeInContainer;
 


### PR DESCRIPTION
Today, when we start editor or start typing, we will add a wrapper element if there is not to make sure always type under an element. Then if there is default format, we will apply this format to this wrapper element.

However, with content model, we will move this format from wrapper DIV element to an inner SPAN element. This causes the height of DIV changes when some default format is specified. So I'd like to change this behavior to apply format directly to a inner SPAN element instead. 

This change adds a new experimental feature to apply this behavior.

## Before type and apply format:
```html
<div><br></div>
```

## After type and apply format:
- Before change
```html
<div style="...">test</div>
```

- After change
```html
<div><span style="...">test</span></div>
```


