### PR TITLE
Content Model Support PRE and CODE: step 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ dist/
 
 # Temp files
 packages/roosterjs-editor-types/lib/compatibleEnum/
-packages/roosterjs-content-model/lib/publicTypes/compatibleEnum/

--- a/packages/roosterjs-content-model/lib/formatHandlers/paragraph/marginFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/paragraph/marginFormatHandler.ts
@@ -12,7 +12,7 @@ const MarginKeys: (keyof MarginFormat & keyof CSSStyleDeclaration)[] = [
  * @internal
  */
 export const marginFormatHandler: FormatHandler<MarginFormat> = {
-    parse: (format, element, context, defaultStyle) => {
+    parse: (format, element, _, defaultStyle) => {
         MarginKeys.forEach(key => {
             const value = element.style[key] || defaultStyle[key];
 
@@ -21,12 +21,12 @@ export const marginFormatHandler: FormatHandler<MarginFormat> = {
             }
         });
     },
-    apply: (format, element) => {
+    apply: (format, element, context) => {
         MarginKeys.forEach(key => {
             const value = format[key];
 
-            if (value) {
-                element.style[key] = value;
+            if (value != context.implicitFormat[key]) {
+                element.style[key] = value || '0';
             }
         });
     },

--- a/packages/roosterjs-content-model/lib/formatHandlers/segment/boldFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/segment/boldFormatHandler.ts
@@ -14,7 +14,7 @@ export const boldFormatHandler: FormatHandler<BoldFormat> = {
         }
     },
     apply: (format, element, context) => {
-        const blockFontWeight = context.implicitSegmentFormat.fontWeight;
+        const blockFontWeight = context.implicitFormat.fontWeight;
 
         if (
             (blockFontWeight && blockFontWeight != format.fontWeight) ||

--- a/packages/roosterjs-content-model/lib/formatHandlers/segment/fontFamilyFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/segment/fontFamilyFormatHandler.ts
@@ -13,7 +13,7 @@ export const fontFamilyFormatHandler: FormatHandler<FontFamilyFormat> = {
         }
     },
     apply: (format, element, context) => {
-        if (format.fontFamily && format.fontFamily != context.implicitSegmentFormat.fontFamily) {
+        if (format.fontFamily && format.fontFamily != context.implicitFormat.fontFamily) {
             element.style.fontFamily = format.fontFamily;
         }
     },

--- a/packages/roosterjs-content-model/lib/formatHandlers/segment/fontSizeFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/segment/fontSizeFormatHandler.ts
@@ -17,7 +17,7 @@ export const fontSizeFormatHandler: FormatHandler<FontSizeFormat> = {
         }
     },
     apply: (format, element, context) => {
-        if (format.fontSize && format.fontSize != context.implicitSegmentFormat.fontSize) {
+        if (format.fontSize && format.fontSize != context.implicitFormat.fontSize) {
             element.style.fontSize = format.fontSize;
         }
     },

--- a/packages/roosterjs-content-model/lib/formatHandlers/segment/italicFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/segment/italicFormatHandler.ts
@@ -16,7 +16,7 @@ export const italicFormatHandler: FormatHandler<ItalicFormat> = {
         }
     },
     apply: (format, element, context) => {
-        const implicitItalic = context.implicitSegmentFormat.italic;
+        const implicitItalic = context.implicitFormat.italic;
 
         if (!!implicitItalic != !!format.italic) {
             if (format.italic) {

--- a/packages/roosterjs-content-model/lib/formatHandlers/segment/textColorFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/segment/textColorFormatHandler.ts
@@ -15,7 +15,7 @@ export const textColorFormatHandler: FormatHandler<TextColorFormat> = {
         }
     },
     apply: (format, element, context) => {
-        const implicitColor = context.implicitSegmentFormat.textColor;
+        const implicitColor = context.implicitFormat.textColor;
 
         if (format.textColor && format.textColor != implicitColor) {
             setColor(

--- a/packages/roosterjs-content-model/lib/formatHandlers/segment/underlineFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/segment/underlineFormatHandler.ts
@@ -16,7 +16,7 @@ export const underlineFormatHandler: FormatHandler<UnderlineFormat> = {
         }
     },
     apply: (format, element, context) => {
-        const blockUnderline = context.implicitSegmentFormat.underline;
+        const blockUnderline = context.implicitFormat.underline;
 
         if (!!blockUnderline != !!format.underline) {
             if (format.underline) {

--- a/packages/roosterjs-content-model/lib/formatHandlers/utils/defaultStyles.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/utils/defaultStyles.ts
@@ -1,4 +1,4 @@
-import { DefaultImplicitSegmentFormatMap } from '../../publicTypes/context/ModelToDomSettings';
+import { DefaultImplicitFormatMap } from '../../publicTypes/context/ModelToDomSettings';
 import { DefaultStyleMap } from '../../publicTypes/context/DomToModelSettings';
 
 const blockElement: Partial<CSSStyleDeclaration> = {
@@ -131,7 +131,7 @@ export const defaultStyleMap: DefaultStyleMap = {
     ul: blockElement,
 };
 
-export const defaultImplicitSegmentFormatMap: DefaultImplicitSegmentFormatMap = {
+export const defaultImplicitFormatMap: DefaultImplicitFormatMap = {
     a: {
         underline: true,
         textColor: HyperLinkColorPlaceholder,

--- a/packages/roosterjs-content-model/lib/index.ts
+++ b/packages/roosterjs-content-model/lib/index.ts
@@ -142,7 +142,7 @@ export {
     FormatAppliersPerCategory,
     ContentModelHandlerMap,
     ContentModelHandlerTypeMap,
-    DefaultImplicitSegmentFormatMap,
+    DefaultImplicitFormatMap,
 } from './publicTypes/context/ModelToDomSettings';
 export { ModelToDomEntityContext } from './publicTypes/context/ModelToDomEntityContext';
 export { ElementProcessor } from './publicTypes/context/ElementProcessor';

--- a/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
@@ -1,5 +1,5 @@
 import { defaultContentModelHandlers } from './defaultContentModelHandlers';
-import { defaultImplicitSegmentFormatMap } from '../../formatHandlers/utils/defaultStyles';
+import { defaultImplicitFormatMap } from '../../formatHandlers/utils/defaultStyles';
 import { EditorContext } from '../../publicTypes/context/EditorContext';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
 import { ModelToDomOption } from '../../publicTypes/IExperimentalContentModelEditor';
@@ -43,9 +43,9 @@ export function createModelToDomContext(
             ...defaultContentModelHandlers,
             ...(options?.modelHandlerOverride || {}),
         },
-        defaultImplicitSegmentFormatMap: {
-            ...defaultImplicitSegmentFormatMap,
-            ...(options?.defaultImplicitSegmentFormatOverride || {}),
+        defaultImplicitFormatMap: {
+            ...defaultImplicitFormatMap,
+            ...(options?.defaultImplicitFormatOverride || {}),
         },
         entities: {},
 

--- a/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
@@ -34,7 +34,7 @@ export function createModelToDomContext(
             threadItemCounts: [],
             nodeStack: [],
         },
-        implicitSegmentFormat: {},
+        implicitFormat: {},
         formatAppliers: getFormatAppliers(
             options?.formatApplierOverride,
             options?.additionalFormatAppliers

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleGeneralModel.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleGeneralModel.ts
@@ -5,6 +5,7 @@ import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandl
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
 import { NodeType } from 'roosterjs-editor-types';
+import { stackFormat } from '../utils/stackFormat';
 
 /**
  * @internal
@@ -22,20 +23,14 @@ export const handleGeneralModel: ContentModelHandler<ContentModelGeneralBlock> =
             context.regularSelection.current.segment = newParent;
         }
 
-        const implicitSegmentFormat = context.implicitSegmentFormat;
-        let segmentElement: HTMLElement;
+        stackFormat(context, group.link ? 'a' : null, () => {
+            let segmentElement: HTMLElement;
 
-        try {
             if (group.link) {
                 segmentElement = doc.createElement('a');
 
                 parent.appendChild(segmentElement);
                 segmentElement.appendChild(newParent);
-
-                context.implicitSegmentFormat = {
-                    ...implicitSegmentFormat,
-                    ...(context.defaultImplicitSegmentFormatMap.a || {}),
-                };
 
                 applyFormat(
                     segmentElement,
@@ -55,9 +50,7 @@ export const handleGeneralModel: ContentModelHandler<ContentModelGeneralBlock> =
             }
 
             applyFormat(segmentElement, context.formatAppliers.segment, group.format, context);
-        } finally {
-            context.implicitSegmentFormat = implicitSegmentFormat;
-        }
+        });
     } else {
         parent.appendChild(newParent);
     }

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleImage.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleImage.ts
@@ -2,6 +2,7 @@ import { applyFormat } from '../utils/applyFormat';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
 import { ContentModelImage } from '../../publicTypes/segment/ContentModelImage';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+import { stackFormat } from '../utils/stackFormat';
 
 /**
  * @internal
@@ -23,20 +24,14 @@ export const handleImage: ContentModelHandler<ContentModelImage> = (
         img.title = imageModel.title;
     }
 
-    const implicitSegmentFormat = context.implicitSegmentFormat;
-    let segmentElement: HTMLElement;
+    stackFormat(context, imageModel.link ? 'a' : null, () => {
+        let segmentElement: HTMLElement;
 
-    try {
         if (imageModel.link) {
             segmentElement = doc.createElement('a');
 
             parent.appendChild(segmentElement);
             segmentElement.appendChild(img);
-
-            context.implicitSegmentFormat = {
-                ...implicitSegmentFormat,
-                ...(context.defaultImplicitSegmentFormatMap.a || {}),
-            };
 
             applyFormat(
                 segmentElement,
@@ -58,9 +53,7 @@ export const handleImage: ContentModelHandler<ContentModelImage> = (
         applyFormat(img, context.formatAppliers.image, imageModel.format, context);
         applyFormat(segmentElement, context.formatAppliers.segment, imageModel.format, context);
         applyFormat(img, context.formatAppliers.dataset, imageModel.dataset, context);
-    } finally {
-        context.implicitSegmentFormat = implicitSegmentFormat;
-    }
+    });
 
     context.regularSelection.current.segment = img;
 

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleParagraph.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleParagraph.ts
@@ -3,6 +3,7 @@ import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandl
 import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
 import { getObjectKeys } from 'roosterjs-editor-dom';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+import { stackFormat } from '../utils/stackFormat';
 
 /**
  * @internal
@@ -14,50 +15,41 @@ export const handleParagraph: ContentModelHandler<ContentModelParagraph> = (
     context: ModelToDomContext
 ) => {
     let container: HTMLElement;
-    const implicitSegmentFormat = context.implicitSegmentFormat;
 
-    if (paragraph.header) {
-        const tag = ('h' + paragraph.header.headerLevel) as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+    stackFormat(context, paragraph.header ? 'h' + paragraph.header.headerLevel : null, () => {
+        if (paragraph.header) {
+            const tag = 'h' + paragraph.header.headerLevel;
 
-        container = doc.createElement(tag);
-        parent.appendChild(container);
-        context.implicitSegmentFormat = {
-            ...implicitSegmentFormat,
-            ...(context.defaultImplicitSegmentFormatMap[tag] || {}),
+            container = doc.createElement(tag);
+            parent.appendChild(container);
+
+            applyFormat(container, context.formatAppliers.block, paragraph.format, context);
+            applyFormat(
+                container,
+                context.formatAppliers.segmentOnBlock,
+                paragraph.header.format,
+                context
+            );
+        } else if (
+            !paragraph.isImplicit ||
+            (getObjectKeys(paragraph.format).length > 0 &&
+                paragraph.segments.some(segment => segment.segmentType != 'SelectionMarker'))
+        ) {
+            container = doc.createElement('div');
+            parent.appendChild(container);
+
+            applyFormat(container, context.formatAppliers.block, paragraph.format, context);
+        } else {
+            container = parent as HTMLElement;
+        }
+
+        context.regularSelection.current = {
+            block: container,
+            segment: null,
         };
 
-        applyFormat(container, context.formatAppliers.block, paragraph.format, context);
-        applyFormat(
-            container,
-            context.formatAppliers.segmentOnBlock,
-            paragraph.header.format,
-            context
-        );
-
-        Object.assign(context.implicitSegmentFormat, paragraph.header.format);
-    } else if (
-        !paragraph.isImplicit ||
-        (getObjectKeys(paragraph.format).length > 0 &&
-            paragraph.segments.some(segment => segment.segmentType != 'SelectionMarker'))
-    ) {
-        container = doc.createElement('div');
-        parent.appendChild(container);
-
-        applyFormat(container, context.formatAppliers.block, paragraph.format, context);
-    } else {
-        container = parent as HTMLElement;
-    }
-
-    context.regularSelection.current = {
-        block: container,
-        segment: null,
-    };
-
-    try {
         paragraph.segments.forEach(segment => {
             context.modelHandlers.segment(doc, container, segment, context);
         });
-    } finally {
-        context.implicitSegmentFormat = implicitSegmentFormat;
-    }
+    });
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleText.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleText.ts
@@ -2,6 +2,7 @@ import { applyFormat } from '../utils/applyFormat';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
 import { ContentModelText } from '../../publicTypes/segment/ContentModelText';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+import { stackFormat } from '../utils/stackFormat';
 
 /**
  * @internal
@@ -13,7 +14,6 @@ export const handleText: ContentModelHandler<ContentModelText> = (
     context: ModelToDomContext
 ) => {
     const txt = doc.createTextNode(segment.text);
-    const implicitSegmentFormat = context.implicitSegmentFormat;
     const element = doc.createElement(segment.link ? 'a' : 'span');
 
     element.appendChild(txt);
@@ -21,21 +21,12 @@ export const handleText: ContentModelHandler<ContentModelText> = (
 
     context.regularSelection.current.segment = txt;
 
-    if (segment.link) {
-        context.implicitSegmentFormat = {
-            ...implicitSegmentFormat,
-            ...(context.defaultImplicitSegmentFormatMap.a || {}),
-        };
-    }
-
-    try {
+    stackFormat(context, segment.link ? 'a' : null, () => {
         applyFormat(element, context.formatAppliers.segment, segment.format, context);
 
         if (segment.link) {
             applyFormat(element, context.formatAppliers.link, segment.link.format, context);
             applyFormat(element, context.formatAppliers.dataset, segment.link.dataset, context);
         }
-    } finally {
-        context.implicitSegmentFormat = implicitSegmentFormat;
-    }
+    });
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/utils/stackFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/utils/stackFormat.ts
@@ -12,7 +12,7 @@ export function stackFormat(
         const implicitFormat = context.implicitFormat;
 
         try {
-            const newFormat = context.defaultImplicitSegmentFormatMap[tagName] || {};
+            const newFormat = context.defaultImplicitFormatMap[tagName] || {};
 
             context.implicitFormat = {
                 ...implicitFormat,

--- a/packages/roosterjs-content-model/lib/modelToDom/utils/stackFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/utils/stackFormat.ts
@@ -1,0 +1,29 @@
+import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+
+/**
+ * @internal
+ */
+export function stackFormat(
+    context: ModelToDomContext,
+    tagName: string | null,
+    callback: () => void
+) {
+    if (tagName) {
+        const implicitFormat = context.implicitFormat;
+
+        try {
+            const newFormat = context.defaultImplicitSegmentFormatMap[tagName] || {};
+
+            context.implicitFormat = {
+                ...implicitFormat,
+                ...newFormat,
+            };
+
+            callback();
+        } finally {
+            context.implicitFormat = implicitFormat;
+        }
+    } else {
+        callback();
+    }
+}

--- a/packages/roosterjs-content-model/lib/publicApi/block/setHeaderLevel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setHeaderLevel.ts
@@ -1,4 +1,5 @@
-import { defaultImplicitSegmentFormatMap } from '../../formatHandlers/utils/defaultStyles';
+import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
+import { defaultImplicitFormatMap } from '../../formatHandlers/utils/defaultStyles';
 import { formatParagraphWithContentModel } from '../utils/formatParagraphWithContentModel';
 import { getObjectKeys } from 'roosterjs-editor-dom';
 import { IExperimentalContentModelEditor } from '../../publicTypes/IExperimentalContentModelEditor';
@@ -20,7 +21,8 @@ export default function setHeaderLevel(
             : para.header && para.header.headerLevel > 0
             ? 'h' + para.header.headerLevel
             : null) as HeaderLevelTags | null;
-        const headerStyle = (tag && defaultImplicitSegmentFormatMap[tag]) || {};
+        const headerStyle =
+            ((tag && defaultImplicitFormatMap[tag]) as ContentModelSegmentFormat) || {};
 
         if (headerLevel > 0) {
             para.header = {
@@ -34,8 +36,10 @@ export default function setHeaderLevel(
         } else {
             delete para.header;
 
+            const headerStyleKeys = getObjectKeys(headerStyle);
+
             para.segments.forEach(segment => {
-                getObjectKeys(headerStyle).forEach(key => {
+                headerStyleKeys.forEach(key => {
                     delete segment.format[key];
                 });
             });

--- a/packages/roosterjs-content-model/lib/publicTypes/IExperimentalContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/IExperimentalContentModelEditor.ts
@@ -3,7 +3,7 @@ import { EditorContext } from './context/EditorContext';
 import { IEditor, SelectionRangeEx } from 'roosterjs-editor-types';
 import {
     ContentModelHandlerMap,
-    DefaultImplicitSegmentFormatMap,
+    DefaultImplicitFormatMap,
     FormatAppliers,
     FormatAppliersPerCategory,
 } from './context/ModelToDomSettings';
@@ -95,7 +95,7 @@ export interface ModelToDomOption {
     /**
      * Overrides default element styles
      */
-    defaultImplicitSegmentFormatOverride?: DefaultImplicitSegmentFormatMap;
+    defaultImplicitFormatOverride?: DefaultImplicitFormatMap;
 }
 
 /**

--- a/packages/roosterjs-content-model/lib/publicTypes/context/ModelToDomFormatContext.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/ModelToDomFormatContext.ts
@@ -1,3 +1,4 @@
+import { ContentModelBlockFormat } from '../format/ContentModelBlockFormat';
 import { ContentModelListItemLevelFormat } from '../format/ContentModelListItemLevelFormat';
 import { ContentModelSegmentFormat } from '../format/ContentModelSegmentFormat';
 
@@ -36,7 +37,7 @@ export interface ModelToDomFormatContext {
     listFormat: ModelToDomListContext;
 
     /**
-     * Existing segment format implicitly applied from parent element
+     * Existing format implicitly applied from parent element
      */
-    implicitSegmentFormat: ContentModelSegmentFormat;
+    implicitFormat: ContentModelSegmentFormat & ContentModelBlockFormat;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/context/ModelToDomSettings.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/ModelToDomSettings.ts
@@ -1,4 +1,5 @@
 import { ContentModelBlock } from '../block/ContentModelBlock';
+import { ContentModelBlockFormat } from '../format/ContentModelBlockFormat';
 import { ContentModelBlockGroup } from '../group/ContentModelBlockGroup';
 import { ContentModelBr } from '../segment/ContentModelBr';
 import { ContentModelEntity } from '../entity/ContentModelEntity';
@@ -19,9 +20,12 @@ import { FormatHandlerTypeMap, FormatKey } from '../format/FormatHandlerTypeMap'
 import { ModelToDomContext } from './ModelToDomContext';
 
 /**
- * Default implicit format map from tag name (lower case) to segment fromat
+ * Default implicit format map from tag name (lower case) to segment format
  */
-export type DefaultImplicitSegmentFormatMap = Record<string, Readonly<ContentModelSegmentFormat>>;
+export type DefaultImplicitFormatMap = Record<
+    string,
+    Readonly<ContentModelSegmentFormat & ContentModelBlockFormat>
+>;
 
 /**
  * Apply format to the given HTML element
@@ -153,7 +157,7 @@ export interface ModelToDomSettings {
     /**
      * Map of default implicit format for segment
      */
-    defaultImplicitSegmentFormatMap: DefaultImplicitSegmentFormatMap;
+    defaultImplicitFormatMap: DefaultImplicitFormatMap;
 
     /**
      * Default Content Model to DOM handlers before overriding.

--- a/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
@@ -27,7 +27,7 @@ describe('createModelToDomContext', () => {
             threadItemCounts: [],
             nodeStack: [],
         },
-        implicitSegmentFormat: {},
+        implicitFormat: {},
         formatAppliers: getFormatAppliers(),
         modelHandlers: defaultContentModelHandlers,
         defaultImplicitSegmentFormatMap: defaultImplicitSegmentFormatMap,
@@ -90,7 +90,7 @@ describe('createModelToDomContext', () => {
             threadItemCounts: [],
             nodeStack: [],
         });
-        expect(context.implicitSegmentFormat).toEqual({});
+        expect(context.implicitFormat).toEqual({});
         expect(context.formatAppliers.block).toEqual([
             ...getFormatAppliers().block,
             mockedBlockApplier,

--- a/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
@@ -1,6 +1,6 @@
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { defaultContentModelHandlers } from '../../../lib/modelToDom/context/defaultContentModelHandlers';
-import { defaultImplicitSegmentFormatMap } from '../../../lib/formatHandlers/utils/defaultStyles';
+import { defaultImplicitFormatMap } from '../../../lib/formatHandlers/utils/defaultStyles';
 import { EditorContext } from '../../../lib/publicTypes/context/EditorContext';
 import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
 import {
@@ -30,7 +30,7 @@ describe('createModelToDomContext', () => {
         implicitFormat: {},
         formatAppliers: getFormatAppliers(),
         modelHandlers: defaultContentModelHandlers,
-        defaultImplicitSegmentFormatMap: defaultImplicitSegmentFormatMap,
+        defaultImplicitFormatMap: defaultImplicitFormatMap,
         entities: {},
         defaultModelHandlers: defaultContentModelHandlers,
         defaultFormatAppliers: defaultFormatAppliers,
@@ -75,7 +75,7 @@ describe('createModelToDomContext', () => {
             modelHandlerOverride: {
                 br: mockedBrHandler,
             },
-            defaultImplicitSegmentFormatOverride: {
+            defaultImplicitFormatOverride: {
                 a: mockedAStyle,
             },
         });
@@ -96,7 +96,7 @@ describe('createModelToDomContext', () => {
             mockedBlockApplier,
         ]);
         expect(context.modelHandlers.br).toBe(mockedBrHandler);
-        expect(context.defaultImplicitSegmentFormatMap.a).toEqual(mockedAStyle);
+        expect(context.defaultImplicitFormatMap.a).toEqual(mockedAStyle);
         expect(context.entities).toEqual({});
         expect(context.defaultModelHandlers).toEqual(defaultContentModelHandlers);
         expect(context.defaultFormatAppliers).toEqual(defaultFormatAppliers);

--- a/packages/roosterjs-content-model/test/formatHandlers/paragraph/marginFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/paragraph/marginFormatHandlerTest.ts
@@ -1,0 +1,106 @@
+import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
+import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { DomToModelContext } from '../../../lib/publicTypes/context/DomToModelContext';
+import { MarginFormat } from '../../../lib/publicTypes/format/formatParts/MarginFormat';
+import { marginFormatHandler } from '../../../lib/formatHandlers/paragraph/marginFormatHandler';
+import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
+
+describe('marginFormatHandler.parse', () => {
+    let div: HTMLElement;
+    let format: MarginFormat;
+    let context: DomToModelContext;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+        format = {};
+        context = createDomToModelContext();
+    });
+
+    it('No margin', () => {
+        marginFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({});
+    });
+
+    it('Has margin in CSS', () => {
+        div.style.margin = '1px 2px 3px 4px';
+        marginFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({
+            marginTop: '1px',
+            marginRight: '2px',
+            marginBottom: '3px',
+            marginLeft: '4px',
+        });
+    });
+
+    it('Has margin in default style', () => {
+        marginFormatHandler.parse(format, div, context, {
+            marginTop: '1em',
+            marginBottom: '1em',
+        });
+        expect(format).toEqual({
+            marginTop: '1em',
+            marginBottom: '1em',
+        });
+    });
+});
+
+describe('marginFormatHandler.apply', () => {
+    let div: HTMLElement;
+    let format: MarginFormat;
+    let context: ModelToDomContext;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+        format = {};
+        context = createModelToDomContext();
+    });
+
+    it('No margin', () => {
+        marginFormatHandler.apply(format, div, context);
+        expect(div.outerHTML).toBe('<div></div>');
+    });
+
+    it('Has margin', () => {
+        format.marginTop = '1px';
+        format.marginRight = '2px';
+        format.marginBottom = '3px';
+        format.marginLeft = '4px';
+
+        marginFormatHandler.apply(format, div, context);
+
+        expect(div.outerHTML).toBe('<div style="margin: 1px 2px 3px 4px;"></div>');
+    });
+
+    it('Has implicit format', () => {
+        context.implicitFormat = {
+            marginTop: '1em',
+            marginBottom: '1em',
+        };
+
+        marginFormatHandler.apply(format, div, context);
+        expect(div.outerHTML).toBe('<div style="margin-top: 0px; margin-bottom: 0px;"></div>');
+    });
+
+    it('Has implicit format and different value in CSS', () => {
+        context.implicitFormat = {
+            marginTop: '1em',
+            marginBottom: '1em',
+        };
+        format.marginTop = '2em';
+
+        marginFormatHandler.apply(format, div, context);
+        expect(div.outerHTML).toBe('<div style="margin-top: 2em; margin-bottom: 0px;"></div>');
+    });
+
+    it('Has implicit format and same value in CSS', () => {
+        context.implicitFormat = {
+            marginTop: '1em',
+            marginBottom: '1em',
+        };
+        format.marginTop = '1em';
+        format.marginBottom = '1em';
+
+        marginFormatHandler.apply(format, div, context);
+        expect(div.outerHTML).toBe('<div></div>');
+    });
+});

--- a/packages/roosterjs-content-model/test/formatHandlers/segment/boldFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/segment/boldFormatHandlerTest.ts
@@ -130,7 +130,7 @@ describe('boldFormatHandler.apply', () => {
 
     it('Turn off bold when there is bold from block', () => {
         div.innerHTML = 'test';
-        context.implicitSegmentFormat.fontWeight = 'bold';
+        context.implicitFormat.fontWeight = 'bold';
 
         boldFormatHandler.apply(format, div, context);
 
@@ -139,7 +139,7 @@ describe('boldFormatHandler.apply', () => {
 
     it('Change bold when there is bold from block', () => {
         div.innerHTML = 'test';
-        context.implicitSegmentFormat.fontWeight = 'bold';
+        context.implicitFormat.fontWeight = 'bold';
         format.fontWeight = '600';
 
         boldFormatHandler.apply(format, div, context);
@@ -149,7 +149,7 @@ describe('boldFormatHandler.apply', () => {
 
     it('No change when bold from block and same with current format', () => {
         div.innerHTML = 'test';
-        context.implicitSegmentFormat.fontWeight = 'bold';
+        context.implicitFormat.fontWeight = 'bold';
         format.fontWeight = 'bold';
 
         boldFormatHandler.apply(format, div, context);

--- a/packages/roosterjs-content-model/test/formatHandlers/segment/fontFamilyFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/segment/fontFamilyFormatHandlerTest.ts
@@ -77,7 +77,7 @@ describe('fontFamilyFormatHandler.apply', () => {
     });
 
     it('Has implicit font family from context', () => {
-        context.implicitSegmentFormat.fontFamily = 'test';
+        context.implicitFormat.fontFamily = 'test';
 
         fontFamilyFormatHandler.apply(format, div, context);
 
@@ -85,7 +85,7 @@ describe('fontFamilyFormatHandler.apply', () => {
     });
 
     it('Has implicit font family from context and same with current format', () => {
-        context.implicitSegmentFormat.fontFamily = 'test';
+        context.implicitFormat.fontFamily = 'test';
         format.fontFamily = 'test';
 
         fontFamilyFormatHandler.apply(format, div, context);
@@ -94,7 +94,7 @@ describe('fontFamilyFormatHandler.apply', () => {
     });
 
     it('Has implicit font family from context but overridden by current format', () => {
-        context.implicitSegmentFormat.fontFamily = 'test';
+        context.implicitFormat.fontFamily = 'test';
         format.fontFamily = 'test2';
 
         fontFamilyFormatHandler.apply(format, div, context);

--- a/packages/roosterjs-content-model/test/formatHandlers/segment/fontSizeFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/segment/fontSizeFormatHandlerTest.ts
@@ -85,7 +85,7 @@ describe('fontSizeFormatHandler.apply', () => {
     });
 
     it('Has implicit font size from context', () => {
-        context.implicitSegmentFormat.fontSize = '20px';
+        context.implicitFormat.fontSize = '20px';
 
         fontSizeFormatHandler.apply(format, div, context);
 
@@ -93,7 +93,7 @@ describe('fontSizeFormatHandler.apply', () => {
     });
 
     it('Has implicit font size from context and same with current format', () => {
-        context.implicitSegmentFormat.fontSize = '20px';
+        context.implicitFormat.fontSize = '20px';
         format.fontSize = '20px';
 
         fontSizeFormatHandler.apply(format, div, context);
@@ -102,7 +102,7 @@ describe('fontSizeFormatHandler.apply', () => {
     });
 
     it('Has implicit font size from context but overridden by current format', () => {
-        context.implicitSegmentFormat.fontSize = '20px';
+        context.implicitFormat.fontSize = '20px';
         format.fontSize = '40px';
 
         fontSizeFormatHandler.apply(format, div, context);

--- a/packages/roosterjs-content-model/test/formatHandlers/segment/underlineFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/segment/underlineFormatHandlerTest.ts
@@ -149,7 +149,7 @@ describe('underlineFormatHandler.apply', () => {
         a.textContent = 'test';
         format.underline = true;
 
-        context.implicitSegmentFormat.underline = true;
+        context.implicitFormat.underline = true;
 
         underlineFormatHandler.apply(format, a, context);
 
@@ -161,7 +161,7 @@ describe('underlineFormatHandler.apply', () => {
 
         a.textContent = 'test';
 
-        context.implicitSegmentFormat.underline = true;
+        context.implicitFormat.underline = true;
 
         underlineFormatHandler.apply(format, a, context);
 

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleGeneralModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleGeneralModelTest.ts
@@ -1,4 +1,5 @@
 import * as applyFormat from '../../../lib/modelToDom/utils/applyFormat';
+import * as stackFormat from '../../../lib/modelToDom/utils/stackFormat';
 import { ContentModelBlockGroup } from '../../../lib/publicTypes/group/ContentModelBlockGroup';
 import { ContentModelHandler } from '../../../lib/publicTypes/context/ContentModelHandler';
 import { ContentModelListItem } from '../../../lib/publicTypes/group/ContentModelListItem';
@@ -141,5 +142,28 @@ describe('handleBlockGroup', () => {
             context
         );
         expect(applyFormat.applyFormat).toHaveBeenCalled();
+    });
+
+    it('call stackFormat', () => {
+        const clonedChild = document.createElement('span');
+        const childMock = ({
+            cloneNode: () => clonedChild,
+            firstChild: true,
+        } as any) as HTMLElement;
+        const group = createGeneralSegment(childMock, { underline: true });
+
+        group.link = {
+            format: {
+                href: '/test',
+            },
+            dataset: {},
+        };
+
+        spyOn(stackFormat, 'stackFormat').and.callThrough();
+
+        handleGeneralModel(document, parent, group, context);
+
+        expect(stackFormat.stackFormat).toHaveBeenCalledTimes(1);
+        expect((<jasmine.Spy>stackFormat.stackFormat).calls.argsFor(0)[1]).toBe('a');
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleImageTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleImageTest.ts
@@ -1,3 +1,4 @@
+import * as stackFormat from '../../../lib/modelToDom/utils/stackFormat';
 import { ContentModelBlock } from '../../../lib/publicTypes/block/ContentModelBlock';
 import { ContentModelHandler } from '../../../lib/publicTypes/context/ContentModelHandler';
 import { ContentModelImage } from '../../../lib/publicTypes/segment/ContentModelImage';
@@ -96,5 +97,22 @@ describe('handleSegment', () => {
         };
 
         runTest(segment, '<a href="/test"><img src="http://test.com/test" data-a="b"></a>', 0);
+    });
+
+    it('call stackFormat', () => {
+        const segment: ContentModelImage = {
+            segmentType: 'Image',
+            src: 'http://test.com/test',
+            format: { underline: true },
+            link: { format: { href: '/test' }, dataset: {} },
+            dataset: {},
+        };
+
+        spyOn(stackFormat, 'stackFormat').and.callThrough();
+
+        runTest(segment, '<a href="/test"><img src="http://test.com/test"></a>', 0);
+
+        expect(stackFormat.stackFormat).toHaveBeenCalledTimes(1);
+        expect((<jasmine.Spy>stackFormat.stackFormat).calls.argsFor(0)[1]).toBe('a');
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleParagraphTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleParagraphTest.ts
@@ -1,3 +1,4 @@
+import * as stackFormat from '../../../lib/modelToDom/utils/stackFormat';
 import { ContentModelHandler } from '../../../lib/publicTypes/context/ContentModelHandler';
 import { ContentModelParagraph } from '../../../lib/publicTypes/block/ContentModelParagraph';
 import { ContentModelSegment } from '../../../lib/publicTypes/segment/ContentModelSegment';
@@ -288,5 +289,35 @@ describe('handleParagraph', () => {
             '<div style="text-align: center;"><span>test</span></div>',
             1
         );
+    });
+
+    it('call stackFormat', () => {
+        handleSegment.and.callFake(originalHandleSegment);
+
+        spyOn(stackFormat, 'stackFormat').and.callThrough();
+
+        runTest(
+            {
+                blockType: 'Paragraph',
+                format: {},
+                header: {
+                    headerLevel: 1,
+                    format: { fontWeight: 'bold', fontSize: '2em' },
+                },
+                segments: [
+                    {
+                        segmentType: 'Text',
+                        format: { fontWeight: 'bold' },
+                        text: 'test',
+                    },
+                ],
+            },
+            '<h1><span>test</span></h1>',
+            1
+        );
+
+        expect(stackFormat.stackFormat).toHaveBeenCalledTimes(2);
+        expect((<jasmine.Spy>stackFormat.stackFormat).calls.argsFor(0)[1]).toBe('h1');
+        expect((<jasmine.Spy>stackFormat.stackFormat).calls.argsFor(1)[1]).toBe(null);
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleTextTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleTextTest.ts
@@ -1,3 +1,4 @@
+import * as stackFormat from '../../../lib/modelToDom/utils/stackFormat';
 import { ContentModelText } from '../../../lib/publicTypes/segment/ContentModelText';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { handleText } from '../../../lib/modelToDom/handlers/handleText';
@@ -47,5 +48,22 @@ describe('handleSegment', () => {
         handleText(document, parent, text, context);
 
         expect(parent.innerHTML).toBe('<a href="/test">test</a>');
+    });
+
+    it('call stackFormat', () => {
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'test',
+            format: { underline: true },
+            link: { format: { href: '/test' }, dataset: {} },
+        };
+
+        spyOn(stackFormat, 'stackFormat').and.callThrough();
+
+        handleText(document, parent, text, context);
+
+        expect(parent.innerHTML).toBe('<a href="/test">test</a>');
+        expect(stackFormat.stackFormat).toHaveBeenCalledTimes(1);
+        expect((<jasmine.Spy>stackFormat.stackFormat).calls.argsFor(0)[1]).toBe('a');
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/utils/stackFormatTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/utils/stackFormatTest.ts
@@ -1,0 +1,57 @@
+import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { stackFormat } from '../../../lib/modelToDom/utils/stackFormat';
+
+describe('stackFormat', () => {
+    it('no tag', () => {
+        const context = createModelToDomContext();
+        const format = {
+            fontSize: '10px',
+        };
+        const callback = jasmine.createSpy().and.callFake(() => {
+            expect(context.implicitFormat).toBe(format);
+        });
+
+        context.implicitFormat = format;
+
+        stackFormat(context, null, callback);
+
+        expect(callback).toHaveBeenCalled();
+        expect(context.implicitFormat).toEqual({
+            fontSize: '10px',
+        });
+    });
+
+    it('has a tag', () => {
+        const context = createModelToDomContext();
+        const callback = jasmine.createSpy().and.callFake(() => {
+            expect(context.implicitFormat).toEqual({
+                underline: true,
+                textColor: '__hyperLinkColor',
+            });
+            context.implicitFormat.fontSize = '10px';
+        });
+
+        stackFormat(context, 'a', callback);
+
+        expect(callback).toHaveBeenCalled();
+        expect(context.implicitFormat).toEqual({});
+    });
+
+    it('has a tag and throw', () => {
+        const context = createModelToDomContext();
+        const callback = jasmine.createSpy().and.callFake(() => {
+            expect(context.implicitFormat).toEqual({
+                underline: true,
+                textColor: '__hyperLinkColor',
+            });
+            context.implicitFormat.fontSize = '10px';
+            throw new Error('test');
+        });
+
+        const func = () => stackFormat(context, 'a', callback);
+
+        expect(func).toThrow();
+        expect(callback).toHaveBeenCalled();
+        expect(context.implicitFormat).toEqual({});
+    });
+});


### PR DESCRIPTION
#1401 

Content Model support PRE and CODE tag step 1: rename `implicitSegmentFormat` to `implicitFormat` and make it support block format as well. Later we will use this format to hold the default margin for PRE tag.

Add a function `stackFormat` for `implicitFormat` since it is already widely used in multiple handlers with the same behavior.

Modify marginFormatHandler to let it support implicitFormat -- if implicit format already has the same margin value (that means the HTML tag has its build in margin), no need to explicitly add margin value in CSS.

Fix and add test cases