### PR TITLE
Content Model: Get init segment format from root container

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/domToContentModel.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/domToContentModel.ts
@@ -1,3 +1,4 @@
+import { computedSegmentFormatHandler } from '../formatHandlers/segment/computedSegmentFormatHandler';
 import { ContentModelDocument } from '../publicTypes/group/ContentModelDocument';
 import { createContentModelDocument } from '../modelApi/creators/createContentModelDocument';
 import { createDomToModelContext } from './context/createDomToModelContext';
@@ -23,7 +24,13 @@ export default function domToContentModel(
     const model = createContentModelDocument();
     const context = createDomToModelContext(editorContext, option);
 
+    // For root element, use computed style as initial value of segment formats
+    parseFormat(root, [computedSegmentFormatHandler.parse], context.segmentFormat, context);
+
+    // Need to calculate direction (ltr or rtl), use it as initial value
     parseFormat(root, [rootDirectionFormatHandler.parse], context.blockFormat, context);
+
+    // Need to calculate zoom scale value from root element, use this value to calculate sizes for elements
     parseFormat(root, [zoomScaleFormatHandler.parse], context.zoomScaleFormat, context);
 
     const processor = option.includeRoot

--- a/packages/roosterjs-content-model/lib/formatHandlers/segment/computedSegmentFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/segment/computedSegmentFormatHandler.ts
@@ -1,6 +1,6 @@
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { FormatHandler } from '../FormatHandler';
-import { isSuperOrSubScript } from './superOrSubScriptFormatHandler';
+import { parseValueWithUnit } from '../utils/parseValueWithUnit';
 
 /**
  * @internal
@@ -10,43 +10,17 @@ export const computedSegmentFormatHandler: FormatHandler<ContentModelSegmentForm
         const computedStyles = element.ownerDocument.defaultView?.getComputedStyle(element);
 
         if (computedStyles) {
-            const {
-                fontFamily,
-                fontSize,
-                fontWeight,
-                fontStyle,
-                textDecoration,
-                verticalAlign,
-                color,
-            } = computedStyles;
+            const { fontFamily, fontSize } = computedStyles;
 
+            // Only read font family and size from root container.
+            // For others, keep them undefined since it is not normal to have bold/italic/... in root container
+            // and we skip colors on purpose since we will get inverted color in dark mode which is not right.
             if (fontFamily) {
                 format.fontFamily = fontFamily;
             }
 
             if (fontSize) {
-                format.fontSize = fontSize;
-            }
-
-            if (fontWeight && fontWeight != '400' && fontWeight != 'normal') {
-                format.fontWeight = fontWeight;
-            }
-
-            if (fontStyle) {
-                format.italic = fontStyle == 'italic' || fontStyle == 'oblique';
-            }
-
-            if (textDecoration) {
-                format.strikethrough = textDecoration.indexOf('line-through') >= 0;
-                format.underline = textDecoration.indexOf('underline') >= 0;
-            }
-
-            if (isSuperOrSubScript(fontSize, verticalAlign)) {
-                format.superOrSubScriptSequence = verticalAlign;
-            }
-
-            if (color) {
-                format.textColor = color;
+                format.fontSize = parseValueWithUnit(fontSize, undefined /*element*/, 'pt') + 'pt';
             }
         }
     },

--- a/packages/roosterjs-content-model/lib/formatHandlers/segment/computedSegmentFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/segment/computedSegmentFormatHandler.ts
@@ -1,0 +1,54 @@
+import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
+import { FormatHandler } from '../FormatHandler';
+import { isSuperOrSubScript } from './superOrSubScriptFormatHandler';
+
+/**
+ * @internal
+ */
+export const computedSegmentFormatHandler: FormatHandler<ContentModelSegmentFormat> = {
+    parse: (format, element) => {
+        const computedStyles = element.ownerDocument.defaultView?.getComputedStyle(element);
+
+        if (computedStyles) {
+            const {
+                fontFamily,
+                fontSize,
+                fontWeight,
+                fontStyle,
+                textDecoration,
+                verticalAlign,
+                color,
+            } = computedStyles;
+
+            if (fontFamily) {
+                format.fontFamily = fontFamily;
+            }
+
+            if (fontSize) {
+                format.fontSize = fontSize;
+            }
+
+            if (fontWeight && fontWeight != '400' && fontWeight != 'normal') {
+                format.fontWeight = fontWeight;
+            }
+
+            if (fontStyle) {
+                format.italic = fontStyle == 'italic' || fontStyle == 'oblique';
+            }
+
+            if (textDecoration) {
+                format.strikethrough = textDecoration.indexOf('line-through') >= 0;
+                format.underline = textDecoration.indexOf('underline') >= 0;
+            }
+
+            if (isSuperOrSubScript(fontSize, verticalAlign)) {
+                format.superOrSubScriptSequence = verticalAlign;
+            }
+
+            if (color) {
+                format.textColor = color;
+            }
+        }
+    },
+    apply: () => {},
+};

--- a/packages/roosterjs-content-model/lib/formatHandlers/utils/parseValueWithUnit.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/utils/parseValueWithUnit.ts
@@ -5,7 +5,11 @@ const MarginValueRegex = /(-?\d+(\.\d+)?)([a-z]+|%)/;
 /**
  * @internal
  */
-export function parseValueWithUnit(value: string = '', element?: HTMLElement): number {
+export function parseValueWithUnit(
+    value: string = '',
+    element?: HTMLElement,
+    resultUnit: 'px' | 'pt' = 'px'
+): number {
     const match = MarginValueRegex.exec(value);
     let result = 0;
 
@@ -35,6 +39,10 @@ export function parseValueWithUnit(value: string = '', element?: HTMLElement): n
         }
     }
 
+    if (result > 0 && resultUnit == 'pt') {
+        result = pxToPt(result);
+    }
+
     return result;
 }
 
@@ -48,4 +56,8 @@ function getFontSize(element: HTMLElement) {
 
 function ptToPx(pt: number): number {
     return Math.round((pt * 4000) / 3) / 1000;
+}
+
+function pxToPt(px: number) {
+    return Math.round((px * 3000) / 4) / 1000;
 }

--- a/packages/roosterjs-content-model/lib/publicApi/segment/changeFontSize.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/segment/changeFontSize.ts
@@ -1,7 +1,7 @@
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { formatSegmentWithContentModel } from '../utils/formatSegmentWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
-import { parseValueWithUnit } from 'roosterjs-content-model/lib/formatHandlers/utils/parseValueWithUnit';
+import { parseValueWithUnit } from '../../formatHandlers/utils/parseValueWithUnit';
 
 /**
  * Default font size sequence, in pt. Suggest editor UI use this sequence as your font size list,
@@ -35,8 +35,7 @@ function changeFontSizeInternal(
     change: 'increase' | 'decrease'
 ) {
     if (format.fontSize) {
-        let sizeInPx = parseValueWithUnit(format.fontSize);
-        let sizeInPt = sizeInPx > 0 ? pxToPt(sizeInPx) : 0;
+        let sizeInPt = parseValueWithUnit(format.fontSize, undefined /*element*/, 'pt');
 
         if (sizeInPt > 0) {
             const newSize = getNewFontSize(sizeInPt, change == 'increase' ? 1 : -1, FONT_SIZES);
@@ -71,8 +70,4 @@ function getNewFontSize(pt: number, changeBase: 1 | -1, fontSizes: number[]): nu
         }
     }
     return pt;
-}
-
-function pxToPt(px: number) {
-    return Math.round((px * 3000) / 4) / 1000;
 }

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatImageWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatImageWithContentModel.ts
@@ -19,9 +19,6 @@ export default function formatImageWithContentModel(
             }
         },
         undefined /** segmentHasStyleCallback **/,
-        undefined /** includingFormatHolder */,
-        {
-            includeRoot: true,
-        }
+        undefined /** includingFormatHolder */
     );
 }

--- a/packages/roosterjs-content-model/test/formatHandlers/segment/computedSegmentFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/segment/computedSegmentFormatHandlerTest.ts
@@ -1,0 +1,57 @@
+import { computedSegmentFormatHandler } from '../../../lib/formatHandlers/segment/computedSegmentFormatHandler';
+import { ContentModelSegmentFormat } from '../../../lib/publicTypes/format/ContentModelSegmentFormat';
+import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
+import { DomToModelContext } from '../../../lib/publicTypes/context/DomToModelContext';
+
+describe('computedSegmentFormatHandler.parse', () => {
+    let div: HTMLElement;
+    let context: DomToModelContext;
+    let format: ContentModelSegmentFormat;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+        context = createDomToModelContext();
+        format = {};
+        document.body.appendChild(div);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(div);
+    });
+
+    it('no style', () => {
+        computedSegmentFormatHandler.parse(format, div, context, {});
+
+        expect(format.fontWeight).toBeUndefined();
+        expect(format.fontFamily).toBeDefined();
+        expect(format.fontSize).toBeDefined();
+        expect(format.textColor).toBeDefined();
+        expect(format.italic).toBeFalse();
+        expect(format.strikethrough).toBeFalse();
+        expect(format.underline).toBeFalse();
+        expect(format.backgroundColor).toBeUndefined();
+    });
+
+    it('has style', () => {
+        div.style.fontWeight = 'bold';
+        div.style.fontFamily = 'Arial';
+        div.style.fontSize = '20pt';
+        div.style.color = 'red';
+        div.style.backgroundColor = 'blue';
+        div.style.textDecoration = 'underline';
+        div.style.fontStyle = 'italic';
+        div.style.verticalAlign = 'sub';
+
+        computedSegmentFormatHandler.parse(format, div, context, {});
+
+        expect(format).toEqual({
+            fontWeight: '700',
+            fontFamily: 'Arial',
+            fontSize: '26.6667px',
+            textColor: 'rgb(255, 0, 0)',
+            italic: true,
+            strikethrough: false,
+            underline: true,
+        });
+    });
+});

--- a/packages/roosterjs-content-model/test/formatHandlers/segment/computedSegmentFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/segment/computedSegmentFormatHandlerTest.ts
@@ -25,10 +25,10 @@ describe('computedSegmentFormatHandler.parse', () => {
         expect(format.fontWeight).toBeUndefined();
         expect(format.fontFamily).toBeDefined();
         expect(format.fontSize).toBeDefined();
-        expect(format.textColor).toBeDefined();
-        expect(format.italic).toBeFalse();
-        expect(format.strikethrough).toBeFalse();
-        expect(format.underline).toBeFalse();
+        expect(format.textColor).toBeUndefined();
+        expect(format.italic).toBeUndefined();
+        expect(format.strikethrough).toBeUndefined();
+        expect(format.underline).toBeUndefined();
         expect(format.backgroundColor).toBeUndefined();
     });
 
@@ -45,13 +45,8 @@ describe('computedSegmentFormatHandler.parse', () => {
         computedSegmentFormatHandler.parse(format, div, context, {});
 
         expect(format).toEqual({
-            fontWeight: '700',
             fontFamily: 'Arial',
-            fontSize: '26.6667px',
-            textColor: 'rgb(255, 0, 0)',
-            italic: true,
-            strikethrough: false,
-            underline: true,
+            fontSize: '20pt',
         });
     });
 });

--- a/packages/roosterjs-content-model/test/publicApi/domToContentModelTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/domToContentModelTest.ts
@@ -15,6 +15,7 @@ describe('domToContentModel', () => {
             },
             defaultStyles: {},
             zoomScaleFormat: {},
+            segmentFormat: {},
         } as any) as DomToModelContext;
 
         spyOn(createDomToModelContext, 'createDomToModelContext').and.returnValue(mockContext);
@@ -54,6 +55,7 @@ describe('domToContentModel', () => {
             },
             defaultStyles: {},
             zoomScaleFormat: {},
+            segmentFormat: {},
         } as any) as DomToModelContext;
 
         spyOn(createDomToModelContext, 'createDomToModelContext').and.returnValue(mockContext);

--- a/packages/roosterjs-content-model/test/publicApi/segment/changeFontSizeTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/segment/changeFontSizeTest.ts
@@ -1,4 +1,3 @@
-import * as getComputedStyles from 'roosterjs-editor-dom/lib/utils/getComputedStyles';
 import * as pendingFormat from '../../../lib/publicApi/format/pendingFormat';
 import changeFontSize from '../../../lib/publicApi/segment/changeFontSize';
 import domToContentModel from '../../../lib/domToModel/domToContentModel';
@@ -358,12 +357,6 @@ describe('changeFontSize', () => {
             setContentModel,
         } as any) as IContentModelEditor;
 
-        spyOn(getComputedStyles, 'getComputedStyle').and.callFake(
-            (node: HTMLElement, style: string) => {
-                return node.style.fontSize;
-            }
-        );
-
         changeFontSize(editor, 'increase');
 
         expect(setContentModel).toHaveBeenCalledWith({
@@ -386,8 +379,5 @@ describe('changeFontSize', () => {
                 },
             ],
         });
-
-        expect(getComputedStyles.getComputedStyle).toHaveBeenCalledTimes(1);
-        expect(getComputedStyles.getComputedStyle).toHaveBeenCalledWith(div, 'font-size');
     });
 });


### PR DESCRIPTION
The Content Model API `getFormatState` will return `undefined` for those styles that is not specified in HTML. For example:
```html
<div id="editorRoot" contenteditable>
<span>test</span>
</div>
```

Since we didn't specify any style in the content, `getFormatState` will return undefined for fontSize, fontFamily, textColor, ...

To fix this, we read computed styles from root element for the following styles:

- fontSize
- fontFamily

For other styles, keep them undefined if not specified since it is not normal to add styles such as bold, italic, ... in root container. And for textColor and backgroundColor, we skip them on purpose since in dark mode we will read the inverted color from container which is not what we want.