### PR TITLE
Introduce custom-defined premade styling options for content model

### DIFF
--- a/demo/scripts/controls/ribbonButtons/contentModel/ContentModelRibbon.tsx
+++ b/demo/scripts/controls/ribbonButtons/contentModel/ContentModelRibbon.tsx
@@ -50,6 +50,7 @@ import {
 } from './tableEditButtons';
 import { spacingButton } from './spacingButton';
 import { spaceAfterButton, spaceBeforeButton } from './spaceBeforeAfterButtons';
+import { applyStylingButton } from './applyStylingButton';
 
 const buttons = [
     formatPainterButton,
@@ -101,6 +102,7 @@ const buttons = [
     spacingButton,
     spaceBeforeButton,
     spaceAfterButton,
+    applyStylingButton,
 ];
 
 export default function ContentModelRibbon(props: { ribbonPlugin: RibbonPlugin; isRtl: boolean }) {

--- a/demo/scripts/controls/ribbonButtons/contentModel/applyStylingButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/applyStylingButton.ts
@@ -1,0 +1,75 @@
+import { RibbonButton } from 'roosterjs-react';
+import {
+    ContentModelSegmentFormat,
+    isContentModelEditor,
+    setStyledDecorator,
+    setStyledSegment,
+} from 'roosterjs-content-model';
+import { getObjectKeys } from 'roosterjs-editor-dom';
+
+const applyStylingButtonKey = 'buttonNameApplyStyling';
+
+interface Style {
+    headingLevel: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+    format: ContentModelSegmentFormat;
+}
+
+const styles: Record<string, Style> = {
+    heading1: {
+        //margin & and what not, merely examples
+        headingLevel: 1,
+        format: {
+            textColor: 'blue',
+            fontSize: '3rem',
+        },
+    },
+    heading2: {
+        //margin & and what not, merely examples
+        headingLevel: 2,
+        format: {
+            textColor: 'red',
+            fontSize: '2rem',
+        },
+    },
+    heading3: {
+        //margin & and what not, merely examples
+        headingLevel: 3,
+        format: {
+            textColor: 'green',
+            fontSize: '1rem',
+        },
+    },
+};
+
+const styleMenuItems = getObjectKeys(styles).reduce((map, key) => {
+    map[key] = key;
+    return map;
+}, <Record<string, string>>{});
+
+//inside decorator(?what about quote) we want to set a new property called styles. If this property
+//is different, we want to replace all format IN DECORATOR and block (paragraph)
+//segments can be ignored as long as they are kept inline if needed
+
+/**
+ * @internal
+ */
+export const applyStylingButton: RibbonButton<typeof applyStylingButtonKey> = {
+    key: applyStylingButtonKey,
+    unlocalizedText: 'Apply Styling',
+    iconName: 'Personalize',
+    dropDownMenu: {
+        items: styleMenuItems,
+        getSelectedItemKey: formatState => formatState.styleName,
+        allowLivePreview: true,
+    },
+    onClick: (editor, style) => {
+        if (isContentModelEditor(editor)) {
+            const { format, headingLevel } = styles[style];
+            if (editor.getSelectionRangeEx().areAllCollapsed) {
+                setStyledDecorator(editor, style, `h${headingLevel}`, format);
+            } else {
+                setStyledSegment(editor, style, format);
+            }
+        }
+    },
+};

--- a/packages/roosterjs-content-model/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/retrieveModelFormatState.ts
@@ -86,6 +86,9 @@ function retrieveFormatStateInternal(
     result.lineHeight = paragraph.format.lineHeight || format.lineHeight;
     result.marginBottom = paragraph.format.marginBottom;
     result.marginTop = paragraph.format.marginTop;
+    result.styleName =
+        (segment.segmentType === 'StyledText' && segment.styleName) ||
+        paragraph.decorator?.styleName;
 
     result.isBold = isBold(format.fontWeight);
     result.isItalic = format.italic;

--- a/packages/roosterjs-content-model/lib/publicApi/block/setStyledDecorator.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setStyledDecorator.ts
@@ -1,0 +1,36 @@
+import { getObjectKeys } from 'roosterjs-editor-dom';
+import type { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
+import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
+import { formatParagraphWithContentModel } from '../utils/formatParagraphWithContentModel';
+
+export default function setStyledDecorator(
+    editor: IContentModelEditor,
+    styleName: string | null,
+    tagName: string | null,
+    format?: ContentModelSegmentFormat
+) {
+    formatParagraphWithContentModel(editor, 'setStyledDecorator', para => {
+        if (tagName) {
+            para.decorator = {
+                tagName,
+                format: format ?? {},
+            };
+            if (styleName) {
+                para.decorator.styleName = styleName;
+            }
+            if (format) {
+                para.segments.forEach(segment => {
+                    Object.assign(segment.format, format);
+                });
+            }
+        } else {
+            if (para.decorator?.format) {
+                const formatKeysToDelete = getObjectKeys(para.decorator.format);
+                para.segments.forEach(segment =>
+                    formatKeysToDelete.forEach(key => delete segment.format[key])
+                );
+            }
+            delete para.decorator;
+        }
+    });
+}

--- a/packages/roosterjs-content-model/lib/publicApi/index.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/index.ts
@@ -42,3 +42,5 @@ export { default as adjustLinkSelection } from './link/adjustLinkSelection';
 export { default as setImageAltText } from './image/setImageAltText';
 export { default as adjustImageSelection } from './image/adjustImageSelection';
 export { default as setParagraphMargin } from './block/setParagraphMargin';
+export { default as setStyledDecorator } from './block/setStyledDecorator';
+export { default as setStyledSegment } from './segment/setStyledSegment';

--- a/packages/roosterjs-content-model/lib/publicApi/segment/setStyledSegment.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/segment/setStyledSegment.ts
@@ -1,0 +1,34 @@
+import { ContentModelSegment } from '../..';
+import type { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
+import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
+import { ContentModelStyledText } from '../../publicTypes/segment/ContentModelStyledText';
+import { formatSegmentWithContentModel } from '../utils/formatSegmentWithContentModel';
+
+export default function setStyledSegment(
+    editor: IContentModelEditor,
+    styleName: string | null,
+    format?: ContentModelSegmentFormat
+) {
+    formatSegmentWithContentModel(
+        editor,
+        'setStyledSegment',
+        (format, _, segment) => {
+            if (!segment) {
+                return;
+            }
+            if (!styleName && segment.segmentType === 'StyledText') {
+                const cleanedSegment = segment as ContentModelSegment & { styleName?: string };
+                cleanedSegment.segmentType = 'Text';
+                segment.format = {};
+                delete cleanedSegment.styleName;
+            }
+            if (styleName && segment && segment.segmentType.indexOf('Text') > -1) {
+                const modifiedSegment = segment as ContentModelStyledText;
+                modifiedSegment.segmentType = 'StyledText';
+                Object.assign(segment.format, format ?? {});
+                modifiedSegment.styleName = styleName;
+            }
+        },
+        undefined
+    );
+}

--- a/packages/roosterjs-content-model/lib/publicTypes/decorator/ContentModelParagraphDecorator.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/decorator/ContentModelParagraphDecorator.ts
@@ -12,4 +12,9 @@ export interface ContentModelParagraphDecorator
      * Tag name of this paragraph
      */
     tagName: string;
+
+    /**
+     * Name of the style applied
+     */
+    styleName?: string;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/enum/SegmentType.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/enum/SegmentType.ts
@@ -8,6 +8,11 @@ export type ContentModelSegmentType =
     | 'Text'
 
     /**
+     * TODO
+     */
+    | 'StyledText'
+
+    /**
      * Represents a BR element
      */
     | 'Br'

--- a/packages/roosterjs-content-model/lib/publicTypes/index.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/index.ts
@@ -17,6 +17,7 @@ export { ContentModelParagraph } from './block/ContentModelParagraph';
 export { ContentModelSegmentBase } from './segment/ContentModelSegmentBase';
 export { ContentModelSelectionMarker } from './segment/ContentModelSelectionMarker';
 export { ContentModelText } from './segment/ContentModelText';
+export { ContentModelStyledText } from './segment/ContentModelStyledText';
 export { ContentModelBr } from './segment/ContentModelBr';
 export { ContentModelImage } from './segment/ContentModelImage';
 export { ContentModelGeneralSegment } from './segment/ContentModelGeneralSegment';

--- a/packages/roosterjs-content-model/lib/publicTypes/segment/ContentModelSegment.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/segment/ContentModelSegment.ts
@@ -4,6 +4,7 @@ import { ContentModelGeneralSegment } from './ContentModelGeneralSegment';
 import { ContentModelImage } from './ContentModelImage';
 import { ContentModelSelectionMarker } from './ContentModelSelectionMarker';
 import { ContentModelText } from './ContentModelText';
+import { ContentModelStyledText } from './ContentModelStyledText';
 
 /**
  * Union type of Content Model Segment
@@ -11,6 +12,7 @@ import { ContentModelText } from './ContentModelText';
 export type ContentModelSegment =
     | ContentModelSelectionMarker
     | ContentModelText
+    | ContentModelStyledText
     | ContentModelBr
     | ContentModelGeneralSegment
     | ContentModelEntity

--- a/packages/roosterjs-content-model/lib/publicTypes/segment/ContentModelStyledText.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/segment/ContentModelStyledText.ts
@@ -1,0 +1,13 @@
+import { ContentModelSegmentBase } from './ContentModelSegmentBase';
+
+/**
+ * Content Model for Text
+ */
+export interface ContentModelStyledText extends ContentModelSegmentBase<'StyledText'> {
+    styleName: string;
+
+    /**
+     * Text content of this segment
+     */
+    text: string;
+}

--- a/packages/roosterjs-editor-core/lib/coreApi/getStyleBasedFormatState.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getStyleBasedFormatState.ts
@@ -99,6 +99,7 @@ export const getStyleBasedFormatState: GetStyleBasedFormatState = (
             lineHeight: styles[4],
             marginTop: styles[5],
             marginBottom: styles[6],
+            styleName: undefined,
         };
     } else {
         const ogTextColorNode =
@@ -140,6 +141,7 @@ export const getStyleBasedFormatState: GetStyleBasedFormatState = (
                   }
                 : undefined,
             lineHeight: styles[4],
+            styleName: undefined,
         };
     }
 };

--- a/packages/roosterjs-editor-types/lib/interface/FormatState.ts
+++ b/packages/roosterjs-editor-types/lib/interface/FormatState.ts
@@ -153,6 +153,12 @@ export interface StyleBasedFormatState {
      * Margin Bottom
      */
     marginBottom?: string;
+
+    /**
+     * Name of current style under cursor
+     * This is always undefined on non-content-model editor
+     */
+    styleName?: string;
 }
 
 /**


### PR DESCRIPTION
Introduces new API for setting a block (or segment) with a predefined format, having the option to see the name of the current selected predefined style in the format state. 

This will allow for the implementation of styles like Headings, Strong, etc

![image](https://user-images.githubusercontent.com/44042957/220432922-c48100d9-79da-4d99-a4a4-f488c742e430.png)
![image](https://user-images.githubusercontent.com/44042957/220433112-f5a7d8e5-e908-4b07-a953-88d00d804940.png)

