### PR TITLE
Add `dir` and `textAlign` in `FormatState`

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/retrieveModelFormatState.ts
@@ -123,6 +123,8 @@ function retrieveParagraphFormat(
     mergeValue(result, 'marginBottom', paragraph.format.marginBottom, isFirst);
     mergeValue(result, 'marginTop', paragraph.format.marginTop, isFirst);
     mergeValue(result, 'headerLevel', validHeaderLevel, isFirst);
+    mergeValue(result, 'textAlign', paragraph.format.textAlign, isFirst);
+    mergeValue(result, 'direction', paragraph.format.direction, isFirst);
 }
 
 function retrieveStructureFormat(

--- a/packages/roosterjs-editor-core/lib/coreApi/getStyleBasedFormatState.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getStyleBasedFormatState.ts
@@ -44,6 +44,8 @@ export const getStyleBasedFormatState: GetStyleBasedFormatState = (
               'line-height',
               'margin-top',
               'margin-bottom',
+              'text-align',
+              'direction',
           ])
         : [];
     const {
@@ -99,6 +101,8 @@ export const getStyleBasedFormatState: GetStyleBasedFormatState = (
             lineHeight: styles[4],
             marginTop: styles[5],
             marginBottom: styles[6],
+            textAlign: styles[7],
+            direction: styles[8],
         };
     } else {
         const ogTextColorNode =
@@ -140,6 +144,8 @@ export const getStyleBasedFormatState: GetStyleBasedFormatState = (
                   }
                 : undefined,
             lineHeight: styles[4],
+            textAlign: styles[7],
+            direction: styles[8],
         };
     }
 };

--- a/packages/roosterjs-editor-types/lib/interface/FormatState.ts
+++ b/packages/roosterjs-editor-types/lib/interface/FormatState.ts
@@ -153,6 +153,16 @@ export interface StyleBasedFormatState {
      * Margin Bottom
      */
     marginBottom?: string;
+
+    /**
+     * Text Align
+     */
+    textAlign?: string;
+
+    /**
+     * Direction of the element ('ltr' or 'rtl')
+     */
+    direction?: string;
 }
 
 /**


### PR DESCRIPTION
Add dir and text-align info in FormatState. They will be used to calculate the alignment (left | center | right) of text at cursor. This state will be displayed to the users through the icons of the button.
![image](https://user-images.githubusercontent.com/63284518/220000583-e1b55d9a-6b1d-48d8-8100-a08ab1818b4c.png)