### PR TITLE
Valid numbering

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -32,6 +32,7 @@ const initialState: BuildInPluginState = {
         ExperimentalFeatures.ListItemAlignment,
         ExperimentalFeatures.PendingStyleBasedFormat,
         ExperimentalFeatures.DefaultFormatInSpan,
+        ExperimentalFeatures.AutoFormatList,
     ],
     isRtl: false,
 };

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/utils/getAutoNumberingListStyle.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/utils/getAutoNumberingListStyle.ts
@@ -159,6 +159,12 @@ export default function getAutoNumberingListStyle(
     return numberingType;
 }
 
+/**
+ * Check if index has only numbers or only letters to avoid sequence of character such 1:1. trigger a list.
+ * @param textBeforeCursor
+ * @param isDoubleParenthesis
+ * @returns
+ */
 function isValidNumbering(textBeforeCursor: string, isDoubleParenthesis: boolean) {
     const index = isDoubleParenthesis
         ? textBeforeCursor.slice(1, -1)

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/utils/getAutoNumberingListStyle.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/utils/getAutoNumberingListStyle.ts
@@ -153,10 +153,15 @@ export default function getAutoNumberingListStyle(
     }
 
     const isDoubleParenthesis = trigger[0] === '(' && trigger[trigger.length - 1] === ')';
-    const numberingType = identifyNumberingListType(
-        trigger,
-        isDoubleParenthesis,
-        previousListStyle
-    );
+    const numberingType = isValidNumbering(trigger, isDoubleParenthesis)
+        ? identifyNumberingListType(trigger, isDoubleParenthesis, previousListStyle)
+        : null;
     return numberingType;
+}
+
+function isValidNumbering(textBeforeCursor: string, isDoubleParenthesis: boolean) {
+    const index = isDoubleParenthesis
+        ? textBeforeCursor.slice(1, -1)
+        : textBeforeCursor.slice(0, -1);
+    return Number(index) || /^[A-Za-z\s]*$/.test(index);
 }

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/utils/getAutoNumberingListStyleTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/utils/getAutoNumberingListStyleTest.ts
@@ -86,4 +86,20 @@ describe('getAutoListStyle ', () => {
     it('(I) ', () => {
         runTest('(I) ', NumberingListType.UpperRomanDoubleParenthesis);
     });
+
+    it('1:1. ', () => {
+        runTest('1:1. ', null);
+    });
+
+    it('30%). ', () => {
+        runTest('30%). ', null);
+    });
+
+    it('4th. ', () => {
+        runTest('4th. ', null);
+    });
+
+    it('30%) ', () => {
+        runTest('30%) ', null);
+    });
 });


### PR DESCRIPTION
Add proper validation to list index to avoid list being triggering by special characters. 
Ex: 1:1. was triggering list because the first character is a number and the last is a proper marker character. 
To avoid that behavior change we check if the string before the marker is number or string without number and special characters 