### PR TITLE
Remove id from cloned image

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -327,6 +327,7 @@ export default class ImageEdit implements EditorPlugin {
     private createWrapper(operation: ImageEditOperation | CompatibleImageEditOperation) {
         //Clone the image and insert the clone in a entity
         this.clonedImage = this.image.cloneNode(true) as HTMLImageElement;
+        this.clonedImage.removeAttribute('id');
         this.wrapper = createElement(
             KnownCreateElementDataIndex.ImageEditWrapper,
             this.image.ownerDocument


### PR DESCRIPTION
When the image is selected it is cloned and this clone is added to the editing wrapper. Then it is necessary to remove the id in the cloned image, so the addUniqueId function do not change the original image id. 

Before: 
![imageIdBug](https://user-images.githubusercontent.com/87443959/210641150-55514a33-2793-4953-8f79-2ca653389a71.gif)

After: 
![imageId](https://user-images.githubusercontent.com/87443959/210641185-ed38468f-931a-4de5-818c-6feeeec2e542.gif)

