### PR TITLE
Type improvements: Blob in readFile, PickerData's onRemove can return null

### DIFF
--- a/packages/roosterjs-editor-dom/lib/utils/readFile.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/readFile.ts
@@ -4,7 +4,7 @@
  * @param callback the callback to invoke with data url of the file.
  * If fail to read, dataUrl will be null
  */
-export default function readFile(file: File, callback: (dataUrl: string | null) => void) {
+export default function readFile(file: Blob, callback: (dataUrl: string | null) => void) {
     if (file) {
         const reader = new FileReader();
         reader.onload = () => {

--- a/packages/roosterjs-editor-types/lib/interface/PickerDataProvider.ts
+++ b/packages/roosterjs-editor-types/lib/interface/PickerDataProvider.ts
@@ -51,7 +51,7 @@ export default interface PickerDataProvider {
      * Function that is called when a delete command is issued.
      * Returns the intended replacement node (if partial delete) or null (if full delete)
      */
-    onRemove: (nodeRemoved: Node, isBackwards: boolean) => Node;
+    onRemove: (nodeRemoved: Node, isBackwards: boolean) => Node | null;
 
     /**
      * Function that is called by the plugin to set the current cursor position as an


### PR DESCRIPTION
Given that `readFile` is using a `FileReader`, it's able to take in a `Blob` object, as well as a `File`. To simplify types in its usage, both should be accepted. (File extends Blob)

`PickerDataProvider`'s typings state that:
> Returns the intended replacement node (if partial delete) or null (if full delete)

As such, `onRemove` should allow for `null` to be returned, as well as a `Node`