### PR TITLE
Content Model: Improve pending format behavior

### DIFF
--- a/packages/roosterjs-content-model/lib/publicApi/block/setIndentation.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setIndentation.ts
@@ -13,7 +13,11 @@ export default function setIndentation(
     indentation: 'indent' | 'outdent',
     length?: number
 ) {
-    formatWithContentModel(editor, 'setIndentation', model =>
-        setModelIndentation(model, indentation, length)
+    formatWithContentModel(
+        editor,
+        'setIndentation',
+        model => setModelIndentation(model, indentation, length),
+        undefined /*options*/,
+        true /*preservePendingFormat*/
     );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
@@ -36,7 +36,11 @@ export default function toggleBlockQuote(
         ...quoteFormat,
     };
 
-    formatWithContentModel(editor, 'toggleBlockQuote', model =>
-        toggleModelBlockQuote(model, fullQuoteFormat, segmentFormat)
+    formatWithContentModel(
+        editor,
+        'toggleBlockQuote',
+        model => toggleModelBlockQuote(model, fullQuoteFormat, segmentFormat),
+        undefined /*options*/,
+        true /*preservePendingFormat*/
     );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/format/applyPendingFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/applyPendingFormat.ts
@@ -4,6 +4,9 @@ import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { iterateSelections } from '../../modelApi/selection/iterateSelections';
 
+const ANSI_SPACE = '\u0020';
+const NON_BREAK_SPACE = '\u00A0';
+
 /**
  * Apply pending format to the text user just input
  * @param editor The editor to get format from
@@ -27,14 +30,19 @@ export default function applyPendingFormat(editor: IContentModelEditor, data: st
 
                     if (previousSegment?.segmentType == 'Text') {
                         const text = previousSegment.text;
+                        const subStr = text.substr(-data.length, data.length);
 
-                        if (text.substr(-data.length, data.length) == data) {
+                        // For space, there can be &#32 (space) or &#160 (&nbsp;), we treat them as the same
+                        if (subStr == data || (data == ANSI_SPACE && subStr == NON_BREAK_SPACE)) {
                             previousSegment.text = text.substring(0, text.length - data.length);
 
-                            const newText = createText(data, {
-                                ...previousSegment.format,
-                                ...format,
-                            });
+                            const newText = createText(
+                                data == ANSI_SPACE ? NON_BREAK_SPACE : data,
+                                {
+                                    ...previousSegment.format,
+                                    ...format,
+                                }
+                            );
 
                             block.segments.splice(index, 0, newText);
                             isChanged = true;

--- a/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
@@ -4,6 +4,7 @@ import { ContentModelLink } from '../../publicTypes/decorator/ContentModelLink';
 import { createContentModelDocument } from '../../modelApi/creators/createContentModelDocument';
 import { createText } from '../../modelApi/creators/createText';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
+import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
 import { HtmlSanitizer, matchLink } from 'roosterjs-editor-dom';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
@@ -64,10 +65,10 @@ export default function insertLink(
                 segments.every(x => x.segmentType == 'SelectionMarker') ||
                 (!!text && text != originalText)
             ) {
-                const segment = createText(
-                    text || (linkData ? linkData.originalUrl : url),
-                    segments[0]?.format
-                );
+                const segment = createText(text || (linkData ? linkData.originalUrl : url), {
+                    ...(segments[0]?.format || {}),
+                    ...(getPendingFormat(editor) || {}),
+                });
                 const doc = createContentModelDocument();
 
                 addLink(segment, link);

--- a/packages/roosterjs-content-model/lib/publicApi/list/toggleBullet.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/toggleBullet.ts
@@ -9,5 +9,11 @@ import { setListType } from '../../modelApi/list/setListType';
  * @param editor The editor to operate on
  */
 export default function toggleBullet(editor: IContentModelEditor) {
-    formatWithContentModel(editor, 'toggleBullet', model => setListType(model, 'UL'));
+    formatWithContentModel(
+        editor,
+        'toggleBullet',
+        model => setListType(model, 'UL'),
+        undefined /*options*/,
+        true /*preservePendingFormat*/
+    );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/list/toggleNumbering.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/toggleNumbering.ts
@@ -9,5 +9,11 @@ import { setListType } from '../../modelApi/list/setListType';
  * @param editor The editor to operate on
  */
 export default function toggleNumbering(editor: IContentModelEditor) {
-    formatWithContentModel(editor, 'toggleNumbering', model => setListType(model, 'OL'));
+    formatWithContentModel(
+        editor,
+        'toggleNumbering',
+        model => setListType(model, 'OL'),
+        undefined /*options*/,
+        true /*preservePendingFormat*/
+    );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
@@ -4,6 +4,7 @@ import { createSelectionMarker } from '../../modelApi/creators/createSelectionMa
 import { createTableStructure } from '../../modelApi/table/createTableStructure';
 import { deleteSelection } from '../../modelApi/selection/deleteSelections';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
+import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { mergeModel } from '../../modelApi/common/mergeModel';
 import { normalizeTable } from '../../modelApi/table/normalizeTable';
@@ -32,7 +33,7 @@ export default function insertTable(
             const doc = createContentModelDocument();
             const table = createTableStructure(doc, columns, rows);
 
-            normalizeTable(table, insertPosition.marker.format);
+            normalizeTable(table, getPendingFormat(editor) || insertPosition.marker.format);
             applyTableFormat(table, format);
             mergeModel(model, doc, {
                 insertPosition,

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatParagraphWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatParagraphWithContentModel.ts
@@ -11,11 +11,17 @@ export function formatParagraphWithContentModel(
     apiName: string,
     setStyleCallback: (paragraph: ContentModelParagraph) => void
 ) {
-    formatWithContentModel(editor, apiName, model => {
-        const paragraphs = getSelectedParagraphs(model);
+    formatWithContentModel(
+        editor,
+        apiName,
+        model => {
+            const paragraphs = getSelectedParagraphs(model);
 
-        paragraphs.forEach(setStyleCallback);
+            paragraphs.forEach(setStyleCallback);
 
-        return paragraphs.length > 0;
-    });
+            return paragraphs.length > 0;
+        },
+        undefined /*options*/,
+        true /*preservePendingFormat*/
+    );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -1,6 +1,7 @@
 import { ChangeSource } from 'roosterjs-editor-types';
 import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
 import { DomToModelOption, IContentModelEditor } from '../../publicTypes/IContentModelEditor';
+import { getPendingFormat, setPendingFormat } from '../../modelApi/format/pendingFormat';
 
 /**
  * @internal
@@ -9,7 +10,8 @@ export function formatWithContentModel(
     editor: IContentModelEditor,
     apiName: string,
     callback: (model: ContentModelDocument) => boolean,
-    domToModelOptions?: DomToModelOption
+    domToModelOptions?: DomToModelOption,
+    preservePendingFormat?: boolean
 ) {
     const model = editor.createContentModel(domToModelOptions);
 
@@ -19,6 +21,15 @@ export function formatWithContentModel(
                 editor.focus();
                 if (model) {
                     editor.setContentModel(model);
+                }
+
+                if (preservePendingFormat) {
+                    const pendingFormat = getPendingFormat(editor);
+                    const pos = editor.getFocusedPosition();
+
+                    if (pendingFormat && pos) {
+                        setPendingFormat(editor, pendingFormat, pos);
+                    }
                 }
             },
             ChangeSource.Format,

--- a/packages/roosterjs-content-model/test/publicApi/block/paragraphTestCommon.ts
+++ b/packages/roosterjs-content-model/test/publicApi/block/paragraphTestCommon.ts
@@ -23,6 +23,8 @@ export function paragraphTestCommon(
         addUndoSnapshot,
         focus: jasmine.createSpy(),
         setContentModel,
+        getCustomData: () => ({}),
+        getFocusedPosition: () => ({}),
     } as any) as IContentModelEditor;
 
     executionCallback(editor);

--- a/packages/roosterjs-content-model/test/publicApi/link/insertLinkTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/link/insertLinkTest.ts
@@ -22,6 +22,8 @@ describe('insertLink', () => {
             addUndoSnapshot: (callback: Function) => callback(),
             setContentModel,
             createContentModel,
+            getCustomData: () => ({}),
+            getFocusedPosition: () => ({}),
         } as any) as IContentModelEditor;
     });
 

--- a/packages/roosterjs-content-model/test/publicApi/list/toggleBulletTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/list/toggleBulletTest.ts
@@ -24,6 +24,8 @@ describe('toggleBullet', () => {
             addUndoSnapshot,
             createContentModel,
             setContentModel,
+            getCustomData: () => ({}),
+            getFocusedPosition: () => ({}),
         } as any) as IContentModelEditor;
 
         spyOn(setListType, 'setListType').and.returnValue(true);

--- a/packages/roosterjs-content-model/test/publicApi/list/toggleNumberingTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/list/toggleNumberingTest.ts
@@ -24,6 +24,8 @@ describe('toggleNumbering', () => {
             addUndoSnapshot,
             createContentModel,
             setContentModel,
+            getCustomData: () => ({}),
+            getFocusedPosition: () => ({}),
         } as any) as IContentModelEditor;
 
         spyOn(setListType, 'setListType').and.returnValue(true);


### PR DESCRIPTION
1. Fix #879 When there is pending format, apply other format such as alignment, direction, toggle list, ... will dismiss pending format. Fix it by preserve pending format and update the position for pending format so when apply the format, it can pass the check.
2. Press SPACE may dismiss pending format because space from keyboard event is 32 but existing space in HTML document is 160. Fix it by treating them as the same character