### PR TITLE
Add a check for Experimental Feature DefaultFormatInSpan

### DIFF
--- a/demo/scripts/controls/sidePane/apiPlayground/region/GetSelectedRegionsPane.tsx
+++ b/demo/scripts/controls/sidePane/apiPlayground/region/GetSelectedRegionsPane.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import ApiPaneProps from '../ApiPaneProps';
-import { IEditor, PositionType, Region } from 'roosterjs-editor-types';
+import { ExperimentalFeatures, IEditor, PositionType, Region } from 'roosterjs-editor-types';
 import {
     createRange,
     getSelectedBlockElementsInRegion,
@@ -55,7 +55,11 @@ export default class GetSelectedRegionsPane extends React.Component<
 
 function Region({ region, editor, index }: { region: Region; editor: IEditor; index: number }) {
     const selectRegion = React.useCallback(() => {
-        const blocks = getSelectedBlockElementsInRegion(region);
+        const blocks = getSelectedBlockElementsInRegion(
+            region,
+            undefined /* createBlockIfEmpty */,
+            editor.isFeatureEnabled(ExperimentalFeatures.DefaultFormatInSpan)
+        );
         if (blocks.length > 0) {
             const range = createRange(
                 blocks[0].getStartNode(),

--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -1,3 +1,4 @@
+import applyListItemStyleWrap from '../utils/applyListItemWrap';
 import blockFormat from '../utils/blockFormat';
 import execCommand from '../utils/execCommand';
 import formatUndoSnapshot from '../utils/formatUndoSnapshot';
@@ -12,6 +13,7 @@ import {
     ChangeSource,
     ClearFormatMode,
     DocumentCommand,
+    ExperimentalFeatures,
     IEditor,
     QueryScope,
 } from 'roosterjs-editor-types';
@@ -34,7 +36,6 @@ import {
     wrap,
 } from 'roosterjs-editor-dom';
 import type { CompatibleClearFormatMode } from 'roosterjs-editor-types/lib/compatibleTypes';
-import applyListItemStyleWrap from '../utils/applyListItemWrap';
 
 const STYLES_TO_REMOVE = ['font', 'text-decoration', 'color', 'background'];
 const TAGS_TO_UNWRAP = 'B,I,U,STRONG,EM,SUB,SUP,STRIKE,FONT,CENTER,H1,H2,H3,H4,H5,H6,UL,OL,LI,SPAN,P,BLOCKQUOTE,CODE,S,PRE'.split(
@@ -200,7 +201,11 @@ function clearBlockFormat(editor: IEditor) {
         editor,
         () => {
             blockFormat(editor, region => {
-                const blocks = getSelectedBlockElementsInRegion(region);
+                const blocks = getSelectedBlockElementsInRegion(
+                    region,
+                    undefined /* createBlockIfEmpty */,
+                    editor.isFeatureEnabled(ExperimentalFeatures.DefaultFormatInSpan)
+                );
                 let nodes = collapseNodesInRegion(region, blocks);
 
                 if (editor.contains(region.rootNode)) {

--- a/packages/roosterjs-editor-api/lib/format/setAlignment.ts
+++ b/packages/roosterjs-editor-api/lib/format/setAlignment.ts
@@ -110,7 +110,11 @@ function alignList(editor: IEditor, alignment: Alignment | CompatibleAlignment) 
     blockFormat(
         editor,
         (region, start, end) => {
-            const blocks = getSelectedBlockElementsInRegion(region);
+            const blocks = getSelectedBlockElementsInRegion(
+                region,
+                undefined /* createBlockIfEmpty */,
+                editor.isFeatureEnabled(ExperimentalFeatures.DefaultFormatInSpan)
+            );
             const startNode = blocks[0].getStartNode();
             const vList = createVListFromRegion(region, true /*includeSiblingLists*/, startNode);
             vList.setAlignment(start, end, alignment);

--- a/packages/roosterjs-editor-api/lib/format/setIndentation.ts
+++ b/packages/roosterjs-editor-api/lib/format/setIndentation.ts
@@ -43,7 +43,11 @@ export default function setIndentation(
     blockFormat(
         editor,
         (region, start, end) => {
-            const blocks = getSelectedBlockElementsInRegion(region, true /*createBlockIfEmpty*/);
+            const blocks = getSelectedBlockElementsInRegion(
+                region,
+                true /*createBlockIfEmpty*/,
+                editor.isFeatureEnabled(ExperimentalFeatures.DefaultFormatInSpan)
+            );
             const blockGroups: BlockElement[][] = [[]];
 
             for (let i = 0; i < blocks.length; i++) {

--- a/packages/roosterjs-editor-api/lib/utils/blockWrap.ts
+++ b/packages/roosterjs-editor-api/lib/utils/blockWrap.ts
@@ -1,5 +1,5 @@
 import blockFormat from './blockFormat';
-import { IEditor } from 'roosterjs-editor-types';
+import { ExperimentalFeatures, IEditor } from 'roosterjs-editor-types';
 import {
     collapseNodesInRegion,
     getSelectedBlockElementsInRegion,
@@ -28,7 +28,11 @@ export default function blockWrap(
     blockFormat(
         editor,
         region => {
-            const blocks = getSelectedBlockElementsInRegion(region, true /*createBlockIfEmpty*/);
+            const blocks = getSelectedBlockElementsInRegion(
+                region,
+                true /*createBlockIfEmpty*/,
+                editor.isFeatureEnabled(ExperimentalFeatures.DefaultFormatInSpan)
+            );
             let nodes = collapseNodesInRegion(region, blocks);
             if (nodes.length > 0) {
                 if (nodes.length == 1) {

--- a/packages/roosterjs-editor-api/test/format/toggleBlockQuoteTest.ts
+++ b/packages/roosterjs-editor-api/test/format/toggleBlockQuoteTest.ts
@@ -23,17 +23,14 @@ describe('toggleBlockQuote', () => {
         expect(result).toBe(expected);
     }
 
-    it('Empty input', () => {
-        runTest(
-            '<!--{"start":[0],"end":[0]}-->',
-            '<blockquote><div><span><br></span></div></blockquote>'
-        );
+    it('Empty input, feature off', () => {
+        runTest('<!--{"start":[0],"end":[0]}-->', '<blockquote><div><br></div></blockquote>');
     });
 
-    TestHelper.itFirefoxOnly('Empty DIV', () => {
+    TestHelper.itFirefoxOnly('Empty DIV, feature off', () => {
         runTest(
             '<div></div><!--{"start":[0],"end":[0]}-->',
-            '<blockquote><div><span><br></span></div></blockquote>'
+            '<blockquote><div><br></div></blockquote>'
         );
     });
 

--- a/packages/roosterjs-editor-core/lib/coreApi/ensureTypeInContainer.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/ensureTypeInContainer.ts
@@ -67,18 +67,20 @@ export const ensureTypeInContainer: EnsureTypeInContainer = (
         // Only reason we don't get the selection block is that we have an empty content div
         // which can happen when users removes everything (i.e. select all and DEL, or backspace from very end to begin)
         // The fix is to add a DIV wrapping, apply default format and move cursor over
-        const newNode = createElement(
-            KnownCreateElementDataIndex.EmptyLine,
+        formatNode = createElement(
+            applyFormatToSpan
+                ? KnownCreateElementDataIndex.EmptyLineFormatInSpan
+                : KnownCreateElementDataIndex.EmptyLine,
             core.contentDiv.ownerDocument
         ) as HTMLElement;
-        core.api.insertNode(core, newNode, {
+        core.api.insertNode(core, formatNode, {
             position: ContentPosition.End,
             updateCursor: false,
             replaceSelection: false,
             insertOnNewLine: false,
         });
 
-        formatNode = newNode.firstChild as HTMLElement;
+        formatNode = applyFormatToSpan ? (formatNode.firstChild as HTMLElement) : formatNode;
 
         // element points to a wrapping node we added "<div><br></div>". We should move the selection left to <br>
         position = new Position(formatNode, PositionType.Begin);

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -976,7 +976,12 @@ export default class Editor implements IEditor {
      */
     public ensureTypeInContainer(position: NodePosition, keyboardEvent?: KeyboardEvent) {
         const core = this.getCore();
-        core.api.ensureTypeInContainer(core, position, keyboardEvent);
+        core.api.ensureTypeInContainer(
+            core,
+            position,
+            keyboardEvent,
+            this.isFeatureEnabled(ExperimentalFeatures.DefaultFormatInSpan)
+        );
     }
 
     //#endregion

--- a/packages/roosterjs-editor-core/test/coreApi/ensureTypeInContainerTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/ensureTypeInContainerTest.ts
@@ -48,7 +48,11 @@ describe('ensureTypeInContainer', () => {
     }
 
     it('empty', () => {
-        runTest('', undefined, undefined, false, '<div><span><br></span></div>');
+        runTest('', undefined, undefined, true, '<div><span><br></span></div>');
+    });
+
+    it('empty, no format span', () => {
+        runTest('', undefined, undefined, true, '<div><br></div>');
     });
 
     it('pure text', () => {
@@ -66,8 +70,20 @@ describe('ensureTypeInContainer', () => {
                 fontSize: '10pt',
             },
             undefined,
-            false,
+            true,
             '<div><span style="font-size: 10pt;"><br></span></div>'
+        );
+    });
+
+    it('empty editor with format, no format span', () => {
+        runTest(
+            '',
+            {
+                fontSize: '10pt',
+            },
+            undefined,
+            false,
+            '<div style="font-size: 10pt;"><br></div>'
         );
     });
 

--- a/packages/roosterjs-editor-core/test/coreApi/ensureTypeInContainerTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/ensureTypeInContainerTest.ts
@@ -52,7 +52,7 @@ describe('ensureTypeInContainer', () => {
     });
 
     it('empty, no format span', () => {
-        runTest('', undefined, undefined, true, '<div><br></div>');
+        runTest('', undefined, undefined, false, '<div><br></div>');
     });
 
     it('pure text', () => {

--- a/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
+++ b/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
@@ -44,7 +44,11 @@ export default function createVListFromRegion(
             nodes.push(list);
         }
     } else {
-        const blocks = getSelectedBlockElementsInRegion(region);
+        const blocks = getSelectedBlockElementsInRegion(
+            region,
+            undefined,
+            true /* shouldApplyFormatToSpan */
+        );
         blocks.forEach(block => {
             const list = getRootListNode(region, ListSelector, block.getStartNode());
 
@@ -67,7 +71,7 @@ export default function createVListFromRegion(
 
         if (nodes.length == 0 && !region.rootNode.firstChild) {
             const newNode = createElement(
-                KnownCreateElementDataIndex.EmptyLine,
+                KnownCreateElementDataIndex.EmptyLineFormatInSpan,
                 region.rootNode.ownerDocument
             )!;
             region.rootNode.appendChild(newNode);

--- a/packages/roosterjs-editor-dom/lib/region/getSelectedBlockElementsInRegion.ts
+++ b/packages/roosterjs-editor-dom/lib/region/getSelectedBlockElementsInRegion.ts
@@ -13,7 +13,8 @@ import { BlockElement, KnownCreateElementDataIndex, RegionBase } from 'roosterjs
  */
 export default function getSelectedBlockElementsInRegion(
     regionBase: RegionBase,
-    createBlockIfEmpty?: boolean
+    createBlockIfEmpty?: boolean,
+    shouldApplyFormatToSpan?: boolean
 ): BlockElement[] {
     const range = getSelectionRangeInRegion(regionBase);
     let blocks: BlockElement[] = [];
@@ -46,7 +47,9 @@ export default function getSelectedBlockElementsInRegion(
 
     if (blocks.length == 0 && regionBase && !regionBase.rootNode.firstChild && createBlockIfEmpty) {
         const newNode = createElement(
-            KnownCreateElementDataIndex.EmptyLine,
+            shouldApplyFormatToSpan
+                ? KnownCreateElementDataIndex.EmptyLineFormatInSpan
+                : KnownCreateElementDataIndex.EmptyLine,
             regionBase.rootNode.ownerDocument
         );
         regionBase.rootNode.appendChild(newNode!);

--- a/packages/roosterjs-editor-dom/lib/utils/createElement.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/createElement.ts
@@ -1,5 +1,6 @@
 import getObjectKeys from '../jsUtils/getObjectKeys';
 import safeInstanceOf from './safeInstanceOf';
+import { Browser } from './Browser';
 import { CreateElementData, KnownCreateElementDataIndex } from 'roosterjs-editor-types';
 import type { CompatibleKnownCreateElementDataIndex } from 'roosterjs-editor-types/lib/compatibleTypes';
 
@@ -11,10 +12,9 @@ export const KnownCreateElementData: Record<KnownCreateElementDataIndex, CreateE
 
     // Edge can sometimes lose current format when Enter to new line.
     // So here we add an extra SPAN for Edge to workaround this bug
-    [KnownCreateElementDataIndex.EmptyLine]: {
-        tag: 'div',
-        children: [{ tag: 'span', children: [{ tag: 'br' }] }],
-    },
+    [KnownCreateElementDataIndex.EmptyLine]: Browser.isEdge
+        ? { tag: 'div', children: [{ tag: 'span', children: [{ tag: 'br' }] }] }
+        : { tag: 'div', children: [{ tag: 'br' }] },
     [KnownCreateElementDataIndex.BlockquoteWrapper]: {
         tag: 'blockquote',
         style: 'margin-top:0;margin-bottom:0',
@@ -61,6 +61,10 @@ export const KnownCreateElementData: Record<KnownCreateElementDataIndex, CreateE
     [KnownCreateElementDataIndex.TableSelector]: {
         tag: 'div',
         style: 'position: fixed; cursor: all-scroll; user-select: none; border: 1px solid #808080',
+    },
+    [KnownCreateElementDataIndex.EmptyLineFormatInSpan]: {
+        tag: 'div',
+        children: [{ tag: 'span', children: [{ tag: 'br' }] }],
     },
 };
 

--- a/packages/roosterjs-editor-dom/test/utils/createElementTest.ts
+++ b/packages/roosterjs-editor-dom/test/utils/createElementTest.ts
@@ -13,7 +13,11 @@ describe('createElement', () => {
     });
 
     it('create by index', () => {
-        runTest(KnownCreateElementDataIndex.EmptyLine, '<div><span><br></span></div>');
+        runTest(KnownCreateElementDataIndex.EmptyLine, '<div><br></div>');
+    });
+
+    it('create by index with span', () => {
+        runTest(KnownCreateElementDataIndex.EmptyLineFormatInSpan, '<div><span><br></span></div>');
     });
 
     it('create by tag', () => {

--- a/packages/roosterjs-editor-types/lib/enum/KnownCreateElementDataIndex.ts
+++ b/packages/roosterjs-editor-types/lib/enum/KnownCreateElementDataIndex.ts
@@ -61,4 +61,9 @@ export const enum KnownCreateElementDataIndex {
      * @deprecated
      */
     TableSelector = 11,
+
+    /**
+     * An empty line without format with span inside of it.
+     */
+    EmptyLineFormatInSpan = 12,
 }


### PR DESCRIPTION
In #1380, we introduced adding Format in Span instead of DIV. 

We added an Experimental Feature but we did not use it to modify the behavior.
Since we added new enums to the repo we cannot fully revert as it would be a breaking change. 

So the fix I propose is to start using the Experimental Feature DefaultFormatInSpan to decide if we want the new behavior to add format to the block div or to the span that is nested in the div.