### PR TITLE
Fix 180500 Table options not work

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/table/applyTableFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/applyTableFormat.ts
@@ -7,6 +7,7 @@ import { ContentModelTableCellFormat } from '../../publicTypes/format/ContentMod
 import { TableBorderFormat } from 'roosterjs-editor-types';
 import { TableMetadataFormat } from '../../publicTypes/format/formatParts/TableMetadataFormat';
 import { updateTableCellMetadata } from '../metadata/updateTableCellMetadata';
+import { updateTableMetadata } from '../metadata/updateTableMetadata';
 
 const DEFAULT_FORMAT: Required<TableMetadataFormat> = {
     topBorderColor: '#ABABAB',
@@ -30,21 +31,24 @@ export function applyTableFormat(
     newFormat?: TableMetadataFormat,
     keepCellShade?: boolean
 ) {
-    const { cells, format } = table;
-    const effectiveMetadata = {
-        ...DEFAULT_FORMAT,
-        ...format,
-        ...(newFormat || {}),
-    };
+    const { cells } = table;
 
-    Object.assign(format, effectiveMetadata);
+    updateTableMetadata(table, format => {
+        const effectiveMetadata = {
+            ...DEFAULT_FORMAT,
+            ...format,
+            ...(newFormat || {}),
+        };
 
-    const bgColorOverrides = updateBgColorOverrides(cells, !keepCellShade);
+        const bgColorOverrides = updateBgColorOverrides(cells, !keepCellShade);
 
-    formatBorders(cells, effectiveMetadata);
-    formatBackgroundColors(cells, effectiveMetadata, bgColorOverrides);
-    setFirstColumnFormat(cells, effectiveMetadata, bgColorOverrides);
-    setHeaderRowFormat(cells, effectiveMetadata, bgColorOverrides);
+        formatBorders(cells, effectiveMetadata);
+        formatBackgroundColors(cells, effectiveMetadata, bgColorOverrides);
+        setFirstColumnFormat(cells, effectiveMetadata, bgColorOverrides);
+        setHeaderRowFormat(cells, effectiveMetadata, bgColorOverrides);
+
+        return effectiveMetadata;
+    });
 }
 
 function updateBgColorOverrides(


### PR DESCRIPTION
Fix VSO 180500 Table options not work.

This is caused by the new method of metadata handling in Content Model. We need to explicitly get table metadata format from table model instead of using its format object since now metadata is not part of format.