### PR TITLE
Content Model: Improve PRE again

### DIFF
--- a/packages/roosterjs-content-model/lib/formatHandlers/block/whiteSpaceFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/block/whiteSpaceFormatHandler.ts
@@ -16,6 +16,9 @@ export const whiteSpaceFormatHandler: FormatHandler<WhiteSpaceFormat> = {
         if (format.whiteSpace == 'pre') {
             const pre = element.ownerDocument.createElement('pre');
 
+            pre.style.marginTop = '0';
+            pre.style.marginBottom = '0';
+
             element.parentNode?.appendChild(pre);
             pre.appendChild(element);
         } else if (format.whiteSpace) {

--- a/packages/roosterjs-content-model/lib/modelToDom/optimizers/mergeNode.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/optimizers/mergeNode.ts
@@ -1,7 +1,7 @@
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import { NodeType } from 'roosterjs-editor-types';
 
-const OptimizeTags = ['SPAN', 'B', 'EM', 'I', 'U', 'SUB', 'SUP', 'STRIKE', 'S', 'A'];
+const OptimizeTags = ['SPAN', 'B', 'EM', 'I', 'U', 'SUB', 'SUP', 'STRIKE', 'S', 'A', 'PRE'];
 
 /**
  * @internal

--- a/packages/roosterjs-content-model/test/formatHandlers/block/whiteSpaceFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/block/whiteSpaceFormatHandlerTest.ts
@@ -72,7 +72,9 @@ describe('whiteSpaceFormatHandler.apply', () => {
     it('Has white space: pre', () => {
         format.whiteSpace = 'pre';
         whiteSpaceFormatHandler.apply(format, div, context);
-        expect(container.innerHTML).toBe('<pre><div></div></pre>');
+        expect(container.innerHTML).toBe(
+            '<pre style="margin-top: 0px; margin-bottom: 0px;"><div></div></pre>'
+        );
     });
 
     it('Has white space: pre-wrap', () => {


### PR DESCRIPTION
With a previous change (#1559), we are using PRE tag instead of CSS white-space: pre for this kind of format. However, this causes another problem that each PRE tag will have additional top and margin bottoms. So we need to set them to 0 to override this behavior.

This is not an ultimate solution, but for now let's go with this way and try to find a better solution later.