### PR TITLE
Content Model: Support "no color" when set color

### DIFF
--- a/packages/roosterjs-content-model/lib/publicApi/segment/setBackgroundColor.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/segment/setBackgroundColor.ts
@@ -13,12 +13,12 @@ export default function setBackgroundColor(
     formatSegmentWithContentModel(
         editor,
         'setBackgroundColor',
-        backgroundColor
+        backgroundColor === null
             ? format => {
-                  format.backgroundColor = backgroundColor;
+                  delete format.backgroundColor;
               }
             : format => {
-                  delete format.backgroundColor;
+                  format.backgroundColor = backgroundColor;
               }
     );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/segment/setBackgroundColor.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/segment/setBackgroundColor.ts
@@ -4,13 +4,21 @@ import { IExperimentalContentModelEditor } from '../../publicTypes/IExperimental
 /**
  * Set background color
  * @param editor The editor to operate on
- * @param backgroundColor The color to set
+ * @param backgroundColor The color to set. Pass null to remove existing color.
  */
 export default function setBackgroundColor(
     editor: IExperimentalContentModelEditor,
-    backgroundColor: string
+    backgroundColor: string | null
 ) {
-    formatSegmentWithContentModel(editor, 'setBackgroundColor', format => {
-        format.backgroundColor = backgroundColor;
-    });
+    formatSegmentWithContentModel(
+        editor,
+        'setBackgroundColor',
+        backgroundColor
+            ? format => {
+                  format.backgroundColor = backgroundColor;
+              }
+            : format => {
+                  delete format.backgroundColor;
+              }
+    );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/segment/setTextColor.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/segment/setTextColor.ts
@@ -13,12 +13,12 @@ export default function setTextColor(
     formatSegmentWithContentModel(
         editor,
         'setTextColor',
-        textColor
+        textColor === null
             ? format => {
-                  format.textColor = textColor;
+                  delete format.textColor;
               }
             : format => {
-                  delete format.textColor;
+                  format.textColor = textColor;
               },
         undefined /* segmentHasStyleCallback*/,
         true /*includingFormatHandler*/

--- a/packages/roosterjs-content-model/lib/publicApi/segment/setTextColor.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/segment/setTextColor.ts
@@ -4,15 +4,22 @@ import { IExperimentalContentModelEditor } from '../../publicTypes/IExperimental
 /**
  * Set text color
  * @param editor The editor to operate on
- * @param textColor The text color to set
+ * @param textColor The text color to set. Pass null to remove existing color.
  */
-export default function setTextColor(editor: IExperimentalContentModelEditor, textColor: string) {
+export default function setTextColor(
+    editor: IExperimentalContentModelEditor,
+    textColor: string | null
+) {
     formatSegmentWithContentModel(
         editor,
         'setTextColor',
-        format => {
-            format.textColor = textColor;
-        },
+        textColor
+            ? format => {
+                  format.textColor = textColor;
+              }
+            : format => {
+                  delete format.textColor;
+              },
         undefined /* segmentHasStyleCallback*/,
         true /*includingFormatHandler*/
     );

--- a/packages/roosterjs-content-model/test/publicApi/segment/setBackgroundColorTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/segment/setBackgroundColorTest.ts
@@ -6,11 +6,12 @@ describe('setBackgroundColor', () => {
     function runTest(
         model: ContentModelDocument,
         result: ContentModelDocument,
-        calledTimes: number
+        calledTimes: number,
+        newColor: string | null = 'red'
     ) {
         segmentTestCommon(
             'setBackgroundColor',
-            editor => setBackgroundColor(editor, 'red'),
+            editor => setBackgroundColor(editor, newColor),
             model,
             result,
             calledTimes
@@ -316,6 +317,47 @@ describe('setBackgroundColor', () => {
                 ],
             },
             1
+        );
+    });
+
+    it('Remove existing color', () => {
+        runTest(
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {},
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: { backgroundColor: 'green' },
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {},
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: {},
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+            },
+            1,
+            null
         );
     });
 });

--- a/packages/roosterjs-content-model/test/publicApi/segment/setTextColorTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/segment/setTextColorTest.ts
@@ -6,11 +6,12 @@ describe('setTextColor', () => {
     function runTest(
         model: ContentModelDocument,
         result: ContentModelDocument,
-        calledTimes: number
+        calledTimes: number,
+        newColor: string | null = 'red'
     ) {
         segmentTestCommon(
             'setTextColor',
-            editor => setTextColor(editor, 'red'),
+            editor => setTextColor(editor, newColor),
             model,
             result,
             calledTimes
@@ -316,6 +317,47 @@ describe('setTextColor', () => {
                 ],
             },
             1
+        );
+    });
+
+    it('Remove existing color', () => {
+        runTest(
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {},
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: { textColor: 'green' },
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {},
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: {},
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+            },
+            1,
+            null
         );
     });
 });


### PR DESCRIPTION
Allow passing null as color value and remove existing color to implement "no color" functionality.