### PR TITLE
Load fluent ui from cdnjs for demo site

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -20,7 +20,7 @@
         <div id="mainPane"></div>
         <script src="https://unpkg.com/react@16.14.0/umd/react.production.min.js"></script>
         <script src="https://unpkg.com/react-dom@16.14.0/umd/react-dom.production.min.js"></script>
-        <script src="https://unpkg.com/@fluentui/react@8.60.1/dist/fluentui-react.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/fluentui-react/8.60.1/fluentui-react.min.js"></script>
         <script src="rooster-min.js"></script>
         <script src="rooster-react-min.js"></script>
         <script src="demo.js"></script>

--- a/demo/scripts/controls/sidePane/editorOptions/OptionsPane.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/OptionsPane.tsx
@@ -33,7 +33,7 @@ const htmlRoosterReact =
     '<div id="root"></div>\n' +
     '<script src="https://unpkg.com/react@16/umd/react.development.js"></script>\n' +
     '<script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>\n' +
-    '<script src="https://unpkg.com/@fluentui/react/dist/fluentui-react.js"></script>\n' +
+    '<script src="https://cdnjs.cloudflare.com/ajax/libs/fluentui-react/8.60.1/fluentui-react.min.js"></script>\n' +
     '<script src="https://microsoft.github.io/roosterjs/rooster-min.js"></script>\n' +
     '<script src="https://microsoft.github.io/roosterjs/rooster-react-min.js"></script>\n' +
     '</body>\n' +

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         <div id="mainPane"></div>
         <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
         <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
-        <script src="https://unpkg.com/@fluentui/react@8.60.1/dist/fluentui-react.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/fluentui-react/8.60.1/fluentui-react.min.js"></script>
         <script src="scripts/demo.js"></script>
     </body>
 </html>


### PR DESCRIPTION
It seems the unpkg site for fluentui is pretty unstable. So let's use cdnjs instead.
This will only impact demo site.