### PR TITLE
Content Model: Support insert image with src

### DIFF
--- a/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
@@ -6,18 +6,26 @@ import { readFile } from 'roosterjs-editor-dom';
 /**
  * Insert an image into current selected position
  * @param editor The editor to operate on
- * @param file Image Blob file
+ * @param file Image Blob file or source string
  */
-export default function insertImage(editor: IContentModelEditor, file: File) {
-    readFile(file, dataUrl => {
-        if (dataUrl && !editor.isDisposed()) {
-            formatWithContentModel(editor, 'insertImage', model => {
-                const image = editor.getDocument().createElement('img');
+export default function insertImage(editor: IContentModelEditor, imageFileOrSrc: File | string) {
+    if (typeof imageFileOrSrc == 'string') {
+        insertImageWithSrc(editor, imageFileOrSrc);
+    } else {
+        readFile(imageFileOrSrc, dataUrl => {
+            if (dataUrl && !editor.isDisposed()) {
+                insertImageWithSrc(editor, dataUrl);
+            }
+        });
+    }
+}
 
-                image.src = dataUrl;
-                insertContent(model, image);
-                return true;
-            });
-        }
+function insertImageWithSrc(editor: IContentModelEditor, src: string) {
+    formatWithContentModel(editor, 'insertImage', model => {
+        const image = editor.getDocument().createElement('img');
+
+        image.src = src;
+        insertContent(model, image);
+        return true;
     });
 }

--- a/packages/roosterjs-content-model/test/publicApi/image/insertImageTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/image/insertImageTest.ts
@@ -108,4 +108,44 @@ describe('insertImage', () => {
             1
         );
     });
+
+    it('Insert image with src', () => {
+        const model = createContentModelDocument();
+        const marker = createSelectionMarker();
+
+        addSegment(model, marker);
+
+        runTest(
+            'insertImage',
+            editor => {
+                insertImage(editor, testUrl);
+            },
+            model,
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {},
+                        isImplicit: true,
+                        segments: [
+                            {
+                                segmentType: 'Image',
+                                src: testUrl,
+                                format: {},
+                                dataset: {},
+                                isSelectedAsImageSelection: false,
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
+                                format: {},
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+            },
+            1
+        );
+    });
 });

--- a/packages/roosterjs-editor-api/lib/format/insertImage.ts
+++ b/packages/roosterjs-editor-api/lib/format/insertImage.ts
@@ -5,37 +5,18 @@ import { IEditor } from 'roosterjs-editor-types';
 /**
  * Insert an image to editor at current selection
  * @param editor The editor instance
- * @param imageFile The image file. There are at least 3 ways to obtain the file object:
- * From local file, from clipboard data, from drag-and-drop
+ * @param imageFileOrSrc Either the image file blob or source string of the image.
  * @param attributes Optional image element attributes
  */
 export default function insertImage(
     editor: IEditor,
-    imageFile: File,
-    attributes?: Record<string, string>
-): void;
-
-/**
- * Insert an image to editor at current selection
- * @param editor The editor instance
- * @param url The image link
- * @param attributes Optional image element attributes
- */
-export default function insertImage(
-    editor: IEditor,
-    url: string,
-    attributes?: Record<string, string>
-): void;
-
-export default function insertImage(
-    editor: IEditor,
-    imageFile: File | string,
+    imageFileOrSrc: File | string,
     attributes?: Record<string, string>
 ): void {
-    if (typeof imageFile == 'string') {
-        insertImageWithSrc(editor, imageFile, attributes);
+    if (typeof imageFileOrSrc == 'string') {
+        insertImageWithSrc(editor, imageFileOrSrc, attributes);
     } else {
-        readFile(imageFile, dataUrl => {
+        readFile(imageFileOrSrc, dataUrl => {
             if (dataUrl && !editor.isDisposed()) {
                 insertImageWithSrc(editor, dataUrl, attributes);
             }


### PR DESCRIPTION
Support insert image with src using insertImage API in content model, to match the original API's behavior.