### PR TITLE
Fix list trigger before a paragraph

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -479,7 +479,7 @@ function shouldTriggerList(
     const traverser = editor.getBlockTraverser();
     const text =
         traverser && traverser.currentBlockElement
-            ? traverser.currentBlockElement.getTextContent()
+            ? traverser.currentBlockElement.getTextContent().slice(0, textBeforeCursor.length)
             : null;
     const isATheBeginning = text && text === textBeforeCursor;
     const listChains = getListChains(editor);


### PR DESCRIPTION
If a trigger character is added at the beginning of the sentence, trigger the list. 
This change should verify if the 4 first characters of a text is equal to a trigger character.  
![fixListTrigger](https://user-images.githubusercontent.com/87443959/215562881-82b97ef1-21ca-4e11-81d4-3bef71d25ecb.gif)
