### PR TITLE
Content Model: Fix #1239 Fix text color when set table cell shade

### DIFF
--- a/demo/scripts/controls/contentModel/components/model/ContentModelTableCellView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelTableCellView.tsx
@@ -10,6 +10,7 @@ import { FormatView } from '../format/FormatView';
 import { MetadataView } from '../format/MetadataView';
 import { PaddingFormatRenderer } from '../format/formatPart/PaddingFormatRenderer';
 import { TableCellMetadataFormatRender } from '../format/formatPart/TableCellMetadataFormatRender';
+import { TextColorFormatRenderer } from '../format/formatPart/TextColorFormatRenderer';
 import { updateTableCellMetadata } from 'roosterjs-content-model/lib/modelApi/metadata/updateTableCellMetadata';
 import { useProperty } from '../../hooks/useProperty';
 import { VerticalAlignFormatRenderer } from '../format/formatPart/VerticalAlignFormatRenderer';
@@ -30,6 +31,7 @@ const TableCellFormatRenderers: FormatRenderer<ContentModelTableCellFormat>[] = 
     PaddingFormatRenderer,
     VerticalAlignFormatRenderer,
     WordBreakFormatRenderer,
+    TextColorFormatRenderer,
 ];
 
 export function ContentModelTableCellView(props: { cell: ContentModelTableCell }) {

--- a/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
@@ -89,7 +89,7 @@ export const tableProcessor: ElementProcessor<HTMLTableElement> = (
                                 );
                                 parseFormat(
                                     td,
-                                    context.formatParsers.segmentOnBlock,
+                                    context.formatParsers.segmentOnTableCell,
                                     context.segmentFormat,
                                     context
                                 );

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -106,6 +106,7 @@ const defaultFormatKeysPerCategory: {
         'backgroundColor',
     ],
     segmentOnBlock: ['fontFamily', 'fontSize', 'underline', 'italic', 'bold', 'textColor'],
+    segmentOnTableCell: ['fontFamily', 'fontSize', 'underline', 'italic', 'bold'],
     tableCell: [
         'border',
         'borderBox',
@@ -114,6 +115,7 @@ const defaultFormatKeysPerCategory: {
         'direction',
         'verticalAlign',
         'wordBreak',
+        'textColor',
     ],
     table: [
         'id',

--- a/packages/roosterjs-content-model/lib/modelApi/table/applyTableFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/applyTableFormat.ts
@@ -3,7 +3,7 @@ import { BorderKeys } from '../../formatHandlers/common/borderFormatHandler';
 import { combineBorderValue, extractBorderValues } from '../../domUtils/borderValues';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { ContentModelTableCell } from '../../publicTypes/group/ContentModelTableCell';
-import { ContentModelTableCellFormat } from '../../publicTypes/format/ContentModelTableCellFormat';
+import { setTableCellBackgroundColor } from './setTableCellBackgroundColor';
 import { TableBorderFormat } from 'roosterjs-editor-types';
 import { TableMetadataFormat } from '../../publicTypes/format/formatParts/TableMetadataFormat';
 import { updateTableCellMetadata } from '../metadata/updateTableCellMetadata';
@@ -188,7 +188,7 @@ function formatBackgroundColors(
                             : bgColorEven
                         : bgColorEven;
 
-                setBackgroundColor(cell.format, color);
+                setTableCellBackgroundColor(cell, color);
             }
         });
     });
@@ -206,7 +206,7 @@ function setFirstColumnFormat(
 
                 if (rowIndex !== 0 && !bgColorOverrides[rowIndex][cellIndex]) {
                     setBorderColor(cell.format, 'borderTop');
-                    setBackgroundColor(cell.format, null /*color*/);
+                    setTableCellBackgroundColor(cell, null /*color*/);
                 }
 
                 if (rowIndex !== cells.length - 1 && rowIndex !== 0) {
@@ -231,7 +231,7 @@ function setHeaderRowFormat(
 
         if (format.hasHeaderRow && format.headerRowColor) {
             if (!bgColorOverrides[rowIndex][cellIndex]) {
-                setBackgroundColor(cell.format, format.headerRowColor);
+                setTableCellBackgroundColor(cell, format.headerRowColor);
             }
 
             setBorderColor(cell.format, 'borderTop', format.headerRowColor);
@@ -246,16 +246,6 @@ function setBorderColor(format: BorderFormat, key: keyof BorderFormat, value?: s
     border.color = value || '';
     border.style = getBorderStyleFromColor(border.color);
     format[key] = combineBorderValue(border);
-}
-
-function setBackgroundColor(format: ContentModelTableCellFormat, color: string | null | undefined) {
-    if (color) {
-        format.backgroundColor = color;
-
-        // TODO: Handle text color when background color is dark
-    } else {
-        delete format.backgroundColor;
-    }
 }
 
 function getBorderStyleFromColor(color?: string): string {

--- a/packages/roosterjs-content-model/lib/modelApi/table/setTableCellBackgroundColor.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/setTableCellBackgroundColor.ts
@@ -1,21 +1,93 @@
-import hasSelectionInBlockGroup from '../../publicApi/selection/hasSelectionInBlockGroup';
-import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
+import { ContentModelTableCell } from '../../publicTypes/group/ContentModelTableCell';
 import { updateTableCellMetadata } from '../metadata/updateTableCellMetadata';
+
+// Using the HSL (hue, saturation and lightness) representation for RGB color values.
+// If the value of the lightness is less than 20, the color is dark.
+// If the value of the lightness is more than 80, the color is bright
+const DARK_COLORS_LIGHTNESS = 20;
+const BRIGHT_COLORS_LIGHTNESS = 80;
+const White = '#ffffff';
+const Black = '#000000';
+const RGBA_REGEX = /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/;
 
 /**
  * @internal
  */
-export function setTableCellBackgroundColor(table: ContentModelTable, color: string) {
-    table.cells.forEach(row =>
-        row.forEach(cell => {
-            if (hasSelectionInBlockGroup(cell)) {
-                cell.format.backgroundColor = color;
-                updateTableCellMetadata(cell, metadata => {
-                    metadata = metadata || {};
-                    metadata.bgColorOverride = true;
-                    return metadata;
-                });
-            }
-        })
-    );
+export function setTableCellBackgroundColor(
+    cell: ContentModelTableCell,
+    color: string | null | undefined,
+    isColorOverride?: boolean
+) {
+    if (color) {
+        cell.format.backgroundColor = color;
+
+        if (isColorOverride) {
+            updateTableCellMetadata(cell, metadata => {
+                metadata = metadata || {};
+                metadata.bgColorOverride = true;
+                return metadata;
+            });
+        }
+
+        const lightness = calculateLightness(color);
+
+        if (lightness < DARK_COLORS_LIGHTNESS) {
+            cell.format.textColor = White;
+        } else if (lightness > BRIGHT_COLORS_LIGHTNESS) {
+            cell.format.textColor = Black;
+        } else {
+            delete cell.format.textColor;
+        }
+    } else {
+        delete cell.format.backgroundColor;
+        delete cell.format.textColor;
+    }
+}
+
+function calculateLightness(color: string) {
+    let r: number;
+    let g: number;
+    let b: number;
+
+    if (color.substring(0, 1) == '#') {
+        [r, g, b] = parseHexColor(color);
+    } else {
+        [r, g, b] = parseRGBColor(color);
+    }
+
+    // Use the values of r,g,b to calculate the lightness in the HSl representation
+    //First calculate the fraction of the light in each color, since in css the value of r,g,b is in the interval of [0,255], we have
+
+    const red = r / 255;
+    const green = g / 255;
+    const blue = b / 255;
+
+    //Then the lightness in the HSL representation is the average between maximum fraction of r,g,b and the minimum fraction
+    return (Math.max(red, green, blue) + Math.min(red, green, blue)) * 50;
+}
+
+function parseHexColor(color: string) {
+    if (color.length === 4) {
+        color = color.replace(/(.)/g, '$1$1');
+    }
+
+    const colors = color.replace('#', '');
+    const r = parseInt(colors.substr(0, 2), 16);
+    const g = parseInt(colors.substr(2, 2), 16);
+    const b = parseInt(colors.substr(4, 2), 16);
+
+    return [r, g, b];
+}
+
+function parseRGBColor(color: string) {
+    const colors = color.match(RGBA_REGEX);
+
+    if (colors) {
+        const r = parseInt(colors[1]);
+        const g = parseInt(colors[2]);
+        const b = parseInt(colors[3]);
+        return [r, g, b];
+    } else {
+        return [255, 255, 255];
+    }
 }

--- a/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
@@ -1,3 +1,4 @@
+import hasSelectionInBlockGroup from '../selection/hasSelectionInBlockGroup';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getFirstSelectedTable } from '../../modelApi/selection/collectSelections';
 import { IExperimentalContentModelEditor } from '../../publicTypes/IExperimentalContentModelEditor';
@@ -11,11 +12,18 @@ import { setTableCellBackgroundColor } from '../../modelApi/table/setTableCellBa
  */
 export default function setTableCellShade(editor: IExperimentalContentModelEditor, color: string) {
     formatWithContentModel(editor, 'setTableCellShade', model => {
-        const tableModel = getFirstSelectedTable(model);
+        const table = getFirstSelectedTable(model);
 
-        if (tableModel) {
-            normalizeTable(tableModel);
-            setTableCellBackgroundColor(tableModel, color);
+        if (table) {
+            normalizeTable(table);
+
+            table.cells.forEach(row =>
+                row.forEach(cell => {
+                    if (hasSelectionInBlockGroup(cell)) {
+                        setTableCellBackgroundColor(cell, color, true /*isColorOverride*/);
+                    }
+                })
+            );
 
             return true;
         } else {

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
@@ -30,6 +30,14 @@ export interface ContentModelFormatMap {
     segmentOnBlock: ContentModelSegmentFormat;
 
     /**
+     * Format type for segment on table cell.
+     * This is very similar with segmentOnBlock, without 'textColor'. Because we will keep
+     * text color style on table cell to indicate auto calculated segment color when set table cell shade.
+     * Segments can set its own text color to override this value
+     */
+    segmentOnTableCell: ContentModelSegmentFormat;
+
+    /**
      * Format type for table
      */
     table: ContentModelTableFormat;

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelTableCellFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelTableCellFormat.ts
@@ -3,6 +3,7 @@ import { BorderBoxFormat } from './formatParts/BorderBoxFormat';
 import { BorderFormat } from './formatParts/BorderFormat';
 import { DirectionFormat } from './formatParts/DirectionFormat';
 import { PaddingFormat } from './formatParts/PaddingFormat';
+import { TextColorFormat } from './formatParts/TextColorFormat';
 import { VerticalAlignFormat } from './formatParts/VerticalAlignFormat';
 import { WordBreakFormat } from '../format/formatParts/WordBreakFormat';
 
@@ -15,4 +16,5 @@ export type ContentModelTableCellFormat = BorderFormat &
     PaddingFormat &
     DirectionFormat &
     VerticalAlignFormat &
-    WordBreakFormat;
+    WordBreakFormat &
+    TextColorFormat;

--- a/packages/roosterjs-content-model/test/domToModel/processors/tableProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/tableProcessorTest.ts
@@ -236,7 +236,7 @@ describe('tableProcessor with format', () => {
             } else if (element == td) {
                 if (handlers == context.formatParsers.tableCell) {
                     (<any>format).format3 = 'td';
-                } else if (handlers == context.formatParsers.segmentOnBlock) {
+                } else if (handlers == context.formatParsers.segmentOnTableCell) {
                     (<any>format).format4 = 'tdSegment';
                 }
             }
@@ -484,5 +484,65 @@ describe('tableProcessor', () => {
         expect(context.listFormat.levels).toBe(listLevels);
         expect(context.listFormat.listParent).toBe(listParent);
         expect(context.listFormat.threadItemCounts).toBe(threadItemCounts);
+    });
+
+    it('Parse text color into table cell format and not impact segment format', () => {
+        const group = createContentModelDocument();
+        const mockedTable = ({
+            tagName: 'table',
+            rows: [
+                {
+                    cells: [
+                        {
+                            colSpan: 1,
+                            rowSpan: 1,
+                            tagName: 'TD',
+                            style: {
+                                color: 'red',
+                            },
+                            dataset: {},
+                            getAttribute: () => '',
+                        },
+                    ],
+                },
+            ],
+            style: {},
+            dataset: {},
+            getAttribute: () => '',
+        } as any) as HTMLTableElement;
+
+        context.segmentFormat = {
+            textColor: 'green',
+        };
+
+        tableProcessor(group, mockedTable, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Table',
+                    format: {},
+                    dataset: {},
+                    widths: [100],
+                    heights: [200],
+                    cells: [
+                        [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    textColor: 'red',
+                                },
+                                spanAbove: false,
+                                spanLeft: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    ],
+                },
+            ],
+        });
     });
 });

--- a/packages/roosterjs-content-model/test/modelApi/table/setTableCellBackgroundColorTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/table/setTableCellBackgroundColorTest.ts
@@ -1,334 +1,127 @@
-import { ContentModelTable } from '../../../lib/publicTypes/block/ContentModelTable';
+import { createTableCell } from '../../../lib/modelApi/creators/createTableCell';
 import { setTableCellBackgroundColor } from '../../../lib/modelApi/table/setTableCellBackgroundColor';
 
 describe('setTableCellBackgroundColor', () => {
-    it('Empty table', () => {
-        const table: ContentModelTable = {
-            blockType: 'Table',
-            cells: [],
-            format: {},
-            widths: [0],
-            heights: [0],
-            dataset: {},
-        };
+    it('Set to null', () => {
+        const cell = createTableCell(1, 1, false, {
+            backgroundColor: 'red',
+        });
 
-        setTableCellBackgroundColor(table, 'red');
+        setTableCellBackgroundColor(cell, null);
 
-        expect(table).toEqual({
-            blockType: 'Table',
-            cells: [],
+        expect(cell).toEqual({
+            blockGroupType: 'TableCell',
             format: {},
-            widths: [0],
-            heights: [0],
+            isHeader: false,
+            spanAbove: false,
+            spanLeft: false,
             dataset: {},
+            blocks: [],
         });
     });
 
-    it('Table without selection', () => {
-        const table: ContentModelTable = {
-            blockType: 'Table',
-            cells: [
-                [
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {},
-                        dataset: {},
-                    },
-                ],
-            ],
-            format: {},
-            widths: [0],
-            heights: [0],
-            dataset: {},
-        };
+    it('Set to a color', () => {
+        const cell = createTableCell(1, 1, false, {
+            backgroundColor: 'red',
+        });
 
-        setTableCellBackgroundColor(table, 'red');
+        setTableCellBackgroundColor(cell, '#ffffff');
 
-        expect(table).toEqual({
-            blockType: 'Table',
-            cells: [
-                [
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {},
-                        dataset: {},
-                    },
-                ],
-            ],
-            format: {},
-            widths: [0],
-            heights: [0],
+        expect(cell).toEqual({
+            blockGroupType: 'TableCell',
+            format: {
+                backgroundColor: '#ffffff',
+                textColor: '#000000',
+            },
+            isHeader: false,
+            spanAbove: false,
+            spanLeft: false,
             dataset: {},
+            blocks: [],
         });
     });
 
-    it('Table with table cell selection', () => {
-        const table: ContentModelTable = {
-            blockType: 'Table',
-            cells: [
-                [
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {},
-                        dataset: {},
-                    },
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {},
-                        isSelected: true,
-                        dataset: {},
-                    },
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {},
-                        isSelected: true,
-                        dataset: {},
-                    },
-                ],
-            ],
-            format: {},
-            widths: [0],
-            heights: [0],
-            dataset: {},
-        };
+    it('Set to a color with override', () => {
+        const cell = createTableCell(1, 1, false, {
+            backgroundColor: 'red',
+        });
 
-        setTableCellBackgroundColor(table, 'red');
+        setTableCellBackgroundColor(cell, '#ffffff', true);
 
-        expect(table).toEqual({
-            blockType: 'Table',
-            cells: [
-                [
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {},
-                        dataset: {},
-                    },
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {
-                            backgroundColor: 'red',
-                        },
-                        dataset: {
-                            editingInfo: '{"bgColorOverride":true}',
-                        },
-                        isSelected: true,
-                    },
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {
-                            backgroundColor: 'red',
-                        },
-                        dataset: {
-                            editingInfo: '{"bgColorOverride":true}',
-                        },
-                        isSelected: true,
-                    },
-                ],
-            ],
-            format: {},
-            widths: [0],
-            heights: [0],
-            dataset: {},
+        expect(cell).toEqual({
+            blockGroupType: 'TableCell',
+            format: {
+                backgroundColor: '#ffffff',
+                textColor: '#000000',
+            },
+            isHeader: false,
+            spanAbove: false,
+            spanLeft: false,
+            dataset: { editingInfo: '{"bgColorOverride":true}' },
+            blocks: [],
         });
     });
 
-    it('Table with table content selection', () => {
-        const table: ContentModelTable = {
-            blockType: 'Table',
-            cells: [
-                [
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {},
-                        dataset: {},
-                    },
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [
-                            {
-                                blockType: 'Paragraph',
-                                segments: [
-                                    {
-                                        segmentType: 'SelectionMarker',
-                                        isSelected: true,
-                                        format: {},
-                                    },
-                                ],
-                                format: {},
-                            },
-                        ],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {},
-                        dataset: {},
-                    },
-                ],
-            ],
-            format: {},
-            widths: [0],
-            heights: [0],
-            dataset: {},
-        };
+    it('Set to a dark color', () => {
+        const cell = createTableCell(1, 1, false, {
+            backgroundColor: 'red',
+        });
 
-        setTableCellBackgroundColor(table, 'red');
+        setTableCellBackgroundColor(cell, '#000000');
 
-        expect(table).toEqual({
-            blockType: 'Table',
-            cells: [
-                [
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {},
-                        dataset: {},
-                    },
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [
-                            {
-                                blockType: 'Paragraph',
-                                segments: [
-                                    {
-                                        segmentType: 'SelectionMarker',
-                                        isSelected: true,
-                                        format: {},
-                                    },
-                                ],
-                                format: {},
-                            },
-                        ],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {
-                            backgroundColor: 'red',
-                        },
-                        dataset: {
-                            editingInfo: '{"bgColorOverride":true}',
-                        },
-                    },
-                ],
-            ],
-            format: {},
-            widths: [0],
-            heights: [0],
+        expect(cell).toEqual({
+            blockGroupType: 'TableCell',
+            format: {
+                backgroundColor: '#000000',
+                textColor: '#ffffff',
+            },
+            isHeader: false,
+            spanAbove: false,
+            spanLeft: false,
             dataset: {},
+            blocks: [],
         });
     });
 
-    it('Table with nested table', () => {
-        const table: ContentModelTable = {
-            blockType: 'Table',
-            cells: [
-                [
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [
-                            {
-                                blockType: 'Table',
-                                format: {},
-                                cells: [
-                                    [
-                                        {
-                                            blockGroupType: 'TableCell',
-                                            spanAbove: false,
-                                            spanLeft: false,
-                                            format: {},
-                                            blocks: [],
-                                            dataset: {},
-                                        },
-                                    ],
-                                ],
-                                widths: [0],
-                                heights: [0],
-                                dataset: {},
-                            },
-                        ],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: {},
-                        isSelected: true,
-                        dataset: {},
-                    },
-                ],
-            ],
-            format: {},
-            widths: [0],
-            heights: [0],
-            dataset: {},
-        };
+    it('Set to a rgb dark color', () => {
+        const cell = createTableCell(1, 1, false, {
+            backgroundColor: 'red',
+        });
 
-        setTableCellBackgroundColor(table, 'red');
+        setTableCellBackgroundColor(cell, 'rgb(0,0,0)');
 
-        expect(table).toEqual({
-            blockType: 'Table',
-            cells: [
-                [
-                    {
-                        blockGroupType: 'TableCell',
-                        blocks: [
-                            {
-                                blockType: 'Table',
-                                format: {},
-                                cells: [
-                                    [
-                                        {
-                                            blockGroupType: 'TableCell',
-                                            spanAbove: false,
-                                            spanLeft: false,
-                                            format: {},
-                                            blocks: [],
-                                            dataset: {},
-                                        },
-                                    ],
-                                ],
-                                widths: [0],
-                                heights: [0],
-                                dataset: {},
-                            },
-                        ],
-                        spanAbove: false,
-                        spanLeft: false,
-                        format: { backgroundColor: 'red' },
-                        isSelected: true,
-                        dataset: {
-                            editingInfo: '{"bgColorOverride":true}',
-                        },
-                    },
-                ],
-            ],
-            format: {},
-            widths: [0],
-            heights: [0],
+        expect(cell).toEqual({
+            blockGroupType: 'TableCell',
+            format: {
+                backgroundColor: 'rgb(0,0,0)',
+                textColor: '#ffffff',
+            },
+            isHeader: false,
+            spanAbove: false,
+            spanLeft: false,
             dataset: {},
+            blocks: [],
+        });
+    });
+
+    it('Set to an unrecognized color', () => {
+        const cell = createTableCell(1, 1, false, {
+            backgroundColor: 'red',
+        });
+
+        setTableCellBackgroundColor(cell, 'wrong');
+
+        expect(cell).toEqual({
+            blockGroupType: 'TableCell',
+            format: {
+                backgroundColor: 'wrong',
+                textColor: '#000000',
+            },
+            isHeader: false,
+            spanAbove: false,
+            spanLeft: false,
+            dataset: {},
+            blocks: [],
         });
     });
 });

--- a/packages/roosterjs-content-model/test/publicApi/table/setTableCellShadeTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/table/setTableCellShadeTest.ts
@@ -1,0 +1,349 @@
+import * as normalizeTable from '../../../lib/modelApi/table/normalizeTable';
+import setTableCellShade from '../../../lib/publicApi/table/setTableCellShade';
+import { ContentModelTable } from '../../../lib/publicTypes/block/ContentModelTable';
+import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
+import { IExperimentalContentModelEditor } from '../../../lib/publicTypes/IExperimentalContentModelEditor';
+
+describe('setTableCellShade', () => {
+    let editor: IExperimentalContentModelEditor;
+    let setContentModel: jasmine.Spy<IExperimentalContentModelEditor['setContentModel']>;
+    let createContentModel: jasmine.Spy<IExperimentalContentModelEditor['createContentModel']>;
+
+    beforeEach(() => {
+        setContentModel = jasmine.createSpy('setContentModel');
+        createContentModel = jasmine.createSpy('createContentModel');
+
+        spyOn(normalizeTable, 'normalizeTable');
+
+        editor = ({
+            focus: () => {},
+            addUndoSnapshot: (callback: Function) => callback(),
+            setContentModel,
+            createContentModel,
+        } as any) as IExperimentalContentModelEditor;
+    });
+
+    function runTest(table: ContentModelTable, expectedTable: ContentModelTable | null) {
+        const model = createContentModelDocument();
+        model.blocks.push(table);
+
+        createContentModel.and.returnValue(model);
+
+        setTableCellShade(editor, 'red');
+
+        if (expectedTable) {
+            expect(setContentModel).toHaveBeenCalledTimes(1);
+            expect(setContentModel).toHaveBeenCalledWith({
+                blockGroupType: 'Document',
+                blocks: [expectedTable],
+            });
+        } else {
+            expect(setContentModel).not.toHaveBeenCalled();
+        }
+    }
+    it('Empty table', () => {
+        runTest(
+            {
+                blockType: 'Table',
+                cells: [],
+                format: {},
+                widths: [0],
+                heights: [0],
+                dataset: {},
+            },
+            null
+        );
+    });
+
+    it('Table without selection', () => {
+        runTest(
+            {
+                blockType: 'Table',
+                cells: [
+                    [
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {},
+                            dataset: {},
+                        },
+                    ],
+                ],
+                format: {},
+                widths: [0],
+                heights: [0],
+                dataset: {},
+            },
+            null
+        );
+    });
+
+    it('Table with table cell selection', () => {
+        runTest(
+            {
+                blockType: 'Table',
+                cells: [
+                    [
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {},
+                            dataset: {},
+                        },
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {},
+                            isSelected: true,
+                            dataset: {},
+                        },
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {},
+                            isSelected: true,
+                            dataset: {},
+                        },
+                    ],
+                ],
+                format: {},
+                widths: [0],
+                heights: [0],
+                dataset: {},
+            },
+            {
+                blockType: 'Table',
+                cells: [
+                    [
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {},
+                            dataset: {},
+                        },
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {
+                                backgroundColor: 'red',
+                                textColor: '#000000',
+                            },
+                            dataset: {
+                                editingInfo: '{"bgColorOverride":true}',
+                            },
+                            isSelected: true,
+                        },
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {
+                                backgroundColor: 'red',
+                                textColor: '#000000',
+                            },
+                            dataset: {
+                                editingInfo: '{"bgColorOverride":true}',
+                            },
+                            isSelected: true,
+                        },
+                    ],
+                ],
+                format: {},
+                widths: [0],
+                heights: [0],
+                dataset: {},
+            }
+        );
+    });
+
+    it('Table with table content selection', () => {
+        runTest(
+            {
+                blockType: 'Table',
+                cells: [
+                    [
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {},
+                            dataset: {},
+                        },
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'SelectionMarker',
+                                            isSelected: true,
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                },
+                            ],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {},
+                            dataset: {},
+                        },
+                    ],
+                ],
+                format: {},
+                widths: [0],
+                heights: [0],
+                dataset: {},
+            },
+            {
+                blockType: 'Table',
+                cells: [
+                    [
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {},
+                            dataset: {},
+                        },
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'SelectionMarker',
+                                            isSelected: true,
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                },
+                            ],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {
+                                backgroundColor: 'red',
+                                textColor: '#000000',
+                            },
+                            dataset: {
+                                editingInfo: '{"bgColorOverride":true}',
+                            },
+                        },
+                    ],
+                ],
+                format: {},
+                widths: [0],
+                heights: [0],
+                dataset: {},
+            }
+        );
+    });
+
+    it('Table with nested table', () => {
+        runTest(
+            {
+                blockType: 'Table',
+                cells: [
+                    [
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [
+                                {
+                                    blockType: 'Table',
+                                    format: {},
+                                    cells: [
+                                        [
+                                            {
+                                                blockGroupType: 'TableCell',
+                                                spanAbove: false,
+                                                spanLeft: false,
+                                                format: {},
+                                                blocks: [],
+                                                dataset: {},
+                                            },
+                                        ],
+                                    ],
+                                    widths: [0],
+                                    heights: [0],
+                                    dataset: {},
+                                },
+                            ],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {},
+                            isSelected: true,
+                            dataset: {},
+                        },
+                    ],
+                ],
+                format: {},
+                widths: [0],
+                heights: [0],
+                dataset: {},
+            },
+            {
+                blockType: 'Table',
+                cells: [
+                    [
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [
+                                {
+                                    blockType: 'Table',
+                                    format: {},
+                                    cells: [
+                                        [
+                                            {
+                                                blockGroupType: 'TableCell',
+                                                spanAbove: false,
+                                                spanLeft: false,
+                                                format: {},
+                                                blocks: [],
+                                                dataset: {},
+                                            },
+                                        ],
+                                    ],
+                                    widths: [0],
+                                    heights: [0],
+                                    dataset: {},
+                                },
+                            ],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {
+                                backgroundColor: 'red',
+                                textColor: '#000000',
+                            },
+                            isSelected: true,
+                            dataset: {
+                                editingInfo: '{"bgColorOverride":true}',
+                            },
+                        },
+                    ],
+                ],
+                format: {},
+                widths: [0],
+                heights: [0],
+                dataset: {},
+            }
+        );
+    });
+});


### PR DESCRIPTION
This is to follow the same behavior with original editor.

When set table cell shade with a very dark color in Content Model, we also change the text color to be bright to keep color contrast rate.