### PR TITLE
Fix list style issue

### DIFF
--- a/packages/roosterjs-editor-api/test/utils/toggleListTypeTest.ts
+++ b/packages/roosterjs-editor-api/test/utils/toggleListTypeTest.ts
@@ -36,7 +36,7 @@ describe('toggleListTypeTest()', () => {
                 '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div>' +
                 '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">' +
                 '<ul><li>test</li></ul>' +
-                '<div><span id="focusNode" style="font-family: &quot;Courier New&quot;; font-size: 20pt; color: rgb(208, 92, 18);"></span></div>' +
+                '<div><span id="focusNode" style="font-family:&quot;Courier New&quot;;font-size:20pt;color:rgb(208, 92, 18)"></span></div>' +
                 '</div>'
         );
     });
@@ -62,7 +62,7 @@ describe('toggleListTypeTest()', () => {
                 '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);"><br></div>' +
                 '<div style="font-family: Arial; font-size: 16pt; color: rgb(0, 111, 201);">' +
                 '<ul><li>test</li></ul>' +
-                '<div><span id="focusNode" style="font-family: &quot;Courier New&quot;; font-size: 20pt; color: rgb(208, 92, 18);"></span></div>' +
+                '<div><span id="focusNode" style="font-family:&quot;Courier New&quot;;font-size:20pt;color:rgb(208, 92, 18)"></span></div>' +
                 '<ul><li>test</li></ul>' +
                 '</div>'
         );

--- a/packages/roosterjs-editor-dom/lib/list/setListItemStyle.ts
+++ b/packages/roosterjs-editor-dom/lib/list/setListItemStyle.ts
@@ -39,20 +39,25 @@ function getInlineChildElementsStyle(element: HTMLElement, styles: string[]) {
     while (contentTraverser.currentInlineElement != currentInlineElement) {
         currentInlineElement = contentTraverser.currentInlineElement;
         let currentNode = currentInlineElement?.getContainerNode() || null;
-        const currentStyle: Record<string | number, string> = {};
+        let currentStyle: Record<string, string> | null = null;
 
         currentNode = currentNode ? findClosestElementAncestor(currentNode) : null;
 
-        // we should consider of when it is the single childnode of element, the parentNode's style should add
+        // we should consider of when it is the single child node of element, the parentNode's style should add
         // such as the "i", "b", "span" node in <li><span><b><i>aa</i></b></span></li>
         while (
             currentNode &&
             currentNode !== element &&
             safeInstanceOf(currentNode, 'HTMLElement') &&
-            (currentNode.textContent?.trim().length || 0) > 0
+            (result.length == 0 || (currentNode.textContent?.trim().length || 0) > 0)
         ) {
             styles.forEach(styleName => {
                 const styleValue = (currentNode as HTMLElement).style.getPropertyValue(styleName);
+
+                if (!currentStyle) {
+                    currentStyle = {};
+                }
+
                 if (styleValue && !currentStyle[styleName]) {
                     currentStyle[styleName] = styleValue;
                 }

--- a/packages/roosterjs-editor-dom/lib/list/setListItemStyle.ts
+++ b/packages/roosterjs-editor-dom/lib/list/setListItemStyle.ts
@@ -48,7 +48,8 @@ function getInlineChildElementsStyle(element: HTMLElement, styles: string[]) {
         while (
             currentNode &&
             currentNode !== element &&
-            safeInstanceOf(currentNode, 'HTMLElement')
+            safeInstanceOf(currentNode, 'HTMLElement') &&
+            (currentNode.textContent?.trim().length || 0) > 0
         ) {
             styles.forEach(styleName => {
                 const styleValue = (currentNode as HTMLElement).style.getPropertyValue(styleName);

--- a/packages/roosterjs-editor-dom/test/list/VListTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/VListTest.ts
@@ -426,7 +426,7 @@ describe('VList.writeBack', () => {
                     listTypes: [ListType.Ordered],
                 },
             ],
-            '<ul><li>item1</li></ul><div>item2</div><ol><li>item3</li></ol>'
+            '<ul><li>item1</li></ul><div><span>item2</span></div><ol><li>item3</li></ol>'
         );
     });
 
@@ -498,7 +498,7 @@ describe('VList.writeBack', () => {
                     listTypes: [ListType.Ordered],
                 },
             ],
-            '<div>text</div><ol start="3"><li>item3</li><li>item4</li></ol><div>text</div><ol start="5"><li>item5</li></ol>',
+            '<div><span>text</span></div><ol start="3"><li>item3</li><li>item4</li></ol><div><span>text</span></div><ol start="5"><li>item5</li></ol>',
             ol
         );
     });


### PR DESCRIPTION
With change #1380 , now we will put a `<SPAN>` tag under `<DIV>` tag as initial content and use the `<SPAN>` tag to hold format. However, this causes auto bullet loses format since it requires all child nodes inside the list have the same format (https://github.com/microsoft/roosterjs/blob/9f1e7c0544948fe5927fba501ef8daea070d3737/packages/roosterjs-editor-dom/lib/list/setListItemStyle.ts#L25). And when we do auto bullet, a `<BR>` node will be added to avoid format issue (https://github.com/microsoft/roosterjs/blob/9f1e7c0544948fe5927fba501ef8daea070d3737/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts#L399), which will cause a different style (no style) than existing `<SPAN>`.

To fix it, add a check to node content, and ignore any node that doesn't have text content (BR doesn't have text content) since even it has some format, user can't see it.

Also fix an issue when turn off list and original list has format applied to `<LI>` node, we need to preserve its format after list is turned off.