### PR TITLE
Content Model: Fix image size for outlook

### DIFF
--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleImage.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleImage.ts
@@ -57,7 +57,7 @@ export const handleImage: ContentModelHandler<ContentModelImage> = (
 
         const { width, height } = imageModel.format;
         const widthNum = width ? parseValueWithUnit(width) : 0;
-        const heightNum = height ? parseFloat(height) : 0;
+        const heightNum = height ? parseValueWithUnit(height) : 0;
 
         if (widthNum > 0) {
             img.width = widthNum;

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleImage.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleImage.ts
@@ -2,7 +2,7 @@ import { applyFormat } from '../utils/applyFormat';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
 import { ContentModelImage } from '../../publicTypes/segment/ContentModelImage';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
-import { parseValueWithUnit } from 'roosterjs-content-model/lib/formatHandlers/utils/parseValueWithUnit';
+import { parseValueWithUnit } from '../../formatHandlers/utils/parseValueWithUnit';
 import { stackFormat } from '../utils/stackFormat';
 
 /**

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleImage.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleImage.ts
@@ -2,6 +2,7 @@ import { applyFormat } from '../utils/applyFormat';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
 import { ContentModelImage } from '../../publicTypes/segment/ContentModelImage';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+import { parseValueWithUnit } from 'roosterjs-content-model/lib/formatHandlers/utils/parseValueWithUnit';
 import { stackFormat } from '../utils/stackFormat';
 
 /**
@@ -53,6 +54,18 @@ export const handleImage: ContentModelHandler<ContentModelImage> = (
         applyFormat(img, context.formatAppliers.image, imageModel.format, context);
         applyFormat(segmentElement, context.formatAppliers.segment, imageModel.format, context);
         applyFormat(img, context.formatAppliers.dataset, imageModel.dataset, context);
+
+        const { width, height } = imageModel.format;
+        const widthNum = width ? parseValueWithUnit(width) : 0;
+        const heightNum = height ? parseFloat(height) : 0;
+
+        if (widthNum > 0) {
+            img.width = widthNum;
+        }
+
+        if (heightNum > 0) {
+            img.height = heightNum;
+        }
     });
 
     context.regularSelection.current.segment = img;

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleImageTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleImageTest.ts
@@ -85,6 +85,22 @@ describe('handleSegment', () => {
         runTest(segment, '<a href="/test"><img src="http://test.com/test"></a>', 0);
     });
 
+    it('image segment with size', () => {
+        const segment: ContentModelImage = {
+            segmentType: 'Image',
+            src: 'http://test.com/test',
+            format: { underline: true, width: '100px', height: '200px' },
+            link: { format: { href: '/test' }, dataset: {} },
+            dataset: {},
+        };
+
+        runTest(
+            segment,
+            '<a href="/test"><img src="http://test.com/test" width="100" height="200" style="width: 100px; height: 200px;"></a>',
+            0
+        );
+    });
+
     it('image segment with dataset', () => {
         const segment: ContentModelImage = {
             segmentType: 'Image',

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleImageTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleImageTest.ts
@@ -4,6 +4,7 @@ import { ContentModelHandler } from '../../../lib/publicTypes/context/ContentMod
 import { ContentModelImage } from '../../../lib/publicTypes/segment/ContentModelImage';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { handleImage } from '../../../lib/modelToDom/handlers/handleImage';
+import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
 import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
 
 describe('handleSegment', () => {
@@ -85,7 +86,7 @@ describe('handleSegment', () => {
         runTest(segment, '<a href="/test"><img src="http://test.com/test"></a>', 0);
     });
 
-    it('image segment with size', () => {
+    itChromeOnly('image segment with size', () => {
         const segment: ContentModelImage = {
             segmentType: 'Image',
             src: 'http://test.com/test',


### PR DESCRIPTION
Outlook can't show resized image correctly if it doesn't have "width" and "height" property. So we need to add them when regenerate content from Content Model.