### PR TITLE
Fix a pending format issue in firefox

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/PendingFormatStatePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/PendingFormatStatePlugin.ts
@@ -99,7 +99,7 @@ export default class PendingFormatStatePlugin
                     this.editor.insertNode(this.state.pendableFormatSpan);
                     this.editor.select(
                         this.state.pendableFormatSpan,
-                        PositionType.Before,
+                        PositionType.Begin,
                         this.state.pendableFormatSpan,
                         PositionType.End
                     );


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1813591

In the pending format code (non-ContentModel), when we apply pending format we put a format SPAN into doc and select before and end of the SPAN to allow the input event replace the SPAN content. This works well in Chrome but not for Firefox. So we change to start at Begin and End of the SPAN to fix the issue.