### PR TITLE
Fix color issue with Font tag

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/table/setTableCellBackgroundColor.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/setTableCellBackgroundColor.ts
@@ -1,4 +1,5 @@
 import { ContentModelTableCell } from '../../publicTypes/group/ContentModelTableCell';
+import { parseColor } from 'roosterjs-editor-dom';
 import { updateTableCellMetadata } from '../../domUtils/metadata/updateTableCellMetadata';
 
 // Using the HSL (hue, saturation and lightness) representation for RGB color values.
@@ -8,7 +9,6 @@ const DARK_COLORS_LIGHTNESS = 20;
 const BRIGHT_COLORS_LIGHTNESS = 80;
 const White = '#ffffff';
 const Black = '#000000';
-const RGBA_REGEX = /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/;
 
 /**
  * @internal
@@ -45,49 +45,18 @@ export function setTableCellBackgroundColor(
 }
 
 function calculateLightness(color: string) {
-    let r: number;
-    let g: number;
-    let b: number;
-
-    if (color.substring(0, 1) == '#') {
-        [r, g, b] = parseHexColor(color);
-    } else {
-        [r, g, b] = parseRGBColor(color);
-    }
+    const colorValues = parseColor(color);
 
     // Use the values of r,g,b to calculate the lightness in the HSl representation
     //First calculate the fraction of the light in each color, since in css the value of r,g,b is in the interval of [0,255], we have
+    if (colorValues) {
+        const red = colorValues[0] / 255;
+        const green = colorValues[1] / 255;
+        const blue = colorValues[2] / 255;
 
-    const red = r / 255;
-    const green = g / 255;
-    const blue = b / 255;
-
-    //Then the lightness in the HSL representation is the average between maximum fraction of r,g,b and the minimum fraction
-    return (Math.max(red, green, blue) + Math.min(red, green, blue)) * 50;
-}
-
-function parseHexColor(color: string) {
-    if (color.length === 4) {
-        color = color.replace(/(.)/g, '$1$1');
-    }
-
-    const colors = color.replace('#', '');
-    const r = parseInt(colors.substr(0, 2), 16);
-    const g = parseInt(colors.substr(2, 2), 16);
-    const b = parseInt(colors.substr(4, 2), 16);
-
-    return [r, g, b];
-}
-
-function parseRGBColor(color: string) {
-    const colors = color.match(RGBA_REGEX);
-
-    if (colors) {
-        const r = parseInt(colors[1]);
-        const g = parseInt(colors[2]);
-        const b = parseInt(colors[3]);
-        return [r, g, b];
+        //Then the lightness in the HSL representation is the average between maximum fraction of r,g,b and the minimum fraction
+        return (Math.max(red, green, blue) + Math.min(red, green, blue)) * 50;
     } else {
-        return [255, 255, 255];
+        return 255;
     }
 }

--- a/packages/roosterjs-content-model/test/formatHandlers/utils/colorTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/utils/colorTest.ts
@@ -169,6 +169,28 @@ describe('getColor with darkColorHandler', () => {
         expect(parseColorValue).toHaveBeenCalledTimes(1);
         expect(parseColorValue).toHaveBeenCalledWith('red');
     });
+
+    it('get color from FONT tag in dark mode', () => {
+        const parseColorValue = jasmine.createSpy().and.returnValue({
+            lightModeColor: 'green',
+        });
+        const findLightColorFromDarkColor = jasmine.createSpy().and.returnValue('red');
+        const darkColorHandler = ({
+            parseColorValue,
+            findLightColorFromDarkColor,
+        } as any) as DarkColorHandler;
+        const font = document.createElement('font');
+
+        font.color = '#112233';
+
+        const color = getColor(font, false, darkColorHandler, true);
+
+        expect(color).toBe('green');
+        expect(parseColorValue).toHaveBeenCalledTimes(1);
+        expect(parseColorValue).toHaveBeenCalledWith('red');
+        expect(findLightColorFromDarkColor).toHaveBeenCalledTimes(1);
+        expect(findLightColorFromDarkColor).toHaveBeenCalledWith('#112233');
+    });
 });
 
 describe('setColor', () => {

--- a/packages/roosterjs-editor-core/lib/editor/DarkColorHandlerImpl.ts
+++ b/packages/roosterjs-editor-core/lib/editor/DarkColorHandlerImpl.ts
@@ -1,5 +1,5 @@
 import { ColorKeyAndValue, DarkColorHandler, ModeIndependentColor } from 'roosterjs-editor-types';
-import { getObjectKeys } from 'roosterjs-editor-dom';
+import { getObjectKeys, parseColor } from 'roosterjs-editor-dom';
 
 const VARIABLE_REGEX = /^\s*var\(\s*(\-\-[a-zA-Z0-9\-_]+)\s*(?:,\s*(.*))?\)\s*$/;
 const VARIABLE_PREFIX = 'var(';
@@ -88,5 +88,32 @@ export default class DarkColorHandlerImpl implements DarkColorHandler {
         }
 
         return { key, lightModeColor, darkModeColor };
+    }
+
+    /**
+     * Find related light mode color from dark mode color.
+     * @param darkColor The existing dark color
+     */
+    findLightColorFromDarkColor(darkColor: string): string | null {
+        const rgbSearch = parseColor(darkColor);
+
+        if (rgbSearch) {
+            const key = getObjectKeys(this.knownColors).find(key => {
+                const rgbCurrent = parseColor(this.knownColors[key].darkModeColor);
+
+                return (
+                    rgbCurrent &&
+                    rgbCurrent[0] == rgbSearch[0] &&
+                    rgbCurrent[1] == rgbSearch[1] &&
+                    rgbCurrent[2] == rgbSearch[2]
+                );
+            });
+
+            if (key) {
+                return this.knownColors[key].lightModeColor;
+            }
+        }
+
+        return null;
     }
 }

--- a/packages/roosterjs-editor-core/test/editor/DarkColorHandlerImplTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/DarkColorHandlerImplTest.ts
@@ -234,3 +234,94 @@ describe('DarkColorHandlerImpl.reset', () => {
         expect(removeProperty).toHaveBeenCalledWith('--dd');
     });
 });
+
+describe('DarkColorHandlerImpl.findLightColorFromDarkColor', () => {
+    it('Not found', () => {
+        const div = ({} as any) as HTMLElement;
+        const handler = new DarkColorHandlerImpl(div, null!);
+
+        const result = handler.findLightColorFromDarkColor('#010203');
+
+        expect(result).toEqual(null);
+    });
+
+    it('Found: HEX to RGB', () => {
+        const div = ({} as any) as HTMLElement;
+        const handler = new DarkColorHandlerImpl(div, null!);
+
+        (handler as any).knownColors = {
+            '--bb': {
+                lightModeColor: 'bb',
+                darkModeColor: 'rgb(4,5,6)',
+            },
+            '--aa': {
+                lightModeColor: 'aa',
+                darkModeColor: 'rgb(1,2,3)',
+            },
+        };
+
+        const result = handler.findLightColorFromDarkColor('#010203');
+
+        expect(result).toEqual('aa');
+    });
+
+    it('Found: HEX to HEX', () => {
+        const div = ({} as any) as HTMLElement;
+        const handler = new DarkColorHandlerImpl(div, null!);
+
+        (handler as any).knownColors = {
+            '--bb': {
+                lightModeColor: 'bb',
+                darkModeColor: 'rgb(4,5,6)',
+            },
+            '--aa': {
+                lightModeColor: 'aa',
+                darkModeColor: '#010203',
+            },
+        };
+
+        const result = handler.findLightColorFromDarkColor('#010203');
+
+        expect(result).toEqual('aa');
+    });
+
+    it('Found: RGB to HEX', () => {
+        const div = ({} as any) as HTMLElement;
+        const handler = new DarkColorHandlerImpl(div, null!);
+
+        (handler as any).knownColors = {
+            '--bb': {
+                lightModeColor: 'bb',
+                darkModeColor: 'rgb(4,5,6)',
+            },
+            '--aa': {
+                lightModeColor: 'aa',
+                darkModeColor: '#010203',
+            },
+        };
+
+        const result = handler.findLightColorFromDarkColor('rgb(1,2,3)');
+
+        expect(result).toEqual('aa');
+    });
+
+    it('Found: RGB to RGB', () => {
+        const div = ({} as any) as HTMLElement;
+        const handler = new DarkColorHandlerImpl(div, null!);
+
+        (handler as any).knownColors = {
+            '--bb': {
+                lightModeColor: 'bb',
+                darkModeColor: 'rgb(4,5,6)',
+            },
+            '--aa': {
+                lightModeColor: 'aa',
+                darkModeColor: 'rgb(1, 2, 3)',
+            },
+        };
+
+        const result = handler.findLightColorFromDarkColor('rgb(1,2,3)');
+
+        expect(result).toEqual('aa');
+    });
+});

--- a/packages/roosterjs-editor-dom/lib/index.ts
+++ b/packages/roosterjs-editor-dom/lib/index.ts
@@ -50,6 +50,7 @@ export { default as createElement, KnownCreateElementData } from './utils/create
 export { default as moveChildNodes } from './utils/moveChildNodes';
 export { default as getIntersectedRect } from './utils/getIntersectedRect';
 export { default as isNodeAfter } from './utils/isNodeAfter';
+export { default as parseColor } from './utils/parseColor';
 
 export { default as VTable } from './table/VTable';
 export { default as isWholeTableSelected } from './table/isWholeTableSelected';

--- a/packages/roosterjs-editor-dom/lib/utils/parseColor.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/parseColor.ts
@@ -1,0 +1,29 @@
+const HEX3_REGEX = /^#([a-fA-F0-9])([a-fA-F0-9])([a-fA-F0-9])$/;
+const HEX6_REGEX = /^#([a-fA-F0-9]{2})([a-fA-F0-9]{2})([a-fA-F0-9]{2})$/;
+const RGB_REGEX = /^rgb\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*\)$/;
+const RGBA_REGEX = /^rgba\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*\)$/;
+
+/**
+ * Parse color string to r/g/b value.
+ * If the given color is not in a recognized format, return null
+ */
+export default function parseColor(color: string): [number, number, number] | null {
+    color = (color || '').trim();
+
+    let match: RegExpMatchArray | null;
+    if ((match = color.match(HEX3_REGEX))) {
+        return [
+            parseInt(match[1] + match[1], 16),
+            parseInt(match[2] + match[2], 16),
+            parseInt(match[3] + match[3], 16),
+        ];
+    } else if ((match = color.match(HEX6_REGEX))) {
+        return [parseInt(match[1], 16), parseInt(match[2], 16), parseInt(match[3], 16)];
+    } else if ((match = color.match(RGB_REGEX) || color.match(RGBA_REGEX))) {
+        return [parseInt(match[1]), parseInt(match[2]), parseInt(match[3])];
+    } else {
+        // CSS color names such as red, green is not included for now.
+        // If need, we can add those colors from https://www.w3.org/wiki/CSS/Properties/color/keywords
+        return null;
+    }
+}

--- a/packages/roosterjs-editor-dom/lib/utils/setColor.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/setColor.ts
@@ -1,3 +1,4 @@
+import parseColor from './parseColor';
 import {
     DarkColorHandler,
     DarkModeDatasetNames,
@@ -147,41 +148,18 @@ function isADarkOrBrightColor(color: string): ColorTones {
  * @returns
  */
 function calculateLightness(color: string) {
-    let r: number;
-    let g: number;
-    let b: number;
+    const colorValues = parseColor(color);
 
-    if (color.substring(0, 1) == '#') {
-        [r, g, b] = getColorsFromHEX(color);
-    } else {
-        [r, g, b] = getColorsFromRGB(color);
-    }
     // Use the values of r,g,b to calculate the lightness in the HSl representation
     //First calculate the fraction of the light in each color, since in css the value of r,g,b is in the interval of [0,255], we have
-    const red = r / 255;
-    const green = g / 255;
-    const blue = b / 255;
-    //Then the lightness in the HSL representation is the average between maximum fraction of r,g,b and the minimum fraction
-    return (Math.max(red, green, blue) + Math.min(red, green, blue)) * 50;
-}
+    if (colorValues) {
+        const red = colorValues[0] / 255;
+        const green = colorValues[1] / 255;
+        const blue = colorValues[2] / 255;
 
-function getColorsFromHEX(color: string) {
-    if (color.length === 4) {
-        color = color.replace(/(.)/g, '$1$1');
+        //Then the lightness in the HSL representation is the average between maximum fraction of r,g,b and the minimum fraction
+        return (Math.max(red, green, blue) + Math.min(red, green, blue)) * 50;
+    } else {
+        return 255;
     }
-    const colors = color.replace('#', '');
-    let r = parseInt(colors.substr(0, 2), 16);
-    let g = parseInt(colors.substr(2, 2), 16);
-    let b = parseInt(colors.substr(4, 2), 16);
-    return [r, g, b];
-}
-
-function getColorsFromRGB(color: string) {
-    const colors = color.match(
-        /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/
-    ) as RegExpMatchArray;
-    let r = parseInt(colors[1]);
-    let g = parseInt(colors[2]);
-    let b = parseInt(colors[3]);
-    return [r, g, b];
 }

--- a/packages/roosterjs-editor-dom/test/utils/parseColorTest.ts
+++ b/packages/roosterjs-editor-dom/test/utils/parseColorTest.ts
@@ -1,0 +1,73 @@
+import parseColor from '../../lib/utils/parseColor';
+
+describe('parseColor', () => {
+    it('empty string', () => {
+        const result = parseColor('');
+        expect(result).toBe(null);
+    });
+
+    it('unrecognized color', () => {
+        const result = parseColor('aaa');
+        expect(result).toBe(null);
+    });
+
+    it('short hex 1', () => {
+        const result = parseColor('#aaa');
+        expect(result).toEqual([170, 170, 170]);
+    });
+
+    it('short hex 2', () => {
+        const result = parseColor('#aaab');
+        expect(result).toEqual(null);
+    });
+
+    it('short hex 3', () => {
+        const result = parseColor('   #aaa   ');
+        expect(result).toEqual([170, 170, 170]);
+    });
+
+    it('long hex 1', () => {
+        const result = parseColor('#ababab');
+        expect(result).toEqual([171, 171, 171]);
+    });
+
+    it('long hex 2', () => {
+        const result = parseColor('#abababc');
+        expect(result).toEqual(null);
+    });
+
+    it('long hex 3', () => {
+        const result = parseColor('  #ababab  ');
+        expect(result).toEqual([171, 171, 171]);
+    });
+
+    it('rgb 1', () => {
+        const result = parseColor('rgb(1,2,3)');
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('rgb 2', () => {
+        const result = parseColor('   rgb(   1   ,   2  ,  3  )  ');
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('rgb 3', () => {
+        const result = parseColor('rgb(1.1, 2.2, 3.3)');
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('rgba 1', () => {
+        const result = parseColor('rgba(1, 2, 3, 4)');
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('rgba 2', () => {
+        const result = parseColor('    rgba(   1.1   ,    2.2   ,  3.3  ,  4.4  )  ');
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('rgba 3', () => {
+        const result = parseColor('rgba(1.1, 2.2, 3.3, 4.4)');
+        expect(result).toEqual([1, 2, 3]);
+    });
+});

--- a/packages/roosterjs-editor-types/lib/interface/DarkColorHandler.ts
+++ b/packages/roosterjs-editor-types/lib/interface/DarkColorHandler.ts
@@ -49,4 +49,10 @@ export default interface DarkColorHandler {
      * Get a copy of known colors
      */
     getKnownColorsCopy(): Readonly<ModeIndependentColor>[];
+
+    /**
+     * Find related light mode color from dark mode color.
+     * @param darkColor The existing dark color
+     */
+    findLightColorFromDarkColor(darkColor: string): string | null;
 }


### PR DESCRIPTION
When input with IME in dark mode in Chrome, it is possible Chrome add a FONT tag and add color attribute but there is not dark color info. So when switch back to light mode, the color will be wrong.

Fix: with VariableBasedDarkColor feature enabled, we now remember all used colors. So we can query from dark color and transform it back to light color in that case.