### PR TITLE
Fix #1529 #1530 and 187095

### DIFF
--- a/demo/scripts/controls/contentModel/components/model/ContentModelListItemView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelListItemView.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ContentModelBlockView } from './ContentModelBlockView';
 import { ContentModelView } from '../ContentModelView';
+import { DirectionFormatRenderers } from '../format/formatPart/DirectionFormatRenderers';
 import { FontFamilyFormatRenderer } from '../format/formatPart/FontFamilyFormatRenderer';
 import { FontSizeFormatRenderer } from '../format/formatPart/FontSizeFormatRenderer';
 import { FormatRenderer } from '../format/utils/FormatRenderer';
@@ -23,6 +24,7 @@ const ListLevelFormatRenders: FormatRenderer<ContentModelListItemLevelFormat>[] 
     ListTypeFormatRenderer,
     ...ListThreadFormatRenderers,
     ...ListMetadataFormatRenderers,
+    ...DirectionFormatRenderers,
 ];
 
 const ListItemFormatHolderRenderers: FormatRenderer<ContentModelSegmentFormat>[] = [

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -93,7 +93,7 @@ const defaultFormatKeysPerCategory: {
 } = {
     block: blockFormatHandlers,
     listItem: ['listItemThread', 'listItemMetadata'],
-    listLevel: ['listType', 'listLevelThread', 'listLevelMetadata'],
+    listLevel: ['listType', 'listLevelThread', 'listLevelMetadata', 'direction'],
     segment: [
         'superOrSubScript',
         'strike',

--- a/packages/roosterjs-content-model/lib/modelApi/block/setModelIndentation.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/block/setModelIndentation.ts
@@ -41,15 +41,19 @@ export function setModelIndentation(
         } else if (block) {
             const { format } = block;
             const { marginLeft, marginRight, direction } = format;
-            const originalValue = parseValueWithUnit(direction == 'rtl' ? marginRight : marginLeft);
+            const isRtl = direction == 'rtl';
+            const originalValue = parseValueWithUnit(isRtl ? marginRight : marginLeft);
             let newValue = (isIndent ? Math.ceil : Math.floor)(originalValue / length) * length;
 
             if (newValue == originalValue) {
                 newValue = Math.max(newValue + length * (isIndent ? 1 : -1), 0);
             }
 
-            format.marginLeft = newValue + 'px';
-            format.marginRight = newValue + 'px';
+            if (isRtl) {
+                format.marginRight = newValue + 'px';
+            } else {
+                format.marginLeft = newValue + 'px';
+            }
         }
     });
 

--- a/packages/roosterjs-content-model/lib/modelApi/list/setListType.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/list/setListType.ts
@@ -35,6 +35,7 @@ export function setListType(model: ContentModelDocument, listType: 'OL' | 'UL') 
 
             if (index >= 0) {
                 const prevBlock = parent.blocks[index - 1];
+                const segmentFormat = block.segments[0]?.format || {};
                 const newListItem = createListItem(
                     [
                         {
@@ -46,9 +47,16 @@ export function setListType(model: ContentModelDocument, listType: 'OL' | 'UL') 
                                     prevBlock.levels[0]?.listType == 'OL')
                                     ? undefined
                                     : 1,
+                            direction: block.format.direction,
+                            textAlign: block.format.textAlign,
                         },
                     ],
-                    block.segments[0]?.format
+                    // For list bullet, we only want to carry over these formats from segments:
+                    {
+                        fontFamily: segmentFormat.fontFamily,
+                        fontSize: segmentFormat.fontSize,
+                        textColor: segmentFormat.textColor,
+                    }
                 );
 
                 // Since there is only one paragraph under the list item, no need to keep its paragraph element (DIV).

--- a/packages/roosterjs-content-model/lib/publicApi/block/setDirection.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setDirection.ts
@@ -11,6 +11,23 @@ export default function setDirection(
     direction: 'ltr' | 'rtl'
 ) {
     formatParagraphWithContentModel(editor, 'setDirection', para => {
-        para.format.direction = direction;
+        const isOldValueRtl = para.format.direction == 'rtl';
+        const isNewValueRtl = direction == 'rtl';
+
+        if (isOldValueRtl != isNewValueRtl) {
+            para.format.direction = direction;
+
+            // Adjust margin when change direction
+            // TODO: make margin and padding direction-aware, like what we did for textAlign. So no need to adjust them here
+            // TODO: Do we also need to handle border here?
+            const marginLeft = para.format.marginLeft;
+            const paddingLeft = para.format.paddingLeft;
+
+            para.format.marginLeft = para.format.marginRight;
+            para.format.marginRight = marginLeft;
+
+            para.format.paddingLeft = para.format.paddingRight;
+            para.format.paddingRight = paddingLeft;
+        }
     });
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelListItemLevelFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelListItemLevelFormat.ts
@@ -1,3 +1,4 @@
+import { DirectionFormat } from './formatParts/DirectionFormat';
 import { ListMetadataFormat } from './formatParts/ListMetadataFormat';
 import { ListThreadFormat } from './formatParts/ListThreadFormat';
 import { ListTypeFormat } from './formatParts/ListTypeFormat';
@@ -7,4 +8,5 @@ import { ListTypeFormat } from './formatParts/ListTypeFormat';
  */
 export type ContentModelListItemLevelFormat = ListTypeFormat &
     ListThreadFormat &
-    ListMetadataFormat;
+    ListMetadataFormat &
+    DirectionFormat;

--- a/packages/roosterjs-content-model/test/modelApi/block/setModelIndentationTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/block/setModelIndentationTest.ts
@@ -62,7 +62,6 @@ describe('indent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '40px',
-                        marginRight: '40px',
                     },
                     segments: [text2],
                 },
@@ -104,7 +103,6 @@ describe('indent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '40px',
-                        marginRight: '40px',
                     },
                     segments: [text1],
                 },
@@ -112,7 +110,6 @@ describe('indent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '80px',
-                        marginRight: '80px',
                     },
                     segments: [text2],
                 },
@@ -120,7 +117,6 @@ describe('indent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '80px',
-                        marginRight: '80px',
                     },
                     segments: [text3],
                 },
@@ -150,7 +146,7 @@ describe('indent', () => {
                 {
                     blockType: 'Paragraph',
                     format: {
-                        marginLeft: '120px',
+                        marginLeft: '20px',
                         marginRight: '120px',
                         direction: 'rtl',
                     },
@@ -193,7 +189,6 @@ describe('indent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '40px',
-                        marginRight: '40px',
                     },
                     segments: [text2],
                 },
@@ -201,7 +196,6 @@ describe('indent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '40px',
-                        marginRight: '40px',
                     },
                     segments: [text3],
                 },
@@ -237,7 +231,6 @@ describe('indent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '40px',
-                        marginRight: '40px',
                     },
                     segments: [text1],
                 },
@@ -250,7 +243,6 @@ describe('indent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '40px',
-                        marginRight: '40px',
                     },
                     segments: [text3],
                 },
@@ -539,7 +531,6 @@ describe('indent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '40px',
-                        marginRight: '40px',
                     },
                     segments: [text3],
                 },
@@ -568,7 +559,6 @@ describe('indent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '75px',
-                        marginRight: '75px',
                     },
                     segments: [text1],
                 },
@@ -670,7 +660,6 @@ describe('outdent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '0px',
-                        marginRight: '0px',
                     },
                     segments: [text2],
                 },
@@ -724,7 +713,6 @@ describe('outdent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '0px',
-                        marginRight: '0px',
                     },
                     segments: [text2],
                 },
@@ -732,7 +720,6 @@ describe('outdent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '40px',
-                        marginRight: '40px',
                     },
                     segments: [text3],
                 },
@@ -775,7 +762,6 @@ describe('outdent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '0px',
-                        marginRight: '0px',
                     },
                     segments: [text1],
                 },
@@ -790,7 +776,6 @@ describe('outdent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '80px',
-                        marginRight: '80px',
                     },
                     segments: [text3],
                 },
@@ -895,7 +880,6 @@ describe('outdent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '0px',
-                        marginRight: '0px',
                     },
                     segments: [text2],
                 },
@@ -903,7 +887,6 @@ describe('outdent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '40px',
-                        marginRight: '40px',
                     },
                     segments: [text3],
                 },
@@ -933,7 +916,7 @@ describe('outdent', () => {
                 {
                     blockType: 'Paragraph',
                     format: {
-                        marginLeft: '40px',
+                        marginLeft: '20px',
                         marginRight: '40px',
                         direction: 'rtl',
                     },
@@ -964,7 +947,6 @@ describe('outdent', () => {
                     blockType: 'Paragraph',
                     format: {
                         marginLeft: '45px',
-                        marginRight: '45px',
                     },
                     segments: [text1],
                 },

--- a/packages/roosterjs-content-model/test/modelApi/list/setListTypeTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/list/setListTypeTest.ts
@@ -51,9 +51,24 @@ describe('indent', () => {
                 {
                     blockGroupType: 'ListItem',
                     blockType: 'BlockGroup',
-                    levels: [{ listType: 'OL', startNumberOverride: 1 }],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            startNumberOverride: 1,
+                            direction: undefined,
+                            textAlign: undefined,
+                        },
+                    ],
                     blocks: [para],
-                    formatHolder: { segmentType: 'SelectionMarker', format: {}, isSelected: true },
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {
+                            fontFamily: undefined,
+                            fontSize: undefined,
+                            textColor: undefined,
+                        },
+                        isSelected: true,
+                    },
                     format: {},
                 },
             ],
@@ -232,11 +247,22 @@ describe('indent', () => {
                         {
                             blockGroupType: 'ListItem',
                             blockType: 'BlockGroup',
-                            levels: [{ listType: 'OL', startNumberOverride: undefined }],
+                            levels: [
+                                {
+                                    listType: 'OL',
+                                    startNumberOverride: undefined,
+                                    direction: undefined,
+                                    textAlign: undefined,
+                                },
+                            ],
                             blocks: [para3],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
-                                format: {},
+                                format: {
+                                    fontFamily: undefined,
+                                    fontSize: undefined,
+                                    textColor: undefined,
+                                },
                                 isSelected: true,
                             },
                             format: {},
@@ -248,5 +274,81 @@ describe('indent', () => {
             ],
         });
         expect(result).toBeTrue();
+    });
+
+    it('Carry over existing segment and direction format', () => {
+        const group = createContentModelDocument();
+        const para = createParagraph(false, {
+            direction: 'rtl',
+            textAlign: 'start',
+            backgroundColor: 'yellow',
+        });
+        const text = createText('test', {
+            fontFamily: 'Arial',
+            fontSize: '10px',
+            textColor: 'black',
+            backgroundColor: 'white',
+            fontWeight: 'bold',
+            italic: true,
+            underline: true,
+        });
+
+        para.segments.push(text);
+        group.blocks.push(para);
+
+        text.isSelected = true;
+
+        const result = setListType(group, 'OL');
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockGroupType: 'ListItem',
+                    blockType: 'BlockGroup',
+                    levels: [
+                        {
+                            listType: 'OL',
+                            startNumberOverride: 1,
+                            direction: 'rtl',
+                            textAlign: 'start',
+                        },
+                    ],
+                    blocks: [para],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {
+                            fontFamily: 'Arial',
+                            fontSize: '10px',
+                            textColor: 'black',
+                        },
+                        isSelected: true,
+                    },
+                    format: {},
+                },
+            ],
+        });
+        expect(result).toBeTrue();
+        expect(para).toEqual({
+            blockType: 'Paragraph',
+            format: { direction: 'rtl', textAlign: 'start', backgroundColor: 'yellow' },
+            isImplicit: true,
+            segments: [
+                {
+                    segmentType: 'Text',
+                    text: 'test',
+                    format: {
+                        fontFamily: 'Arial',
+                        fontSize: '10px',
+                        textColor: 'black',
+                        backgroundColor: 'white',
+                        fontWeight: 'bold',
+                        italic: true,
+                        underline: true,
+                    },
+                    isSelected: true,
+                },
+            ],
+        });
     });
 });

--- a/packages/roosterjs-content-model/test/publicApi/block/setDirectionTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/block/setDirectionTest.ts
@@ -99,6 +99,10 @@ describe('setDirection', () => {
                         blockType: 'Paragraph',
                         format: {
                             direction: 'rtl',
+                            marginLeft: undefined,
+                            marginRight: undefined,
+                            paddingLeft: undefined,
+                            paddingRight: undefined,
                         },
                         segments: [
                             {
@@ -145,6 +149,10 @@ describe('setDirection', () => {
                         blockType: 'Paragraph',
                         format: {
                             direction: 'rtl',
+                            marginLeft: undefined,
+                            marginRight: undefined,
+                            paddingLeft: undefined,
+                            paddingRight: undefined,
                         },
                         segments: [
                             {
@@ -254,6 +262,10 @@ describe('setDirection', () => {
                         blockType: 'Paragraph',
                         format: {
                             direction: 'rtl',
+                            marginLeft: undefined,
+                            marginRight: undefined,
+                            paddingLeft: undefined,
+                            paddingRight: undefined,
                         },
                         segments: [
                             {
@@ -268,6 +280,10 @@ describe('setDirection', () => {
                         blockType: 'Paragraph',
                         format: {
                             direction: 'rtl',
+                            marginLeft: undefined,
+                            marginRight: undefined,
+                            paddingLeft: undefined,
+                            paddingRight: undefined,
                         },
                         segments: [
                             {
@@ -369,6 +385,10 @@ describe('setDirection', () => {
                         blockType: 'Paragraph',
                         format: {
                             direction: 'rtl',
+                            marginLeft: undefined,
+                            marginRight: undefined,
+                            paddingLeft: undefined,
+                            paddingRight: undefined,
                         },
                         segments: [
                             {
@@ -392,6 +412,125 @@ describe('setDirection', () => {
                                 segmentType: 'Text',
                                 text: 'test',
                                 format: {},
+                            },
+                        ],
+                    },
+                ],
+            },
+            1
+        );
+    });
+
+    it('Swap margin and padding when direction changes', () => {
+        runTest(
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {
+                            marginLeft: '10px',
+                            marginRight: '20px',
+                            paddingLeft: '30px',
+                            paddingRight: '40px',
+                        },
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: {},
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
+                                format: {},
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {
+                            direction: 'rtl',
+                            marginLeft: '20px',
+                            marginRight: '10px',
+                            paddingLeft: '40px',
+                            paddingRight: '30px',
+                        },
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: {},
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
+                                format: {},
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+            },
+            1
+        );
+    });
+
+    it('Do not swap margin and padding when direction is not changed', () => {
+        runTest(
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {
+                            marginLeft: '10px',
+                            marginRight: '20px',
+                            paddingLeft: '30px',
+                            paddingRight: '40px',
+                            direction: 'rtl',
+                        },
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: {},
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
+                                format: {},
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {
+                            direction: 'rtl',
+                            marginLeft: '10px',
+                            marginRight: '20px',
+                            paddingLeft: '30px',
+                            paddingRight: '40px',
+                        },
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: {},
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
+                                format: {},
+                                isSelected: true,
                             },
                         ],
                     },


### PR DESCRIPTION
#1529 

Carry direction format when set list type

#1530 

Only set one side margin when indent, and swap margin and padding when change direction

187095: The blank space of a line will also be highlighted when bulleting or numbering the highlighted lines

When convert paragraph to list, only carry fontFamily, fontSize and textColor to the list so background color won't be impacted.