### PR TITLE
Delimiters in Content Model

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/context/createDomToModelContext.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/context/createDomToModelContext.ts
@@ -17,7 +17,7 @@ export function createDomToModelContext(
         ...(editorContext || {
             isDarkMode: false,
             getDarkColor: undefined,
-            experimentalFeatures: [],
+            isFeatureEnabled: undefined,
         }),
 
         blockFormat: {},

--- a/packages/roosterjs-content-model/lib/domToModel/context/createDomToModelContext.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/context/createDomToModelContext.ts
@@ -17,6 +17,7 @@ export function createDomToModelContext(
         ...(editorContext || {
             isDarkMode: false,
             getDarkColor: undefined,
+            experimentalFeatures: [],
         }),
 
         blockFormat: {},
@@ -53,6 +54,10 @@ export function createDomToModelContext(
 
         defaultElementProcessors: defaultProcessorMap,
         defaultFormatParsers: defaultFormatParsers,
+
+        shouldSkipProcessElement: {
+            ...(options?.shouldSkipProcessElement || {}),
+        },
     };
 
     if (options?.alwaysNormalizeTable) {

--- a/packages/roosterjs-content-model/lib/domToModel/processors/childProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/childProcessor.ts
@@ -17,6 +17,10 @@ export const childProcessor: ElementProcessor<ParentNode> = (
     const [nodeStartOffset, nodeEndOffset] = getRegularSelectionOffsets(context, parent);
     let index = 0;
 
+    if (context.shouldSkipProcessElement?.child?.(parent, context)) {
+        return;
+    }
+
     for (let child = parent.firstChild; child; child = child.nextSibling) {
         handleRegularSelection(index, context, group, nodeStartOffset, nodeEndOffset);
 

--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -1,16 +1,20 @@
 import contentModelToDom from '../modelToDom/contentModelToDom';
 import domToContentModel from '../domToModel/domToContentModel';
 import { ContentModelDocument } from '../publicTypes/group/ContentModelDocument';
+import { DelimiterClasses, SelectionRangeTypes } from 'roosterjs-editor-types';
+import { DomToModelContext } from '../publicTypes/context/DomToModelContext';
 import { Editor } from 'roosterjs-editor-core';
 import { EditorContext } from '../publicTypes/context/EditorContext';
 import { Position, restoreContentWithEntityPlaceholder } from 'roosterjs-editor-dom';
-import { SelectionRangeTypes } from 'roosterjs-editor-types';
-
+import { safeInstanceOf } from 'roosterjs-editor-dom';
+import { ShouldSkipProcessElementMap } from '../publicTypes/context/DomToModelSettings';
 import {
     DomToModelOption,
     IContentModelEditor,
     ModelToDomOption,
 } from '../publicTypes/IContentModelEditor';
+
+const ZERO_WIDTH_SPACE = '\u200B';
 
 /**
  * Editor for Content Model.
@@ -28,7 +32,15 @@ export default class ContentModelEditor extends Editor implements IContentModelE
             selectionRange: this.getSelectionRangeEx(),
             alwaysNormalizeTable: true,
             ...(option || {}),
+            shouldSkipProcessElement: this.createShouldHandleElement(),
         });
+    }
+
+    private createShouldHandleElement(): Partial<ShouldSkipProcessElementMap> | undefined {
+        return {
+            child: (element: ParentNode, context: DomToModelContext): boolean =>
+                !!isDelimiter(element, context),
+        };
     }
 
     /**
@@ -68,6 +80,16 @@ export default class ContentModelEditor extends Editor implements IContentModelE
             isDarkMode: this.isDarkMode(),
             getDarkColor: core.lifecycle.getDarkColor,
             darkColorHandler: this.getDarkColorHandler(),
+            experimentalFeatures: core.lifecycle.experimentalFeatures,
         };
     }
+}
+
+function isDelimiter(element: Node, context: DomToModelContext) {
+    return (
+        safeInstanceOf(element, 'HTMLSpanElement') &&
+        (element.className === DelimiterClasses.DELIMITER_AFTER ||
+            element.className === DelimiterClasses.DELIMITER_BEFORE) &&
+        element.textContent === ZERO_WIDTH_SPACE
+    );
 }

--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -80,7 +80,7 @@ export default class ContentModelEditor extends Editor implements IContentModelE
             isDarkMode: this.isDarkMode(),
             getDarkColor: core.lifecycle.getDarkColor,
             darkColorHandler: this.getDarkColorHandler(),
-            experimentalFeatures: core.lifecycle.experimentalFeatures,
+            isFeatureEnabled: this.isFeatureEnabled.bind(this),
         };
     }
 }

--- a/packages/roosterjs-content-model/lib/editor/isFeatureEnabled.ts
+++ b/packages/roosterjs-content-model/lib/editor/isFeatureEnabled.ts
@@ -1,0 +1,9 @@
+import { EditorContext } from 'roosterjs-content-model/lib/publicTypes';
+import { ExperimentalFeatures } from 'roosterjs-editor-types/lib';
+
+/**
+ * @internal
+ */
+export default function isFeatureEnabled(context: EditorContext, feature: ExperimentalFeatures) {
+    return context.experimentalFeatures.indexOf(feature) >= 0;
+}

--- a/packages/roosterjs-content-model/lib/editor/isFeatureEnabled.ts
+++ b/packages/roosterjs-content-model/lib/editor/isFeatureEnabled.ts
@@ -5,5 +5,5 @@ import { ExperimentalFeatures } from 'roosterjs-editor-types/lib';
  * @internal
  */
 export default function isFeatureEnabled(context: EditorContext, feature: ExperimentalFeatures) {
-    return context.experimentalFeatures.indexOf(feature) >= 0;
+    return context.isFeatureEnabled(feature);
 }

--- a/packages/roosterjs-content-model/lib/modelApi/common/insertContent.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/insertContent.ts
@@ -21,7 +21,7 @@ export function insertContent(
             htmlContent,
             {
                 isDarkMode: !!isFromDarkMode,
-                experimentalFeatures: [],
+                isFeatureEnabled: () => false,
             },
             {
                 includeRoot: true,

--- a/packages/roosterjs-content-model/lib/modelApi/common/insertContent.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/insertContent.ts
@@ -21,6 +21,7 @@ export function insertContent(
             htmlContent,
             {
                 isDarkMode: !!isFromDarkMode,
+                experimentalFeatures: [],
             },
             {
                 includeRoot: true,

--- a/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
@@ -21,6 +21,7 @@ export function createModelToDomContext(
         ...(editorContext || {
             isDarkMode: false,
             getDarkColor: undefined,
+            experimentalFeatures: [],
         }),
         regularSelection: {
             current: {

--- a/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/context/createModelToDomContext.ts
@@ -21,7 +21,7 @@ export function createModelToDomContext(
         ...(editorContext || {
             isDarkMode: false,
             getDarkColor: undefined,
-            experimentalFeatures: [],
+            isFeatureEnabled: undefined,
         }),
         regularSelection: {
             current: {

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
@@ -1,9 +1,15 @@
 import { applyFormat } from '../utils/applyFormat';
-import { commitEntity, createEntityPlaceholder, getObjectKeys } from 'roosterjs-editor-dom';
 import { ContentModelEntity } from '../../publicTypes/entity/ContentModelEntity';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
 import { Entity } from 'roosterjs-editor-types';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+import {
+    addDelimiters,
+    commitEntity,
+    createEntityPlaceholder,
+    getObjectKeys,
+    isBlockElement,
+} from 'roosterjs-editor-dom';
 
 /**
  * @internal
@@ -40,14 +46,28 @@ export const handleEntity: ContentModelHandler<ContentModelEntity> = (
 
     if (!entity) {
         parent.appendChild(wrapper);
+
+        addDelimiterElements(wrapper, isReadonly, context);
     } else {
         // Create a comment as placeholder and insert into DOM tree.
         // If the entity DOM can be reused, the original DOM node will be preserved without any change
         // so that in case there is something that is sensitive to its DOM path (e.g. IFRAME), no need to cause it reloaded.
         // For entity that is not directly under root, later we will replace the comment with its original DOM node
-        parent.appendChild(createEntityPlaceholder(entity));
+        const placeholder = createEntityPlaceholder(entity);
+        parent.appendChild(placeholder);
+
+        addDelimiterElements(placeholder, isReadonly, context);
 
         // Save the entity DOM wrapper node and its placeholder into context so that later we know how to handle it
         context.entities[entity.id] = wrapper;
     }
 };
+function addDelimiterElements(
+    wrapper: HTMLElement,
+    isReadonly: boolean,
+    context: ModelToDomContext
+) {
+    if (!isBlockElement(wrapper) && isReadonly) {
+        addDelimiters(wrapper);
+    }
+}

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
@@ -1,7 +1,7 @@
 import { applyFormat } from '../utils/applyFormat';
 import { ContentModelEntity } from '../../publicTypes/entity/ContentModelEntity';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
-import { Entity } from 'roosterjs-editor-types';
+import { Entity, ExperimentalFeatures } from 'roosterjs-editor-types';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
 import {
     addDelimiters,
@@ -67,7 +67,11 @@ function addDelimiterElements(
     isReadonly: boolean,
     context: ModelToDomContext
 ) {
-    if (!isBlockElement(wrapper) && isReadonly) {
+    if (
+        context.isFeatureEnabled?.(ExperimentalFeatures.InlineEntityReadOnlyDelimiters) &&
+        !isBlockElement(wrapper) &&
+        isReadonly
+    ) {
         addDelimiters(wrapper);
     }
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/IContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/IContentModelEditor.ts
@@ -11,6 +11,7 @@ import {
     ElementProcessorMap,
     FormatParsers,
     FormatParsersPerCategory,
+    ShouldSkipProcessElementMap,
 } from './context/DomToModelSettings';
 
 /**
@@ -53,6 +54,11 @@ export interface DomToModelOption {
      * @default false
      */
     alwaysNormalizeTable?: boolean;
+
+    /**
+     * Checks whether elements needs to be skipped from being processed
+     */
+    shouldSkipProcessElement?: Partial<ShouldSkipProcessElementMap>;
 }
 
 /**

--- a/packages/roosterjs-content-model/lib/publicTypes/context/DomToModelSettings.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/DomToModelSettings.ts
@@ -3,6 +3,7 @@ import { ContentModelFormatMap } from '../format/ContentModelFormatMap';
 import { DomToModelContext } from './DomToModelContext';
 import { ElementProcessor } from './ElementProcessor';
 import { FormatHandlerTypeMap, FormatKey } from '../format/FormatHandlerTypeMap';
+import { ShouldSkipProcessElement } from './ShouldProcessElement';
 
 /**
  * A type of Default style map, from tag name string (in upper case) to a static style object
@@ -93,6 +94,13 @@ export type ElementProcessorMap = {
         center?: ElementProcessor<HTMLElement>;
     };
 
+export type ShouldSkipProcessElementMap = {
+    /**
+     * Common processor for child nodes of a given element
+     */
+    child: ShouldSkipProcessElement<ParentNode>;
+};
+
 /**
  * Represents settings to customize DOM to Content Model conversion
  */
@@ -123,4 +131,9 @@ export interface DomToModelSettings {
      * This provides a way to call original format parser from an overridden parser function
      */
     defaultFormatParsers: Readonly<FormatParsers>;
+
+    /**
+     *
+     */
+    shouldSkipProcessElement?: Readonly<Partial<ShouldSkipProcessElementMap>>;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/context/EditorContext.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/EditorContext.ts
@@ -1,4 +1,5 @@
-import { DarkColorHandler } from 'roosterjs-editor-types';
+import { DarkColorHandler, ExperimentalFeatures } from 'roosterjs-editor-types';
+import type { CompatibleExperimentalFeatures } from 'roosterjs-editor-types/lib/compatibleTypes';
 
 /**
  * An editor context interface used by ContentModel PAI
@@ -20,4 +21,10 @@ export interface EditorContext {
      * Dark model color handler
      */
     darkColorHandler?: DarkColorHandler | null;
+
+    /**
+     * Check if the given experimental feature is enabled in the editor
+     * @param feature The feature to check
+     */
+    experimentalFeatures: (ExperimentalFeatures | CompatibleExperimentalFeatures)[];
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/context/EditorContext.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/EditorContext.ts
@@ -26,5 +26,5 @@ export interface EditorContext {
      * Check if the given experimental feature is enabled in the editor
      * @param feature The feature to check
      */
-    experimentalFeatures: (ExperimentalFeatures | CompatibleExperimentalFeatures)[];
+    isFeatureEnabled?: (feature: ExperimentalFeatures | CompatibleExperimentalFeatures) => boolean;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/context/ShouldProcessElement.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/ShouldProcessElement.ts
@@ -1,0 +1,12 @@
+import { DomToModelContext } from './DomToModelContext';
+
+/**
+ * A function type that checks if the current element should be skipped when do DOM to Content Model conversion
+ * @param group Parent content model group
+ * @param element The element to process
+ * @param context The context object to provide related information
+ */
+export type ShouldSkipProcessElement<T extends Node> = (
+    element: T,
+    context: DomToModelContext
+) => boolean;

--- a/packages/roosterjs-content-model/test/domToModel/context/createDomToModelContextTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/context/createDomToModelContextTest.ts
@@ -13,7 +13,7 @@ describe('createDomToModelContext', () => {
     const editorContext: EditorContext = {
         isDarkMode: false,
         getDarkColor: undefined,
-        experimentalFeatures: [],
+        isFeatureEnabled: undefined,
     };
     const listFormat: DomToModelListFormat = {
         threadItemCounts: [],
@@ -52,7 +52,7 @@ describe('createDomToModelContext', () => {
         const editorContext: EditorContext = {
             isDarkMode: true,
             getDarkColor: () => '',
-            experimentalFeatures: [],
+            isFeatureEnabled: undefined,
         };
 
         const context = createDomToModelContext(editorContext);
@@ -193,12 +193,13 @@ describe('createDomToModelContext', () => {
 
     it('with base parameters and wrong selection 1', () => {
         const getDarkColor = () => '';
+        const isFeatureEnabled = () => true;
 
         const context = createDomToModelContext(
             {
                 isDarkMode: true,
                 getDarkColor,
-                experimentalFeatures: [],
+                isFeatureEnabled,
             },
             {
                 selectionRange: {
@@ -213,7 +214,7 @@ describe('createDomToModelContext', () => {
             isDarkMode: true,
             getDarkColor: getDarkColor,
             isInSelection: false,
-            experimentalFeatures: [],
+            isFeatureEnabled,
             blockFormat: {},
             zoomScaleFormat: {},
             segmentFormat: {},
@@ -231,12 +232,13 @@ describe('createDomToModelContext', () => {
 
     it('with base parameters and wrong selection 2', () => {
         const getDarkColor = () => '';
+        const isFeatureEnabled = () => true;
 
         const context = createDomToModelContext(
             {
                 isDarkMode: true,
                 getDarkColor,
-                experimentalFeatures: [],
+                isFeatureEnabled,
             },
             {
                 selectionRange: {
@@ -252,7 +254,7 @@ describe('createDomToModelContext', () => {
         expect(context).toEqual({
             isDarkMode: true,
             getDarkColor: getDarkColor,
-            experimentalFeatures: [],
+            isFeatureEnabled,
             isInSelection: false,
             blockFormat: {},
             zoomScaleFormat: {},

--- a/packages/roosterjs-content-model/test/domToModel/context/createDomToModelContextTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/context/createDomToModelContextTest.ts
@@ -13,6 +13,7 @@ describe('createDomToModelContext', () => {
     const editorContext: EditorContext = {
         isDarkMode: false,
         getDarkColor: undefined,
+        experimentalFeatures: [],
     };
     const listFormat: DomToModelListFormat = {
         threadItemCounts: [],
@@ -24,6 +25,7 @@ describe('createDomToModelContext', () => {
         formatParsers: getFormatParsers(),
         defaultElementProcessors: defaultProcessorMap,
         defaultFormatParsers: defaultFormatParsers,
+        shouldSkipProcessElement: {},
     };
     it('no param', () => {
         const context = createDomToModelContext();
@@ -50,6 +52,7 @@ describe('createDomToModelContext', () => {
         const editorContext: EditorContext = {
             isDarkMode: true,
             getDarkColor: () => '',
+            experimentalFeatures: [],
         };
 
         const context = createDomToModelContext(editorContext);
@@ -195,6 +198,7 @@ describe('createDomToModelContext', () => {
             {
                 isDarkMode: true,
                 getDarkColor,
+                experimentalFeatures: [],
             },
             {
                 selectionRange: {
@@ -209,6 +213,7 @@ describe('createDomToModelContext', () => {
             isDarkMode: true,
             getDarkColor: getDarkColor,
             isInSelection: false,
+            experimentalFeatures: [],
             blockFormat: {},
             zoomScaleFormat: {},
             segmentFormat: {},
@@ -231,6 +236,7 @@ describe('createDomToModelContext', () => {
             {
                 isDarkMode: true,
                 getDarkColor,
+                experimentalFeatures: [],
             },
             {
                 selectionRange: {
@@ -246,6 +252,7 @@ describe('createDomToModelContext', () => {
         expect(context).toEqual({
             isDarkMode: true,
             getDarkColor: getDarkColor,
+            experimentalFeatures: [],
             isInSelection: false,
             blockFormat: {},
             zoomScaleFormat: {},

--- a/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
@@ -12,7 +12,7 @@ describe('createModelToDomContext', () => {
     const editorContext: EditorContext = {
         isDarkMode: false,
         getDarkColor: undefined,
-        experimentalFeatures: [],
+        isFeatureEnabled: undefined,
     };
     const defaultResult: ModelToDomContext = {
         ...editorContext,
@@ -44,7 +44,7 @@ describe('createModelToDomContext', () => {
         const editorContext: EditorContext = {
             isDarkMode: true,
             getDarkColor: () => '',
-            experimentalFeatures: [],
+            isFeatureEnabled: undefined,
         };
 
         const context = createModelToDomContext(editorContext);

--- a/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/context/createModelToDomContextTest.ts
@@ -12,6 +12,7 @@ describe('createModelToDomContext', () => {
     const editorContext: EditorContext = {
         isDarkMode: false,
         getDarkColor: undefined,
+        experimentalFeatures: [],
     };
     const defaultResult: ModelToDomContext = {
         ...editorContext,
@@ -43,6 +44,7 @@ describe('createModelToDomContext', () => {
         const editorContext: EditorContext = {
             isDarkMode: true,
             getDarkColor: () => '',
+            experimentalFeatures: [],
         };
 
         const context = createModelToDomContext(editorContext);

--- a/packages/roosterjs-content-model/test/editor/ContentModelEditorTest.ts
+++ b/packages/roosterjs-content-model/test/editor/ContentModelEditorTest.ts
@@ -3,7 +3,15 @@ import * as domToContentModel from '../../lib/domToModel/domToContentModel';
 import * as entityPlaceholderUtils from 'roosterjs-editor-dom/lib/entity/entityPlaceholderUtils';
 import ContentModelEditor from '../../lib/editor/ContentModelEditor';
 import { ContentModelDocument } from '../../lib/publicTypes/group/ContentModelDocument';
+import { EditorContext } from '../../lib/publicTypes/context/EditorContext';
 import { EditorPlugin, PluginEventType, SelectionRangeTypes } from 'roosterjs-editor-types';
+
+const editorContext: EditorContext = {
+    isDarkMode: false,
+    getDarkColor: () => '',
+    darkColorHandler: undefined,
+    isFeatureEnabled: () => true,
+};
 
 describe('ContentModelEditor', () => {
     it('domToContentModel', () => {
@@ -13,6 +21,7 @@ describe('ContentModelEditor', () => {
         const mockedResult = 'Result' as any;
         const mockedShouldHandle = 'Result' as any;
 
+        spyOn(editor as any, 'createEditorContext').and.returnValue(editorContext);
         spyOn(editor as any, 'createShouldHandleElement').and.returnValue(mockedShouldHandle);
         spyOn(domToContentModel, 'default').and.returnValue(mockedResult);
 
@@ -20,24 +29,15 @@ describe('ContentModelEditor', () => {
 
         expect(model).toBe(mockedResult);
         expect(domToContentModel.default).toHaveBeenCalledTimes(1);
-        expect(domToContentModel.default).toHaveBeenCalledWith(
-            div,
-            {
-                isDarkMode: false,
-                getDarkColor: (editor as any).core.lifecycle.getDarkColor,
-                darkColorHandler: null,
-                experimentalFeatures: (editor as any).core.lifecycle.experimentalFeatures,
+        expect(domToContentModel.default).toHaveBeenCalledWith(div, editorContext, {
+            selectionRange: {
+                type: SelectionRangeTypes.Normal,
+                areAllCollapsed: true,
+                ranges: [],
             },
-            {
-                selectionRange: {
-                    type: SelectionRangeTypes.Normal,
-                    areAllCollapsed: true,
-                    ranges: [],
-                },
-                alwaysNormalizeTable: true,
-                shouldSkipProcessElement: mockedShouldHandle,
-            }
-        );
+            alwaysNormalizeTable: true,
+            shouldSkipProcessElement: mockedShouldHandle,
+        });
     });
 
     it('setContentModel with normal selection', () => {
@@ -53,6 +53,7 @@ describe('ContentModelEditor', () => {
         const mockedResult = [mockedFragment, mockedRange, mockedPairs] as any;
         const mockedModel = 'MockedModel' as any;
 
+        spyOn(editor as any, 'createEditorContext').and.returnValue(editorContext);
         spyOn(contentModelToDom, 'default').and.returnValue(mockedResult);
         spyOn(entityPlaceholderUtils, 'restoreContentWithEntityPlaceholder');
 
@@ -62,12 +63,7 @@ describe('ContentModelEditor', () => {
         expect(contentModelToDom.default).toHaveBeenCalledWith(
             document,
             mockedModel,
-            {
-                isDarkMode: false,
-                getDarkColor: (editor as any).core.lifecycle.getDarkColor,
-                darkColorHandler: null,
-                experimentalFeatures: (editor as any).core.lifecycle.experimentalFeatures,
-            },
+            editorContext,
             undefined
         );
         expect(entityPlaceholderUtils.restoreContentWithEntityPlaceholder).toHaveBeenCalledTimes(1);
@@ -91,6 +87,7 @@ describe('ContentModelEditor', () => {
         const mockedResult = [mockedFragment, mockedRange, mockedPairs] as any;
         const mockedModel = 'MockedModel' as any;
 
+        spyOn(editor as any, 'createEditorContext').and.returnValue(editorContext);
         spyOn(contentModelToDom, 'default').and.returnValue(mockedResult);
         spyOn(entityPlaceholderUtils, 'restoreContentWithEntityPlaceholder');
 
@@ -100,12 +97,7 @@ describe('ContentModelEditor', () => {
         expect(contentModelToDom.default).toHaveBeenCalledWith(
             document,
             mockedModel,
-            {
-                isDarkMode: false,
-                getDarkColor: (editor as any).core.lifecycle.getDarkColor,
-                darkColorHandler: null,
-                experimentalFeatures: (editor as any).core.lifecycle.experimentalFeatures,
-            },
+            editorContext,
             undefined
         );
         expect(entityPlaceholderUtils.restoreContentWithEntityPlaceholder).toHaveBeenCalledTimes(1);

--- a/packages/roosterjs-content-model/test/editor/ContentModelEditorTest.ts
+++ b/packages/roosterjs-content-model/test/editor/ContentModelEditorTest.ts
@@ -11,7 +11,9 @@ describe('ContentModelEditor', () => {
         const editor = new ContentModelEditor(div);
 
         const mockedResult = 'Result' as any;
+        const mockedShouldHandle = 'Result' as any;
 
+        spyOn(editor as any, 'createShouldHandleElement').and.returnValue(mockedShouldHandle);
         spyOn(domToContentModel, 'default').and.returnValue(mockedResult);
 
         const model = editor.createContentModel();
@@ -24,6 +26,7 @@ describe('ContentModelEditor', () => {
                 isDarkMode: false,
                 getDarkColor: (editor as any).core.lifecycle.getDarkColor,
                 darkColorHandler: null,
+                experimentalFeatures: (editor as any).core.lifecycle.experimentalFeatures,
             },
             {
                 selectionRange: {
@@ -32,6 +35,7 @@ describe('ContentModelEditor', () => {
                     ranges: [],
                 },
                 alwaysNormalizeTable: true,
+                shouldSkipProcessElement: mockedShouldHandle,
             }
         );
     });
@@ -62,6 +66,7 @@ describe('ContentModelEditor', () => {
                 isDarkMode: false,
                 getDarkColor: (editor as any).core.lifecycle.getDarkColor,
                 darkColorHandler: null,
+                experimentalFeatures: (editor as any).core.lifecycle.experimentalFeatures,
             },
             undefined
         );
@@ -99,6 +104,7 @@ describe('ContentModelEditor', () => {
                 isDarkMode: false,
                 getDarkColor: (editor as any).core.lifecycle.getDarkColor,
                 darkColorHandler: null,
+                experimentalFeatures: (editor as any).core.lifecycle.experimentalFeatures,
             },
             undefined
         );

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleEntityTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleEntityTest.ts
@@ -1,7 +1,6 @@
 import * as addDelimiters from 'roosterjs-editor-dom/lib/delimiter/addDelimiters';
 import { ContentModelEntity } from '../../../lib/publicTypes/entity/ContentModelEntity';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
-import { ExperimentalFeatures } from 'roosterjs-editor-types';
 import { handleEntity } from '../../../lib/modelToDom/handlers/handleEntity';
 import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
 
@@ -26,7 +25,7 @@ describe('handleEntity', () => {
         };
 
         const parent = document.createElement('div');
-
+        context.isFeatureEnabled = () => false;
         handleEntity(document, parent, entityModel, context);
 
         expect(parent.innerHTML).toBe('<entity-placeholder id="entity_1"></entity-placeholder>');
@@ -74,7 +73,7 @@ describe('handleEntity', () => {
         };
 
         const parent = document.createElement('div');
-        context.experimentalFeatures = [ExperimentalFeatures.InlineEntityReadOnlyDelimiters];
+        context.isFeatureEnabled = () => true;
         handleEntity(document, parent, entityModel, context);
 
         expect(parent.innerHTML).toBe('<entity-placeholder id="entity_1"></entity-placeholder>');

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleEntityTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleEntityTest.ts
@@ -1,5 +1,7 @@
+import * as addDelimiters from 'roosterjs-editor-dom/lib/delimiter/addDelimiters';
 import { ContentModelEntity } from '../../../lib/publicTypes/entity/ContentModelEntity';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { ExperimentalFeatures } from 'roosterjs-editor-types';
 import { handleEntity } from '../../../lib/modelToDom/handlers/handleEntity';
 import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
 
@@ -8,6 +10,7 @@ describe('handleEntity', () => {
 
     beforeEach(() => {
         context = createModelToDomContext();
+        spyOn(addDelimiters, 'default').and.callFake(() => {});
     });
 
     it('Simple block entity', () => {
@@ -33,6 +36,7 @@ describe('handleEntity', () => {
         expect(div.outerHTML).toBe(
             '<div class="_Entity _EType_entity _EId_entity_1 _EReadonly_1" contenteditable="false"></div>'
         );
+        expect(addDelimiters.default).toHaveBeenCalledTimes(0);
     });
 
     it('Fake entity', () => {
@@ -54,5 +58,32 @@ describe('handleEntity', () => {
         expect(parent.innerHTML).toBe('<div>test</div>');
         expect(context.entities).toEqual({});
         expect(div.outerHTML).toBe('<div>test</div>');
+        expect(addDelimiters.default).toHaveBeenCalledTimes(0);
+    });
+
+    it('Simple inline readonly entity', () => {
+        const span = document.createElement('span');
+        const entityModel: ContentModelEntity = {
+            blockType: 'Entity',
+            segmentType: 'Entity',
+            format: {},
+            id: 'entity_1',
+            type: 'entity',
+            isReadonly: true,
+            wrapper: span,
+        };
+
+        const parent = document.createElement('div');
+        context.experimentalFeatures = [ExperimentalFeatures.InlineEntityReadOnlyDelimiters];
+        handleEntity(document, parent, entityModel, context);
+
+        expect(parent.innerHTML).toBe('<entity-placeholder id="entity_1"></entity-placeholder>');
+        expect(context.entities).toEqual({
+            entity_1: span,
+        });
+        expect(span.outerHTML).toBe(
+            '<span class="_Entity _EType_entity _EId_entity_1 _EReadonly_1" contenteditable="false"></span>'
+        );
+        expect(addDelimiters.default).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/roosterjs-content-model/test/publicApi/domToContentModelTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/domToContentModelTest.ts
@@ -3,6 +3,7 @@ import * as normalizeContentModel from '../../lib/modelApi/common/normalizeConte
 import domToContentModel from '../../lib/domToModel/domToContentModel';
 import { ContentModelDocument } from '../../lib/publicTypes/group/ContentModelDocument';
 import { DomToModelContext } from '../../lib/publicTypes/context/DomToModelContext';
+import { EditorContext } from '../../lib/publicTypes/context/EditorContext';
 
 describe('domToContentModel', () => {
     it('Not include root', () => {
@@ -25,7 +26,7 @@ describe('domToContentModel', () => {
         const options = {
             includeRoot: false,
         };
-        const editorContext = { isDarkMode: false };
+        const editorContext: EditorContext = { isDarkMode: false, experimentalFeatures: [] };
         const model = domToContentModel(rootElement, editorContext, options);
         const result: ContentModelDocument = {
             blockGroupType: 'Document',
@@ -65,7 +66,7 @@ describe('domToContentModel', () => {
         const options = {
             includeRoot: true,
         };
-        const editorContext = { isDarkMode: false };
+        const editorContext: EditorContext = { isDarkMode: false, experimentalFeatures: [] };
         const model = domToContentModel(rootElement, editorContext, options);
         const result: ContentModelDocument = {
             blockGroupType: 'Document',

--- a/packages/roosterjs-content-model/test/publicApi/domToContentModelTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/domToContentModelTest.ts
@@ -26,7 +26,7 @@ describe('domToContentModel', () => {
         const options = {
             includeRoot: false,
         };
-        const editorContext: EditorContext = { isDarkMode: false, experimentalFeatures: [] };
+        const editorContext: EditorContext = { isDarkMode: false, isFeatureEnabled: undefined };
         const model = domToContentModel(rootElement, editorContext, options);
         const result: ContentModelDocument = {
             blockGroupType: 'Document',
@@ -66,7 +66,7 @@ describe('domToContentModel', () => {
         const options = {
             includeRoot: true,
         };
-        const editorContext: EditorContext = { isDarkMode: false, experimentalFeatures: [] };
+        const editorContext: EditorContext = { isDarkMode: false, isFeatureEnabled: undefined };
         const model = domToContentModel(rootElement, editorContext, options);
         const result: ContentModelDocument = {
             blockGroupType: 'Document',

--- a/packages/roosterjs-editor-api/lib/format/insertEntity.ts
+++ b/packages/roosterjs-editor-api/lib/format/insertEntity.ts
@@ -118,6 +118,9 @@ export default function insertEntity(
         editor.isFeatureEnabled(ExperimentalFeatures.InlineEntityReadOnlyDelimiters)
     ) {
         addDelimiters(entity.wrapper);
+        if (entity.wrapper.nextElementSibling) {
+            editor.select(new Position(entity.wrapper.nextElementSibling, PositionType.After));
+        }
     }
 
     editor.triggerContentChangedEvent(ChangeSource.InsertEntity, entity);

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
@@ -1,6 +1,12 @@
 import * as getComputedStyles from 'roosterjs-editor-dom/lib/utils/getComputedStyles';
-import { Entity, IEditor, Keys, PluginKeyDownEvent } from 'roosterjs-editor-types';
 import { EntityFeatures } from '../../../lib/plugins/ContentEdit/features/entityFeatures';
+import {
+    Entity,
+    ExperimentalFeatures,
+    IEditor,
+    Keys,
+    PluginKeyDownEvent,
+} from 'roosterjs-editor-types';
 import {
     addDelimiters,
     commitEntity,
@@ -46,7 +52,9 @@ describe('Content Edit Features |', () => {
         editor = <IEditor>(<any>{
             getDocument: () => document,
             getElementAtCursor: (selector: string, node: Node) =>
-                findClosestElementAncestor(node, document.body, selector),
+                selector && node
+                    ? findClosestElementAncestor(node, document.body, selector)
+                    : testContainer,
             addContentEditFeature: () => {},
             queryElements: (selector: string) => {
                 return document.querySelectorAll(selector);
@@ -60,6 +68,9 @@ describe('Content Edit Features |', () => {
                     collapsed: true,
                 },
             select,
+            isFeatureEnabled: (feature: ExperimentalFeatures) => {
+                return feature === ExperimentalFeatures.InlineEntityReadOnlyDelimiters;
+            },
         });
 
         ({ entity, delimiterAfter, delimiterBefore } = addEntityBeforeEach(entity, wrapper));


### PR DESCRIPTION
When converting Dom to Content Model, remove delimiters.
When converting Content Model to DOM, add delimiters around Inline Readonly Entities