### PR TITLE
Fix #1509: Make insert table pane better shown when there is global CSS for box-sizing

### DIFF
--- a/packages-ui/roosterjs-react/lib/ribbon/component/buttons/insertTable.tsx
+++ b/packages-ui/roosterjs-react/lib/ribbon/component/buttons/insertTable.tsx
@@ -26,6 +26,7 @@ const classNames = mergeStyleSets({
         width: '160px',
         minWidth: 'auto',
         padding: '4px',
+        boxSizing: 'content-box',
     },
     tablePaneInner: {
         lineHeight: '12px',


### PR DESCRIPTION
To fix #1509 , explicitly add CSS for box-sizing to avoid global CSS style break the UI