### PR TITLE
Restore Ctrl+Click behavior on Firefox

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -1,4 +1,4 @@
-import { Browser, isCharacterValue, isCtrlOrMetaPressed, matchLink } from 'roosterjs-editor-dom';
+import { isCharacterValue, isCtrlOrMetaPressed, matchLink } from 'roosterjs-editor-dom';
 import {
     DOMEventHandler,
     EditorPlugin,
@@ -141,7 +141,6 @@ export default class HyperLink implements EditorPlugin {
 
                 let href: string | null;
                 if (
-                    !Browser.isFirefox &&
                     (href = this.tryGetHref(anchor)) &&
                     isCtrlOrMetaPressed(event.rawEvent) &&
                     event.rawEvent.button === 0

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -145,6 +145,7 @@ export default class HyperLink implements EditorPlugin {
                     isCtrlOrMetaPressed(event.rawEvent) &&
                     event.rawEvent.button === 0
                 ) {
+                    event.rawEvent.preventDefault();
                     try {
                         const target = this.target || '_blank';
                         const window = this.editor?.getDocument().defaultView;

--- a/packages/roosterjs-editor-plugins/test/HyperLink/HyperLinkTest.ts
+++ b/packages/roosterjs-editor-plugins/test/HyperLink/HyperLinkTest.ts
@@ -1,5 +1,4 @@
 import { IEditor, PluginEventType } from 'roosterjs-editor-types';
-import { Browser } from 'roosterjs-editor-dom';
 import { HyperLink } from '../../lib/HyperLink';
 import { initEditor } from '../TestHelper';
 
@@ -70,11 +69,8 @@ describe('HyperLink plugin', () => {
                 button: 0,
             } as unknown) as MouseEvent,
         });
-        if (Browser.isFirefox) {
-            expect(openSpy).not.toHaveBeenCalled();
-        } else {
-            expect(openSpy).toHaveBeenCalledWith(HREF, '_blank');
-        }
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(openSpy).toHaveBeenCalledWith(HREF, '_blank');
     });
 
     it('Does not open the link if its only clicked', () => {

--- a/packages/roosterjs-editor-plugins/test/HyperLink/HyperLinkTest.ts
+++ b/packages/roosterjs-editor-plugins/test/HyperLink/HyperLinkTest.ts
@@ -67,6 +67,7 @@ describe('HyperLink plugin', () => {
                 srcElement: anchor,
                 ctrlKey: true,
                 button: 0,
+                preventDefault: () => {},
             } as unknown) as MouseEvent,
         });
         expect(openSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Ctrl+Clicking an anchor with the Hyperlink plugin enabled no longer opens a new tab on Firefox. Restore behavior by removing the Firefox specific code found in Hyperlink plugin and calling `window.open` always.

<img width="217" alt="image" src="https://user-images.githubusercontent.com/44042957/201754476-f869097f-f7b6-4385-8a08-08317ebf6821.png">
