### PR TITLE
Content Model: Remove unused method and parameters

### DIFF
--- a/demo/scripts/controls/editor/ExperimentalContentModelEditor.ts
+++ b/demo/scripts/controls/editor/ExperimentalContentModelEditor.ts
@@ -11,7 +11,7 @@ import {
     ModelToDomOption,
 } from 'roosterjs-content-model';
 import {
-    getComputedStyles,
+    // getComputedStyles,
     Position,
     restoreContentWithEntityPlaceholder,
 } from 'roosterjs-editor-dom';
@@ -93,8 +93,6 @@ export default class ExperimentalContentModelEditor extends Editor
     private createEditorContext(): EditorContext {
         return {
             isDarkMode: this.isDarkMode(),
-            zoomScale: this.getZoomScale(),
-            isRightToLeft: getComputedStyles(this.contentDiv, 'direction')[0] == 'rtl',
             getDarkColor: this.getDarkColor,
             darkColorHandler: this.getDarkColorHandler(),
         };

--- a/demo/scripts/controls/editor/isContentModelEditor.ts
+++ b/demo/scripts/controls/editor/isContentModelEditor.ts
@@ -6,5 +6,5 @@ export default function isContentModelEditor(
 ): editor is IExperimentalContentModelEditor {
     const experimentalEditor = editor as IExperimentalContentModelEditor;
 
-    return !!experimentalEditor.createEditorContext && 'contentDiv' in experimentalEditor;
+    return !!experimentalEditor.createContentModel && 'contentDiv' in experimentalEditor;
 }

--- a/packages/roosterjs-content-model/lib/domToModel/context/createDomToModelContext.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/context/createDomToModelContext.ts
@@ -16,8 +16,6 @@ export function createDomToModelContext(
     const context: DomToModelContext = {
         ...(editorContext || {
             isDarkMode: false,
-            zoomScale: 1,
-            isRightToLeft: false,
             getDarkColor: undefined,
         }),
 

--- a/packages/roosterjs-content-model/lib/domToModel/context/createDomToModelContext.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/context/createDomToModelContext.ts
@@ -23,6 +23,7 @@ export function createDomToModelContext(
 
         blockFormat: {},
         segmentFormat: {},
+        scaleFormat: {},
         isInSelection: false,
 
         listFormat: {
@@ -52,10 +53,6 @@ export function createDomToModelContext(
         defaultElementProcessors: defaultProcessorMap,
         defaultFormatParsers: defaultFormatParsers,
     };
-
-    if (editorContext?.isRightToLeft) {
-        context.blockFormat.direction = 'rtl';
-    }
 
     if (options?.alwaysNormalizeTable) {
         context.alwaysNormalizeTable = true;

--- a/packages/roosterjs-content-model/lib/domToModel/context/defaultProcessors.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/context/defaultProcessors.ts
@@ -11,6 +11,7 @@ import { knownElementProcessor } from '../processors/knownElementProcessor';
 import { listItemProcessor } from '../processors/listItemProcessor';
 import { listProcessor } from '../processors/listProcessor';
 import { quoteProcessor } from '../processors/quoteProcessor';
+import { rootProcessor } from '../processors/rootProcessor';
 import { tableProcessor } from '../processors/tableProcessor';
 import { textProcessor } from '../processors/textProcessor';
 
@@ -53,6 +54,7 @@ export const defaultProcessorMap: ElementProcessorMap = {
     '*': generalProcessor,
     '#text': textProcessor,
     element: elementProcessor,
+    root: rootProcessor,
     entity: entityProcessor,
     child: childProcessor,
 };

--- a/packages/roosterjs-content-model/lib/domToModel/processors/rootProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/rootProcessor.ts
@@ -1,0 +1,14 @@
+import { ElementProcessor } from '../../publicTypes/context/ElementProcessor';
+import { parseFormat } from '../utils/parseFormat';
+import { rootDirectionFormatHandler } from '../../formatHandlers/root/rootDirectionFormatHandler';
+import { scaleFormatHandler } from '../../formatHandlers/root/scaleFormatHandler';
+
+/**
+ * @internal
+ */
+export const rootProcessor: ElementProcessor<HTMLElement> = (group, element, context) => {
+    parseFormat(element, [rootDirectionFormatHandler.parse], context.blockFormat, context);
+    parseFormat(element, [scaleFormatHandler.parse], context.scaleFormat, context);
+
+    context.elementProcessors.child(group, element, context);
+};

--- a/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
@@ -43,7 +43,7 @@ export const tableProcessor: ElementProcessor<HTMLTableElement> = (
 
         const columnPositions: number[] = [0];
         const rowPositions: number[] = [0];
-        const zoomScale = context.zoomScale;
+        const zoomScale = context.scaleFormat.scale || 1;
 
         for (let row = 0; row < tableElement.rows.length; row++) {
             const tr = tableElement.rows[row];

--- a/packages/roosterjs-content-model/lib/formatHandlers/root/rootDirectionFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/root/rootDirectionFormatHandler.ts
@@ -1,0 +1,16 @@
+import { DirectionFormat } from '../../publicTypes/format/formatParts/DirectionFormat';
+import { FormatHandler } from '../FormatHandler';
+
+/**
+ * @internal
+ */
+export const rootDirectionFormatHandler: FormatHandler<DirectionFormat> = {
+    parse: (format, element) => {
+        const style = element.ownerDocument.defaultView?.getComputedStyle(element);
+
+        if (style?.direction == 'rtl') {
+            format.direction = 'rtl';
+        }
+    },
+    apply: () => {},
+};

--- a/packages/roosterjs-content-model/lib/formatHandlers/root/scaleFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/root/scaleFormatHandler.ts
@@ -1,5 +1,5 @@
 import { FormatHandler } from '../FormatHandler';
-import { ScaleFormat } from 'roosterjs-content-model/lib/publicTypes/format/formatParts/ScaleFormat';
+import { ScaleFormat } from '../../publicTypes/format/formatParts/ScaleFormat';
 
 /**
  * @internal

--- a/packages/roosterjs-content-model/lib/formatHandlers/root/scaleFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/root/scaleFormatHandler.ts
@@ -1,0 +1,18 @@
+import { FormatHandler } from '../FormatHandler';
+import { ScaleFormat } from 'roosterjs-content-model/lib/publicTypes/format/formatParts/ScaleFormat';
+
+/**
+ * @internal
+ */
+export const scaleFormatHandler: FormatHandler<ScaleFormat> = {
+    parse: (format, element) => {
+        const originalWidth = element.getBoundingClientRect().width;
+        const visualWidth = element.offsetWidth;
+
+        format.scale =
+            visualWidth > 0 && originalWidth > 0
+                ? Math.round((originalWidth / visualWidth) * 100) / 100
+                : 1;
+    },
+    apply: () => {},
+};

--- a/packages/roosterjs-content-model/lib/index.ts
+++ b/packages/roosterjs-content-model/lib/index.ts
@@ -118,6 +118,7 @@ export {
 export { DatasetFormat } from './publicTypes/format/formatParts/DatasetFormat';
 export { WhiteSpaceFormat } from './publicTypes/format/formatParts/WhiteSpaceFormat';
 export { WordBreakFormat } from './publicTypes/format/formatParts/WordBreakFormat';
+export { ScaleFormat } from './publicTypes/format/formatParts/ScaleFormat';
 
 export { ContentModelFormatMap } from './publicTypes/format/ContentModelFormatMap';
 

--- a/packages/roosterjs-content-model/lib/modelApi/common/insertContent.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/insertContent.ts
@@ -21,8 +21,6 @@ export function insertContent(
             htmlContent,
             {
                 isDarkMode: !!isFromDarkMode,
-                zoomScale: 1,
-                isRightToLeft: false,
             },
             {
                 includeRoot: true,

--- a/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
@@ -51,6 +51,5 @@ export function createModelToDomContext(
 
         defaultModelHandlers: defaultContentModelHandlers,
         defaultFormatAppliers: defaultFormatAppliers,
-        doNotReuseEntityDom: !!options?.doNotReuseEntityDom,
     };
 }

--- a/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
@@ -20,8 +20,6 @@ export function createModelToDomContext(
     return {
         ...(editorContext || {
             isDarkMode: false,
-            isRightToLeft: false,
-            zoomScale: 1,
             getDarkColor: undefined,
         }),
         regularSelection: {

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
@@ -38,7 +38,7 @@ export const handleEntity: ContentModelHandler<ContentModelEntity> = (
         parent = span;
     }
 
-    if (context.doNotReuseEntityDom || !entity) {
+    if (!entity) {
         parent.appendChild(wrapper);
     } else {
         // Create a comment as placeholder and insert into DOM tree.

--- a/packages/roosterjs-content-model/lib/publicApi/domToContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/domToContentModel.ts
@@ -7,22 +7,22 @@ import { normalizeContentModel } from '../modelApi/common/normalizeContentModel'
 
 /**
  * Create Content Model from DOM tree in this editor
- * @param root Root element of DOM tree to create Content Model from
+ * @param rootElement Root element of DOM tree to create Content Model from
  * @param editorContext Context of content model editor
  * @param option The option to customize the behavior of DOM to Content Model conversion
  * @returns A ContentModelDocument object that contains all the models created from the give root element
  */
 export default function domToContentModel(
-    root: HTMLElement,
+    rootElement: HTMLElement,
     editorContext: EditorContext,
     option: DomToModelOption
 ): ContentModelDocument {
     const model = createContentModelDocument();
     const domToModelContext = createDomToModelContext(editorContext, option);
-    const { element, child } = domToModelContext.elementProcessors;
-    const processor = option.includeRoot ? element : child;
+    const { element, root } = domToModelContext.elementProcessors;
+    const processor = option.includeRoot ? element : root;
 
-    processor(model, root, domToModelContext);
+    processor(model, rootElement, domToModelContext);
 
     normalizeContentModel(model);
 

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -14,7 +14,7 @@ export function formatWithContentModel(
     callback: (model: ContentModelDocument) => boolean,
     domToModelOptions?: DomToModelOption
 ) {
-    const model = editor.createContentModel(undefined /*rootNode*/, domToModelOptions);
+    const model = editor.createContentModel(domToModelOptions);
 
     if (callback(model)) {
         editor.addUndoSnapshot(

--- a/packages/roosterjs-content-model/lib/publicTypes/IExperimentalContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/IExperimentalContentModelEditor.ts
@@ -1,6 +1,5 @@
 import { ContentModelDocument } from './group/ContentModelDocument';
 import { ContentModelSegmentFormat } from './format/ContentModelSegmentFormat';
-import { EditorContext } from './context/EditorContext';
 import { IEditor, SelectionRangeEx } from 'roosterjs-editor-types';
 import {
     ContentModelHandlerMap,
@@ -62,23 +61,6 @@ export interface DomToModelOption {
  */
 export interface ModelToDomOption {
     /**
-     * A callback to specify how to merge DOM tree generated from Content Model in to existing container
-     * @param source Source document fragment that is generated from Content Model
-     * @param target Target container, usually to be editor root container
-     * @param entities An array of entity wrapper - placeholder pairs, used for reuse existing DOM structure for entity
-     */
-    mergingCallback?: (
-        source: DocumentFragment,
-        target: HTMLElement,
-        entities: Record<string, HTMLElement>
-    ) => void;
-
-    /**
-     * When set to true, directly put entity DOM nodes into the result DOM tree when doing Content Model to DOM conversion and do not use placeholder
-     */
-    doNotReuseEntityDom?: boolean;
-
-    /**
      * Overrides default format appliers
      */
     formatApplierOverride?: Partial<FormatAppliers>;
@@ -106,17 +88,10 @@ export interface ModelToDomOption {
  */
 export interface IExperimentalContentModelEditor extends IEditor {
     /**
-     * Create a EditorContext object used by ContentModel API
-     */
-    createEditorContext(): EditorContext;
-
-    /**
      * Create Content Model from DOM tree in this editor
-     * @param rootNode Optional start node. If provided, Content Model will be created from this node (including itself),
-     * otherwise it will create Content Model for the whole content in editor.
      * @param option The options to customize the behavior of DOM to Content Model conversion
      */
-    createContentModel(rootNode?: HTMLElement, option?: DomToModelOption): ContentModelDocument;
+    createContentModel(option?: DomToModelOption): ContentModelDocument;
 
     /**
      * Set content with content model

--- a/packages/roosterjs-content-model/lib/publicTypes/context/DomToModelFormatContext.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/DomToModelFormatContext.ts
@@ -3,6 +3,7 @@ import { ContentModelBlockGroup } from '../group/ContentModelBlockGroup';
 import { ContentModelLink } from '../decorator/ContentModelLink';
 import { ContentModelListItemLevelFormat } from '../format/ContentModelListItemLevelFormat';
 import { ContentModelSegmentFormat } from '../format/ContentModelSegmentFormat';
+import { ScaleFormat } from '../format/formatParts/ScaleFormat';
 
 /**
  * Represents the context object used when do DOM to Content Model conversion and processing a List
@@ -47,6 +48,11 @@ export interface DomToModelFormatContext {
      * Context of hyper link info
      */
     link: ContentModelLink;
+
+    /**
+     * Zoom scale of the content
+     */
+    scaleFormat: ScaleFormat;
 
     /**
      * When process table, whether we should always normalize it.

--- a/packages/roosterjs-content-model/lib/publicTypes/context/DomToModelSettings.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/DomToModelSettings.ts
@@ -83,6 +83,11 @@ export type ElementProcessorMap = {
         child: ElementProcessor<ParentNode>;
 
         /**
+         * Processor for root element when root is not included in Content Model since we still need to get some format from root (e.g. rtl direction)
+         */
+        root: ElementProcessor<HTMLElement>;
+
+        /**
          * Workaround for typescript 4.4.4 that doesn't have element "strike" in its element type
          */
         strike?: ElementProcessor<HTMLElement>;

--- a/packages/roosterjs-content-model/lib/publicTypes/context/EditorContext.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/EditorContext.ts
@@ -10,16 +10,6 @@ export interface EditorContext {
     isDarkMode: boolean;
 
     /**
-     * Zoom scale of the content
-     */
-    zoomScale: number;
-
-    /**
-     * Whether current content is from right to left
-     */
-    isRightToLeft: boolean;
-
-    /**
      * Calculate color for dark mode
      * @param lightColor Light mode color
      * @returns Dark mode color calculated from lightColor

--- a/packages/roosterjs-content-model/lib/publicTypes/context/ModelToDomEntityContext.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/ModelToDomEntityContext.ts
@@ -3,11 +3,6 @@
  */
 export interface ModelToDomEntityContext {
     /**
-     * When set to true, directly put entity DOM nodes into the result DOM tree when doing Content Model to DOM conversion and do not use placeholder
-     */
-    doNotReuseEntityDom: boolean;
-
-    /**
      * Entities collected during DOM tree generation, used for reusing existing DOM structure of entities
      */
     entities: Record<string, HTMLElement>;

--- a/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/ScaleFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/ScaleFormat.ts
@@ -1,0 +1,9 @@
+/**
+ * Format of scale
+ */
+export type ScaleFormat = {
+    /**
+     * Scale number
+     */
+    scale?: number;
+};

--- a/packages/roosterjs-content-model/test/domToModel/context/createDomToModelContextTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/context/createDomToModelContextTest.ts
@@ -12,8 +12,6 @@ import {
 describe('createDomToModelContext', () => {
     const editorContext: EditorContext = {
         isDarkMode: false,
-        zoomScale: 1,
-        isRightToLeft: false,
         getDarkColor: undefined,
     };
     const listFormat: DomToModelListFormat = {
@@ -34,6 +32,7 @@ describe('createDomToModelContext', () => {
             ...editorContext,
             segmentFormat: {},
             blockFormat: {},
+            scaleFormat: {},
             isInSelection: false,
             listFormat,
             link: {
@@ -47,8 +46,6 @@ describe('createDomToModelContext', () => {
     it('with content model context', () => {
         const editorContext: EditorContext = {
             isDarkMode: true,
-            zoomScale: 2,
-            isRightToLeft: true,
             getDarkColor: () => '',
         };
 
@@ -57,9 +54,8 @@ describe('createDomToModelContext', () => {
         expect(context).toEqual({
             ...editorContext,
             segmentFormat: {},
-            blockFormat: {
-                direction: 'rtl',
-            },
+            blockFormat: {},
+            scaleFormat: {},
             isInSelection: false,
             listFormat,
             link: {
@@ -92,6 +88,7 @@ describe('createDomToModelContext', () => {
             ...editorContext,
             segmentFormat: {},
             blockFormat: {},
+            scaleFormat: {},
             isInSelection: false,
             regularSelection: {
                 startContainer: 'DIV 1' as any,
@@ -129,6 +126,7 @@ describe('createDomToModelContext', () => {
             ...editorContext,
             segmentFormat: {},
             blockFormat: {},
+            scaleFormat: {},
             isInSelection: false,
             tableSelection: {
                 table: mockTable,
@@ -160,6 +158,7 @@ describe('createDomToModelContext', () => {
             ...editorContext,
             segmentFormat: {},
             blockFormat: {},
+            scaleFormat: {},
             link: {
                 format: {},
                 dataset: {},
@@ -180,8 +179,6 @@ describe('createDomToModelContext', () => {
         const context = createDomToModelContext(
             {
                 isDarkMode: true,
-                zoomScale: 2,
-                isRightToLeft: true,
                 getDarkColor,
             },
             {
@@ -195,13 +192,10 @@ describe('createDomToModelContext', () => {
 
         expect(context).toEqual({
             isDarkMode: true,
-            zoomScale: 2,
-            isRightToLeft: true,
             getDarkColor: getDarkColor,
             isInSelection: false,
-            blockFormat: {
-                direction: 'rtl',
-            },
+            blockFormat: {},
+            scaleFormat: {},
             segmentFormat: {},
             listFormat,
             link: {
@@ -218,8 +212,6 @@ describe('createDomToModelContext', () => {
         const context = createDomToModelContext(
             {
                 isDarkMode: true,
-                zoomScale: 2,
-                isRightToLeft: true,
                 getDarkColor,
             },
             {
@@ -235,13 +227,10 @@ describe('createDomToModelContext', () => {
 
         expect(context).toEqual({
             isDarkMode: true,
-            zoomScale: 2,
-            isRightToLeft: true,
             getDarkColor: getDarkColor,
             isInSelection: false,
-            blockFormat: {
-                direction: 'rtl',
-            },
+            blockFormat: {},
+            scaleFormat: {},
             segmentFormat: {},
             link: {
                 format: {},

--- a/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
@@ -11,8 +11,6 @@ import {
 describe('createModelToDomContext', () => {
     const editorContext: EditorContext = {
         isDarkMode: false,
-        zoomScale: 1,
-        isRightToLeft: false,
         getDarkColor: undefined,
     };
     const defaultResult: ModelToDomContext = {
@@ -44,8 +42,6 @@ describe('createModelToDomContext', () => {
     it('with content model context', () => {
         const editorContext: EditorContext = {
             isDarkMode: true,
-            zoomScale: 2,
-            isRightToLeft: true,
             getDarkColor: () => '',
         };
 

--- a/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
@@ -34,7 +34,6 @@ describe('createModelToDomContext', () => {
         entities: {},
         defaultModelHandlers: defaultContentModelHandlers,
         defaultFormatAppliers: defaultFormatAppliers,
-        doNotReuseEntityDom: false,
     };
     it('no param', () => {
         const context = createModelToDomContext();
@@ -59,13 +58,11 @@ describe('createModelToDomContext', () => {
     });
 
     it('with overrides', () => {
-        const mockedMergingCallback = 'mergingCallback' as any;
         const mockedBoldApplier = 'bold' as any;
         const mockedBlockApplier = 'block' as any;
         const mockedBrHandler = 'br' as any;
         const mockedAStyle = 'a' as any;
         const context = createModelToDomContext(undefined, {
-            mergingCallback: mockedMergingCallback,
             formatApplierOverride: {
                 bold: mockedBoldApplier,
             },

--- a/packages/roosterjs-content-model/test/domToModel/processors/tableProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/tableProcessorTest.ts
@@ -318,7 +318,7 @@ describe('tableProcessor with format', () => {
         } as any) as HTMLTableElement;
 
         const doc = createContentModelDocument();
-        context.zoomScale = 2;
+        context.scaleFormat.scale = 2;
 
         tableProcessor(doc, mockedTable, context);
 

--- a/packages/roosterjs-content-model/test/formatHandlers/block/directionFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/block/directionFormatHandlerTest.ts
@@ -87,7 +87,7 @@ describe('directionFormatHandler.parse', () => {
     });
 
     it('RTL', () => {
-        context.isRightToLeft = true;
+        context.blockFormat.direction = 'rtl';
 
         runTest('left', null, 'rtl', null, 'end', 'rtl', undefined);
         runTest('center', null, 'rtl', null, 'center', 'rtl', undefined);

--- a/packages/roosterjs-content-model/test/publicApi/format/getFormatStateTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/format/getFormatStateTest.ts
@@ -33,7 +33,7 @@ describe('getFormatState', () => {
             isDarkMode: () => false,
             getZoomScale: () => 1,
             getPendingFormat: () => pendingFormat,
-            createContentModel: (root: Node, options: DomToModelOption) => {
+            createContentModel: (options: DomToModelOption) => {
                 const model = createContentModelDocument();
                 const editorDiv = document.createElement('div');
 

--- a/packages/roosterjs-content-model/test/publicApi/format/getSegmentFormatTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/format/getSegmentFormatTest.ts
@@ -27,7 +27,7 @@ describe('getSegmentFormat', () => {
             isDarkMode: () => false,
             getZoomScale: () => 1,
             getPendingFormat: () => pendingFormat,
-            createContentModel: (root: Node, options: DomToModelOption) => {
+            createContentModel: (options: DomToModelOption) => {
                 const model = createContentModelDocument();
                 const editorDiv = document.createElement('div');
 

--- a/packages/roosterjs-content-model/test/publicApi/segment/changeFontSizeTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/segment/changeFontSizeTest.ts
@@ -294,7 +294,7 @@ describe('changeFontSize', () => {
         div.style.fontSize = '20pt';
 
         const editor = ({
-            createContentModel: (startNode: any, option: any) =>
+            createContentModel: (option: any) =>
                 domToContentModel(div, null!, {
                     selectionRange: {
                         type: SelectionRangeTypes.Normal,


### PR DESCRIPTION
Some methods and parameters were added before but not used any more, so let's remove them:

- ModelToDomEntityContext.doNotReuseEntityDom
- ModelToDomOption.mergingCallback
- ModelToDomOption.doNotReuseEntityDom
- IExperimentalContentModelEditor.createEditorContext
- IExperimentalContentModelEditor.createContentModel: parameter rootNode
