### PR TITLE
Check if there is rotate  handle, before update the rotate handles

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -499,13 +499,15 @@ export default class ImageEdit implements EditorPlugin {
                     this.updateWrapper();
                 }
 
-                updateRotateHandlePosition(
-                    this.editInfo,
-                    this.editor.getVisibleViewport(),
-                    marginVertical,
-                    rotateCenter,
-                    rotateHandle
-                );
+                if (rotateHandle && rotateCenter) {
+                    updateRotateHandlePosition(
+                        this.editInfo,
+                        this.editor.getVisibleViewport(),
+                        marginVertical,
+                        rotateCenter,
+                        rotateHandle
+                    );
+                }
 
                 updateHandleCursor(resizeHandles, angleRad);
             }

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -499,7 +499,8 @@ export default class ImageEdit implements EditorPlugin {
                     this.updateWrapper();
                 }
 
-                if (rotateHandle && rotateCenter) {
+                const viewport = this.editor.getVisibleViewport();
+                if (rotateHandle && rotateCenter && viewport) {
                     updateRotateHandlePosition(
                         this.editInfo,
                         this.editor.getVisibleViewport(),

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
@@ -51,19 +51,22 @@ export function updateRotateHandlePosition(
     rotateCenter: HTMLElement,
     rotateHandle: HTMLElement
 ) {
-    const top = rotateHandle.getBoundingClientRect()?.top - editorRect?.top;
-    const { angleRad, heightPx } = editInfo;
-    const cosAngle = Math.cos(angleRad);
-    const adjustedDistance =
-        cosAngle <= 0
-            ? Number.MAX_SAFE_INTEGER
-            : (top + heightPx / 2 + marginVertical) / cosAngle - heightPx / 2;
+    const rotateHandleRect = rotateHandle.getBoundingClientRect();
+    if (rotateHandleRect) {
+        const top = rotateHandleRect.top - editorRect?.top;
+        const { angleRad, heightPx } = editInfo;
+        const cosAngle = Math.cos(angleRad);
+        const adjustedDistance =
+            cosAngle <= 0
+                ? Number.MAX_SAFE_INTEGER
+                : (top + heightPx / 2 + marginVertical) / cosAngle - heightPx / 2;
 
-    const rotateGap = Math.max(Math.min(ROTATE_GAP, adjustedDistance), 0);
-    const rotateTop = Math.max(Math.min(ROTATE_SIZE, adjustedDistance - rotateGap), 0);
-    rotateCenter.style.top = -rotateGap + 'px';
-    rotateCenter.style.height = rotateGap + 'px';
-    rotateHandle.style.top = -rotateTop + 'px';
+        const rotateGap = Math.max(Math.min(ROTATE_GAP, adjustedDistance), 0);
+        const rotateTop = Math.max(Math.min(ROTATE_SIZE, adjustedDistance - rotateGap), 0);
+        rotateCenter.style.top = -rotateGap + 'px';
+        rotateCenter.style.height = rotateGap + 'px';
+        rotateHandle.style.top = -rotateTop + 'px';
+    }
 }
 
 /**


### PR DESCRIPTION
For some editing operations, the rotate handle are not rendered. Then we need to check if they exist, before we update them. 