### PR TITLE
Add data to the ContentChanged event after inserting in PickerPlugin

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
@@ -104,12 +104,18 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                         this.editor.insertNode(htmlNode);
                     }
                     this.setIsSuggesting(false);
+
+                    return {
+                        wordToReplace,
+                        htmlNode,
+                    };
                 };
 
                 this.editor.addUndoSnapshot(
                     insertNode,
                     this.pickerOptions.changeSource,
-                    this.pickerOptions.handleAutoComplete
+                    this.pickerOptions.handleAutoComplete,
+                    {}
                 );
             },
             (isSuggesting: boolean) => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
@@ -114,8 +114,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                 this.editor.addUndoSnapshot(
                     insertNode,
                     this.pickerOptions.changeSource,
-                    this.pickerOptions.handleAutoComplete,
-                    {}
+                    this.pickerOptions.handleAutoComplete
                 );
             },
             (isSuggesting: boolean) => {


### PR DESCRIPTION
Add HTMLNode and the Word replaced on when triggering the content changed event in the PickerPlugin, so we use that data on the changed event event in other plugins 