### PR TITLE
Content Model: Fix PRE tag

### DIFF
--- a/packages/roosterjs-content-model/lib/formatHandlers/block/whiteSpaceFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/block/whiteSpaceFormatHandler.ts
@@ -13,7 +13,12 @@ export const whiteSpaceFormatHandler: FormatHandler<WhiteSpaceFormat> = {
         }
     },
     apply: (format, element) => {
-        if (format.whiteSpace) {
+        if (format.whiteSpace == 'pre') {
+            const pre = element.ownerDocument.createElement('pre');
+
+            element.parentNode?.appendChild(pre);
+            pre.appendChild(element);
+        } else if (format.whiteSpace) {
             element.style.whiteSpace = format.whiteSpace;
         }
     },

--- a/packages/roosterjs-content-model/test/formatHandlers/block/whiteSpaceFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/block/whiteSpaceFormatHandlerTest.ts
@@ -51,23 +51,33 @@ describe('whiteSpaceFormatHandler.parse', () => {
 
 describe('whiteSpaceFormatHandler.apply', () => {
     let div: HTMLElement;
+    let container: HTMLElement;
     let format: WhiteSpaceFormat;
     let context: ModelToDomContext;
 
     beforeEach(() => {
+        container = document.createElement('div');
         div = document.createElement('div');
+        container.appendChild(div);
+
         format = {};
         context = createModelToDomContext();
     });
 
     it('No white space', () => {
         whiteSpaceFormatHandler.apply(format, div, context);
-        expect(div.outerHTML).toBe('<div></div>');
+        expect(container.innerHTML).toBe('<div></div>');
     });
 
-    it('Has white space', () => {
+    it('Has white space: pre', () => {
         format.whiteSpace = 'pre';
         whiteSpaceFormatHandler.apply(format, div, context);
-        expect(div.outerHTML).toBe('<div style="white-space: pre;"></div>');
+        expect(container.innerHTML).toBe('<pre><div></div></pre>');
+    });
+
+    it('Has white space: pre-wrap', () => {
+        format.whiteSpace = 'pre-wrap';
+        whiteSpaceFormatHandler.apply(format, div, context);
+        expect(container.innerHTML).toBe('<div style="white-space: pre-wrap;"></div>');
     });
 });


### PR DESCRIPTION
I found that "style: white-space: pre" is not well-handled by CTS. So let's use `<PRE>` tag instead.