### PR TITLE
Content Model: fix inline entity loses format issue

### DIFF
--- a/demo/scripts/controls/contentModel/components/model/ContentModelEntityView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelEntityView.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import { BlockFormatView } from '../format/BlockFormatView';
 import { ContentModelEntity } from 'roosterjs-content-model';
 import { ContentModelView } from '../ContentModelView';
+import { SegmentFormatView } from '../format/SegmentFormatView';
 import { useProperty } from '../../hooks/useProperty';
 
 const styles = require('./ContentModelEntityView.scss');
@@ -55,6 +57,15 @@ export function ContentModelEntityView(props: { entity: ContentModelEntity }) {
         );
     }, [type, isReadonly, id]);
 
+    const getFormat = React.useCallback(() => {
+        return (
+            <>
+                <SegmentFormatView format={entity.format} />
+                <BlockFormatView format={entity.format} />
+            </>
+        );
+    }, [entity.format]);
+
     return (
         <ContentModelView
             title="Entity"
@@ -62,6 +73,7 @@ export function ContentModelEntityView(props: { entity: ContentModelEntity }) {
             className={styles.modelEntity}
             jsonSource={entity}
             getContent={getContent}
+            getFormat={getFormat}
         />
     );
 }

--- a/packages/roosterjs-content-model/lib/domToModel/processors/entityProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/entityProcessor.ts
@@ -12,7 +12,7 @@ export const entityProcessor: ElementProcessor<HTMLElement> = (group, element, c
     const entity = getEntityFromElement(element);
 
     if (entity) {
-        const entityModel = createEntity(entity, context.segmentFormat, context.blockFormat);
+        const entityModel = createEntity(entity, context.segmentFormat);
         const isBlockEntity = isBlockElement(element, context);
 
         if (isBlockEntity) {

--- a/packages/roosterjs-content-model/lib/domToModel/processors/entityProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/entityProcessor.ts
@@ -12,7 +12,7 @@ export const entityProcessor: ElementProcessor<HTMLElement> = (group, element, c
     const entity = getEntityFromElement(element);
 
     if (entity) {
-        const entityModel = createEntity(entity);
+        const entityModel = createEntity(entity, context.segmentFormat, context.blockFormat);
         const isBlockEntity = isBlockElement(element, context);
 
         if (isBlockEntity) {

--- a/packages/roosterjs-content-model/lib/modelApi/creators/createEntity.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/creators/createEntity.ts
@@ -1,5 +1,5 @@
 import { ContentModelEntity } from '../../publicTypes/entity/ContentModelEntity';
-import { ContentModelSegmentFormat } from 'roosterjs-content-model/lib/publicTypes/format/ContentModelSegmentFormat';
+import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { Entity } from 'roosterjs-editor-types';
 
 /**

--- a/packages/roosterjs-content-model/lib/modelApi/creators/createEntity.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/creators/createEntity.ts
@@ -1,16 +1,25 @@
+import { ContentModelBlockFormat } from 'roosterjs-content-model/lib/publicTypes/format/ContentModelBlockFormat';
 import { ContentModelEntity } from '../../publicTypes/entity/ContentModelEntity';
+import { ContentModelSegmentFormat } from 'roosterjs-content-model/lib/publicTypes/format/ContentModelSegmentFormat';
 import { Entity } from 'roosterjs-editor-types';
 
 /**
  * @internal
  */
-export function createEntity(entity: Entity): ContentModelEntity {
+export function createEntity(
+    entity: Entity,
+    segmentFormat?: ContentModelSegmentFormat,
+    blockFormat?: ContentModelBlockFormat
+): ContentModelEntity {
     const { id, type, isReadonly, wrapper } = entity;
 
     return {
         segmentType: 'Entity',
         blockType: 'Entity',
-        format: {},
+        format: {
+            ...(blockFormat || {}),
+            ...(segmentFormat || {}),
+        },
         id,
         type,
         isReadonly,

--- a/packages/roosterjs-content-model/lib/modelApi/creators/createEntity.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/creators/createEntity.ts
@@ -1,4 +1,3 @@
-import { ContentModelBlockFormat } from 'roosterjs-content-model/lib/publicTypes/format/ContentModelBlockFormat';
 import { ContentModelEntity } from '../../publicTypes/entity/ContentModelEntity';
 import { ContentModelSegmentFormat } from 'roosterjs-content-model/lib/publicTypes/format/ContentModelSegmentFormat';
 import { Entity } from 'roosterjs-editor-types';
@@ -8,8 +7,7 @@ import { Entity } from 'roosterjs-editor-types';
  */
 export function createEntity(
     entity: Entity,
-    segmentFormat?: ContentModelSegmentFormat,
-    blockFormat?: ContentModelBlockFormat
+    segmentFormat?: ContentModelSegmentFormat
 ): ContentModelEntity {
     const { id, type, isReadonly, wrapper } = entity;
 
@@ -17,7 +15,6 @@ export function createEntity(
         segmentType: 'Entity',
         blockType: 'Entity',
         format: {
-            ...(blockFormat || {}),
             ...(segmentFormat || {}),
         },
         id,

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
@@ -1,4 +1,5 @@
-import { commitEntity, createEntityPlaceholder } from 'roosterjs-editor-dom';
+import { applyFormat } from '../utils/applyFormat';
+import { commitEntity, createEntityPlaceholder, getObjectKeys } from 'roosterjs-editor-dom';
 import { ContentModelEntity } from '../../publicTypes/entity/ContentModelEntity';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
@@ -12,10 +13,18 @@ export const handleEntity: ContentModelHandler<ContentModelEntity> = (
     entityModel: ContentModelEntity,
     context: ModelToDomContext
 ) => {
-    const { wrapper, id, type, isReadonly } = entityModel;
+    const { wrapper, id, type, isReadonly, format } = entityModel;
 
     // Commit the entity attributes in case there is any change
     commitEntity(wrapper, type, isReadonly, id);
+
+    if (getObjectKeys(format).length > 0) {
+        const span = doc.createElement('span');
+
+        parent.appendChild(span);
+        applyFormat(span, context.formatAppliers.segment, format, context);
+        parent = span;
+    }
 
     if (context.doNotReuseEntityDom) {
         parent.appendChild(wrapper);

--- a/packages/roosterjs-content-model/test/modelApi/creators/creatorsTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/creators/creatorsTest.ts
@@ -360,6 +360,27 @@ describe('Creators', () => {
         });
     });
 
+    it('createEntity with format', () => {
+        const id = 'entity_1';
+        const type = 'entity';
+        const isReadonly = true;
+        const wrapper = document.createElement('div');
+        const entity: Entity = { id, type, isReadonly, wrapper };
+        const entityModel = createEntity(entity, {
+            fontSize: '10pt',
+        });
+
+        expect(entityModel).toEqual({
+            blockType: 'Entity',
+            segmentType: 'Entity',
+            format: { fontSize: '10pt' },
+            id,
+            type,
+            isReadonly,
+            wrapper,
+        });
+    });
+
     it('createImage', () => {
         const imageModel = createImage('test');
 


### PR DESCRIPTION
When an entity is put under some element which has inline format, we need to apply this format to the entity when write back to make sure it has the same layout.