### PR TITLE
Fix cursor jump bug. 

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -32,6 +32,7 @@ const initialState: BuildInPluginState = {
         ExperimentalFeatures.ListItemAlignment,
         ExperimentalFeatures.PendingStyleBasedFormat,
         ExperimentalFeatures.DefaultFormatInSpan,
+        ExperimentalFeatures.AutoFormatList,
     ],
     isRtl: false,
 };

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -330,10 +330,11 @@ const AutoNumberingList: BuildInEditFeature<PluginKeyboardEvent> = {
 };
 
 const getPreviousListItem = (editor: IEditor, textRange: Range) => {
-    const previousNode = editor
+    const blockElement = editor
         .getBodyTraverser(textRange?.startContainer)
-        .getPreviousBlockElement()
-        ?.collapseToSingleElement();
+        .getPreviousBlockElement();
+    console.log(blockElement);
+    const previousNode = blockElement?.getEndNode();
     return getTagOfNode(previousNode) === 'LI' ? previousNode : undefined;
 };
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -333,7 +333,6 @@ const getPreviousListItem = (editor: IEditor, textRange: Range) => {
     const blockElement = editor
         .getBodyTraverser(textRange?.startContainer)
         .getPreviousBlockElement();
-    console.log(blockElement);
     const previousNode = blockElement?.getEndNode();
     return getTagOfNode(previousNode) === 'LI' ? previousNode : undefined;
 };


### PR DESCRIPTION
Every time space character is triggered, rooster checks if a list can be trigger, it caused getPreviousListItem() to be triggered and by consequence collapseToSingleNode() causing the an odd behavior after pressing space. 
To avoid that problem collapseToSingleNode() was removed and getEndNode() was used to get the previous list item. 
Before the fix:
![collapseBug](https://user-images.githubusercontent.com/87443959/203160786-43eac7bf-8a47-4edc-bff1-41ec219922bf.gif)

After the fix: 
![collapseBuFixed](https://user-images.githubusercontent.com/87443959/203160798-e733baaf-490c-4c11-9ace-266efc04d363.gif)
