### PR TITLE
Content Model: Fix two list issues

### DIFF
--- a/packages/roosterjs-content-model/lib/formatHandlers/list/listItemMetadataFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/list/listItemMetadataFormatHandler.ts
@@ -47,7 +47,7 @@ export const listItemMetadataFormatHandler: FormatHandler<ListMetadataFormat> = 
                     : UnorderedMap[format.unorderedStyleType!] ??
                       DefaultUnorderedListStyles[depth % DefaultUnorderedListStyles.length];
 
-            if (style && style != 'decimal' && style != 'disc') {
+            if (style && (depth > 0 || (style != 'decimal' && style != 'disc'))) {
                 element.style.listStyleType = style;
             }
         }

--- a/packages/roosterjs-content-model/lib/modelApi/list/setListType.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/list/setListType.ts
@@ -28,6 +28,12 @@ export function setListType(model: ContentModelDocument, listType: 'OL' | 'UL') 
             if (!alreadyInExpectedType && level) {
                 level.listType = listType;
                 item.levels.push(level);
+            } else if (
+                item.blocks.length == 1 &&
+                item.blocks[0].blockType == 'Paragraph' &&
+                item.blocks[0].isImplicit
+            ) {
+                item.blocks[0].isImplicit = false;
             }
         } else {
             const group = item.path[0];

--- a/packages/roosterjs-content-model/lib/modelApi/list/setListType.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/list/setListType.ts
@@ -49,6 +49,10 @@ export function setListType(model: ContentModelDocument, listType: 'OL' | 'UL') 
                 item.paragraph.segments[0]?.format
             );
 
+            // Since there is only one paragraph under the list item, no need to keep its paragraph element (DIV).
+            // TODO: Do we need to keep the CSS styles applied to original DIV?
+            item.paragraph.isImplicit = true;
+
             newListItem.blocks.push(item.paragraph);
 
             group.blocks.splice(index, 1, newListItem);

--- a/packages/roosterjs-content-model/test/modelApi/list/setListTypeTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/list/setListTypeTest.ts
@@ -62,6 +62,19 @@ describe('indent', () => {
             document: document,
         });
         expect(result).toBeTrue();
+        expect(para).toEqual({
+            blockType: 'Paragraph',
+            format: {},
+            isImplicit: true,
+            segments: [
+                {
+                    segmentType: 'Text',
+                    text: 'test',
+                    format: {},
+                    isSelected: true,
+                },
+            ],
+        });
     });
 
     it('Group with single list item selection in a different type', () => {
@@ -124,6 +137,51 @@ describe('indent', () => {
             document: document,
         });
         expect(result).toBeTrue();
+    });
+
+    it('Group with single list item selection in same type with implicit paragraph', () => {
+        const group = createContentModelDocument(document);
+        const para = createParagraph();
+        const text = createText('test');
+        const listItem = createListItem([{ listType: 'OL' }]);
+
+        para.isImplicit = true;
+        para.segments.push(text);
+        listItem.blocks.push(para);
+        group.blocks.push(listItem);
+
+        text.isSelected = true;
+
+        const result = setListType(group, 'OL');
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockGroupType: 'ListItem',
+                    blockType: 'BlockGroup',
+                    levels: [],
+                    blocks: [para],
+                    formatHolder: { segmentType: 'SelectionMarker', format: {}, isSelected: true },
+                    format: {},
+                },
+            ],
+            document: document,
+        });
+        expect(result).toBeTrue();
+        expect(para).toEqual({
+            blockType: 'Paragraph',
+            format: {},
+            isImplicit: false,
+            segments: [
+                {
+                    segmentType: 'Text',
+                    format: {},
+                    isSelected: true,
+                    text: 'test',
+                },
+            ],
+        });
     });
 
     it('Group with mixed selection', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,9 +1714,9 @@ debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
     ms "^2.1.1"
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.3, debug@~4.3.1, debug@~4.3.2:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -5296,9 +5296,9 @@ socket.io-adapter@~2.3.3:
   integrity sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==
 
 socket.io-parser@~4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.4.tgz#9ea21b0d61508d18196ef04a2c6b9ab630f4c2b0"
-  integrity sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.5.tgz#cb404382c32324cc962f27f3a44058cf6e0552df"
+  integrity sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==
   dependencies:
     "@types/component-emitter" "^1.2.10"
     component-emitter "~1.3.0"


### PR DESCRIPTION
1. When convert existing paragraph to list, no need to keep its DIV tag by setting paragraph.isImplicit = true. So when quit the list (keep press Enter key on empty list element), there will be no CSS applied to newly added DIV tag and make the layout consistent before we start a list.

e.g.: Before change, turn on a list will cause a DIV tag inside:
```html
<ol>
 <li>
   <div><span style="...">text</span></div>
 </li>
</ol>
```

after change, DIV tag is gone:
```html
<ol>
 <li>
   <span style="...">text</span>
 </li>
</ol>
```

2. For deep bullet list, we need to apply its list style by default to override browser's default behavior.
Browser default style tags: disc, circle, square, square, square, ...
Our behavior: disc, circle, square, disc, circle, square, ...