### PR TITLE
Content Model: Improve clearFormat API

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/common/clearModelFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/clearModelFormat.ts
@@ -1,3 +1,4 @@
+import { adjustWordSelection } from '../selection/adjustWordSelection';
 import { applyTableFormat } from '../table/applyTableFormat';
 import { arrayPush } from 'roosterjs-editor-dom';
 import { ContentModelBlock } from '../../publicTypes/block/ContentModelBlock';
@@ -39,27 +40,40 @@ export function clearModelFormat(
             }
         },
         {
-            includeListFormatHolder: 'anySegment',
+            includeListFormatHolder: 'never', // No need to include list format holder since the whole list need to be cleared
         }
     );
 
-    // If a full block or multiple blocks are selected, clear block format first
+    const marker = segmentsToClear[0];
+
+    // 1. Clear block format no matter what selection it is
+    blocksToClear.forEach(([path]) => {
+        clearListFormat(path);
+    });
+
+    // 2. If selection is collapsed, add selection to whole word to clear if any
     if (
-        (blocksToClear.length == 1 && isOnlySelectionMarkerSelected(blocksToClear[0][1])) ||
-        blocksToClear.length > 1 ||
-        blocksToClear.some(x => isWholeBlockSelected(x[1]))
+        segmentsToClear.length == 1 &&
+        marker.segmentType == 'SelectionMarker' &&
+        blocksToClear.length == 1
     ) {
+        segmentsToClear.splice(0, segmentsToClear.length, ...adjustWordSelection(model, marker));
+    }
+
+    // 3. If a full block or multiple blocks are selected, clear block format
+    else if (blocksToClear.length > 1 || blocksToClear.some(x => isWholeBlockSelected(x[1]))) {
         for (let i = blocksToClear.length - 1; i >= 0; i--) {
             const [path, block] = blocksToClear[i];
 
             clearBlockFormat(path, block, segmentsToClear);
-            clearListFormat(path);
             clearQuoteFormat(path, block);
         }
     }
 
-    // Then clear segments format and table format if any
+    // 4. Finally clear format for segments
     clearSegmentsFormat(segmentsToClear, defaultSegmentFormat);
+
+    // 5. Clear format for table if any
     createTablesFormat(tablesToClear);
 }
 
@@ -84,7 +98,10 @@ function clearSegmentsFormat(
 ) {
     segmentsToClear.forEach(x => {
         x.format = { ...(defaultSegmentFormat || {}) };
-        delete x.link;
+
+        if (x.link) {
+            delete x.link.format.textColor;
+        }
     });
 }
 
@@ -151,16 +168,14 @@ function clearBlockFormat(
             path[0].blocks.splice(index, 1);
         }
     } else if (block.blockType == 'Paragraph') {
-        arrayPush(segmentsToClear, block.segments);
+        block.segments.forEach(segment => {
+            if (segmentsToClear.indexOf(segment) < 0) {
+                segmentsToClear.push(segment);
+            }
+        });
         block.format = {};
         delete block.decorator;
     }
-}
-
-function isOnlySelectionMarkerSelected(block: ContentModelBlock) {
-    const segments = block.blockType == 'Paragraph' ? block.segments.filter(x => x.isSelected) : [];
-
-    return segments.length == 1 && segments[0].segmentType == 'SelectionMarker';
 }
 
 function isWholeBlockSelected(block: ContentModelBlock) {

--- a/packages/roosterjs-content-model/lib/modelApi/common/clearModelFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/clearModelFormat.ts
@@ -54,10 +54,8 @@ export function clearModelFormat(
     ) {
         segmentsToClear.splice(0, segmentsToClear.length, ...adjustWordSelection(model, marker));
         clearListFormat(blocksToClear[0][0]);
-    }
-
-    // 2. If a full block or multiple blocks are selected, clear block format
-    else if (blocksToClear.length > 1 || blocksToClear.some(x => isWholeBlockSelected(x[1]))) {
+    } else if (blocksToClear.length > 1 || blocksToClear.some(x => isWholeBlockSelected(x[1]))) {
+        // 2. If a full block or multiple blocks are selected, clear block format
         for (let i = blocksToClear.length - 1; i >= 0; i--) {
             const [path, block] = blocksToClear[i];
 

--- a/packages/roosterjs-content-model/lib/modelApi/common/clearModelFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/clearModelFormat.ts
@@ -40,7 +40,11 @@ export function clearModelFormat(
             }
         },
         {
-            includeListFormatHolder: 'anySegment',
+            // When there is a default format to apply, we know how to handle segment format under list.
+            // So no need to clear format of list number.
+            // Otherwise, we will clear all format of selected text. And since they are under LI tag, we
+            // also need to clear the format of LI (format holder) so that the format is really cleared
+            includeListFormatHolder: defaultSegmentFormat ? 'never' : 'anySegment',
         }
     );
 

--- a/packages/roosterjs-content-model/lib/modelApi/common/clearModelFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/clearModelFormat.ts
@@ -61,7 +61,7 @@ export function clearModelFormat(
         for (let i = blocksToClear.length - 1; i >= 0; i--) {
             const [path, block] = blocksToClear[i];
 
-            clearBlockFormat(path, block, segmentsToClear);
+            clearBlockFormat(path, block);
             clearListFormat(path);
             clearQuoteFormat(path, block);
         }
@@ -153,11 +153,7 @@ function clearListFormat(path: ContentModelBlockGroup[]) {
     }
 }
 
-function clearBlockFormat(
-    path: ContentModelBlockGroup[],
-    block: ContentModelBlock,
-    segmentsToClear: ContentModelSegment[]
-) {
+function clearBlockFormat(path: ContentModelBlockGroup[], block: ContentModelBlock) {
     if (block.blockType == 'Divider') {
         const index = path[0].blocks.indexOf(block);
 
@@ -165,11 +161,6 @@ function clearBlockFormat(
             path[0].blocks.splice(index, 1);
         }
     } else if (block.blockType == 'Paragraph') {
-        block.segments.forEach(segment => {
-            if (segmentsToClear.indexOf(segment) < 0) {
-                segmentsToClear.push(segment);
-            }
-        });
         block.format = {};
         delete block.decorator;
     }

--- a/packages/roosterjs-content-model/test/modelApi/common/clearModelFormatTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/clearModelFormatTest.ts
@@ -443,9 +443,7 @@ describe('clearModelFormat', () => {
                     levels: [],
                     formatHolder: {
                         segmentType: 'SelectionMarker',
-                        format: {
-                            fontSize: '20px',
-                        },
+                        format: {},
                         isSelected: true,
                     },
                     format: {},
@@ -467,7 +465,14 @@ describe('clearModelFormat', () => {
             ],
         });
         expect(blocks).toEqual([[[list, model], para]]);
-        expect(segments).toEqual([text]);
+        expect(segments).toEqual([
+            text,
+            {
+                segmentType: 'SelectionMarker',
+                format: {},
+                isSelected: true,
+            },
+        ]);
         expect(tables).toEqual([]);
     });
 

--- a/packages/roosterjs-content-model/test/modelApi/common/clearModelFormatTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/clearModelFormatTest.ts
@@ -476,6 +476,65 @@ describe('clearModelFormat', () => {
         expect(tables).toEqual([]);
     });
 
+    it('Model with selection under list, has defaultSegmentFormat', () => {
+        const model = createContentModelDocument();
+        const list = createListItem([{ listType: 'OL' }], { fontSize: '20px' });
+        const para = createParagraph(false, { lineHeight: '10px' });
+        const text = createText('test', { textColor: 'green' });
+
+        text.isSelected = true;
+
+        para.segments.push(text);
+        list.blocks.push(para);
+        model.blocks.push(list);
+
+        const blocks: any[] = [];
+        const segments: any[] = [];
+        const tables: any[] = [];
+
+        clearModelFormat(model, blocks, segments, tables, {
+            fontSize: '10px',
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    levels: [],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {
+                            fontSize: '20px',
+                        },
+                        isSelected: true,
+                    },
+                    format: {},
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            format: {},
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    format: {
+                                        fontSize: '10px',
+                                    },
+                                    text: 'test',
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(blocks).toEqual([[[list, model], para]]);
+        expect(segments).toEqual([text]);
+        expect(tables).toEqual([]);
+    });
+
     it('Model with selection under quote', () => {
         const model = createContentModelDocument();
         const quote = createQuote({ lineHeight: '25px' });


### PR DESCRIPTION
Better match Word's behavior:
1. When selection is collapsed, clear segment format for the impacted word if any
2. When selection is collapsed, clear list if any
3. When selection is not collapsed, clear segment format for selected content, but do not clear list
4. When selection covers full paragraph, or across multiple paragraphs, clear segment format for selected content, and clear block format for impacted blocks
5. Do not remove link