### PR TITLE
ClearFormat API improvements

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -34,6 +34,7 @@ import {
     wrap,
 } from 'roosterjs-editor-dom';
 import type { CompatibleClearFormatMode } from 'roosterjs-editor-types/lib/compatibleTypes';
+import applyListItemStyleWrap from '../utils/applyListItemWrap';
 
 const STYLES_TO_REMOVE = ['font', 'text-decoration', 'color', 'background'];
 const TAGS_TO_UNWRAP = 'B,I,U,STRONG,EM,SUB,SUP,STRIKE,FONT,CENTER,H1,H2,H3,H4,H5,H6,UL,OL,LI,SPAN,P,BLOCKQUOTE,CODE,S,PRE'.split(
@@ -229,6 +230,15 @@ function clearInlineFormat(editor: IEditor) {
     }, ChangeSource.Format);
 }
 
+function setDefaultFontWeight(editor: IEditor, fontWeight: string = '400') {
+    applyListItemStyleWrap(
+        editor,
+        'font-weight',
+        element => (element.style.fontWeight = fontWeight),
+        'setDefaultFontWeight'
+    );
+}
+
 function setDefaultFormat(editor: IEditor) {
     const defaultFormat = editor.getDefaultFormat();
     const isDefaultFormatEmpty = getObjectKeys(defaultFormat).length === 0;
@@ -281,6 +291,8 @@ function setDefaultFormat(editor: IEditor) {
         }
         if (defaultFormat.bold) {
             toggleBold(editor);
+        } else {
+            setDefaultFontWeight(editor);
         }
         if (defaultFormat.italic) {
             toggleItalic(editor);

--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -143,14 +143,14 @@ function removeNotTableDefaultStyles(element: HTMLTableElement) {
 
 /**
  * Verifies recursively if a node and its parents have any siblings
- * Ignoring the children of contentDiv
+ * Ignoring the children of contentDiv and returning true if any parent is LI
  * @returns `true` if this node, and its parents (minus the children of the contentDiv) have no siblings
  */
 function isNodeWholeBlock(node: Node, editor: IEditor) {
     let currentNode = node;
     while (currentNode && editor.contains(currentNode.parentNode)) {
         if (currentNode.nextSibling || currentNode.previousSibling) {
-            return false;
+            return safeInstanceOf(currentNode, 'HTMLLIElement');
         }
         currentNode = currentNode.parentNode;
     }

--- a/packages/roosterjs-editor-api/test/format/clearFormatTest.ts
+++ b/packages/roosterjs-editor-api/test/format/clearFormatTest.ts
@@ -39,7 +39,7 @@ describe('clearFormat()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div id="text" style=""><span style="font-family: arial; font-size: 12pt; color: black;">text</span></div>'
+            '<div id="text" style=""><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">text</span></div>'
         );
     });
 
@@ -63,7 +63,7 @@ describe('clearFormat()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div id="text"><span style="font-family: arial; font-size: 12pt; color: black;">This is a </span><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">link</span></a><span style="font-family: arial; font-size: 12pt; color: black;">.</span></div>'
+            '<div id="text"><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">This is a </span><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt; font-weight: 400;">link</span></a><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">.</span></div>'
         );
     });
 
@@ -79,7 +79,7 @@ describe('clearFormat()', () => {
 
         // Assert
         expect(editor.getContent()).toBe(
-            '<div id="text"><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">link</span></a></div>'
+            '<div id="text"><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt; font-weight: 400;">link</span></a></div>'
         );
     });
 
@@ -97,7 +97,7 @@ describe('clearFormat()', () => {
 
             // Assert
             expect(editor.getContent()).toBe(
-                '<div id="text" style=""><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">hello</span></a><span style="font-family: arial; font-size: 12pt; color: black;"> World!</span></div>'
+                '<div id="text" style=""><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt; font-weight: 400;">hello</span></a><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;"> World!</span></div>'
             );
         }
     );
@@ -116,7 +116,7 @@ describe('clearFormat()', () => {
 
             // Assert
             expect(editor.getContent()).toBe(
-                '<span style="font-family: arial; font-size: 12pt; color: black;">This is a test text with </span><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt;">Hyperlink.</span></a>'
+                '<span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">This is a test text with </span><a href="http://microsoft.com"><span style="font-family: arial; font-size: 12pt; font-weight: 400;">Hyperlink.</span></a>'
             );
         }
     );
@@ -231,7 +231,7 @@ describe('clearAutodetectFormat tests', () => {
     TestHelper.itFirefoxOnly('removes text format when selecting a cell of a table', () => {
         editor.setContent(TABLE_TEST);
         const expectedFormat =
-            '<div style="width:95.75pt;padding:0in 5.4pt 0in 5.4pt"> </div><div>asdfadf<o:p>&nbsp;</o:p></div><div style="width:95.75pt;padding:0in 5.4pt 0in 5.4pt"> </div>';
+            ' <p style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;margin-bottom:0in">asdfadf<span style="color:red"><o:p>&nbsp;</o:p></span></p> ';
 
         let table: HTMLTableElement = doc.getElementById('testTable') as HTMLTableElement;
         let cell = table.rows[0].cells[2];
@@ -280,7 +280,7 @@ describe('clearAutodetectFormat Partial Tests', () => {
         const originalText =
             '<h1 id="testHeader" style="margin-right:0in;margin-left:0in;font-size:24pt;font-family:&quot;Times New Roman&quot;, serif"><span style="font-size: 24pt; font-family: Arial, sans-serif;">Header middle text 1</span></h1>';
         const expectedFormat =
-            '<span style="font-size: 24pt; font-family: Arial, sans-serif;">Header </span><span style="font-family: arial; font-size: 12pt; color: black;">middle</span><span style="font-size: 24pt; font-family: Arial, sans-serif;"> text 1</span>';
+            '<span style="font-size: 24pt; font-family: Arial, sans-serif;">Header </span><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">middle</span><span style="font-size: 24pt; font-family: Arial, sans-serif;"> text 1</span>';
         editor.setContent(originalText);
 
         let header = doc.getElementById('testHeader');
@@ -300,7 +300,7 @@ describe('clearAutodetectFormat Partial Tests', () => {
         const originalContent =
             '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul type="disc" style="margin-bottom:0in"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">item 1</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Item 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
         const expectedFormat =
-            '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul style="margin-bottom:0in" type="disc"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">item 1</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-family: arial; font-size: 12pt; color: black;">Item</span><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif"> 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
+            '<p style="margin:0in 0in 8pt;line-height:107%;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif;color:black"></span></p><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><span style="font-size:13.5pt;font-family:Arial, sans-serif;color:black"></span></p></div><div></div><ul style="margin-bottom:0in" type="disc"> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">item 1</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-family: arial; font-size: 12pt; color: black; font-weight: 400;">Item</span><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif"> 2</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">Sdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li> <li style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;color:black;mso-margin-top-alt:auto;mso-margin-bottom-alt:auto;mso-list:l0 level1 lfo1;tab-stops:list .5in"><span style="font-size:13.5pt;font-family:&quot;Arial&quot;,sans-serif">asdasd</span><span style="font-size:13.5pt"><o:p>&nbsp;</o:p></span></li></ul><div></div><div><p style="background-color:rgb(255, 255, 255);margin:0in 0in 8pt;line-height:15.6933px;font-size:11pt;font-family:Calibri, sans-serif"><o:p></o:p></p></div>';
         editor.setContent(originalContent);
 
         const ul = doc.getElementsByTagName('ul')[0];
@@ -451,7 +451,7 @@ describe('clearAutodetectFormat tests with defaultFormat | ', () => {
             },
             () => {
                 const expectedFormat =
-                    '<div style="width:95.75pt;padding:0in 5.4pt 0in 5.4pt"> </div><div><b><span style="font-family: arial; font-size: 12pt; color: black;">asdfadf</span></b><o:p>&nbsp;</o:p></div><div style="width:95.75pt;padding:0in 5.4pt 0in 5.4pt"> </div>';
+                    ' <p style="margin:0in 0in 8pt;font-size:11pt;font-family:Calibri, sans-serif;margin-bottom:0in"><b><span style="font-family: arial; font-size: 12pt; color: black;">asdfadf</span></b><span style="color:red"><o:p>&nbsp;</o:p></span></p> ';
                 let table: HTMLTableElement = doc.getElementById('testTable') as HTMLTableElement;
                 let cell = table.rows[0].cells[2];
                 table = doc.getElementsByTagName('table')[0] as HTMLTableElement;

--- a/packages/roosterjs-editor-plugins/test/HyperLink/HyperLinkTest.ts
+++ b/packages/roosterjs-editor-plugins/test/HyperLink/HyperLinkTest.ts
@@ -1,0 +1,94 @@
+import { IEditor, PluginEventType } from 'roosterjs-editor-types';
+import { Browser } from 'roosterjs-editor-dom';
+import { HyperLink } from '../../lib/HyperLink';
+import { initEditor } from '../TestHelper';
+
+const HREF = 'https://microsoft.github.io/roosterjs';
+const editorId = 'editorId';
+
+describe('HyperLink plugin', () => {
+    let editor: IEditor;
+    let plugin: HyperLink;
+    let anchor: HTMLAnchorElement;
+    let div: HTMLDivElement;
+    let eventHandlers: Record<string, Function>;
+
+    beforeEach(() => {
+        anchor = document.createElement('a');
+        anchor.href = HREF;
+        plugin = new HyperLink();
+        editor = initEditor(editorId, [plugin]);
+        spyOn(editor, 'addDomEventHandler').and.callFake(x => void (eventHandlers = <any>x));
+        plugin.initialize(editor);
+        const editorDiv = (<any>editor).core.contentDiv;
+        if (!editorDiv) {
+            throw 'Unable to find editor div';
+        }
+        div = editorDiv;
+    });
+
+    afterEach(() => {
+        editor.dispose();
+        div.remove();
+        eventHandlers = {};
+    });
+
+    it('Removes title attribute if nothing is being hovered', () => {
+        div.appendChild(anchor);
+
+        eventHandlers.mouseover({
+            type: 'mouseover',
+            target: anchor,
+        });
+
+        eventHandlers.mouseout({
+            type: 'mouseout',
+            target: anchor,
+        });
+
+        expect(div.getAttribute('title')).toEqual(null);
+    });
+
+    it('Displays the link as default for links', () => {
+        div.appendChild(anchor);
+        eventHandlers.mouseover({
+            type: 'mouseover',
+            target: anchor,
+        });
+        expect(div.getAttribute('title')).toEqual(HREF);
+    });
+
+    it('Opens the link whenever Ctrl+Click', () => {
+        const openSpy = spyOn(window, 'open');
+        div.appendChild(anchor);
+        plugin.onPluginEvent({
+            eventType: PluginEventType.MouseUp,
+            rawEvent: ({
+                target: anchor,
+                srcElement: anchor,
+                ctrlKey: true,
+                button: 0,
+            } as unknown) as MouseEvent,
+        });
+        if (Browser.isFirefox) {
+            expect(openSpy).not.toHaveBeenCalled();
+        } else {
+            expect(openSpy).toHaveBeenCalledWith(HREF, '_blank');
+        }
+    });
+
+    it('Does not open the link if its only clicked', () => {
+        const openSpy = spyOn(window, 'open');
+        div.appendChild(anchor);
+        plugin.onPluginEvent({
+            eventType: PluginEventType.MouseUp,
+            rawEvent: ({
+                target: anchor,
+                srcElement: anchor,
+                ctrlKey: false,
+                button: 0,
+            } as unknown) as MouseEvent,
+        });
+        expect(openSpy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
1. Prevents block format being applied when `AutoDetect`ing clear format and an entire element is being selected (eg. an entire table cell, an entire bold word) by identifying if the node completely selected has any siblings (or its parents)
<img width="323" alt="image" src="https://user-images.githubusercontent.com/44042957/201770577-37087d18-c9e8-41ee-aca7-e409a6d1b199.png">
Wrong result:
<img width="290" alt="image" src="https://user-images.githubusercontent.com/44042957/201770601-b51449f0-51c2-43d2-9d50-16e11023124d.png">
Fix:
<img width="297" alt="image" src="https://user-images.githubusercontent.com/44042957/201770826-0fd6e20e-a955-4a40-a9f4-34c4be8d4336.png">

Should be noted that this introduces a behavior change when clearing the format of the content of table cells:
Selection:
<img width="181" alt="image" src="https://user-images.githubusercontent.com/44042957/202027506-ac3fd7f6-80d8-43b6-a3ba-0d7d4563ece5.png">
Previous:
<img width="167" alt="image" src="https://user-images.githubusercontent.com/44042957/202027395-b8298275-ef6d-4291-bf3b-de80724cbcb8.png">
New:
<img width="176" alt="image" src="https://user-images.githubusercontent.com/44042957/202027362-da97e33e-4993-482a-bcdc-e01139ac35b7.png">


2. Addresses partial formats of `<h1>` blocks appearing bolder by setting a standard fontWeight when defaultFormat is defined.
Previous:
<img width="191" alt="image" src="https://user-images.githubusercontent.com/44042957/202027875-d812b446-2961-42b1-9a40-50a9d14b0de0.png">
Fix:
<img width="167" alt="image" src="https://user-images.githubusercontent.com/44042957/202027898-d3afd3fa-66f7-4352-9af0-097c8ddbb212.png">
