### PR TITLE
Fix background color issue that can go across block element (ContentModel and original)

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/entityProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/entityProcessor.ts
@@ -4,6 +4,7 @@ import { createEntity } from '../../modelApi/creators/createEntity';
 import { ElementProcessor } from '../../publicTypes/context/ElementProcessor';
 import { getEntityFromElement } from 'roosterjs-editor-dom';
 import { isBlockElement } from '../utils/isBlockElement';
+import { stackFormat } from '../utils/stackFormat';
 
 /**
  * @internal
@@ -12,13 +13,20 @@ export const entityProcessor: ElementProcessor<HTMLElement> = (group, element, c
     const entity = getEntityFromElement(element);
 
     if (entity) {
-        const entityModel = createEntity(entity, context.segmentFormat);
         const isBlockEntity = isBlockElement(element, context);
 
-        if (isBlockEntity) {
-            addBlock(group, entityModel);
-        } else {
-            addSegment(group, entityModel);
-        }
+        stackFormat(
+            context,
+            { segment: isBlockEntity ? 'shallowCloneForBlock' : undefined },
+            () => {
+                const entityModel = createEntity(entity, context.segmentFormat);
+
+                if (isBlockEntity) {
+                    addBlock(group, entityModel);
+                } else {
+                    addSegment(group, entityModel);
+                }
+            }
+        );
     }
 };

--- a/packages/roosterjs-content-model/lib/domToModel/processors/fontProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/fontProcessor.ts
@@ -1,4 +1,5 @@
 import { ElementProcessor } from '../../publicTypes/context/ElementProcessor';
+import { isBlockElement } from '../utils/isBlockElement';
 import { parseFormat } from '../utils/parseFormat';
 import { stackFormat } from '../utils/stackFormat';
 
@@ -25,7 +26,7 @@ export const fontProcessor: ElementProcessor<HTMLFontElement> = (group, element,
     stackFormat(
         context,
         {
-            segment: 'shallowClone',
+            segment: isBlockElement(element, context) ? 'shallowCloneForBlock' : 'shallowClone',
         },
         () => {
             const fontFamily = element.getAttribute('face');

--- a/packages/roosterjs-content-model/lib/domToModel/processors/imageProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/imageProcessor.ts
@@ -18,7 +18,7 @@ export const imageProcessor: ElementProcessor<HTMLImageElement> = (group, elemen
     stackFormat(
         context,
         {
-            segment: 'shallowClone',
+            segment: isBlock ? 'shallowCloneForBlock' : 'shallowClone',
             paragraph: isBlock ? 'empty' : 'shallowClone',
         },
         () => {

--- a/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
@@ -20,7 +20,7 @@ export const knownElementProcessor: ElementProcessor<HTMLElement> = (group, elem
     stackFormat(
         context,
         {
-            segment: 'shallowClone',
+            segment: isBlock ? 'shallowCloneForBlock' : 'shallowClone',
             paragraph: 'shallowClone',
             link: isLink ? 'empty' : undefined,
         },

--- a/packages/roosterjs-content-model/lib/domToModel/processors/listItemProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/listItemProcessor.ts
@@ -18,7 +18,7 @@ export const listItemProcessor: ElementProcessor<HTMLLIElement> = (group, elemen
         stackFormat(
             context,
             {
-                segment: 'shallowClone',
+                segment: 'shallowCloneForBlock',
             },
             () => {
                 parseFormat(

--- a/packages/roosterjs-content-model/lib/domToModel/processors/listProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/listProcessor.ts
@@ -20,7 +20,7 @@ export const listProcessor: ElementProcessor<HTMLOListElement | HTMLUListElement
     stackFormat(
         context,
         {
-            segment: 'shallowClone',
+            segment: 'shallowCloneForBlock',
         },
         () => {
             processMetadata(element, context, level);

--- a/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
@@ -29,7 +29,7 @@ export const tableProcessor: ElementProcessor<HTMLTableElement> = (
     const { table: selectedTable, firstCell, lastCell } = context.tableSelection || {};
     const hasTableSelection = selectedTable == tableElement && !!firstCell && !!lastCell;
 
-    stackFormat(context, { segment: 'shallowClone', paragraph: 'empty' }, () => {
+    stackFormat(context, { segment: 'shallowCloneForBlock', paragraph: 'empty' }, () => {
         parseFormat(tableElement, context.formatParsers.table, table.format, context);
         parseFormat(
             tableElement,

--- a/packages/roosterjs-content-model/test/domToModel/utils/stackFormatTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/utils/stackFormatTest.ts
@@ -21,4 +21,26 @@ describe('stackFormat', () => {
         });
         expect(context.segmentFormat).toEqual({ a: 1 } as any);
     });
+
+    it('shallow clone segment format for block', () => {
+        const context = createDomToModelContext();
+
+        context.segmentFormat.fontSize = '20px';
+        context.segmentFormat.textColor = 'red';
+        context.segmentFormat.backgroundColor = 'green';
+
+        stackFormat(context, { segment: 'shallowCloneForBlock' }, () => {
+            expect(context.segmentFormat).toEqual({
+                fontSize: '20px',
+                textColor: 'red',
+            });
+
+            context.segmentFormat.fontSize = '40px';
+        });
+        expect(context.segmentFormat).toEqual({
+            fontSize: '20px',
+            textColor: 'red',
+            backgroundColor: 'green',
+        });
+    });
 });

--- a/packages/roosterjs-editor-core/lib/coreApi/selectTable.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/selectTable.ts
@@ -133,8 +133,10 @@ function buildCss(
                         tag,
                         tdCount
                     );
+                    const elementsSelector = selector + ' *';
 
                     selectors.push(selector);
+                    selectors.push(elementsSelector);
                     firstSelected = firstSelected || table.querySelector(selector);
                     lastSelected = table.querySelector(selector);
                 }


### PR DESCRIPTION
Consider HTML
```html
<span style="background-color: red">
  line 1
  <div> line 2</div>
  line 3
</span>
```
It will be rendered as 
<img width="44" alt="image" src="https://user-images.githubusercontent.com/23065085/205125530-fefd5ac2-02b7-46f9-9fb3-77049a0adb6b.png">

Because the background color is declared in an inline element (SPAN) so it can't be inherited by a block element (DIV). So we need to respect this behavior in Content Model, when processing a block element, need to remove the background color from segment format in context.

This also causes a problem, when doing table selection, the text inside may incorrectly get background (or people can explicitly set background color to the text), then this color will cover table selection background color. To fix it, add a css rule for all elements under selected table cells to apply the same background for selection as well.
