### PR TITLE
More ImageSelection plugin into core plugin

### DIFF
--- a/demo/scripts/controls/BuildInPluginState.ts
+++ b/demo/scripts/controls/BuildInPluginState.ts
@@ -22,7 +22,6 @@ export interface BuildInPluginList {
     tableEditMenu: boolean;
     contextMenu: boolean;
     autoFormat: boolean;
-    imageSelection: boolean;
 }
 
 export default interface BuildInPluginState {

--- a/demo/scripts/controls/getToggleablePlugins.ts
+++ b/demo/scripts/controls/getToggleablePlugins.ts
@@ -6,7 +6,6 @@ import { CutPasteListChain } from 'roosterjs-editor-plugins/lib/CutPasteListChai
 import { EditorPlugin } from 'roosterjs-editor-types';
 import { HyperLink } from 'roosterjs-editor-plugins/lib/HyperLink';
 import { ImageEdit } from 'roosterjs-editor-plugins/lib/ImageEdit';
-import { ImageSelection } from 'roosterjs-editor-plugins';
 import { Paste } from 'roosterjs-editor-plugins/lib/Paste';
 import { TableCellSelection } from 'roosterjs-editor-plugins/lib/TableCellSelection';
 import { TableResize } from 'roosterjs-editor-plugins/lib/TableResize';
@@ -40,7 +39,6 @@ export default function getToggleablePlugins(initState: BuildInPluginState) {
         paste: pluginList.paste ? new Paste() : null,
         watermark: pluginList.watermark ? new Watermark(initState.watermarkText) : null,
         imageEdit,
-        imageSelection: pluginList.imageSelection ? new ImageSelection() : null,
         cutPasteListChain: pluginList.cutPasteListChain ? new CutPasteListChain() : null,
         tableCellSelection: pluginList.tableCellSelection ? new TableCellSelection() : null,
         tableResize: pluginList.tableResize ? new TableResize() : null,

--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -21,7 +21,6 @@ const initialState: BuildInPluginState = {
         tableEditMenu: true,
         contextMenu: true,
         autoFormat: true,
-        imageSelection: true,
     },
     contentEditFeatures: getDefaultContentEditFeatureSettings(),
     defaultFormat: {},

--- a/demo/scripts/controls/sidePane/editorOptions/Plugins.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/Plugins.tsx
@@ -61,7 +61,6 @@ export default class Plugins extends React.Component<PluginsProps, {}> {
                         'Show customized context menu for special cases'
                     )}
                     {this.renderPluginItem('tableCellSelection', 'Table Cell Selection')}
-                    {this.renderPluginItem('imageSelection', 'Image Selection')}
                 </tbody>
             </table>
         );

--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -14,13 +14,10 @@ const mouseRightButton = 2;
 const mouseLeftButton = 0;
 
 /**
- * Requires @see ExperimentalFeatures.ImageSelection to be enabled.
  * Detect image selection and help highlight the image
  */
 export default class ImageSelection implements EditorPlugin {
     private editor: IEditor | null = null;
-
-    constructor() {}
 
     /**
      * Get a friendly name of  this plugin
@@ -41,7 +38,7 @@ export default class ImageSelection implements EditorPlugin {
      * Dispose this plugin
      */
     dispose() {
-        this.editor.select(null);
+        this.editor?.select(null);
         this.editor = null;
     }
 
@@ -73,7 +70,7 @@ export default class ImageSelection implements EditorPlugin {
                     if (keyDownSelection.type === SelectionRangeTypes.ImageSelection) {
                         if (key === Escape) {
                             this.editor.select(keyDownSelection.image, PositionType.Before);
-                            this.editor.getSelectionRange().collapse();
+                            this.editor.getSelectionRange()?.collapse();
                             event.rawEvent.stopPropagation();
                         } else {
                             this.editor.select(keyDownSelection.ranges[0]);

--- a/packages/roosterjs-editor-core/lib/corePlugins/createCorePlugins.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/createCorePlugins.ts
@@ -2,6 +2,7 @@ import CopyPastePlugin from './CopyPastePlugin';
 import DOMEventPlugin from './DOMEventPlugin';
 import EditPlugin from './EditPlugin';
 import EntityPlugin from './EntityPlugin';
+import ImageSelection from './ImageSelection';
 import LifecyclePlugin from './LifecyclePlugin';
 import MouseUpPlugin from './MouseUpPlugin';
 import NormalizeTablePlugin from './NormalizeTablePlugin';
@@ -41,6 +42,7 @@ export default function createCorePlugins(
         mouseUp: map.mouseUp || new MouseUpPlugin(),
         copyPaste: map.copyPaste || new CopyPastePlugin(options),
         entity: map.entity || new EntityPlugin(),
+        imageSelection: map.imageSelection || new ImageSelection(),
         normalizeTable: map.normalizeTable || new NormalizeTablePlugin(),
         lifecycle: map.lifecycle || new LifecyclePlugin(options, contentDiv),
     };

--- a/packages/roosterjs-editor-core/test/corePlugins/imageSelectionTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/imageSelectionTest.ts
@@ -1,7 +1,7 @@
-import { Editor } from 'roosterjs-editor-core';
-import { IEditor } from 'roosterjs-editor-types';
-import { ImageSelection } from '../../lib/ImageSelection';
+import Editor from '../../lib/editor/Editor';
+import ImageSelection from '../../lib/corePlugins/ImageSelection';
 import {
+    IEditor,
     EditorOptions,
     SelectionRangeTypes,
     PluginEvent,

--- a/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
@@ -52,6 +52,7 @@ describe('Editor', () => {
             'MouseUp',
             'CopyPaste',
             'Entity',
+            'ImageSelection',
             'NormalizeTable',
             'Lifecycle',
         ]);
@@ -161,6 +162,7 @@ describe('Editor', () => {
             'test mouse up',
             'CopyPaste',
             'Entity',
+            'ImageSelection',
             'NormalizeTable',
             'Lifecycle',
         ]);

--- a/packages/roosterjs-editor-plugins/lib/ImageSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/ImageSelection.ts
@@ -1,1 +1,0 @@
-export * from './plugins/ImageSelection/index';

--- a/packages/roosterjs-editor-plugins/lib/index.ts
+++ b/packages/roosterjs-editor-plugins/lib/index.ts
@@ -11,4 +11,3 @@ export * from './TableResize';
 export * from './Watermark';
 export * from './TableCellSelection';
 export * from './AutoFormat';
-export * from './ImageSelection';

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageSelection/index.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageSelection/index.ts
@@ -1,1 +1,0 @@
-export { default as ImageSelection } from './ImageSelection';

--- a/packages/roosterjs-editor-types/lib/interface/CorePlugins.ts
+++ b/packages/roosterjs-editor-types/lib/interface/CorePlugins.ts
@@ -61,6 +61,11 @@ export default interface CorePlugins {
     readonly entity: PluginWithState<EntityPluginState>;
 
     /**
+     * Image selection Plugin detects image selection and help highlight the image
+     */
+    readonly imageSelection: EditorPlugin;
+
+    /**
      * NormalizeTable plugin makes sure each table in editor has TBODY/THEAD/TFOOT tag around TR tags
      */
     readonly normalizeTable: EditorPlugin;


### PR DESCRIPTION
After the recent change to ImageEdit plugin, now ImageEdit has hard dependency to ImageSelection plugin. So we need to move it into editor core to be a core plugin. And ideally it should be a core plugin since it provides basic selection functionalities.

Given ImageSelection plugin was under an experimental feature before, and this is the first time we release it without any experimental feature setting, I think it is fine to just move it without bumping major version.

And TableSelection should also be in core, but consider its size and it has been in plugin package for a while, we will keep it there for now, and later in roosterjs v9 it will be part of core.