### PR TITLE
Content Model: Fix data set conflict between format handlers

### DIFF
--- a/packages/roosterjs-content-model/lib/formatHandlers/common/datasetFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/common/datasetFormatHandler.ts
@@ -19,7 +19,9 @@ export const datasetFormatHandler: FormatHandler<DatasetFormat> = {
         const dataset = element.dataset;
 
         getObjectKeys(dataset).forEach(key => {
-            if (DatasetNameToIgnore.indexOf(key) < 0) format[key] = dataset[key] || '';
+            if (DatasetNameToIgnore.indexOf(key) < 0) {
+                format[key] = dataset[key] || '';
+            }
         });
     },
 

--- a/packages/roosterjs-content-model/lib/formatHandlers/common/datasetFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/common/datasetFormatHandler.ts
@@ -1,6 +1,15 @@
+import { DarkModeDatasetNames } from 'roosterjs-editor-types/lib';
 import { DatasetFormat } from '../../publicTypes/format/formatParts/DatasetFormat';
 import { FormatHandler } from '../FormatHandler';
 import { getObjectKeys } from 'roosterjs-editor-dom';
+
+// These keys of dataset should be ignored by this format handler because they will be taken care by other format handlers
+const DatasetNameToIgnore: (string | number)[] = [
+    DarkModeDatasetNames.OriginalAttributeBackgroundColor,
+    DarkModeDatasetNames.OriginalAttributeColor,
+    DarkModeDatasetNames.OriginalStyleBackgroundColor,
+    DarkModeDatasetNames.OriginalStyleColor,
+];
 
 /**
  * @internal
@@ -10,7 +19,7 @@ export const datasetFormatHandler: FormatHandler<DatasetFormat> = {
         const dataset = element.dataset;
 
         getObjectKeys(dataset).forEach(key => {
-            format[key] = dataset[key] || '';
+            if (DatasetNameToIgnore.indexOf(key) < 0) format[key] = dataset[key] || '';
         });
     },
 

--- a/packages/roosterjs-content-model/lib/formatHandlers/common/datasetFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/common/datasetFormatHandler.ts
@@ -1,4 +1,4 @@
-import { DarkModeDatasetNames } from 'roosterjs-editor-types/lib';
+import { DarkModeDatasetNames } from 'roosterjs-editor-types';
 import { DatasetFormat } from '../../publicTypes/format/formatParts/DatasetFormat';
 import { FormatHandler } from '../FormatHandler';
 import { getObjectKeys } from 'roosterjs-editor-dom';

--- a/packages/roosterjs-content-model/test/formatHandlers/common/datasetFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/common/datasetFormatHandlerTest.ts
@@ -30,6 +30,18 @@ describe('datasetFormatHandler.parse', () => {
             c: 'd',
         });
     });
+
+    it('Ignore some of the keys', () => {
+        div.dataset.a = 'b';
+        div.dataset.c = 'd';
+        div.dataset.ogsc = 'red';
+        div.dataset.ogsb = 'green';
+        datasetFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({
+            a: 'b',
+            c: 'd',
+        });
+    });
 });
 
 describe('datasetFormatHandler.apply', () => {


### PR DESCRIPTION
The following dataset names should be ignored by datasetFormatHandler, because they will also be handled by textColorFormatHandler and backgroundColorFormatHandler in dark mode. If they are handled by both handlers, it is possible a new value be overwritten with old ones by the second handler.