### PR TITLE
Fix image size in Content Model

### DIFF
--- a/packages/roosterjs-content-model/lib/formatHandlers/common/sizeFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/common/sizeFormatHandler.ts
@@ -1,6 +1,8 @@
 import { FormatHandler } from '../FormatHandler';
 import { SizeFormat } from '../../publicTypes/format/formatParts/SizeFormat';
 
+const PercentageRegex = /[\d\.]+%/;
+
 /**
  * @internal
  */
@@ -55,7 +57,12 @@ export const sizeFormatHandler: FormatHandler<SizeFormat> = {
 };
 
 function tryParseSize(element: HTMLElement, attrName: 'width' | 'height'): string | undefined {
-    const value = parseInt(element.getAttribute(attrName) || '');
+    const attrValue = element.getAttribute(attrName);
+    const value = parseInt(attrValue || '');
 
-    return Number.isNaN(value) ? undefined : value + 'px';
+    return attrValue && PercentageRegex.test(attrValue)
+        ? attrValue
+        : Number.isNaN(value)
+        ? undefined
+        : value + 'px';
 }

--- a/packages/roosterjs-content-model/test/formatHandlers/common/sizeFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/common/sizeFormatHandlerTest.ts
@@ -58,6 +58,17 @@ describe('sizeFormatHandler.parse', () => {
         expect(format).toEqual({ width: '10px', height: '20px' });
     });
 
+    it('Element with width and height in attribute in percentage', () => {
+        const element = document.createElement('div');
+
+        element.setAttribute('width', '30%');
+        element.setAttribute('height', '40%');
+
+        sizeFormatHandler.parse(format, element, context, {});
+
+        expect(format).toEqual({ width: '30%', height: '40%' });
+    });
+
     it('Element with min/max size', () => {
         const element = document.createElement('div');
 


### PR DESCRIPTION
When process image with Content Model, we read its size from both CSS and HTML attribute. Here we missed a case that HTML attribute width/height value is a percentage, we need to keep the "%" in its width/height value.