### PR TITLE
Use keypress instead of keydown in AutoFormat plugin

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/AutoFormat/AutoFormat.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/AutoFormat/AutoFormat.ts
@@ -7,7 +7,7 @@ import {
     PositionType,
 } from 'roosterjs-editor-types';
 
-const specialCharacters = /[`!@#$%^&*()_+\=\[\]{};':"\\|,.<>\/?~]/;
+const specialCharacters = /[`!@#$%^&*()+\=\[\]{};':"\\|,.<>\/?~]/;
 
 /**
  * Automatically transform -- into hyphen, if typed between two words.
@@ -55,7 +55,7 @@ export default class AutoFormat implements EditorPlugin {
             this.lastKeyTyped = '';
         }
 
-        if (event.eventType === PluginEventType.KeyDown) {
+        if (event.eventType === PluginEventType.KeyPress) {
             const keyTyped = event.rawEvent.key;
 
             if (keyTyped && keyTyped.length > 1) {

--- a/packages/roosterjs-editor-plugins/lib/plugins/AutoFormat/AutoFormat.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/AutoFormat/AutoFormat.ts
@@ -7,7 +7,7 @@ import {
     PositionType,
 } from 'roosterjs-editor-types';
 
-const specialCharacters = /[`!@#$%^&*()+\=\[\]{};':"\\|,.<>\/?~]/;
+const specialCharacters = /[`!@#$%^&*()_+\=\[\]{};':"\\|,.<>\/?~]/;
 
 /**
  * Automatically transform -- into hyphen, if typed between two words.

--- a/packages/roosterjs-editor-plugins/test/AutoFormat/autoFormatTest.ts
+++ b/packages/roosterjs-editor-plugins/test/AutoFormat/autoFormatTest.ts
@@ -17,7 +17,7 @@ describe('AutoHyphen |', () => {
 
     const keyDown = (keysTyped: string): PluginEvent => {
         return {
-            eventType: PluginEventType.KeyDown,
+            eventType: PluginEventType.KeyPress,
             rawEvent: <KeyboardEvent>{
                 key: keysTyped,
             },


### PR DESCRIPTION
AutoFormat Plugin does not need to observe key like SHIFT,CTRL, ALT, ESC, then switch keydown to keypress. 
![autoFormatKeyPress](https://user-images.githubusercontent.com/87443959/221990979-e126fc5e-4e66-4481-8ec9-7d29a48351e4.gif)
