### PR TITLE
Fix #1443: Support CSS style word-break in ContentModel for table cell

### DIFF
--- a/demo/scripts/controls/contentModel/components/format/formatPart/WordBreakFormatRenderer.ts
+++ b/demo/scripts/controls/contentModel/components/format/formatPart/WordBreakFormatRenderer.ts
@@ -1,0 +1,8 @@
+import { createTextFormatRenderer } from '../utils/createTextFormatRenderer';
+import { WordBreakFormat } from 'roosterjs-content-model';
+
+export const WordBreakFormatRenderer = createTextFormatRenderer<WordBreakFormat>(
+    'Word break',
+    format => format.wordBreak,
+    (format, value) => (format.wordBreak = value)
+);

--- a/demo/scripts/controls/contentModel/components/model/ContentModelTableCellView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelTableCellView.tsx
@@ -13,6 +13,7 @@ import { TableCellMetadataFormatRender } from '../format/formatPart/TableCellMet
 import { updateTableCellMetadata } from 'roosterjs-content-model/lib/modelApi/metadata/updateTableCellMetadata';
 import { useProperty } from '../../hooks/useProperty';
 import { VerticalAlignFormatRenderer } from '../format/formatPart/VerticalAlignFormatRenderer';
+import { WordBreakFormatRenderer } from '../format/formatPart/WordBreakFormatRenderer';
 import {
     ContentModelTableCell,
     ContentModelTableCellFormat,
@@ -28,6 +29,7 @@ const TableCellFormatRenderers: FormatRenderer<ContentModelTableCellFormat>[] = 
     BackgroundColorFormatRenderer,
     PaddingFormatRenderer,
     VerticalAlignFormatRenderer,
+    WordBreakFormatRenderer,
 ];
 
 export function ContentModelTableCellView(props: { cell: ContentModelTableCell }) {

--- a/packages/roosterjs-content-model/lib/formatHandlers/common/wordBreakFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/common/wordBreakFormatHandler.ts
@@ -1,0 +1,20 @@
+import { FormatHandler } from '../FormatHandler';
+import { WordBreakFormat } from '../../publicTypes/format/formatParts/WordBreakFormat';
+
+/**
+ * @internal
+ */
+export const wordBreakFormatHandler: FormatHandler<WordBreakFormat> = {
+    parse: (format, element, _, defaultStyle) => {
+        const wordBreak = element.style.wordBreak || defaultStyle.wordBreak;
+
+        if (wordBreak) {
+            format.wordBreak = wordBreak;
+        }
+    },
+    apply: (format, element) => {
+        if (format.wordBreak) {
+            element.style.wordBreak = format.wordBreak;
+        }
+    },
+};

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -30,6 +30,7 @@ import { textColorFormatHandler } from './segment/textColorFormatHandler';
 import { underlineFormatHandler } from './segment/underlineFormatHandler';
 import { verticalAlignFormatHandler } from './common/verticalAlignFormatHandler';
 import { whiteSpaceFormatHandler } from './block/whiteSpaceFormatHandler';
+import { wordBreakFormatHandler } from './common/wordBreakFormatHandler';
 import {
     FormatApplier,
     FormatAppliers,
@@ -74,6 +75,7 @@ const defaultFormatHandlerMap: FormatHandlers = {
     underline: underlineFormatHandler,
     verticalAlign: verticalAlignFormatHandler,
     whiteSpace: whiteSpaceFormatHandler,
+    wordBreak: wordBreakFormatHandler,
 };
 
 const defaultFormatKeysPerCategory: {
@@ -94,7 +96,15 @@ const defaultFormatKeysPerCategory: {
         'backgroundColor',
     ],
     segmentOnBlock: ['fontFamily', 'fontSize', 'underline', 'italic', 'bold', 'textColor'],
-    tableCell: ['border', 'borderBox', 'backgroundColor', 'padding', 'direction', 'verticalAlign'],
+    tableCell: [
+        'border',
+        'borderBox',
+        'backgroundColor',
+        'padding',
+        'direction',
+        'verticalAlign',
+        'wordBreak',
+    ],
     table: [
         'id',
         'border',

--- a/packages/roosterjs-content-model/lib/index.ts
+++ b/packages/roosterjs-content-model/lib/index.ts
@@ -101,6 +101,7 @@ export {
 } from './publicTypes/format/formatParts/ImageMetadataFormat';
 export { DatasetFormat } from './publicTypes/format/formatParts/DatasetFormat';
 export { WhiteSpaceFormat } from './publicTypes/format/formatParts/WhiteSpaceFormat';
+export { WordBreakFormat } from './publicTypes/format/formatParts/WordBreakFormat';
 
 export { ContentModelFormatMap } from './publicTypes/format/ContentModelFormatMap';
 

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelTableCellFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelTableCellFormat.ts
@@ -4,7 +4,7 @@ import { BorderFormat } from './formatParts/BorderFormat';
 import { DirectionFormat } from './formatParts/DirectionFormat';
 import { PaddingFormat } from './formatParts/PaddingFormat';
 import { VerticalAlignFormat } from './formatParts/VerticalAlignFormat';
-import { WordBreakFormat } from 'roosterjs-content-model/lib';
+import { WordBreakFormat } from '../format/formatParts/WordBreakFormat';
 
 /**
  * Format of table cell

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelTableCellFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelTableCellFormat.ts
@@ -4,6 +4,7 @@ import { BorderFormat } from './formatParts/BorderFormat';
 import { DirectionFormat } from './formatParts/DirectionFormat';
 import { PaddingFormat } from './formatParts/PaddingFormat';
 import { VerticalAlignFormat } from './formatParts/VerticalAlignFormat';
+import { WordBreakFormat } from 'roosterjs-content-model/lib';
 
 /**
  * Format of table cell
@@ -13,4 +14,5 @@ export type ContentModelTableCellFormat = BorderFormat &
     BackgroundColorFormat &
     PaddingFormat &
     DirectionFormat &
-    VerticalAlignFormat;
+    VerticalAlignFormat &
+    WordBreakFormat;

--- a/packages/roosterjs-content-model/lib/publicTypes/format/FormatHandlerTypeMap.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/FormatHandlerTypeMap.ts
@@ -24,6 +24,7 @@ import { TextColorFormat } from './formatParts/TextColorFormat';
 import { UnderlineFormat } from './formatParts/UnderlineFormat';
 import { VerticalAlignFormat } from './formatParts/VerticalAlignFormat';
 import { WhiteSpaceFormat } from './formatParts/WhiteSpaceFormat';
+import { WordBreakFormat } from 'roosterjs-content-model/lib';
 
 /**
  * Represents a record of all format handlers
@@ -168,6 +169,11 @@ export interface FormatHandlerTypeMap {
      * Format for WhiteSpaceFormat
      */
     whiteSpace: WhiteSpaceFormat;
+
+    /**
+     * Format for WordBreakFormat
+     */
+    wordBreak: WordBreakFormat;
 }
 
 /**

--- a/packages/roosterjs-content-model/lib/publicTypes/format/FormatHandlerTypeMap.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/FormatHandlerTypeMap.ts
@@ -24,7 +24,7 @@ import { TextColorFormat } from './formatParts/TextColorFormat';
 import { UnderlineFormat } from './formatParts/UnderlineFormat';
 import { VerticalAlignFormat } from './formatParts/VerticalAlignFormat';
 import { WhiteSpaceFormat } from './formatParts/WhiteSpaceFormat';
-import { WordBreakFormat } from 'roosterjs-content-model/lib';
+import { WordBreakFormat } from './formatParts/WordBreakFormat';
 
 /**
  * Represents a record of all format handlers

--- a/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/WordBreakFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/WordBreakFormat.ts
@@ -1,0 +1,9 @@
+/**
+ * Format of word break
+ */
+export type WordBreakFormat = {
+    /**
+     * Word break CSS value
+     */
+    wordBreak?: string;
+};

--- a/packages/roosterjs-content-model/test/formatHandlers/common/wordBreakFormatHandlerTest copy.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/common/wordBreakFormatHandlerTest copy.ts
@@ -1,0 +1,52 @@
+import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
+import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { DomToModelContext } from '../../../lib/publicTypes/context/DomToModelContext';
+import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
+import { WordBreakFormat } from '../../../lib/publicTypes/format/formatParts/WordBreakFormat';
+import { wordBreakFormatHandler } from '../../../lib/formatHandlers/common/wordBreakFormatHandler';
+
+describe('wordBreakFormatHandler.parse', () => {
+    let div: HTMLElement;
+    let format: WordBreakFormat;
+    let context: DomToModelContext;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+        format = {};
+        context = createDomToModelContext();
+    });
+
+    it('No word break', () => {
+        wordBreakFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({});
+    });
+
+    it('Has word break', () => {
+        div.style.wordBreak = 'break-word';
+        wordBreakFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({ wordBreak: 'break-word' });
+    });
+});
+
+describe('wordBreakFormatHandler.apply', () => {
+    let div: HTMLElement;
+    let format: WordBreakFormat;
+    let context: ModelToDomContext;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+        format = {};
+        context = createModelToDomContext();
+    });
+
+    it('No word break', () => {
+        wordBreakFormatHandler.apply(format, div, context);
+        expect(div.outerHTML).toBe('<div></div>');
+    });
+
+    it('Has word-break', () => {
+        format.wordBreak = 'break-word';
+        wordBreakFormatHandler.apply(format, div, context);
+        expect(div.outerHTML).toBe('<div style="word-break: break-word;"></div>');
+    });
+});


### PR DESCRIPTION
Repro:
1. insert a table
2. type some very long word in table cell
3. resize table to make the word wrap
4. recreate the doc using content model
result: word break style is lost so the table cell width changes

Fix: support word break style in table cell