### PR TITLE
Content Model code simplify 1: Remove unused methods and parameters

### DIFF
--- a/demo/scripts/controls/editor/ExperimentalContentModelEditor.ts
+++ b/demo/scripts/controls/editor/ExperimentalContentModelEditor.ts
@@ -39,7 +39,7 @@ export default class ExperimentalContentModelEditor extends Editor
     /**
      * Create a EditorContext object used by ContentModel API
      */
-    createEditorContext(): EditorContext {
+    private createEditorContext(): EditorContext {
         return {
             isDarkMode: this.isDarkMode(),
             zoomScale: this.getZoomScale(),
@@ -51,13 +51,10 @@ export default class ExperimentalContentModelEditor extends Editor
 
     /**
      * Create Content Model from DOM tree in this editor
-     * @param startNode Optional start node. If provided, Content Model will be created from this node (including itself),
-     * otherwise it will create Content Model for the whole content in editor.
      * @param option The option to customize the behavior of DOM to Content Model conversion
      */
-    createContentModel(startNode?: HTMLElement, option?: DomToModelOption): ContentModelDocument {
-        return domToContentModel(startNode || this.contentDiv, this.createEditorContext(), {
-            includeRoot: !!startNode,
+    createContentModel(option?: DomToModelOption): ContentModelDocument {
+        return domToContentModel(this.contentDiv, this.createEditorContext(), {
             selectionRange: this.getSelectionRangeEx(),
             alwaysNormalizeTable: true,
             ...(option || {}),
@@ -67,7 +64,6 @@ export default class ExperimentalContentModelEditor extends Editor
     /**
      * Set content with content model
      * @param model The content model to set
-     * @param mergingCallback A callback to indicate how should the new content be integrated into existing content
      * @param option Additional options to customize the behavior of Content Model to DOM conversion
      */
     setContentModel(model: ContentModelDocument, option?: ModelToDomOption) {
@@ -77,17 +73,16 @@ export default class ExperimentalContentModelEditor extends Editor
             this.createEditorContext(),
             option
         );
-        const mergingCallback = option?.mergingCallback || restoreContentWithEntityPlaceholder;
 
         if (range?.type == SelectionRangeTypes.Normal) {
             // Need to get start and end from range position before merge because range can be changed during merging
             const start = Position.getStart(range.ranges[0]);
             const end = Position.getEnd(range.ranges[0]);
 
-            mergingCallback(fragment, this.contentDiv, entityPairs);
+            restoreContentWithEntityPlaceholder(fragment, this.contentDiv, entityPairs);
             this.select(start, end);
         } else {
-            mergingCallback(fragment, this.contentDiv, entityPairs);
+            restoreContentWithEntityPlaceholder(fragment, this.contentDiv, entityPairs);
             this.select(range);
         }
     }

--- a/demo/scripts/controls/editor/isContentModelEditor.ts
+++ b/demo/scripts/controls/editor/isContentModelEditor.ts
@@ -6,5 +6,5 @@ export default function isContentModelEditor(
 ): editor is IExperimentalContentModelEditor {
     const experimentalEditor = editor as IExperimentalContentModelEditor;
 
-    return !!experimentalEditor.createEditorContext && 'contentDiv' in experimentalEditor;
+    return !!experimentalEditor.createContentModel && 'contentDiv' in experimentalEditor;
 }

--- a/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
@@ -51,6 +51,5 @@ export function createModelToDomContext(
 
         defaultModelHandlers: defaultContentModelHandlers,
         defaultFormatAppliers: defaultFormatAppliers,
-        doNotReuseEntityDom: !!options?.doNotReuseEntityDom,
     };
 }

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
@@ -38,7 +38,7 @@ export const handleEntity: ContentModelHandler<ContentModelEntity> = (
         parent = span;
     }
 
-    if (context.doNotReuseEntityDom || !entity) {
+    if (!entity) {
         parent.appendChild(wrapper);
     } else {
         // Create a comment as placeholder and insert into DOM tree.

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -14,7 +14,7 @@ export function formatWithContentModel(
     callback: (model: ContentModelDocument) => boolean,
     domToModelOptions?: DomToModelOption
 ) {
-    const model = editor.createContentModel(undefined /*rootNode*/, domToModelOptions);
+    const model = editor.createContentModel(domToModelOptions);
 
     if (callback(model)) {
         editor.addUndoSnapshot(

--- a/packages/roosterjs-content-model/lib/publicTypes/IExperimentalContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/IExperimentalContentModelEditor.ts
@@ -1,6 +1,5 @@
 import { ContentModelDocument } from './group/ContentModelDocument';
 import { ContentModelSegmentFormat } from './format/ContentModelSegmentFormat';
-import { EditorContext } from './context/EditorContext';
 import { IEditor, SelectionRangeEx } from 'roosterjs-editor-types';
 import {
     ContentModelHandlerMap,
@@ -62,23 +61,6 @@ export interface DomToModelOption {
  */
 export interface ModelToDomOption {
     /**
-     * A callback to specify how to merge DOM tree generated from Content Model in to existing container
-     * @param source Source document fragment that is generated from Content Model
-     * @param target Target container, usually to be editor root container
-     * @param entities An array of entity wrapper - placeholder pairs, used for reuse existing DOM structure for entity
-     */
-    mergingCallback?: (
-        source: DocumentFragment,
-        target: HTMLElement,
-        entities: Record<string, HTMLElement>
-    ) => void;
-
-    /**
-     * When set to true, directly put entity DOM nodes into the result DOM tree when doing Content Model to DOM conversion and do not use placeholder
-     */
-    doNotReuseEntityDom?: boolean;
-
-    /**
      * Overrides default format appliers
      */
     formatApplierOverride?: Partial<FormatAppliers>;
@@ -106,17 +88,12 @@ export interface ModelToDomOption {
  */
 export interface IExperimentalContentModelEditor extends IEditor {
     /**
-     * Create a EditorContext object used by ContentModel API
-     */
-    createEditorContext(): EditorContext;
-
-    /**
      * Create Content Model from DOM tree in this editor
      * @param rootNode Optional start node. If provided, Content Model will be created from this node (including itself),
      * otherwise it will create Content Model for the whole content in editor.
      * @param option The options to customize the behavior of DOM to Content Model conversion
      */
-    createContentModel(rootNode?: HTMLElement, option?: DomToModelOption): ContentModelDocument;
+    createContentModel(option?: DomToModelOption): ContentModelDocument;
 
     /**
      * Set content with content model

--- a/packages/roosterjs-content-model/lib/publicTypes/context/ModelToDomEntityContext.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/ModelToDomEntityContext.ts
@@ -3,11 +3,6 @@
  */
 export interface ModelToDomEntityContext {
     /**
-     * When set to true, directly put entity DOM nodes into the result DOM tree when doing Content Model to DOM conversion and do not use placeholder
-     */
-    doNotReuseEntityDom: boolean;
-
-    /**
      * Entities collected during DOM tree generation, used for reusing existing DOM structure of entities
      */
     entities: Record<string, HTMLElement>;

--- a/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
@@ -34,7 +34,6 @@ describe('createModelToDomContext', () => {
         entities: {},
         defaultModelHandlers: defaultContentModelHandlers,
         defaultFormatAppliers: defaultFormatAppliers,
-        doNotReuseEntityDom: false,
     };
     it('no param', () => {
         const context = createModelToDomContext();
@@ -59,13 +58,11 @@ describe('createModelToDomContext', () => {
     });
 
     it('with overrides', () => {
-        const mockedMergingCallback = 'mergingCallback' as any;
         const mockedBoldApplier = 'bold' as any;
         const mockedBlockApplier = 'block' as any;
         const mockedBrHandler = 'br' as any;
         const mockedAStyle = 'a' as any;
         const context = createModelToDomContext(undefined, {
-            mergingCallback: mockedMergingCallback,
             formatApplierOverride: {
                 bold: mockedBoldApplier,
             },

--- a/packages/roosterjs-content-model/test/publicApi/format/getFormatStateTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/format/getFormatStateTest.ts
@@ -33,7 +33,7 @@ describe('getFormatState', () => {
             isDarkMode: () => false,
             getZoomScale: () => 1,
             getPendingFormat: () => pendingFormat,
-            createContentModel: (root: Node, options: DomToModelOption) => {
+            createContentModel: (options: DomToModelOption) => {
                 const model = createContentModelDocument();
                 const editorDiv = document.createElement('div');
 

--- a/packages/roosterjs-content-model/test/publicApi/format/getSegmentFormatTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/format/getSegmentFormatTest.ts
@@ -27,7 +27,7 @@ describe('getSegmentFormat', () => {
             isDarkMode: () => false,
             getZoomScale: () => 1,
             getPendingFormat: () => pendingFormat,
-            createContentModel: (root: Node, options: DomToModelOption) => {
+            createContentModel: (options: DomToModelOption) => {
                 const model = createContentModelDocument();
                 const editorDiv = document.createElement('div');
 

--- a/packages/roosterjs-content-model/test/publicApi/segment/changeFontSizeTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/segment/changeFontSizeTest.ts
@@ -294,7 +294,7 @@ describe('changeFontSize', () => {
         div.style.fontSize = '20pt';
 
         const editor = ({
-            createContentModel: (startNode: any, option: any) =>
+            createContentModel: (option: any) =>
                 domToContentModel(div, null!, {
                     selectionRange: {
                         type: SelectionRangeTypes.Normal,


### PR DESCRIPTION
Some methods and parameters were added before but not used any more, so let's remove them:

- ModelToDomEntityContext.doNotReuseEntityDom
- ModelToDomOption.mergingCallback
- ModelToDomOption.doNotReuseEntityDom
- IExperimentalContentModelEditor.createEditorContext
- IExperimentalContentModelEditor.createContentModel: parameter rootNode