### PR TITLE
Content Model: Support align table to center

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/quoteProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/quoteProcessor.ts
@@ -16,11 +16,11 @@ export const quoteProcessor: ElementProcessor<HTMLQuoteElement> = (group, elemen
         stackFormat(
             context,
             {
-                paragraph: 'empty',
+                paragraph: 'shallowCopyInherit',
                 segment: 'shallowCloneForBlock',
             },
             () => {
-                const quoteFormat: ContentModelBlockFormat = {};
+                const quoteFormat: ContentModelBlockFormat = { ...context.blockFormat };
                 const segmentFormat: ContentModelSegmentFormat = {};
 
                 parseFormat(element, context.formatParsers.block, quoteFormat, context);

--- a/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts
@@ -26,118 +26,126 @@ export const tableProcessor: ElementProcessor<HTMLTableElement> = (
     tableElement,
     context
 ) => {
-    const table = createTable(tableElement.rows.length);
-    const { table: selectedTable, firstCell, lastCell } = context.tableSelection || {};
-    const hasTableSelection = selectedTable == tableElement && !!firstCell && !!lastCell;
+    stackFormat(
+        context,
+        { segment: 'shallowCloneForBlock', paragraph: 'shallowCopyInherit' },
+        () => {
+            const table = createTable(tableElement.rows.length, context.blockFormat);
+            const { table: selectedTable, firstCell, lastCell } = context.tableSelection || {};
+            const hasTableSelection = selectedTable == tableElement && !!firstCell && !!lastCell;
 
-    stackFormat(context, { segment: 'shallowCloneForBlock', paragraph: 'empty' }, () => {
-        parseFormat(tableElement, context.formatParsers.table, table.format, context);
-        parseFormat(
-            tableElement,
-            context.formatParsers.segmentOnBlock,
-            context.segmentFormat,
-            context
-        );
-        parseFormat(tableElement, context.formatParsers.dataset, table.dataset, context);
-        addBlock(group, table);
+            parseFormat(tableElement, context.formatParsers.table, table.format, context);
+            parseFormat(
+                tableElement,
+                context.formatParsers.segmentOnBlock,
+                context.segmentFormat,
+                context
+            );
+            parseFormat(tableElement, context.formatParsers.dataset, table.dataset, context);
+            addBlock(group, table);
 
-        const columnPositions: number[] = [0];
-        const rowPositions: number[] = [0];
-        const zoomScale = context.zoomScaleFormat.zoomScale || 1;
+            const columnPositions: number[] = [0];
+            const rowPositions: number[] = [0];
+            const zoomScale = context.zoomScaleFormat.zoomScale || 1;
 
-        for (let row = 0; row < tableElement.rows.length; row++) {
-            const tr = tableElement.rows[row];
-            for (let sourceCol = 0, targetCol = 0; sourceCol < tr.cells.length; sourceCol++) {
-                for (; table.cells[row][targetCol]; targetCol++) {}
+            for (let row = 0; row < tableElement.rows.length; row++) {
+                const tr = tableElement.rows[row];
+                for (let sourceCol = 0, targetCol = 0; sourceCol < tr.cells.length; sourceCol++) {
+                    for (; table.cells[row][targetCol]; targetCol++) {}
 
-                const td = tr.cells[sourceCol];
-                const hasSelectionBeforeCell = context.isInSelection;
-                const colEnd = targetCol + td.colSpan;
-                const rowEnd = row + td.rowSpan;
-                const needCalcWidth = columnPositions[colEnd] === undefined;
-                const needCalcHeight = rowPositions[rowEnd] === undefined;
+                    const td = tr.cells[sourceCol];
+                    const hasSelectionBeforeCell = context.isInSelection;
+                    const colEnd = targetCol + td.colSpan;
+                    const rowEnd = row + td.rowSpan;
+                    const needCalcWidth = columnPositions[colEnd] === undefined;
+                    const needCalcHeight = rowPositions[rowEnd] === undefined;
 
-                if (needCalcWidth || needCalcHeight) {
-                    const rect = getBoundingClientRect(td);
+                    if (needCalcWidth || needCalcHeight) {
+                        const rect = getBoundingClientRect(td);
 
-                    if (rect.width > 0 || rect.height > 0) {
-                        if (needCalcWidth) {
-                            columnPositions[colEnd] =
-                                columnPositions[targetCol] + rect.width / zoomScale;
-                        }
+                        if (rect.width > 0 || rect.height > 0) {
+                            if (needCalcWidth) {
+                                columnPositions[colEnd] =
+                                    columnPositions[targetCol] + rect.width / zoomScale;
+                            }
 
-                        if (needCalcHeight) {
-                            rowPositions[rowEnd] = rowPositions[row] + rect.height / zoomScale;
+                            if (needCalcHeight) {
+                                rowPositions[rowEnd] = rowPositions[row] + rect.height / zoomScale;
+                            }
                         }
                     }
-                }
 
-                for (let colSpan = 1; colSpan <= td.colSpan; colSpan++, targetCol++) {
-                    for (let rowSpan = 1; rowSpan <= td.rowSpan; rowSpan++) {
-                        const hasTd = colSpan == 1 && rowSpan == 1;
-                        const cell = createTableCell(colSpan > 1, rowSpan > 1, td.tagName == 'TH');
+                    for (let colSpan = 1; colSpan <= td.colSpan; colSpan++, targetCol++) {
+                        for (let rowSpan = 1; rowSpan <= td.rowSpan; rowSpan++) {
+                            const hasTd = colSpan == 1 && rowSpan == 1;
+                            const cell = createTableCell(
+                                colSpan > 1,
+                                rowSpan > 1,
+                                td.tagName == 'TH'
+                            );
 
-                        table.cells[row + rowSpan - 1][targetCol] = cell;
+                            table.cells[row + rowSpan - 1][targetCol] = cell;
 
-                        if (hasTd) {
-                            stackFormat(context, { segment: 'shallowClone' }, () => {
-                                parseFormat(
-                                    td,
-                                    context.formatParsers.tableCell,
-                                    cell.format,
-                                    context
-                                );
-                                parseFormat(
-                                    td,
-                                    context.formatParsers.segmentOnTableCell,
-                                    context.segmentFormat,
-                                    context
-                                );
-                                parseFormat(
-                                    td,
-                                    context.formatParsers.dataset,
-                                    cell.dataset,
-                                    context
-                                );
+                            if (hasTd) {
+                                stackFormat(context, { segment: 'shallowClone' }, () => {
+                                    parseFormat(
+                                        td,
+                                        context.formatParsers.tableCell,
+                                        cell.format,
+                                        context
+                                    );
+                                    parseFormat(
+                                        td,
+                                        context.formatParsers.segmentOnTableCell,
+                                        context.segmentFormat,
+                                        context
+                                    );
+                                    parseFormat(
+                                        td,
+                                        context.formatParsers.dataset,
+                                        cell.dataset,
+                                        context
+                                    );
 
-                                const { listParent, levels } = context.listFormat;
+                                    const { listParent, levels } = context.listFormat;
 
-                                context.listFormat.listParent = undefined;
-                                context.listFormat.levels = [];
+                                    context.listFormat.listParent = undefined;
+                                    context.listFormat.levels = [];
 
-                                try {
-                                    context.elementProcessors.child(cell, td, context);
-                                } finally {
-                                    context.listFormat.listParent = listParent;
-                                    context.listFormat.levels = levels;
-                                }
-                            });
-                        }
+                                    try {
+                                        context.elementProcessors.child(cell, td, context);
+                                    } finally {
+                                        context.listFormat.listParent = listParent;
+                                        context.listFormat.levels = levels;
+                                    }
+                                });
+                            }
 
-                        const hasSelectionAfterCell = context.isInSelection;
+                            const hasSelectionAfterCell = context.isInSelection;
 
-                        if (
-                            (hasSelectionBeforeCell && hasSelectionAfterCell) ||
-                            (hasTableSelection &&
-                                row >= firstCell.y &&
-                                row <= lastCell.y &&
-                                targetCol >= firstCell.x &&
-                                targetCol <= lastCell.x)
-                        ) {
-                            cell.isSelected = true;
+                            if (
+                                (hasSelectionBeforeCell && hasSelectionAfterCell) ||
+                                (hasTableSelection &&
+                                    row >= firstCell.y &&
+                                    row <= lastCell.y &&
+                                    targetCol >= firstCell.x &&
+                                    targetCol <= lastCell.x)
+                            ) {
+                                cell.isSelected = true;
+                            }
                         }
                     }
                 }
             }
-        }
 
-        table.widths = calcSizes(columnPositions);
-        table.heights = calcSizes(rowPositions);
+            table.widths = calcSizes(columnPositions);
+            table.heights = calcSizes(rowPositions);
 
-        if (context.alwaysNormalizeTable) {
-            normalizeTable(table);
+            if (context.alwaysNormalizeTable) {
+                normalizeTable(table);
+            }
         }
-    });
+    );
 };
 
 function calcSizes(positions: number[]): number[] {

--- a/packages/roosterjs-content-model/lib/modelApi/creators/createTable.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/creators/createTable.ts
@@ -1,10 +1,11 @@
+import { ContentModelBlockFormat } from '../../publicTypes/format/ContentModelBlockFormat';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { ContentModelTableCell } from '../../publicTypes/group/ContentModelTableCell';
 
 /**
  * @internal
  */
-export function createTable(rowCount: number): ContentModelTable {
+export function createTable(rowCount: number, format?: ContentModelBlockFormat): ContentModelTable {
     const rows: ContentModelTableCell[][] = [];
 
     for (let i = 0; i < rowCount; i++) {
@@ -14,7 +15,7 @@ export function createTable(rowCount: number): ContentModelTable {
     return {
         blockType: 'Table',
         cells: rows,
-        format: {},
+        format: { ...(format || {}) },
         widths: [],
         heights: [],
         dataset: {},

--- a/packages/roosterjs-content-model/test/domToModel/processors/quoteProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/quoteProcessorTest.ts
@@ -241,7 +241,9 @@ describe('quoteProcessor', () => {
         const childProcessor = jasmine
             .createSpy('childProcessor')
             .and.callFake((group, element, context) => {
-                expect(context.blockFormat).toEqual({});
+                expect(context.blockFormat).toEqual({
+                    backgroundColor: 'red',
+                });
                 expect(context.segmentFormat).toEqual({
                     fontSize: '20px',
                 });
@@ -269,10 +271,57 @@ describe('quoteProcessor', () => {
                         marginBottom: '1em',
                         marginLeft: '40px',
                         borderLeft: '1px solid black',
+                        backgroundColor: 'red',
                     },
                     quoteSegmentFormat: {
                         textColor: 'blue',
                     },
+                },
+            ],
+        });
+
+        expect(childProcessor).toHaveBeenCalledTimes(1);
+    });
+
+    it('Verify inherited formats from context are correctly handled', () => {
+        const group = createContentModelDocument();
+        const quote = document.createElement('blockquote');
+        const childProcessor = jasmine.createSpy('childProcessor');
+
+        quote.style.borderLeft = 'solid 1px black';
+
+        context.blockFormat.backgroundColor = 'red';
+        context.blockFormat.textAlign = 'center';
+        context.blockFormat.isTextAlignFromAttr = true;
+        context.blockFormat.lineHeight = '2';
+        context.blockFormat.whiteSpace = 'pre';
+        context.blockFormat.direction = 'rtl';
+
+        context.elementProcessors.child = childProcessor;
+
+        quoteProcessor(group, quote, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'Quote',
+                    blocks: [],
+                    format: {
+                        marginTop: '1em',
+                        marginRight: '40px',
+                        marginBottom: '1em',
+                        marginLeft: '40px',
+                        borderLeft: '1px solid black',
+                        backgroundColor: 'red',
+                        textAlign: 'center',
+                        isTextAlignFromAttr: true,
+                        lineHeight: '2',
+                        whiteSpace: 'pre',
+                        direction: 'rtl',
+                    },
+                    quoteSegmentFormat: {},
                 },
             ],
         });

--- a/packages/roosterjs-content-model/test/domToModel/processors/tableProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/tableProcessorTest.ts
@@ -545,4 +545,45 @@ describe('tableProcessor', () => {
             ],
         });
     });
+
+    it('Check inherited format from context', () => {
+        const group = createContentModelDocument();
+        const mockedTable = ({
+            tagName: 'table',
+            rows: [],
+            style: {},
+            dataset: {},
+            getAttribute: () => '',
+        } as any) as HTMLTableElement;
+
+        context.blockFormat.backgroundColor = 'red';
+        context.blockFormat.textAlign = 'center';
+        context.blockFormat.isTextAlignFromAttr = true;
+        context.blockFormat.lineHeight = '2';
+        context.blockFormat.whiteSpace = 'pre';
+        context.blockFormat.direction = 'rtl';
+
+        tableProcessor(group, mockedTable, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Table',
+                    format: {
+                        backgroundColor: 'red',
+                        textAlign: 'center',
+                        isTextAlignFromAttr: true,
+                        lineHeight: '2',
+                        whiteSpace: 'pre',
+                        direction: 'rtl',
+                    },
+                    dataset: {},
+                    widths: [],
+                    heights: [],
+                    cells: [],
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
When align a table to center using a DIV around:
```html
<div align="center">
  <table><tr><td>test</td></tr></table>
</div>
```
Content Model need to remember those inheritable block formats such as textAlign when process table so that the table can be centered. Similarly for Quote.

In this PR we handle the following block formats to inherit them:
- BackgroundColorFormat
- DirectionFormat
- LineHeightFormat
- WhiteSpaceFormat

Known issue: Background color from outer DIV can't be correctly handled. We can handle it later when need.

Test HTML:

```html
<div align=center style="background-color:red;line-height:2;white-space:pre" dir=rtl><blockquote style="border-left: 3px solid rgb(200, 200, 200); border-top-color: rgb(200, 200, 200); border-right-color: rgb(200, 200, 200); border-bottom-color: rgb(200, 200, 200); padding-left: 10px; color: rgb(102, 102, 102);"><div><span>aaa
bbb</span></div></blockquote></div>

<div align=center style="background-color:red;line-height:2;white-space:pre" dir=rtl><table><tr><td>aaa
bbb</td/></tr></table></div>
```