### PR TITLE
Content Model: Keep root level entity when format with Content Model

### DIFF
--- a/demo/scripts/utils/trustedHTMLHandler.ts
+++ b/demo/scripts/utils/trustedHTMLHandler.ts
@@ -2,7 +2,7 @@ import * as DOMPurify from 'dompurify';
 
 export function trustedHTMLHandler(html: string): string {
     const result = DOMPurify.sanitize(html, {
-        ADD_TAGS: ['head', 'meta', '#comment'],
+        ADD_TAGS: ['head', 'meta', '#comment', 'iframe'],
         ADD_ATTR: ['name', 'content'],
         WHOLE_DOCUMENT: true,
         RETURN_TRUSTED_TYPE: true,

--- a/packages/roosterjs-content-model/lib/domToModel/processors/entityProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/entityProcessor.ts
@@ -16,18 +16,22 @@ export const entityProcessor: ElementProcessor<HTMLElement> = (group, element, c
     const { id, type, isReadonly } = entity || { isReadonly: true };
     const isBlockEntity = isBlockElement(element, context);
 
-    stackFormat(context, { segment: isBlockEntity ? 'shallowCloneForBlock' : undefined }, () => {
-        const entityModel = createEntity(element, isReadonly, context.segmentFormat, id, type);
+    stackFormat(
+        context,
+        { segment: isBlockEntity ? 'empty' : undefined, paragraph: 'empty' },
+        () => {
+            const entityModel = createEntity(element, isReadonly, context.segmentFormat, id, type);
 
-        // TODO: Need to handle selection for editable entity
-        if (context.isInSelection) {
-            entityModel.isSelected = true;
-        }
+            // TODO: Need to handle selection for editable entity
+            if (context.isInSelection) {
+                entityModel.isSelected = true;
+            }
 
-        if (isBlockEntity) {
-            addBlock(group, entityModel);
-        } else {
-            addSegment(group, entityModel);
+            if (isBlockEntity) {
+                addBlock(group, entityModel);
+            } else {
+                addSegment(group, entityModel);
+            }
         }
-    });
+    );
 };

--- a/packages/roosterjs-content-model/test/domToModel/processors/entityProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/entityProcessorTest.ts
@@ -156,4 +156,45 @@ describe('entityProcessor', () => {
             ],
         });
     });
+
+    it('Clear format for block entity', () => {
+        const group = createContentModelDocument();
+        const div = document.createElement('div');
+
+        commitEntity(div, 'entity', true, 'entity_1');
+        context.isInSelection = true;
+        context.segmentFormat = {
+            fontFamily: 'Arial',
+            fontSize: '10px',
+        };
+        context.blockFormat = {
+            lineHeight: '20px',
+        };
+
+        entityProcessor(group, div, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    segmentType: 'Entity',
+                    blockType: 'Entity',
+                    format: {},
+                    id: 'entity_1',
+                    type: 'entity',
+                    isReadonly: true,
+                    wrapper: div,
+                    isSelected: true,
+                },
+            ],
+        });
+
+        expect(context.segmentFormat).toEqual({
+            fontFamily: 'Arial',
+            fontSize: '10px',
+        });
+        expect(context.blockFormat).toEqual({
+            lineHeight: '20px',
+        });
+    });
 });


### PR DESCRIPTION
In a recent change (https://github.com/microsoft/roosterjs/pull/1567) I added default segment format when create content model. However this change will also apply format to block entities so it breaks the "keep root level entity" behavior. That means:
1. Insert a root level block entity
2. Regenerate document using Content Model

Expect: Entity node is not touched during content regeneration
Actual: A SPAN tag is created around the entity node so the node is moved

To fix it, we need to avoid applying default segment format to block entity.

Add test case to protect this behavior.