### PR TITLE
remove new max-width

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
@@ -72,7 +72,6 @@ export default function applyChange(
     image.src = newSrc;
 
     if (wasResized || state == ImageEditInfoState.FullyChanged) {
-        image.style.maxWidth = 'initial';
         image.width = targetWidth;
         image.height = targetHeight;
         image.style.width = targetWidth + 'px';


### PR DESCRIPTION
When apply changes to a image that was resized, do not set maxWidth to initial. 