### PR TITLE
Fix #1586 text-decoration is removed from HtmlSanitizer

### DIFF
--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/getAllowedValues.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/getAllowedValues.ts
@@ -165,7 +165,6 @@ const DEFAULT_STYLE_VALUES: { [name: string]: string } = {
     'outline-style': 'none',
     'outline-width': '0px',
     overflow: 'visible',
-    'text-decoration': 'none',
     '-webkit-text-stroke-width': '0px',
     'word-wrap': 'break-word',
     'margin-left': '0px',


### PR DESCRIPTION
We set "none" as default value for text-decoration, but for A tag it is not default value.

So the easiest way to fix is to remove this default value. 

(With content model this issue will be auto fixed)