### PR TITLE
Fix a list color issue in dark mode (#1428)

### DIFF
--- a/packages/roosterjs-editor-api/lib/utils/applyListItemWrap.ts
+++ b/packages/roosterjs-editor-api/lib/utils/applyListItemWrap.ts
@@ -41,7 +41,7 @@ export default function applyListItemStyleWrap(
 function applyStyleToListItems(parentNodes: Node[], styles: string[]) {
     parentNodes.forEach(node => {
         if (safeInstanceOf(node, 'HTMLLIElement')) {
-            setListItemStyle(node, styles, true /*isCssStyle*/);
+            setListItemStyle(node, styles);
         }
     });
 }

--- a/packages/roosterjs-editor-api/lib/utils/applyListItemWrap.ts
+++ b/packages/roosterjs-editor-api/lib/utils/applyListItemWrap.ts
@@ -41,7 +41,7 @@ export default function applyListItemStyleWrap(
 function applyStyleToListItems(parentNodes: Node[], styles: string[]) {
     parentNodes.forEach(node => {
         if (safeInstanceOf(node, 'HTMLLIElement')) {
-            setListItemStyle(node, styles);
+            setListItemStyle(node, styles, true /*isCssStyle*/);
         }
     });
 }

--- a/packages/roosterjs-editor-dom/lib/list/VListItem.ts
+++ b/packages/roosterjs-editor-dom/lib/list/VListItem.ts
@@ -32,6 +32,9 @@ const unorderedListStyles = ['disc', 'circle', 'square'];
 const MARGIN_BASE = '0in 0in 0in 0.5in';
 const NEGATIVE_MARGIN = '-.25in';
 
+const stylesToInherit = ['font-size', 'font-family', 'color'];
+const attrsToInherit = ['data-ogsc', 'data-ogsb', 'data-ogac', 'data-ogab'];
+
 /**
  * @internal
  * The definition for the number of BulletListType or NumberingListType
@@ -362,8 +365,8 @@ export default class VListItem {
 
         // 4. Inherit styles of the child element to the li, so we are able to apply the styles to the ::marker
         if (this.listTypes.length > 1) {
-            const stylesToInherit = ['font-size', 'font-family', 'color'];
-            setListItemStyle(this.node, stylesToInherit);
+            setListItemStyle(this.node, stylesToInherit, true /*isCssStyle*/);
+            setListItemStyle(this.node, attrsToInherit, false /*isCssStyle*/);
         }
 
         // 5. If this is not a list item now, need to unwrap the LI node and do proper handling
@@ -394,6 +397,14 @@ export default class VListItem {
                             ...getStyles(node),
                         };
                         setStyles(node, styles);
+
+                        attrsToInherit.forEach(attr => {
+                            const attrValue = this.node.getAttribute(attr);
+
+                            if (attrValue) {
+                                node.setAttribute(attr, attrValue);
+                            }
+                        });
                     }
                 }
             }

--- a/packages/roosterjs-editor-dom/lib/list/setListItemStyle.ts
+++ b/packages/roosterjs-editor-dom/lib/list/setListItemStyle.ts
@@ -8,12 +8,12 @@ import { InlineElement } from 'roosterjs-editor-types';
  * If the child inline elements have different styles, it will not modify the styles of the list item
  * @param element the LI Element to set the styles
  * @param styles The styles that should be applied to the element.
- * @param isCssStyle True means the given styles are CSS style names, false means they are HTML attributes
+ * @param isCssStyle True means the given styles are CSS style names, false means they are HTML attributes @default true
  */
 export default function setListItemStyle(
     element: HTMLLIElement,
     styles: string[],
-    isCssStyle: boolean
+    isCssStyle: boolean = true
 ) {
     const elementsStyles = getInlineChildElementsStyle(element, styles, isCssStyle);
 

--- a/packages/roosterjs-editor-dom/lib/list/setListItemStyle.ts
+++ b/packages/roosterjs-editor-dom/lib/list/setListItemStyle.ts
@@ -1,8 +1,6 @@
 import ContentTraverser from '../contentTraverser/ContentTraverser';
 import findClosestElementAncestor from '../utils/findClosestElementAncestor';
-import getStyles from '../style/getStyles';
 import safeInstanceOf from '../utils/safeInstanceOf';
-import setStyles from '../style/setStyles';
 import { InlineElement } from 'roosterjs-editor-types';
 
 /**
@@ -10,10 +8,14 @@ import { InlineElement } from 'roosterjs-editor-types';
  * If the child inline elements have different styles, it will not modify the styles of the list item
  * @param element the LI Element to set the styles
  * @param styles The styles that should be applied to the element.
+ * @param isCssStyle True means the given styles are CSS style names, false means they are HTML attributes
  */
-export default function setListItemStyle(element: HTMLLIElement, styles: string[]) {
-    const elementsStyles = getInlineChildElementsStyle(element, styles);
-    let stylesToApply: Record<string, string> = getStyles(element);
+export default function setListItemStyle(
+    element: HTMLLIElement,
+    styles: string[],
+    isCssStyle: boolean
+) {
+    const elementsStyles = getInlineChildElementsStyle(element, styles, isCssStyle);
 
     styles.forEach(styleName => {
         const styleValues = elementsStyles.map(style =>
@@ -25,13 +27,16 @@ export default function setListItemStyle(element: HTMLLIElement, styles: string[
             (styleValues.length == 1 || new Set(styleValues).size == 1) &&
             styleValues[0]
         ) {
-            stylesToApply[styleName] = styleValues[0];
+            if (isCssStyle) {
+                element.style.setProperty(styleName, styleValues[0]);
+            } else {
+                element.setAttribute(styleName, styleValues[0]);
+            }
         }
     });
-    setStyles(element, stylesToApply);
 }
 
-function getInlineChildElementsStyle(element: HTMLElement, styles: string[]) {
+function getInlineChildElementsStyle(element: HTMLElement, styles: string[], isCssStyle: boolean) {
     const result: Record<string, string>[] = [];
     const contentTraverser = ContentTraverser.createBodyTraverser(element);
     let currentInlineElement: InlineElement | null = null;
@@ -51,8 +56,12 @@ function getInlineChildElementsStyle(element: HTMLElement, styles: string[]) {
             safeInstanceOf(currentNode, 'HTMLElement') &&
             (result.length == 0 || (currentNode.textContent?.trim().length || 0) > 0)
         ) {
+            const element: HTMLElement = currentNode;
+
             styles.forEach(styleName => {
-                const styleValue = (currentNode as HTMLElement).style.getPropertyValue(styleName);
+                const styleValue = isCssStyle
+                    ? element.style.getPropertyValue(styleName)
+                    : element.getAttribute(styleName);
 
                 if (!currentStyle) {
                     currentStyle = {};

--- a/packages/roosterjs-editor-dom/test/list/VListItemTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/VListItemTest.ts
@@ -405,7 +405,7 @@ describe('VListItem.writeBack', () => {
 
         // Assert
         expect(listStack[0].innerHTML).toBe(
-            '<ol><li style="font-size:14px;font-family:Courier New;color:blue"><span style="font-size: 14px; font-family: Courier New; color: blue;">test</span></li></ol>'
+            '<ol><li style="font-size: 14px; font-family: Courier New; color: blue;"><span style="font-size: 14px; font-family: Courier New; color: blue;">test</span></li></ol>'
         );
     });
 

--- a/packages/roosterjs-editor-dom/test/list/setListItemStyleTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/setListItemStyleTest.ts
@@ -18,7 +18,7 @@ describe('setListItemStyle', () => {
                     textContent: 'test',
                 },
             ],
-            'font-size:72pt;color:blue'
+            'font-size: 72pt; color: blue;'
         );
     });
 
@@ -36,7 +36,7 @@ describe('setListItemStyle', () => {
                     textContent: 'test',
                 },
             ],
-            'font-size:72pt;color:blue'
+            'font-size: 72pt; color: blue;'
         );
     });
 
@@ -59,7 +59,7 @@ describe('setListItemStyle', () => {
                     textContent: 'test',
                 },
             ],
-            'font-size:72pt;font-family:Tahoma;color:blue'
+            'font-size: 72pt; font-family: Tahoma; color: blue;'
         );
     });
 
@@ -77,7 +77,7 @@ describe('setListItemStyle', () => {
                     textContent: 'test',
                 },
             ],
-            'font-size:72pt'
+            'font-size: 72pt;'
         );
     });
 
@@ -100,7 +100,7 @@ describe('setListItemStyle', () => {
                     textContent: 'test',
                 },
             ],
-            'font-size:72pt'
+            'font-size: 72pt;'
         );
     });
 
@@ -169,7 +169,7 @@ describe('setListItemStyle', () => {
                     textContent: 'test',
                 },
             ],
-            'font-size:72pt;font-family:Tahoma;color:blue'
+            'font-size: 72pt; font-family: Tahoma; color: blue;'
         );
     });
 
@@ -225,11 +225,11 @@ describe('setListItemStyle', () => {
         listItemElement.appendChild(divElement);
 
         // Act
-        setListItemStyle(listItemElement, stylesToInherit);
+        setListItemStyle(listItemElement, stylesToInherit, true /*isCssStyle*/);
 
         // Assert
         expect(listItemElement.getAttribute('style')).toBe(
-            'font-size:72pt;font-family:Tahoma;color:blue'
+            'font-size: 72pt; font-family: Tahoma; color: blue;'
         );
     });
 
@@ -269,11 +269,11 @@ describe('setListItemStyle', () => {
         listItemElement.appendChild(spanElement);
 
         // Act
-        setListItemStyle(listItemElement, stylesToInherit);
+        setListItemStyle(listItemElement, stylesToInherit, true /*isCssStyle*/);
 
         // Assert
         expect(listItemElement.getAttribute('style')).toBe(
-            'font-size:72pt;font-family:Tahoma;color:blue'
+            'font-size: 72pt; font-family: Tahoma; color: blue;'
         );
     });
 
@@ -293,11 +293,11 @@ describe('setListItemStyle', () => {
         listItemElement.appendChild(spanElement);
 
         // Act;
-        setListItemStyle(listItemElement, stylesToInherit);
+        setListItemStyle(listItemElement, stylesToInherit, true /*isCssStyle*/);
 
         // Assert;
         expect(listItemElement.getAttribute('style')).toBe(
-            'font-size:72pt;font-family:Tahoma;color:blue'
+            'font-size: 72pt; font-family: Tahoma; color: blue;'
         );
     });
 
@@ -318,11 +318,11 @@ describe('setListItemStyle', () => {
         listItemElement.appendChild(divElement);
 
         // Act;
-        setListItemStyle(listItemElement, stylesToInherit);
+        setListItemStyle(listItemElement, stylesToInherit, true /*isCssStyle*/);
 
         // Assert;
         expect(listItemElement.getAttribute('style')).toBe(
-            'font-size:72pt;font-family:Tahoma;color:blue'
+            'font-size: 72pt; font-family: Tahoma; color: blue;'
         );
     });
 
@@ -335,7 +335,7 @@ describe('setListItemStyle', () => {
         });
 
         // Act
-        setListItemStyle(listItemElement, stylesToInherit);
+        setListItemStyle(listItemElement, stylesToInherit, true /*isCssStyle*/);
 
         // Assert
         expect(listItemElement.getAttribute('style')).toBe(result);

--- a/packages/roosterjs-editor-dom/test/list/setListItemStyleTest.ts
+++ b/packages/roosterjs-editor-dom/test/list/setListItemStyleTest.ts
@@ -326,6 +326,34 @@ describe('setListItemStyle', () => {
         );
     });
 
+    it('Set HTML attribute', () => {
+        // Arrange;
+        const listItemElement = document.createElement('li');
+        const divElement = document.createElement('div');
+
+        const spanElement = createElement({
+            elementTag: 'span',
+            styles: '',
+            textContent: 'test',
+        });
+
+        spanElement.dataset.ogsc = 'red';
+        spanElement.dataset.ogsb = 'blue';
+
+        const b = document.createElement('b');
+        b.appendChild(spanElement);
+        divElement.appendChild(b);
+        listItemElement.appendChild(divElement);
+
+        // Act;
+        setListItemStyle(listItemElement, ['data-ogsb', 'data-ogsc'], false /*isCssStyle*/);
+
+        // Assert;
+        expect(listItemElement.outerHTML).toBe(
+            '<li data-ogsb="blue" data-ogsc="red"><div><b><span data-ogsc="red" data-ogsb="blue">test</span></b></div></li>'
+        );
+    });
+
     function runTest(childElement: TestChildElement[], result: string) {
         // Arrange
         let listItemElement = document.createElement('li');
@@ -344,7 +372,11 @@ describe('setListItemStyle', () => {
     function createElement(input: TestChildElement): HTMLElement {
         const { elementTag, styles, textContent } = input;
         const element = document.createElement(elementTag);
-        element.setAttribute('style', styles);
+
+        if (styles) {
+            element.setAttribute('style', styles);
+        }
+
         element.textContent = textContent;
         return element;
     }


### PR DESCRIPTION
Fix bug #1428 
This is because when start/end a list, we copied the text styles (font, size, color), but we didn't copy the original light mode color if editor is in dark mode. The fix is to copy them as well.