### PR TITLE
Fix changing font size doesn't work for empty selections

### DIFF
--- a/packages/roosterjs-editor-api/lib/utils/applyInlineStyle.ts
+++ b/packages/roosterjs-editor-api/lib/utils/applyInlineStyle.ts
@@ -42,7 +42,9 @@ export default function applyInlineStyle(
         } else if (editor.isFeatureEnabled(ExperimentalFeatures.PendingStyleBasedFormat)) {
             editor.triggerPluginEvent(PluginEventType.PendingFormatStateChanged, {
                 formatState: {},
-                formatCallback: safeCallback,
+                // Here we use callback instead of safeCallback because we know it's contentEditable.
+                // In addition, for elements that are not added to the DOM tree, isContentEditable always returns false on Safari.
+                formatCallback: callback,
             });
             editor.triggerContentChangedEvent(ChangeSource.Format);
         } else {


### PR DESCRIPTION
Note that, this bug affects Safari only, it can be reproduced using the roosterjs demo and other clients too.

A typical scenario is that we want to change the font size for an empty draft, or use a different font size before typing.

To apply these changes, we create an editable span to apply pending format state. Unfortunately, for elements that are not added to the DOM tree, `HTMLElement.isContenteditable` is always `false` on Safari, for example:

```js
const span = document.createElement('span');
span.contentEditable = 'true';
// document.body.appendChild(span);
console.log(span.isContentEditable); // --> false
```

Since we already know the element is editable in `editor.triggerPluginEvent(PluginEventType.PendingFormatStateChanged`, we simply remove the check to avoid running into this bug.