### PR TITLE
Fix #1532: Support isCode in FormatState

### DIFF
--- a/packages-ui/roosterjs-react/lib/ribbon/component/buttons/code.ts
+++ b/packages-ui/roosterjs-react/lib/ribbon/component/buttons/code.ts
@@ -10,7 +10,7 @@ export const code: RibbonButton<CodeButtonStringKey> = {
     key: 'buttonNameCode',
     unlocalizedText: 'Code',
     iconName: 'Code',
-    isChecked: formatState => !!formatState.isCode,
+    isChecked: formatState => !!formatState.isCodeBlock,
     onClick: editor => {
         toggleCodeBlock(editor);
     },

--- a/packages-ui/roosterjs-react/lib/ribbon/component/buttons/code.ts
+++ b/packages-ui/roosterjs-react/lib/ribbon/component/buttons/code.ts
@@ -10,7 +10,7 @@ export const code: RibbonButton<CodeButtonStringKey> = {
     key: 'buttonNameCode',
     unlocalizedText: 'Code',
     iconName: 'Code',
-    isChecked: formatState => formatState.isCode,
+    isChecked: formatState => !!formatState.isCode,
     onClick: editor => {
         toggleCodeBlock(editor);
     },

--- a/packages-ui/roosterjs-react/lib/ribbon/component/buttons/code.ts
+++ b/packages-ui/roosterjs-react/lib/ribbon/component/buttons/code.ts
@@ -10,6 +10,7 @@ export const code: RibbonButton<CodeButtonStringKey> = {
     key: 'buttonNameCode',
     unlocalizedText: 'Code',
     iconName: 'Code',
+    isChecked: formatState => formatState.isCode,
     onClick: editor => {
         toggleCodeBlock(editor);
     },

--- a/packages/roosterjs-content-model/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/retrieveModelFormatState.ts
@@ -112,7 +112,10 @@ function retrieveFormatStateInternal(
     if (tableContext) {
         retrieveTableFormat(tableContext, result);
     }
+
+    // TODO: Support Code block in format state for Content Model
 }
+
 function retrieveTableFormat(tableContext: TableSelectionContext, result: FormatState) {
     const tableFormat = updateTableMetadata(tableContext.table);
 

--- a/packages/roosterjs-editor-api/lib/format/getFormatState.ts
+++ b/packages/roosterjs-editor-api/lib/format/getFormatState.ts
@@ -49,6 +49,7 @@ export function getElementBasedFormatState(
         canUnlink: !!editor.queryElements('a[href]', QueryScope.OnSelection)[0],
         canAddImageAltText: !!editor.queryElements('img', QueryScope.OnSelection)[0],
         isBlockQuote: !!editor.queryElements('blockquote', QueryScope.OnSelection)[0],
+        isCode: !!editor.queryElements('code', QueryScope.OnSelection)[0],
         isInTable: !!table,
         tableFormat: tableFormat,
         tableHasHeader: hasHeader,

--- a/packages/roosterjs-editor-api/lib/format/getFormatState.ts
+++ b/packages/roosterjs-editor-api/lib/format/getFormatState.ts
@@ -49,7 +49,7 @@ export function getElementBasedFormatState(
         canUnlink: !!editor.queryElements('a[href]', QueryScope.OnSelection)[0],
         canAddImageAltText: !!editor.queryElements('img', QueryScope.OnSelection)[0],
         isBlockQuote: !!editor.queryElements('blockquote', QueryScope.OnSelection)[0],
-        isCode: !!editor.queryElements('code', QueryScope.OnSelection)[0],
+        isCodeBlock: !!editor.queryElements('pre>code', QueryScope.OnSelection)[0],
         isInTable: !!table,
         tableFormat: tableFormat,
         tableHasHeader: hasHeader,

--- a/packages/roosterjs-editor-types/lib/interface/FormatState.ts
+++ b/packages/roosterjs-editor-types/lib/interface/FormatState.ts
@@ -60,6 +60,11 @@ export interface ElementBasedFormatState {
     isBlockQuote?: boolean;
 
     /**
+     * Whether the text is in Code block
+     */
+    isCode?: boolean;
+
+    /**
      * Whether unlink command can be called to the text
      */
     canUnlink?: boolean;

--- a/packages/roosterjs-editor-types/lib/interface/FormatState.ts
+++ b/packages/roosterjs-editor-types/lib/interface/FormatState.ts
@@ -62,7 +62,7 @@ export interface ElementBasedFormatState {
     /**
      * Whether the text is in Code block
      */
-    isCode?: boolean;
+    isCodeBlock?: boolean;
 
     /**
      * Whether unlink command can be called to the text


### PR DESCRIPTION
Support isCode in FormatState.

This change doesn't include the format state change for Content Model. It will be covered later.