### PR TITLE
Content Model: Fix table format

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/reducedModelChildProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/reducedModelChildProcessor.ts
@@ -1,4 +1,4 @@
-import { contains } from 'roosterjs-editor-dom';
+import { contains, getTagOfNode } from 'roosterjs-editor-dom';
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
 import { DomToModelContext } from '../../publicTypes/context/DomToModelContext';
 import { getRegularSelectionOffsets } from '../utils/getRegularSelectionOffsets';
@@ -61,7 +61,14 @@ function createNodeStack(root: Node, startNode: Node): Node[] {
     let node: Node | null = startNode;
 
     while (node && contains(root, node)) {
-        result.push(node);
+        if (getTagOfNode(node) == 'TABLE') {
+            // For table, we can't do a reduced model creation since we need to handle their cells and indexes,
+            // so clean up whatever we already have, and just put table into the stack
+            result.splice(0, result.length, node);
+        } else {
+            result.push(node);
+        }
+
         node = node.parentNode;
     }
 

--- a/packages/roosterjs-content-model/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/retrieveModelFormatState.ts
@@ -19,11 +19,15 @@ export function retrieveModelFormatState(
     formatState: FormatState
 ) {
     let isFirst = true;
-    let previousTableContext: TableSelectionContext | undefined;
+    let firstTableContext: TableSelectionContext | undefined;
 
     iterateSelections(
         [model],
         (path, tableContext, block, segments) => {
+            if (tableContext && !firstTableContext) {
+                firstTableContext = tableContext;
+            }
+
             if (isFirst) {
                 if (block?.blockType == 'Paragraph' && segments?.[0]) {
                     retrieveFormatStateInternal(
@@ -36,14 +40,13 @@ export function retrieveModelFormatState(
                     );
                 } else if (tableContext) {
                     retrieveTableFormat(tableContext, formatState);
-                    previousTableContext = tableContext;
                 }
                 isFirst = false;
             } else {
                 formatState.isMultilineSelection = true;
 
-                if (tableContext && previousTableContext) {
-                    const { table, colIndex, rowIndex } = previousTableContext;
+                if (tableContext && firstTableContext) {
+                    const { table, colIndex, rowIndex } = firstTableContext;
 
                     if (
                         tableContext.table == table &&
@@ -52,9 +55,6 @@ export function retrieveModelFormatState(
                         formatState.canMergeTableCell = true;
                     }
                 }
-
-                // Return true to stop iteration since we have already got everything we need
-                return true;
             }
         },
         {

--- a/packages/roosterjs-content-model/test/domToModel/processors/reducedModelChildProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/reducedModelChildProcessorTest.ts
@@ -202,4 +202,75 @@ describe('reducedModelChildProcessor', () => {
             ],
         });
     });
+
+    it('With table, need to do format for all table cells', () => {
+        const doc = createContentModelDocument();
+        const div = document.createElement('div');
+        div.innerHTML =
+            'aa<table><tr><td>test1</td><td><span id="selection">test2</span></td></tr></table>bb';
+        context.selectionRootNode = div.querySelector('#selection') as HTMLElement;
+
+        reducedModelChildProcessor(doc, div, context);
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Table',
+                    cells: [
+                        [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [
+                                    {
+                                        blockType: 'Paragraph',
+                                        segments: [
+                                            {
+                                                segmentType: 'Text',
+                                                text: 'test1',
+                                                format: {},
+                                            },
+                                        ],
+                                        format: {},
+                                        isImplicit: true,
+                                    },
+                                ],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [
+                                    {
+                                        blockType: 'Paragraph',
+                                        segments: [
+                                            {
+                                                segmentType: 'Text',
+                                                text: 'test2',
+                                                format: {},
+                                            },
+                                        ],
+                                        format: {},
+                                        isImplicit: true,
+                                    },
+                                ],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    ],
+                    format: {},
+                    widths: [],
+                    heights: [],
+                    dataset: {},
+                },
+            ],
+        });
+    });
 });

--- a/packages/roosterjs-content-model/test/modelApi/common/retrieveModelFormatStateTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/retrieveModelFormatStateTest.ts
@@ -1,4 +1,5 @@
 import * as iterateSelections from '../../../lib/modelApi/selection/iterateSelections';
+import { addSegment } from '../../../lib/modelApi/common/addSegment';
 import { applyTableFormat } from '../../../lib/modelApi/table/applyTableFormat';
 import { ContentModelSegmentFormat } from '../../../lib/publicTypes/format/ContentModelSegmentFormat';
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
@@ -9,6 +10,7 @@ import { createQuote } from '../../../lib/modelApi/creators/createQuote';
 import { createSelectionMarker } from '../../../lib/modelApi/creators/createSelectionMarker';
 import { createTable } from '../../../lib/modelApi/creators/createTable';
 import { createTableCell } from '../../../lib/modelApi/creators/createTableCell';
+import { createText } from '../../../lib/modelApi/creators/createText';
 import { FormatState } from 'roosterjs-editor-types';
 import { retrieveModelFormatState } from '../../../lib/modelApi/common/retrieveModelFormatState';
 
@@ -370,6 +372,74 @@ describe('retrieveModelFormatState', () => {
             tableHasHeader: false,
             isMultilineSelection: true,
             canMergeTableCell: true,
+        });
+    });
+
+    it('With multiple table cell selected, multiple content is in table cell', () => {
+        const model = createContentModelDocument();
+        const result: FormatState = {};
+        const cell1 = createTableCell();
+        const cell2 = createTableCell();
+        const cell3 = createTableCell();
+        const table = createTable(1);
+
+        const text1 = createText('text1');
+        const text2 = createText('text2');
+        const text3 = createText('text3');
+        const text4 = createText('text4');
+
+        cell2.isSelected = true;
+        cell3.isSelected = true;
+
+        addSegment(cell2, text1);
+        addSegment(cell2, text2);
+        addSegment(cell3, text3);
+        addSegment(cell3, text4);
+
+        table.cells[0] = [cell1, cell2, cell3];
+        model.blocks.push(table);
+
+        retrieveModelFormatState(model, null, result);
+
+        expect(result).toEqual({
+            isInTable: true,
+            tableHasHeader: false,
+            isMultilineSelection: true,
+            canMergeTableCell: true,
+        });
+    });
+
+    it('With selection marker under table cell', () => {
+        const model = createContentModelDocument();
+        const result: FormatState = {};
+        const cell1 = createTableCell();
+        const cell2 = createTableCell();
+        const cell3 = createTableCell();
+        const table = createTable(1);
+
+        const marker = createSelectionMarker();
+        addSegment(cell2, marker);
+
+        table.cells[0] = [cell1, cell2, cell3];
+        model.blocks.push(table);
+
+        retrieveModelFormatState(model, null, result);
+
+        expect(result).toEqual({
+            isBold: false,
+            isSuperscript: false,
+            isSubscript: false,
+            canUnlink: false,
+            canAddImageAltText: false,
+            isInTable: true,
+            tableHasHeader: false,
+            fontName: undefined,
+            fontSize: undefined,
+            backgroundColor: undefined,
+            textColor: undefined,
+            isItalic: undefined,
+            isUnderline: undefined,
+            isStrikeThrough: undefined,
         });
     });
 });


### PR DESCRIPTION
Bug: when there is segment under a selected table cell, existing code can't retrieve table format info correctly.
1. We always need to remember the first table context when retrieve format, so that we can compare the selected table cell index later
2. When compare table cell index, if current table cell index is the same with previous one, we need to keep running because there may be more selections in other table cell, so we can't stop the loop.

This causes the result of "canMergeTableCell" in FormatState may not be accurate.

Fix dev code and add test case as well.