### PR TITLE
ContentModel: Improve Divider

### DIFF
--- a/demo/scripts/controls/contentModel/components/format/BlockFormatView.tsx
+++ b/demo/scripts/controls/contentModel/components/format/BlockFormatView.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { BackgroundColorFormatRenderer } from './formatPart/BackgroundColorFormatRenderer';
+import { BorderFormatRenderers } from './formatPart/BorderFormatRenderers';
 import { ContentModelBlockFormat, ContentModelSegmentFormat } from 'roosterjs-content-model';
 import { DirectionFormatRenderers } from './formatPart/DirectionFormatRenderers';
 import { FormatRenderer } from './utils/FormatRenderer';
@@ -16,6 +17,7 @@ const BlockFormatRenders: FormatRenderer<ContentModelBlockFormat>[] = [
     PaddingFormatRenderer,
     LineHeightFormatRenderer,
     WhiteSpaceFormatRenderer,
+    ...BorderFormatRenderers,
 ];
 
 export function BlockFormatView(props: { format: ContentModelSegmentFormat }) {

--- a/demo/scripts/controls/contentModel/components/model/ContentModelDividerView.scss
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelDividerView.scss
@@ -1,3 +1,3 @@
 .modelDivider {
-    background-color: #ccf;
+    background-color: #c0f;
 }

--- a/demo/scripts/controls/contentModel/components/model/ContentModelDividerView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelDividerView.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { BackgroundColorFormatRenderer } from '../format/formatPart/BackgroundColorFormatRenderer';
+import { BorderFormatRenderers } from '../format/formatPart/BorderFormatRenderers';
 import { ContentModelDivider, ContentModelDividerFormat } from 'roosterjs-content-model';
 import { ContentModelView } from '../ContentModelView';
 import { DirectionFormatRenderers } from '../format/formatPart/DirectionFormatRenderers';
@@ -21,6 +22,7 @@ const DividerFormatRenders: FormatRenderer<ContentModelDividerFormat>[] = [
     PaddingFormatRenderer,
     LineHeightFormatRenderer,
     WhiteSpaceFormatRenderer,
+    ...BorderFormatRenderers,
     DisplayFormatRenderer,
     ...SizeFormatRenderers,
 ];

--- a/demo/scripts/controls/contentModel/components/model/ContentModelDividerView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelDividerView.tsx
@@ -1,10 +1,29 @@
 import * as React from 'react';
-import { BlockFormatView } from '../format/BlockFormatView';
-import { ContentModelDivider } from 'roosterjs-content-model';
+import { BackgroundColorFormatRenderer } from '../format/formatPart/BackgroundColorFormatRenderer';
+import { ContentModelDivider, ContentModelDividerFormat } from 'roosterjs-content-model';
 import { ContentModelView } from '../ContentModelView';
+import { DirectionFormatRenderers } from '../format/formatPart/DirectionFormatRenderers';
+import { DisplayFormatRenderer } from '../format/formatPart/DisplayFormatRenderer';
+import { FormatRenderer } from '../format/utils/FormatRenderer';
+import { FormatView } from '../format/FormatView';
+import { LineHeightFormatRenderer } from '../format/formatPart/LineHeightFormatRenderer';
+import { MarginFormatRenderer } from '../format/formatPart/MarginFormatRenderer';
+import { PaddingFormatRenderer } from '../format/formatPart/PaddingFormatRenderer';
+import { SizeFormatRenderers } from '../format/formatPart/SizeFormatRenderers';
 import { useProperty } from '../../hooks/useProperty';
+import { WhiteSpaceFormatRenderer } from '../format/formatPart/WhiteSpaceFormatRenderer';
 
 const styles = require('./ContentModelDividerView.scss');
+const DividerFormatRenders: FormatRenderer<ContentModelDividerFormat>[] = [
+    BackgroundColorFormatRenderer,
+    ...DirectionFormatRenderers,
+    MarginFormatRenderer,
+    PaddingFormatRenderer,
+    LineHeightFormatRenderer,
+    WhiteSpaceFormatRenderer,
+    DisplayFormatRenderer,
+    ...SizeFormatRenderers,
+];
 
 export function ContentModelDividerView(props: { divider: ContentModelDivider }) {
     const { divider } = props;
@@ -29,7 +48,7 @@ export function ContentModelDividerView(props: { divider: ContentModelDivider })
     }, [tagName]);
 
     const getFormat = React.useCallback(() => {
-        return <BlockFormatView format={divider.format} />;
+        return <FormatView format={divider.format} renderers={DividerFormatRenders} />;
     }, [divider.format]);
 
     return (

--- a/demo/scripts/controls/contentModel/components/model/ContentModelQuoteView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelQuoteView.tsx
@@ -1,21 +1,14 @@
 import * as React from 'react';
-import { BackgroundColorFormatRenderer } from '../format/formatPart/BackgroundColorFormatRenderer';
+import { BlockFormatView } from '../format/BlockFormatView';
 import { BlockGroupContentView } from './BlockGroupContentView';
-import { BorderFormatRenderers } from '../format/formatPart/BorderFormatRenderers';
 import { ContentModelView } from '../ContentModelView';
-import { DirectionFormatRenderers } from '../format/formatPart/DirectionFormatRenderers';
 import { FontFamilyFormatRenderer } from '../format/formatPart/FontFamilyFormatRenderer';
 import { FontSizeFormatRenderer } from '../format/formatPart/FontSizeFormatRenderer';
 import { FormatRenderer } from '../format/utils/FormatRenderer';
 import { FormatView } from '../format/FormatView';
-import { LineHeightFormatRenderer } from '../format/formatPart/LineHeightFormatRenderer';
-import { MarginFormatRenderer } from '../format/formatPart/MarginFormatRenderer';
-import { PaddingFormatRenderer } from '../format/formatPart/PaddingFormatRenderer';
 import { TextColorFormatRenderer } from '../format/formatPart/TextColorFormatRenderer';
-import { WhiteSpaceFormatRenderer } from '../format/formatPart/WhiteSpaceFormatRenderer';
 import {
     ContentModelQuote,
-    ContentModelQuoteFormat,
     ContentModelSegmentFormat,
     hasSelectionInBlock,
 } from 'roosterjs-content-model';
@@ -27,15 +20,6 @@ import {
 
 const styles = require('./ContentModelQuoteView.scss');
 
-const QuoteBlockFormatRenders: FormatRenderer<ContentModelQuoteFormat>[] = [
-    BackgroundColorFormatRenderer,
-    ...DirectionFormatRenderers,
-    MarginFormatRenderer,
-    PaddingFormatRenderer,
-    LineHeightFormatRenderer,
-    WhiteSpaceFormatRenderer,
-    ...BorderFormatRenderers,
-];
 const QuoteSegmentFormatRenders: FormatRenderer<ContentModelSegmentFormat>[] = [
     TextColorFormatRenderer,
     FontSizeFormatRenderer,
@@ -54,7 +38,7 @@ export function ContentModelQuoteView(props: { quote: ContentModelQuote }) {
     const getFormat = React.useCallback(() => {
         return (
             <>
-                <FormatView format={quote.format} renderers={QuoteBlockFormatRenders} />
+                <BlockFormatView format={quote.format} />
                 <FormatView
                     format={quote.quoteSegmentFormat}
                     renderers={QuoteSegmentFormatRenders}

--- a/demo/scripts/controls/sidePane/contentModel/ContentModelPanePlugin.ts
+++ b/demo/scripts/controls/sidePane/contentModel/ContentModelPanePlugin.ts
@@ -34,7 +34,18 @@ export default class ContentModelPanePlugin extends SidePanePluginImpl<
     }
 
     onPluginEvent(e: PluginEvent) {
-        if (e.eventType == PluginEventType.Input || e.eventType == PluginEventType.ContentChanged) {
+        if (e.eventType == PluginEventType.ContentChanged && e.source == 'RefreshModel') {
+            this.getComponent(component => {
+                const model = isContentModelEditor(this.editor)
+                    ? this.editor.createContentModel()
+                    : null;
+                component.setContentModel(model);
+                setCurrentContentModel(this.editor, model);
+            });
+        } else if (
+            e.eventType == PluginEventType.Input ||
+            e.eventType == PluginEventType.ContentChanged
+        ) {
             this.onModelChange();
         }
 

--- a/packages/roosterjs-content-model/lib/domToModel/processors/hrProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/hrProcessor.ts
@@ -14,7 +14,7 @@ export const hrProcessor: ElementProcessor<HTMLHRElement> = (group, element, con
             paragraph: 'shallowClone',
         },
         () => {
-            parseFormat(element, context.formatParsers.block, context.blockFormat, context);
+            parseFormat(element, context.formatParsers.divider, context.blockFormat, context);
 
             const hr = createDivider('hr', context.blockFormat);
 

--- a/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
@@ -1,12 +1,12 @@
 import { addBlock } from '../../modelApi/common/addBlock';
-import { ContentModelBlockFormat } from 'roosterjs-content-model/lib/publicTypes/format/ContentModelBlockFormat';
+import { ContentModelBlockFormat } from '../../publicTypes/format/ContentModelBlockFormat';
 import { ContentModelDivider } from '../../publicTypes/block/ContentModelDivider';
 import { ContentModelParagraphDecorator } from '../../publicTypes/decorator/ContentModelParagraphDecorator';
 import { createDivider } from '../../modelApi/creators/createDivider';
 import { createParagraph } from '../../modelApi/creators/createParagraph';
 import { createParagraphDecorator } from '../../modelApi/creators/createParagraphDecorator';
 import { ElementProcessor } from '../../publicTypes/context/ElementProcessor';
-import { extractBorderValues } from 'roosterjs-content-model/lib/domUtils/borderValues';
+import { extractBorderValues } from '../../domUtils/borderValues';
 import { isBlockElement } from '../utils/isBlockElement';
 import { parseFormat } from '../utils/parseFormat';
 import { stackFormat } from '../utils/stackFormat';

--- a/packages/roosterjs-content-model/lib/domToModel/processors/quoteProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/quoteProcessor.ts
@@ -1,5 +1,5 @@
 import { addBlock } from '../../modelApi/common/addBlock';
-import { ContentModelQuoteFormat } from '../../publicTypes/format/ContentModelQuoteFormat';
+import { ContentModelBlockFormat } from '../../publicTypes/format/ContentModelBlockFormat';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { createQuote } from '../../modelApi/creators/createQuote';
 import { ElementProcessor } from '../../publicTypes/context/ElementProcessor';
@@ -20,10 +20,10 @@ export const quoteProcessor: ElementProcessor<HTMLQuoteElement> = (group, elemen
                 segment: 'shallowCloneForBlock',
             },
             () => {
-                const quoteFormat: ContentModelQuoteFormat = {};
+                const quoteFormat: ContentModelBlockFormat = {};
                 const segmentFormat: ContentModelSegmentFormat = {};
 
-                parseFormat(element, context.formatParsers.quote, quoteFormat, context);
+                parseFormat(element, context.formatParsers.block, quoteFormat, context);
                 parseFormat(element, context.formatParsers.segmentOnBlock, segmentFormat, context);
 
                 const quote = createQuote(quoteFormat, segmentFormat);

--- a/packages/roosterjs-content-model/lib/formatHandlers/common/borderFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/common/borderFormatHandler.ts
@@ -20,7 +20,7 @@ export const borderFormatHandler: FormatHandler<BorderFormat> = {
             const value = element.style[key];
 
             if (value) {
-                format[key] = value;
+                format[key] = value == 'none' ? '' : value;
             }
         });
     },

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -127,6 +127,16 @@ const defaultFormatKeysPerCategory: {
         'whiteSpace',
         'border',
     ],
+    divider: [
+        'backgroundColor',
+        'direction',
+        'margin',
+        'padding',
+        'lineHeight',
+        'whiteSpace',
+        'display',
+        'size',
+    ],
 };
 
 /**

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -78,10 +78,20 @@ const defaultFormatHandlerMap: FormatHandlers = {
     wordBreak: wordBreakFormatHandler,
 };
 
+const blockFormatHandlers: (keyof FormatHandlerTypeMap)[] = [
+    'backgroundColor',
+    'direction',
+    'margin',
+    'padding',
+    'lineHeight',
+    'whiteSpace',
+    'border',
+];
+
 const defaultFormatKeysPerCategory: {
     [key in keyof ContentModelFormatMap]: (keyof FormatHandlerTypeMap)[];
 } = {
-    block: ['backgroundColor', 'direction', 'margin', 'padding', 'lineHeight', 'whiteSpace'],
+    block: blockFormatHandlers,
     listItem: ['listItemThread', 'listItemMetadata'],
     listLevel: ['listType', 'listLevelThread', 'listLevelMetadata'],
     segment: [
@@ -118,25 +128,7 @@ const defaultFormatKeysPerCategory: {
     image: ['id', 'size', 'margin', 'padding', 'borderBox'],
     link: ['link'],
     dataset: ['dataset'],
-    quote: [
-        'backgroundColor',
-        'direction',
-        'margin',
-        'padding',
-        'lineHeight',
-        'whiteSpace',
-        'border',
-    ],
-    divider: [
-        'backgroundColor',
-        'direction',
-        'margin',
-        'padding',
-        'lineHeight',
-        'whiteSpace',
-        'display',
-        'size',
-    ],
+    divider: [...blockFormatHandlers, 'display', 'size'],
 };
 
 /**

--- a/packages/roosterjs-content-model/lib/index.ts
+++ b/packages/roosterjs-content-model/lib/index.ts
@@ -79,7 +79,6 @@ export { ContentModelListItemLevelFormat } from './publicTypes/format/ContentMod
 export { ContentModelImageFormat } from './publicTypes/format/ContentModelImageFormat';
 export { ContentModelWithFormat } from './publicTypes/format/ContentModelWithFormat';
 export { ContentModelWithDataset } from './publicTypes/format/ContentModelWithDataset';
-export { ContentModelQuoteFormat } from './publicTypes/format/ContentModelQuoteFormat';
 export { ContentModelDividerFormat } from './publicTypes/format/ContentModelDividerFormat';
 
 export { VerticalAlignFormat } from './publicTypes/format/formatParts/VerticalAlignFormat';

--- a/packages/roosterjs-content-model/lib/index.ts
+++ b/packages/roosterjs-content-model/lib/index.ts
@@ -80,6 +80,7 @@ export { ContentModelImageFormat } from './publicTypes/format/ContentModelImageF
 export { ContentModelWithFormat } from './publicTypes/format/ContentModelWithFormat';
 export { ContentModelWithDataset } from './publicTypes/format/ContentModelWithDataset';
 export { ContentModelQuoteFormat } from './publicTypes/format/ContentModelQuoteFormat';
+export { ContentModelDividerFormat } from './publicTypes/format/ContentModelDividerFormat';
 
 export { VerticalAlignFormat } from './publicTypes/format/formatParts/VerticalAlignFormat';
 export { BackgroundColorFormat } from './publicTypes/format/formatParts/BackgroundColorFormat';

--- a/packages/roosterjs-content-model/lib/modelApi/block/toggleModelBlockQuote.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/block/toggleModelBlockQuote.ts
@@ -1,10 +1,10 @@
 import { areSameFormats } from '../../domToModel/utils/areSameFormats';
 import { ContentModelBlock } from '../../publicTypes/block/ContentModelBlock';
+import { ContentModelBlockFormat } from '../../publicTypes/format/ContentModelBlockFormat';
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
 import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
 import { ContentModelListItem } from '../../publicTypes/group/ContentModelListItem';
 import { ContentModelQuote } from '../../publicTypes/group/ContentModelQuote';
-import { ContentModelQuoteFormat } from '../../publicTypes/format/ContentModelQuoteFormat';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { createQuote } from '../creators/createQuote';
 import { getOperationalBlocks, OperationalBlocks } from '../selection/collectSelections';
@@ -18,7 +18,7 @@ import { wrapBlockStep1, WrapBlockStep1Result, wrapBlockStep2 } from '../common/
  */
 export function toggleModelBlockQuote(
     model: ContentModelDocument,
-    quoteFormat: ContentModelQuoteFormat,
+    quoteFormat: ContentModelBlockFormat,
     segmentFormat: ContentModelSegmentFormat
 ): boolean {
     const paragraphOfQuote = getOperationalBlocks<ContentModelQuote | ContentModelListItem>(
@@ -67,7 +67,7 @@ export function toggleModelBlockQuote(
 
 function canMergeQuote(
     target: ContentModelBlock,
-    quoteFormat: ContentModelQuoteFormat,
+    quoteFormat: ContentModelBlockFormat,
     segmentFormat: ContentModelSegmentFormat
 ): target is ContentModelQuote {
     return (

--- a/packages/roosterjs-content-model/lib/modelApi/creators/createQuote.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/creators/createQuote.ts
@@ -1,12 +1,12 @@
+import { ContentModelBlockFormat } from '../../publicTypes/format/ContentModelBlockFormat';
 import { ContentModelQuote } from '../../publicTypes/group/ContentModelQuote';
-import { ContentModelQuoteFormat } from '../../publicTypes/format/ContentModelQuoteFormat';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 
 /**
  * @internal
  */
 export function createQuote(
-    format?: ContentModelQuoteFormat,
+    format?: ContentModelBlockFormat,
     quoteSegmentFormat?: ContentModelSegmentFormat
 ): ContentModelQuote {
     return {

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleDivider.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleDivider.ts
@@ -14,7 +14,7 @@ export const handleDivider: ContentModelHandler<ContentModelDivider> = (
 ) => {
     const element = doc.createElement(divider.tagName);
 
-    applyFormat(element, context.formatAppliers.block, divider.format, context);
+    applyFormat(element, context.formatAppliers.divider, divider.format, context);
 
     parent.appendChild(element);
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleQuote.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleQuote.ts
@@ -21,7 +21,7 @@ export const handleQuote: ContentModelHandler<ContentModelQuote> = (
         parent.appendChild(blockQuote);
 
         stackFormat(context, QuoteTagName, () => {
-            applyFormat(blockQuote, context.formatAppliers.quote, quote.format, context);
+            applyFormat(blockQuote, context.formatAppliers.block, quote.format, context);
             applyFormat(
                 blockQuote,
                 context.formatAppliers.segmentOnBlock,

--- a/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
@@ -1,16 +1,16 @@
-import { ContentModelQuoteFormat } from '../../publicTypes/format/ContentModelQuoteFormat';
+import { ContentModelBlockFormat } from '../../publicTypes/format/ContentModelBlockFormat';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IExperimentalContentModelEditor } from '../../publicTypes/IExperimentalContentModelEditor';
 import { toggleModelBlockQuote } from '../../modelApi/block/toggleModelBlockQuote';
 
-const DefaultQuoteFormat: ContentModelQuoteFormat = {
+const DefaultQuoteFormat: ContentModelBlockFormat = {
     borderLeft: '3px solid rgb(200, 200, 200)', // TODO: Support RTL
 };
 const DefaultSegmentFormat: ContentModelSegmentFormat = {
     textColor: 'rgb(102, 102, 102)',
 };
-const BuildInQuoteFormat: ContentModelQuoteFormat = {
+const BuildInQuoteFormat: ContentModelBlockFormat = {
     marginTop: '1em',
     marginBottom: '1em',
     marginLeft: '40px',
@@ -28,7 +28,7 @@ const BuildInQuoteFormat: ContentModelQuoteFormat = {
  */
 export default function toggleBlockQuote(
     editor: IExperimentalContentModelEditor,
-    quoteFormat: ContentModelQuoteFormat = DefaultQuoteFormat,
+    quoteFormat: ContentModelBlockFormat = DefaultQuoteFormat,
     segmentFormat: ContentModelSegmentFormat = DefaultSegmentFormat
 ) {
     const fullQuoteFormat = {

--- a/packages/roosterjs-content-model/lib/publicTypes/block/ContentModelDivider.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/block/ContentModelDivider.ts
@@ -1,10 +1,13 @@
 import { ContentModelBlockBase } from './ContentModelBlockBase';
+import { ContentModelDividerFormat } from '../format/ContentModelDividerFormat';
 import { Selectable } from '../selection/Selectable';
 
 /**
  * Content Model of horizontal divider
  */
-export interface ContentModelDivider extends ContentModelBlockBase<'Divider'>, Selectable {
+export interface ContentModelDivider
+    extends ContentModelBlockBase<'Divider', ContentModelDividerFormat>,
+        Selectable {
     /**
      * Tag name of this element, either HR or DIV
      */

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelBlockFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelBlockFormat.ts
@@ -1,4 +1,5 @@
 import { BackgroundColorFormat } from './formatParts/BackgroundColorFormat';
+import { BorderFormat } from './formatParts/BorderFormat';
 import { DirectionFormat } from './formatParts/DirectionFormat';
 import { LineHeightFormat } from './formatParts/LineHeightFormat';
 import { MarginFormat } from './formatParts/MarginFormat';
@@ -13,4 +14,5 @@ export type ContentModelBlockFormat = BackgroundColorFormat &
     MarginFormat &
     PaddingFormat &
     LineHeightFormat &
-    WhiteSpaceFormat;
+    WhiteSpaceFormat &
+    BorderFormat;

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelDividerFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelDividerFormat.ts
@@ -1,0 +1,8 @@
+import { ContentModelBlockFormat } from './ContentModelBlockFormat';
+import { DisplayFormat } from './formatParts/DisplayFormat';
+import { SizeFormat } from './formatParts/SizeFormat';
+
+/**
+ * The format object for a divider in Content Model
+ */
+export type ContentModelDividerFormat = ContentModelBlockFormat & DisplayFormat & SizeFormat;

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
@@ -1,4 +1,5 @@
 import { ContentModelBlockFormat } from './ContentModelBlockFormat';
+import { ContentModelDividerFormat } from './ContentModelDividerFormat';
 import { ContentModelImageFormat } from './ContentModelImageFormat';
 import { ContentModelListItemLevelFormat } from './ContentModelListItemLevelFormat';
 import { ContentModelQuoteFormat } from './ContentModelQuoteFormat';
@@ -68,4 +69,9 @@ export interface ContentModelFormatMap {
      * Format type for quote
      */
     quote: ContentModelQuoteFormat;
+
+    /**
+     * Format type for divider
+     */
+    divider: ContentModelDividerFormat;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
@@ -2,7 +2,6 @@ import { ContentModelBlockFormat } from './ContentModelBlockFormat';
 import { ContentModelDividerFormat } from './ContentModelDividerFormat';
 import { ContentModelImageFormat } from './ContentModelImageFormat';
 import { ContentModelListItemLevelFormat } from './ContentModelListItemLevelFormat';
-import { ContentModelQuoteFormat } from './ContentModelQuoteFormat';
 import { ContentModelSegmentFormat } from './ContentModelSegmentFormat';
 import { ContentModelTableCellFormat } from './ContentModelTableCellFormat';
 import { ContentModelTableFormat } from './ContentModelTableFormat';
@@ -64,11 +63,6 @@ export interface ContentModelFormatMap {
      * Format type for dataset
      */
     dataset: DatasetFormat;
-
-    /**
-     * Format type for quote
-     */
-    quote: ContentModelQuoteFormat;
 
     /**
      * Format type for divider

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelQuoteFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelQuoteFormat.ts
@@ -1,7 +1,0 @@
-import { BorderFormat } from './formatParts/BorderFormat';
-import { ContentModelBlockFormat } from './ContentModelBlockFormat';
-
-/**
- * The format object for a quote in Content Model
- */
-export type ContentModelQuoteFormat = ContentModelBlockFormat & BorderFormat;

--- a/packages/roosterjs-content-model/lib/publicTypes/group/ContentModelQuote.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/group/ContentModelQuote.ts
@@ -1,6 +1,5 @@
 import { ContentModelBlockBase } from '../block/ContentModelBlockBase';
 import { ContentModelBlockGroupBase } from './ContentModelBlockGroupBase';
-import { ContentModelQuoteFormat } from '../format/ContentModelQuoteFormat';
 import { ContentModelSegmentFormat } from '../format/ContentModelSegmentFormat';
 
 /**
@@ -8,6 +7,6 @@ import { ContentModelSegmentFormat } from '../format/ContentModelSegmentFormat';
  */
 export interface ContentModelQuote
     extends ContentModelBlockGroupBase<'Quote'>,
-        ContentModelBlockBase<'BlockGroup', ContentModelQuoteFormat> {
+        ContentModelBlockBase<'BlockGroup'> {
     quoteSegmentFormat: ContentModelSegmentFormat;
 }

--- a/packages/roosterjs-content-model/test/domToModel/processors/hrProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/hrProcessorTest.ts
@@ -72,4 +72,28 @@ describe('hrProcessor', () => {
             ],
         });
     });
+
+    it('HR with width and display', () => {
+        const doc = createContentModelDocument();
+        const hr = document.createElement('hr');
+
+        hr.style.display = 'inline-block';
+        hr.style.width = '98%';
+
+        hrProcessor(doc, hr, context);
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Divider',
+                    tagName: 'hr',
+                    format: {
+                        display: 'inline-block',
+                        width: '98%',
+                    },
+                },
+            ],
+        });
+    });
 });

--- a/packages/roosterjs-content-model/test/domToModel/processors/knownElementProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/knownElementProcessorTest.ts
@@ -467,6 +467,88 @@ describe('knownElementProcessor', () => {
         });
     });
 
+    it('Div with padding', () => {
+        const group = createContentModelDocument();
+        const div = document.createElement('div');
+
+        div.style.padding = '20px 0 40px';
+
+        knownElementProcessor(group, div, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Divider',
+                    tagName: 'div',
+                    format: {
+                        paddingTop: '20px',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {
+                        paddingLeft: '0px',
+                        paddingRight: '0px',
+                    },
+                    segments: [],
+                },
+                {
+                    blockType: 'Divider',
+                    tagName: 'div',
+                    format: { paddingBottom: '40px' },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [],
+                    format: {},
+                    isImplicit: true,
+                },
+            ],
+        });
+    });
+
+    it('Div with border', () => {
+        const group = createContentModelDocument();
+        const div = document.createElement('div');
+
+        div.style.border = 'solid 1px black';
+
+        knownElementProcessor(group, div, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Divider',
+                    tagName: 'div',
+                    format: {
+                        borderTop: '1px solid black',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {
+                        borderLeft: '1px solid black',
+                        borderRight: '1px solid black',
+                    },
+                    segments: [],
+                },
+                {
+                    blockType: 'Divider',
+                    tagName: 'div',
+                    format: { borderBottom: '1px solid black' },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [],
+                    format: {},
+                    isImplicit: true,
+                },
+            ],
+        });
+    });
+
     it('BLOCKQUOTE used for indent', () => {
         const group = createContentModelDocument();
         const quote = document.createElement('blockquote');

--- a/packages/roosterjs-content-model/test/formatHandlers/common/borderFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/common/borderFormatHandlerTest.ts
@@ -52,6 +52,29 @@ describe('borderFormatHandler.parse', () => {
             borderLeft: '4px solid red',
         });
     });
+
+    it('Has border width none value', () => {
+        div.style.borderWidth = '1px 2px 3px 4px';
+        div.style.borderStyle = 'none';
+        div.style.borderColor = 'red';
+
+        borderFormatHandler.parse(format, div, context, {});
+
+        expect(format).toEqual({
+            borderTop: '1px none red',
+            borderRight: '2px none red',
+            borderBottom: '3px none red',
+            borderLeft: '4px none red',
+        });
+    });
+
+    it('Has border width none value only', () => {
+        div.style.borderStyle = 'none';
+
+        borderFormatHandler.parse(format, div, context, {});
+
+        expect(format).toEqual({});
+    });
 });
 
 describe('borderFormatHandler.apply', () => {

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleDividerTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleDividerTest.ts
@@ -68,4 +68,23 @@ describe('handleDivider', () => {
 
         expect(parent.innerHTML).toBe('<hr style="display: inline-block; width: 98%;">');
     });
+
+    it('DIV with border and padding', () => {
+        const hr: ContentModelDivider = {
+            blockType: 'Divider',
+            tagName: 'hr',
+            format: {
+                borderTop: 'solid 1px black',
+                paddingBottom: '30px',
+            },
+        };
+
+        const parent = document.createElement('div');
+
+        handleDivider(document, parent, hr, context);
+
+        expect(parent.innerHTML).toBe(
+            '<hr style="padding-bottom: 30px; border-top: 1px solid black;">'
+        );
+    });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleDividerTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleDividerTest.ts
@@ -51,4 +51,21 @@ describe('handleDivider', () => {
 
         expect(parent.innerHTML).toBe('<div style="margin-top: 10px;"></div>');
     });
+
+    it('HR with size and display', () => {
+        const hr: ContentModelDivider = {
+            blockType: 'Divider',
+            tagName: 'hr',
+            format: {
+                display: 'inline-block',
+                width: '98%',
+            },
+        };
+
+        const parent = document.createElement('div');
+
+        handleDivider(document, parent, hr, context);
+
+        expect(parent.innerHTML).toBe('<hr style="display: inline-block; width: 98%;">');
+    });
 });


### PR DESCRIPTION
Support the following CSS styles for HR block:
- display
- width, height, ...

Move `BorderFormat` from `ContentModelQuoteFormat` to `ContentModelBlockFormat`, and remove `ContentModelQuoteFormat`.

Improve the handling of divider in `knownElementProcessor`, add handling for border and padding to make Content Model more like original content.

For DIV-based divider, if there is also requirement, we can support it later.