### PR TITLE
Add filter to client rects

### DIFF
--- a/packages/roosterjs-editor-dom/lib/utils/getIntersectedRect.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/getIntersectedRect.ts
@@ -32,14 +32,13 @@ export default function getIntersectedRect(
 ): Rect | null {
     const rects = elements
         .map(element => normalizeRect(element.getBoundingClientRect()))
-        .filter(element => !!element)
         .concat(additionalRects) as Rect[];
 
     const result: Rect = {
-        top: Math.max(...rects.map(r => r.top)),
-        bottom: Math.min(...rects.map(r => r.bottom)),
-        left: Math.max(...rects.map(r => r.left)),
-        right: Math.min(...rects.map(r => r.right)),
+        top: Math.max(...rects.filter(r => !!r).map(r => r.top)),
+        bottom: Math.min(...rects.filter(r => !!r).map(r => r.bottom)),
+        left: Math.max(...rects.filter(r => !!r).map(r => r.left)),
+        right: Math.min(...rects.filter(r => !!r).map(r => r.right)),
     };
 
     return result.top < result.bottom && result.left < result.right ? result : null;

--- a/packages/roosterjs-editor-dom/lib/utils/getIntersectedRect.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/getIntersectedRect.ts
@@ -32,13 +32,14 @@ export default function getIntersectedRect(
 ): Rect | null {
     const rects = elements
         .map(element => normalizeRect(element.getBoundingClientRect()))
-        .concat(additionalRects) as Rect[];
+        .concat(additionalRects)
+        .filter(element => !!element) as Rect[];
 
     const result: Rect = {
-        top: Math.max(...rects.filter(r => !!r).map(r => r.top)),
-        bottom: Math.min(...rects.filter(r => !!r).map(r => r.bottom)),
-        left: Math.max(...rects.filter(r => !!r).map(r => r.left)),
-        right: Math.min(...rects.filter(r => !!r).map(r => r.right)),
+        top: Math.max(...rects.map(r => r.top)),
+        bottom: Math.min(...rects.map(r => r.bottom)),
+        left: Math.max(...rects.map(r => r.left)),
+        right: Math.min(...rects.map(r => r.right)),
     };
 
     return result.top < result.bottom && result.left < result.right ? result : null;


### PR DESCRIPTION
Change `getIntersectedRect` to also filter `additionalRects ` to avoid undefined values.