### PR TITLE
Content Model: Fix a bug when process margin

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
@@ -109,8 +109,9 @@ function tryCreateDivider(
 
     if (margin > 0) {
         result = createDivider('div', { [propName]: format[propName] });
-        delete format[propName];
     }
+
+    delete format[propName];
 
     return result;
 }


### PR DESCRIPTION
When there is margin for an element, we have code to read its value and convert the top/bottom margin to a divider. However, if the margin value is 0, we skip doing that and keep the 0 value. 

For 0 margin we don't need to create divider, but we should still delete this value from the format since we have already processed it. So that if there is inner element already contains build-in margin value, we won't override it.