### PR TITLE
Keep image wrapper under scroll container. 

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -657,10 +657,10 @@ function getColorString(color: string | ModeIndependentColor, isDarkMode: boolea
 }
 
 function fitImageContainer(editor: IEditor, zoomWrapper: HTMLElement) {
-    const { top } = editor.getScrollContainer()?.getBoundingClientRect();
+    const top = editor.getScrollContainer()?.getBoundingClientRect()?.top;
     const zoomWrapperRect = zoomWrapper?.getBoundingClientRect();
-    const zoomWrapperTop = zoomWrapperRect.top;
-    if (zoomWrapperTop < top) {
+    const zoomWrapperTop = zoomWrapperRect?.top;
+    if (top && zoomWrapperTop && zoomWrapperTop < top) {
         const zoomWrapperHeight = top - zoomWrapperRect.top;
         const zoomWrapperHeightPercent = 100 * (zoomWrapperHeight / zoomWrapperRect.height);
         zoomWrapper.style.clipPath = `polygon(0 ${zoomWrapperHeightPercent}%, 100% ${zoomWrapperHeightPercent}%, 100% 100%, 0 100%)`;

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -90,11 +90,6 @@ const DARK_MODE_BGCOLOR = '#333';
 const MAX_SMALL_SIZE_IMAGE = 10000;
 
 /**
- * A container to ensure the image wrapper will be inside the editor.
- */
-const FIT_CONTAINER = 'FIT_CONTAINER';
-
-/**
  * ImageEdit plugin provides the ability to edit an inline image in editor, including image resizing, rotation and cropping
  */
 export default class ImageEdit implements EditorPlugin {
@@ -411,12 +406,8 @@ export default class ImageEdit implements EditorPlugin {
      */
     private removeWrapper = () => {
         const doc = this.editor.getDocument();
-        if (this.zoomWrapper) {
-            const container =
-                this.zoomWrapper?.parentElement.id === FIT_CONTAINER
-                    ? this.zoomWrapper.parentElement
-                    : this.zoomWrapper;
-            doc.body?.removeChild(container);
+        if (this.zoomWrapper && doc.body?.contains(this.zoomWrapper)) {
+            doc.body?.removeChild(this.zoomWrapper);
             this.toggleImageVisibility(this.image, true /** showImage */);
         }
         this.wrapper = null;

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -317,7 +317,7 @@ export default class ImageEdit implements EditorPlugin {
      * quit editing mode when editor lose focus
      */
     private onBlur = () => {
-        //  this.setEditingImage(null, true);
+        this.setEditingImage(null, true);
     };
 
     /**


### PR DESCRIPTION
If the image top is bigger than the editor scroll container, use clip-path css property to cut the top to avoid overlay the content above. 

**Before:**
![ViewPortBug](https://user-images.githubusercontent.com/87443959/207413909-6cbde01e-e144-4c76-916f-4a9ca46ba2ca.gif)

**After:**
![ViewPortFix](https://user-images.githubusercontent.com/87443959/207413975-392ac3b3-ea0d-42ca-8c4e-2bb4c18e2426.gif)
