### PR TITLE
Content Model Selection API step 1: Improve existing code

### DIFF
--- a/demo/scripts/controls/editor/ExperimentalContentModelEditor.ts
+++ b/demo/scripts/controls/editor/ExperimentalContentModelEditor.ts
@@ -76,18 +76,16 @@ export default class ExperimentalContentModelEditor extends Editor
         );
         const mergingCallback = option?.mergingCallback || restoreContentWithEntityPlaceholder;
 
-        if (range) {
-            if (range.type == SelectionRangeTypes.Normal) {
-                // Need to get start and end from range position before merge because range can be changed during merging
-                const start = Position.getStart(range.ranges[0]);
-                const end = Position.getEnd(range.ranges[0]);
+        if (range?.type == SelectionRangeTypes.Normal) {
+            // Need to get start and end from range position before merge because range can be changed during merging
+            const start = Position.getStart(range.ranges[0]);
+            const end = Position.getEnd(range.ranges[0]);
 
-                mergingCallback(fragment, this.contentDiv, entityPairs);
-                this.select(start, end);
-            } else {
-                mergingCallback(fragment, this.contentDiv, entityPairs);
-                this.select(range);
-            }
+            mergingCallback(fragment, this.contentDiv, entityPairs);
+            this.select(start, end);
+        } else {
+            mergingCallback(fragment, this.contentDiv, entityPairs);
+            this.select(range);
         }
     }
 }

--- a/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
@@ -71,6 +71,10 @@ export const knownElementProcessor: ElementProcessor<HTMLElement> = (group, elem
                 );
 
                 if (topDivider) {
+                    if (context.isInSelection) {
+                        topDivider.isSelected = true;
+                    }
+
                     addBlock(group, topDivider);
                 }
 
@@ -82,6 +86,10 @@ export const knownElementProcessor: ElementProcessor<HTMLElement> = (group, elem
             context.elementProcessors.child(group, element, context);
 
             if (bottomDivider) {
+                if (context.isInSelection) {
+                    bottomDivider.isSelected = true;
+                }
+
                 addBlock(group, bottomDivider);
             }
         }

--- a/packages/roosterjs-content-model/lib/index.ts
+++ b/packages/roosterjs-content-model/lib/index.ts
@@ -33,6 +33,7 @@ export { combineBorderValue, extractBorderValues, Border } from './domUtils/bord
 export { ContentModelBlockGroupType } from './publicTypes/enum/BlockGroupType';
 export { ContentModelBlockType } from './publicTypes/enum/BlockType';
 export { ContentModelSegmentType } from './publicTypes/enum/SegmentType';
+export { Selectable } from './publicTypes/selection/Selectable';
 
 export { ContentModelBlockBase } from './publicTypes/block/ContentModelBlockBase';
 export { ContentModelTable } from './publicTypes/block/ContentModelTable';

--- a/packages/roosterjs-content-model/lib/modelApi/common/isEmpty.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/isEmpty.ts
@@ -30,11 +30,11 @@ export function isBlockEmpty(block: ContentModelBlock): boolean {
 export function isBlockGroupEmpty(group: ContentModelBlockGroup): boolean {
     switch (group.blockGroupType) {
         case 'Quote':
+        case 'ListItem':
             return group.blocks.every(isBlockEmpty);
 
         case 'Document':
         case 'General':
-        case 'ListItem':
         case 'TableCell':
             return false;
 

--- a/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts
@@ -1,28 +1,28 @@
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
+import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
+import { createBr } from '../creators/createBr';
 import { isBlockEmpty, isSegmentEmpty } from './isEmpty';
 
 /**
  * @internal
  */
-export function normalizeModel(group: ContentModelBlockGroup) {
+export function normalizeContentModel(group: ContentModelBlockGroup) {
     for (let i = group.blocks.length - 1; i >= 0; i--) {
         const block = group.blocks[i];
 
         switch (block.blockType) {
             case 'BlockGroup':
-                normalizeModel(block);
+                normalizeContentModel(block);
                 break;
             case 'Paragraph':
-                for (let j = block.segments.length - 1; j >= 0; j--) {
-                    if (isSegmentEmpty(block.segments[j])) {
-                        block.segments.splice(j, 1);
-                    }
-                }
+                removeEmptySegments(block);
+
+                normalizeParagraph(block);
                 break;
             case 'Table':
                 for (let r = 0; r < block.cells.length; r++) {
                     for (let c = 0; c < block.cells[r].length; c++) {
-                        normalizeModel(block.cells[r][c]);
+                        normalizeContentModel(block.cells[r][c]);
                     }
                 }
                 break;
@@ -30,6 +30,32 @@ export function normalizeModel(group: ContentModelBlockGroup) {
 
         if (isBlockEmpty(block)) {
             group.blocks.splice(i, 1);
+        }
+    }
+}
+
+function removeEmptySegments(block: ContentModelParagraph) {
+    for (let j = block.segments.length - 1; j >= 0; j--) {
+        if (isSegmentEmpty(block.segments[j])) {
+            block.segments.splice(j, 1);
+        }
+    }
+}
+
+function normalizeParagraph(block: ContentModelParagraph) {
+    if (!block.isImplicit) {
+        const segments = block.segments;
+
+        if (segments.length == 1 && segments[0].segmentType == 'SelectionMarker') {
+            segments.push(createBr(segments[0].format));
+        } else if (
+            segments.length > 1 &&
+            segments[segments.length - 1].segmentType == 'Br' &&
+            segments.some(
+                segment => segment.segmentType != 'SelectionMarker' && segment.segmentType != 'Br'
+            )
+        ) {
+            segments.pop();
         }
     }
 }

--- a/packages/roosterjs-content-model/lib/modelApi/common/wrapBlock.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/wrapBlock.ts
@@ -20,7 +20,7 @@ export function wrapBlockStep1<T extends ContentModelBlockGroup & ContentModelBl
     parent: ContentModelBlockGroup | null,
     blockToWrap: ContentModelBlock,
     creator: () => T,
-    canMerge: (target: Object | null | undefined) => target is T
+    canMerge: (target: ContentModelBlock) => target is T
 ) {
     const index = parent?.blocks.indexOf(blockToWrap) ?? -1;
 
@@ -43,7 +43,7 @@ export function wrapBlockStep1<T extends ContentModelBlockGroup & ContentModelBl
  */
 export function wrapBlockStep2<T extends ContentModelBlockGroup & ContentModelBlock>(
     step1Result: WrapBlockStep1Result<T>[],
-    canMerge: (target: Object | null | undefined, current: T) => target is T
+    canMerge: (target: ContentModelBlock, current: T) => target is T
 ) {
     step1Result.forEach(({ parent, wrapper }) => {
         const index = parent.blocks.indexOf(wrapper);

--- a/packages/roosterjs-content-model/lib/modelApi/table/getSelectedCells.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/getSelectedCells.ts
@@ -1,6 +1,15 @@
 import hasSelectionInBlockGroup from '../../publicApi/selection/hasSelectionInBlockGroup';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
-import { TableSelectionCoordinates } from '../selection/setSelectionToTable';
+
+/**
+ * @internal
+ */
+export interface TableSelectionCoordinates {
+    firstRow: number;
+    firstCol: number;
+    lastRow: number;
+    lastCol: number;
+}
 
 /**
  * @internal

--- a/packages/roosterjs-content-model/lib/publicApi/contentModelToDom.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/contentModelToDom.ts
@@ -54,18 +54,7 @@ function extractSelectionRange(context: ModelToDomContext): SelectionRangeEx | n
     let startPosition: NodePosition | undefined;
     let endPosition: NodePosition | undefined;
 
-    if (tableSelection?.table) {
-        return {
-            type: SelectionRangeTypes.TableSelection,
-            ranges: [],
-            areAllCollapsed: false,
-            table: tableSelection.table,
-            coordinates: {
-                firstCell: tableSelection.firstCell,
-                lastCell: tableSelection.lastCell,
-            },
-        };
-    } else if (imageSelection?.image) {
+    if (imageSelection?.image) {
         return {
             type: SelectionRangeTypes.ImageSelection,
             ranges: [createRange(imageSelection.image)],
@@ -82,6 +71,17 @@ function extractSelectionRange(context: ModelToDomContext): SelectionRangeEx | n
             type: SelectionRangeTypes.Normal,
             ranges: [createRange(startPosition, endPosition)],
             areAllCollapsed: range.collapsed,
+        };
+    } else if (tableSelection?.table) {
+        return {
+            type: SelectionRangeTypes.TableSelection,
+            ranges: [],
+            areAllCollapsed: false,
+            table: tableSelection.table,
+            coordinates: {
+                firstCell: tableSelection.firstCell,
+                lastCell: tableSelection.lastCell,
+            },
         };
     } else {
         return null;

--- a/packages/roosterjs-content-model/lib/publicApi/domToContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/domToContentModel.ts
@@ -3,7 +3,7 @@ import { createContentModelDocument } from '../modelApi/creators/createContentMo
 import { createDomToModelContext } from '../domToModel/context/createDomToModelContext';
 import { DomToModelOption } from '../publicTypes/IExperimentalContentModelEditor';
 import { EditorContext } from '../publicTypes/context/EditorContext';
-import { normalizeModel } from '../modelApi/common/normalizeContentModel';
+import { normalizeContentModel } from '../modelApi/common/normalizeContentModel';
 
 /**
  * Create Content Model from DOM tree in this editor
@@ -24,7 +24,7 @@ export default function domToContentModel(
 
     processor(model, root, domToModelContext);
 
-    normalizeModel(model);
+    normalizeContentModel(model);
 
     return model;
 }

--- a/packages/roosterjs-content-model/lib/publicApi/selection/hasSelectionInBlock.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/selection/hasSelectionInBlock.ts
@@ -18,6 +18,7 @@ export default function hasSelectionInBlock(block: ContentModelBlock): boolean {
             return hasSelectionInBlockGroup(block);
 
         case 'Divider':
+        case 'Entity':
             return !!block.isSelected;
 
         default:

--- a/packages/roosterjs-content-model/lib/publicTypes/block/ContentModelDivider.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/block/ContentModelDivider.ts
@@ -1,16 +1,12 @@
 import { ContentModelBlockBase } from './ContentModelBlockBase';
+import { Selectable } from '../selection/Selectable';
 
 /**
  * Content Model of horizontal divider
  */
-export interface ContentModelDivider extends ContentModelBlockBase<'Divider'> {
+export interface ContentModelDivider extends ContentModelBlockBase<'Divider'>, Selectable {
     /**
      * Tag name of this element, either HR or DIV
      */
     tagName: 'hr' | 'div';
-
-    /**
-     * Whether this element is selected
-     */
-    isSelected?: boolean;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/group/ContentModelTableCell.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/group/ContentModelTableCell.ts
@@ -2,6 +2,7 @@ import { ContentModelBlockGroupBase } from './ContentModelBlockGroupBase';
 import { ContentModelTableCellFormat } from '../format/ContentModelTableCellFormat';
 import { ContentModelWithDataset } from '../format/ContentModelWithDataset';
 import { ContentModelWithFormat } from '../format/ContentModelWithFormat';
+import { Selectable } from '../selection/Selectable';
 import { TableCellMetadataFormat } from 'roosterjs-editor-types';
 
 /**
@@ -10,7 +11,8 @@ import { TableCellMetadataFormat } from 'roosterjs-editor-types';
 export interface ContentModelTableCell
     extends ContentModelBlockGroupBase<'TableCell'>,
         ContentModelWithFormat<ContentModelTableCellFormat>,
-        ContentModelWithDataset<TableCellMetadataFormat> {
+        ContentModelWithDataset<TableCellMetadataFormat>,
+        Selectable {
     /**
      * Whether this cell is spanned from left cell
      */
@@ -25,9 +27,4 @@ export interface ContentModelTableCell
      * Whether this cell is a table header (TH) element
      */
     isHeader?: boolean;
-
-    /**
-     * Whether this cell is selected
-     */
-    isSelected?: boolean;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/segment/ContentModelSegmentBase.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/segment/ContentModelSegmentBase.ts
@@ -2,6 +2,7 @@ import { ContentModelLink } from '../decorator/ContentModelLink';
 import { ContentModelSegmentFormat } from '../format/ContentModelSegmentFormat';
 import { ContentModelSegmentType } from '../enum/SegmentType';
 import { ContentModelWithFormat } from '../format/ContentModelWithFormat';
+import { Selectable } from '../selection/Selectable';
 
 /**
  * Base type of Content Model Segment
@@ -9,16 +10,11 @@ import { ContentModelWithFormat } from '../format/ContentModelWithFormat';
 export interface ContentModelSegmentBase<
     T extends ContentModelSegmentType,
     TFormat extends ContentModelSegmentFormat = ContentModelSegmentFormat
-> extends ContentModelWithFormat<TFormat> {
+> extends ContentModelWithFormat<TFormat>, Selectable {
     /**
      * Type of this segment
      */
     segmentType: T;
-
-    /**
-     * Whether this segment is selected
-     */
-    isSelected?: boolean;
 
     /**
      * Hyperlink info

--- a/packages/roosterjs-content-model/lib/publicTypes/selection/Selectable.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/selection/Selectable.ts
@@ -1,0 +1,9 @@
+/**
+ * Represents a selectable Content Model object
+ */
+export interface Selectable {
+    /**
+     * Whether this model object is selected
+     */
+    isSelected?: boolean;
+}

--- a/packages/roosterjs-content-model/test/domToModel/processors/knownElementProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/knownElementProcessorTest.ts
@@ -485,4 +485,56 @@ describe('knownElementProcessor', () => {
             ],
         });
     });
+
+    it('BLOCKQUOTE used for indent with selection', () => {
+        const group = createContentModelDocument();
+        const quote = document.createElement('blockquote');
+        quote.appendChild(document.createTextNode('test1'));
+
+        context.isInSelection = true;
+        knownElementProcessor(group, quote, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Divider',
+                    tagName: 'div',
+                    format: {
+                        marginTop: '1em',
+                    },
+                    isSelected: true,
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {
+                        marginLeft: '40px',
+                        marginRight: '40px',
+                    },
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test1',
+                            isSelected: true,
+                        },
+                    ],
+                },
+                {
+                    blockType: 'Divider',
+                    tagName: 'div',
+                    format: {
+                        marginBottom: '1em',
+                    },
+                    isSelected: true,
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [],
+                    isImplicit: true,
+                },
+            ],
+        });
+    });
 });

--- a/packages/roosterjs-content-model/test/modelApi/common/isEmptyTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/isEmptyTest.ts
@@ -137,7 +137,7 @@ describe('isEmpty', () => {
             },
         });
 
-        expect(result).toBeFalse();
+        expect(result).toBeTrue();
     });
 
     it('List item has empty block', () => {
@@ -160,7 +160,7 @@ describe('isEmpty', () => {
             ],
         });
 
-        expect(result).toBeFalse();
+        expect(result).toBeTrue();
     });
 
     it('Empty general node', () => {

--- a/packages/roosterjs-content-model/test/modelApi/common/normalizeContentModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/normalizeContentModelTest.ts
@@ -1,0 +1,209 @@
+import { createBr } from '../../../lib/modelApi/creators/createBr';
+import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
+import { createParagraph } from '../../../lib/modelApi/creators/createParagraph';
+import { createSelectionMarker } from '../../../lib/modelApi/creators/createSelectionMarker';
+import { createTable } from '../../../lib/modelApi/creators/createTable';
+import { createTableCell } from '../../../lib/modelApi/creators/createTableCell';
+import { createText } from '../../../lib/modelApi/creators/createText';
+import { normalizeContentModel } from '../../../lib/modelApi/common/normalizeContentModel';
+
+describe('normalizeContentModel', () => {
+    it('Empty model', () => {
+        const model = createContentModelDocument();
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [],
+        });
+    });
+
+    it('Remove empty paragraph', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const text = createText('');
+
+        para.segments.push(text);
+        model.blocks.push(para);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [],
+        });
+    });
+
+    it('Remove empty segment from paragraph', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const text1 = createText('test1');
+        const text2 = createText('');
+        const text3 = createText('test2');
+
+        para.segments.push(text1, text2, text3);
+        model.blocks.push(para);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test1',
+                        },
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test2',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Normalize paragraph', () => {
+        const model = createContentModelDocument();
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const marker = createSelectionMarker();
+        const text = createText('test');
+        const br = createBr();
+
+        para1.segments.push(marker);
+        para2.segments.push(text, br);
+        model.blocks.push(para1, para2);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Do not normalize implicit paragraph', () => {
+        const model = createContentModelDocument();
+        const para1 = createParagraph(true /*isImplicit*/);
+        const para2 = createParagraph(true /*isImplicit*/);
+        const marker = createSelectionMarker();
+        const text = createText('test');
+        const br = createBr();
+
+        para1.segments.push(marker);
+        para2.segments.push(text, br);
+        model.blocks.push(para1, para2);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    isImplicit: true,
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test',
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                    isImplicit: true,
+                },
+            ],
+        });
+    });
+
+    it('Normalize table cell', () => {
+        const model = createContentModelDocument();
+        const table = createTable(1);
+        const cell = createTableCell();
+        const para = createParagraph();
+        const text = createText('');
+
+        para.segments.push(text);
+        cell.blocks.push(para);
+        table.cells[0].push(cell);
+        model.blocks.push(table);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Table',
+                    format: {},
+                    cells: [
+                        [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanAbove: false,
+                                spanLeft: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    ],
+                    widths: [],
+                    heights: [],
+                    dataset: {},
+                },
+            ],
+        });
+    });
+});

--- a/packages/roosterjs-content-model/test/publicApi/selection/hasSelectionInBlockTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/selection/hasSelectionInBlockTest.ts
@@ -2,6 +2,7 @@ import hasSelectionInBlock from '../../../lib/publicApi/selection/hasSelectionIn
 import hasSelectionInBlockGroup from '../../../lib/publicApi/selection/hasSelectionInBlockGroup';
 import { ContentModelBlock } from '../../../lib/publicTypes/block/ContentModelBlock';
 import { ContentModelDivider } from '../../../lib/publicTypes/block/ContentModelDivider';
+import { ContentModelEntity } from '../../../lib/publicTypes/entity/ContentModelEntity';
 import { ContentModelTableCell } from '../../../lib/publicTypes/group/ContentModelTableCell';
 
 describe('hasSelectionInBlock', () => {
@@ -226,6 +227,23 @@ describe('hasSelectionInBlock', () => {
             tagName: 'hr',
             format: {},
             isSelected: true,
+        };
+
+        const result = hasSelectionInBlock(block);
+
+        expect(result).toBeTrue();
+    });
+
+    it('Entity has selection', () => {
+        const block: ContentModelEntity = {
+            blockType: 'Entity',
+            segmentType: 'Entity',
+            format: {},
+            isSelected: true,
+            type: 'entity',
+            id: 'entity',
+            wrapper: null!,
+            isReadonly: false,
         };
 
         const result = hasSelectionInBlock(block);


### PR DESCRIPTION
To improve existing selection API in content model, we first do some change to existing API
- Add an interface `Selectable`
- Modify existing interfaces to consume Selectable
- Other minor refactors