### PR TITLE
Fix for image selection

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -62,17 +62,17 @@ export default class ImageSelection implements EditorPlugin {
                         } else if (event.rawEvent.button === mouseLeftButton) {
                             this.editor.select(target);
                         }
-                    } else if (safeInstanceOf(target, 'HTMLElement')) {
-                        const mouseSelection = this.editor.getSelectionRangeEx();
-                        const range = this.editor.getSelectionRange();
-                        if (
-                            range &&
-                            mouseSelection &&
-                            mouseSelection.type === SelectionRangeTypes.ImageSelection
-                        ) {
-                            this.editor.select(range);
-                            event.rawEvent.stopPropagation();
-                        }
+                    }
+                    break;
+                case PluginEventType.MouseDown:
+                    const mouseTarget = event.rawEvent.target;
+                    const mouseSelection = this.editor.getSelectionRangeEx();
+                    if (
+                        !safeInstanceOf(mouseTarget, 'HTMLImageElement') &&
+                        mouseSelection &&
+                        mouseSelection.type === SelectionRangeTypes.ImageSelection
+                    ) {
+                        this.editor.select(null);
                     }
                     break;
                 case PluginEventType.KeyUp:

--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -68,9 +68,9 @@ export default class ImageSelection implements EditorPlugin {
                     const mouseTarget = event.rawEvent.target;
                     const mouseSelection = this.editor.getSelectionRangeEx();
                     if (
-                        !safeInstanceOf(mouseTarget, 'HTMLImageElement') &&
                         mouseSelection &&
-                        mouseSelection.type === SelectionRangeTypes.ImageSelection
+                        mouseSelection.type === SelectionRangeTypes.ImageSelection &&
+                        mouseSelection.image !== mouseTarget
                     ) {
                         this.editor.select(null);
                     }

--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -62,6 +62,17 @@ export default class ImageSelection implements EditorPlugin {
                         } else if (event.rawEvent.button === mouseLeftButton) {
                             this.editor.select(target);
                         }
+                    } else if (safeInstanceOf(target, 'HTMLElement')) {
+                        const mouseSelection = this.editor.getSelectionRangeEx();
+                        const range = this.editor.getSelectionRange();
+                        if (
+                            range &&
+                            mouseSelection &&
+                            mouseSelection.type === SelectionRangeTypes.ImageSelection
+                        ) {
+                            this.editor.select(range);
+                            event.rawEvent.stopPropagation();
+                        }
                     }
                     break;
                 case PluginEventType.KeyUp:


### PR DESCRIPTION
Bug: if ImageEditPlugin and TableCellSelection are disable, image selection does work properly. 
After an image is selected, is not possible unselect it. 

Fix: verify if a element was click and if the a image is selected, then if the condition is true, select the element selected. 

![imageEditBUGTEST](https://user-images.githubusercontent.com/87443959/213005800-b97217e7-c18a-475d-92a9-a33b128e69c1.gif)
