### PR TITLE
Improve dark color again

### DIFF
--- a/packages/roosterjs-editor-core/lib/coreApi/getContent.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getContent.ts
@@ -58,7 +58,8 @@ export const getContent: GetContent = (
                 false /*includeSelf*/,
                 null /*callback*/,
                 ColorTransformDirection.DarkToLight,
-                !!core.darkColorHandler
+                !!core.darkColorHandler,
+                core.lifecycle.isDarkMode
             );
         }
 

--- a/packages/roosterjs-editor-core/lib/coreApi/setContent.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/setContent.ts
@@ -55,7 +55,8 @@ export const setContent: SetContent = (
             false /*includeSelf*/,
             null /*callback*/,
             isDarkMode ? ColorTransformDirection.LightToDark : ColorTransformDirection.DarkToLight,
-            true /*forceTransform*/
+            true /*forceTransform*/,
+            metadata?.isDarkMode
         );
         contentChanged = true;
     }

--- a/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
@@ -1,4 +1,4 @@
-import { arrayPush, getTagOfNode, safeInstanceOf, setColor, toArray } from 'roosterjs-editor-dom';
+import { arrayPush, safeInstanceOf, setColor, toArray } from 'roosterjs-editor-dom';
 import {
     ColorTransformDirection,
     DarkColorHandler,
@@ -49,7 +49,10 @@ export const transformColor: TransformColor = (
     direction: ColorTransformDirection | CompatibleColorTransformDirection,
     forceTransform?: boolean
 ) => {
-    const { darkColorHandler } = core;
+    const {
+        darkColorHandler,
+        lifecycle: { isDarkMode },
+    } = core;
     const elements =
         rootNode && (forceTransform || core.lifecycle.isDarkMode)
             ? getAll(rootNode, includeSelf)
@@ -58,7 +61,12 @@ export const transformColor: TransformColor = (
     callback?.();
 
     if (darkColorHandler) {
-        transformV2(elements, darkColorHandler, direction == ColorTransformDirection.LightToDark);
+        transformV2(
+            elements,
+            darkColorHandler,
+            direction == ColorTransformDirection.LightToDark,
+            isDarkMode
+        );
     } else {
         if (direction == ColorTransformDirection.DarkToLight) {
             transformToLightMode(elements);
@@ -70,15 +78,22 @@ export const transformColor: TransformColor = (
     }
 };
 
-function transformV2(elements: HTMLElement[], darkColorHandler: DarkColorHandler, toDark: boolean) {
+function transformV2(
+    elements: HTMLElement[],
+    darkColorHandler: DarkColorHandler,
+    toDark: boolean,
+    isInDarkMode: boolean
+) {
     elements.forEach(element => {
         ColorAttributeName.forEach((names, i) => {
-            const color =
-                tryFetchAndClearFontColor(element, toDark, darkColorHandler, names) ||
-                darkColorHandler.parseColorValue(
-                    element.style.getPropertyValue(names[ColorAttributeEnum.CssColor]) ||
-                        element.getAttribute(names[ColorAttributeEnum.HtmlColor])
-                ).lightModeColor;
+            const color = darkColorHandler.parseColorValue(
+                element.style.getPropertyValue(names[ColorAttributeEnum.CssColor]) ||
+                    element.getAttribute(names[ColorAttributeEnum.HtmlColor]),
+                isInDarkMode
+            ).lightModeColor;
+
+            element.style.setProperty(names[ColorAttributeEnum.CssColor], null);
+            element.removeAttribute(names[ColorAttributeEnum.HtmlColor]);
 
             if (color && color != 'inherit') {
                 setColor(
@@ -201,36 +216,4 @@ function getAll(rootNode: Node, includeSelf: boolean): HTMLElement[] {
 function isHTMLElement(element: Element): element is HTMLElement {
     const htmlElement = <HTMLElement>element;
     return !!htmlElement.style && !!htmlElement.dataset;
-}
-
-/**
- * There is a known issue that when input with IME in Chrome, it is possible Chrome insert a new FONT tag with colors.
- * If editor is in dark mode, this color will cause the FONT tag doesn't have light mode color info so that after convert
- * to light mode the color will be wrong.
- * To workaround it, we check if this is a known color (for light mode with VariableBasedDarkColor enabled, all used colors
- * are stored in darkColorHandler), then use the related light mode color instead.
- */
-function tryFetchAndClearFontColor(
-    element: HTMLElement,
-    toDark: boolean,
-    darkColorHandler: DarkColorHandler,
-    names: { [key in ColorAttributeEnum]: string }
-) {
-    let darkColor: string | null;
-
-    if (
-        getTagOfNode(element) == 'FONT' &&
-        !element.style.getPropertyValue(names[ColorAttributeEnum.CssColor]) &&
-        !toDark &&
-        (darkColor = element.getAttribute(names[ColorAttributeEnum.HtmlColor]))
-    ) {
-        const lightColor = darkColorHandler.findLightColorFromDarkColor(darkColor);
-
-        if (lightColor) {
-            element.removeAttribute(names[ColorAttributeEnum.HtmlColor]);
-            return lightColor;
-        }
-    }
-
-    return null;
 }

--- a/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/transformColor.ts
@@ -47,12 +47,10 @@ export const transformColor: TransformColor = (
     includeSelf: boolean,
     callback: (() => void) | null,
     direction: ColorTransformDirection | CompatibleColorTransformDirection,
-    forceTransform?: boolean
+    forceTransform?: boolean,
+    fromDarkMode?: boolean
 ) => {
-    const {
-        darkColorHandler,
-        lifecycle: { isDarkMode },
-    } = core;
+    const { darkColorHandler } = core;
     const elements =
         rootNode && (forceTransform || core.lifecycle.isDarkMode)
             ? getAll(rootNode, includeSelf)
@@ -64,8 +62,8 @@ export const transformColor: TransformColor = (
         transformV2(
             elements,
             darkColorHandler,
-            direction == ColorTransformDirection.LightToDark,
-            isDarkMode
+            !!fromDarkMode,
+            direction == ColorTransformDirection.LightToDark
         );
     } else {
         if (direction == ColorTransformDirection.DarkToLight) {
@@ -81,15 +79,15 @@ export const transformColor: TransformColor = (
 function transformV2(
     elements: HTMLElement[],
     darkColorHandler: DarkColorHandler,
-    toDark: boolean,
-    isInDarkMode: boolean
+    fromDark: boolean,
+    toDark: boolean
 ) {
     elements.forEach(element => {
         ColorAttributeName.forEach((names, i) => {
             const color = darkColorHandler.parseColorValue(
                 element.style.getPropertyValue(names[ColorAttributeEnum.CssColor]) ||
                     element.getAttribute(names[ColorAttributeEnum.HtmlColor]),
-                isInDarkMode
+                fromDark
             ).lightModeColor;
 
             element.style.setProperty(names[ColorAttributeEnum.CssColor], null);

--- a/packages/roosterjs-editor-core/lib/editor/DarkColorHandlerImpl.ts
+++ b/packages/roosterjs-editor-core/lib/editor/DarkColorHandlerImpl.ts
@@ -67,10 +67,12 @@ export default class DarkColorHandlerImpl implements DarkColorHandler {
      * Parse an existing color value, if it is in variable-based color format, extract color key,
      * light color and query related dark color if any
      * @param color The color string to parse
+     * @param isInDarkMode Whether current content is in dark mode. When set to true, if the color value is not in dark var format,
+     * we will treat is as a dark mode color and try to find a matched dark mode color.
      */
-    parseColorValue(color: string | undefined | null): ColorKeyAndValue {
+    parseColorValue(color: string | undefined | null, isInDarkMode?: boolean): ColorKeyAndValue {
         let key: string | undefined;
-        let lightModeColor = color || '';
+        let lightModeColor = '';
         let darkModeColor: string | undefined;
 
         if (color) {
@@ -84,6 +86,17 @@ export default class DarkColorHandlerImpl implements DarkColorHandler {
                 } else {
                     lightModeColor = '';
                 }
+            } else if (isInDarkMode) {
+                // If editor is in dark mode but the color is not in dark color format, it is possible the color was inserted from external code
+                // without any light color info. So we first try to see if there is a known dark color can match this color, and use its related
+                // light color as light mode color. Otherwise we need to drop this color to avoid show "white on white" content.
+                lightModeColor = this.findLightColorFromDarkColor(color) || '';
+
+                if (lightModeColor) {
+                    darkModeColor = color;
+                }
+            } else {
+                lightModeColor = color;
             }
         }
 

--- a/packages/roosterjs-editor-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-editor-core/lib/editor/Editor.ts
@@ -1004,7 +1004,9 @@ export default class Editor implements IEditor {
      * @param nextDarkMode The next status of dark mode. True if the editor should be in dark mode, false if not.
      */
     public setDarkModeState(nextDarkMode?: boolean) {
-        if (this.isDarkMode() == !!nextDarkMode) {
+        const isDarkMode = this.isDarkMode();
+
+        if (isDarkMode == !!nextDarkMode) {
             return;
         }
         const core = this.getCore();
@@ -1017,7 +1019,8 @@ export default class Editor implements IEditor {
             nextDarkMode
                 ? ColorTransformDirection.LightToDark
                 : ColorTransformDirection.DarkToLight,
-            true /*forceTransform*/
+            true /*forceTransform*/,
+            isDarkMode
         );
 
         this.triggerContentChangedEvent(

--- a/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
@@ -356,7 +356,6 @@ describe('transform to light mode v2', () => {
         expectedRegisterColorCalls: [string, boolean, string][]
     ) {
         const core = createEditorCore(div, {
-            inDarkMode: true,
             getDarkColor,
         });
         const parseColorValue = jasmine
@@ -370,7 +369,15 @@ describe('transform to light mode v2', () => {
 
         core.darkColorHandler = ({ parseColorValue, registerColor } as any) as DarkColorHandler;
 
-        transformColor(core, element, true, null, ColorTransformDirection.DarkToLight);
+        transformColor(
+            core,
+            element,
+            true /*includeSelf*/,
+            null /*callback*/,
+            ColorTransformDirection.DarkToLight,
+            true /*forceTransform*/,
+            true /*fromDark*/
+        );
 
         expect(element.outerHTML).toBe(expectedHtml);
         expect(parseColorValue).toHaveBeenCalledTimes(expectedParseValueCalls.length);

--- a/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/transformColorTest.ts
@@ -251,7 +251,7 @@ describe('transform to dark mode v2', () => {
         expectedRegisterColorCalls: [string, boolean, string][]
     ) {
         const core = createEditorCore(div, {
-            inDarkMode: true,
+            inDarkMode: false,
             getDarkColor,
         });
         const parseColorValue = jasmine
@@ -265,14 +265,14 @@ describe('transform to dark mode v2', () => {
 
         core.darkColorHandler = ({ parseColorValue, registerColor } as any) as DarkColorHandler;
 
-        transformColor(core, element, true, null, ColorTransformDirection.LightToDark);
+        transformColor(core, element, true, null, ColorTransformDirection.LightToDark, true);
 
         expect(element.outerHTML).toBe(expectedHtml);
         expect(parseColorValue).toHaveBeenCalledTimes(expectedParseValueCalls.length);
         expect(registerColor).toHaveBeenCalledTimes(expectedRegisterColorCalls.length);
 
         expectedParseValueCalls.forEach(v => {
-            expect(parseColorValue).toHaveBeenCalledWith(v);
+            expect(parseColorValue).toHaveBeenCalledWith(v, false);
         });
         expectedRegisterColorCalls.forEach(v => {
             expect(registerColor).toHaveBeenCalledWith(...v);
@@ -308,7 +308,7 @@ describe('transform to dark mode v2', () => {
 
         runTest(
             element,
-            '<div color="red" bgcolor="green" style="color: blue; background-color: yellow;"></div>',
+            '<div style="color: blue; background-color: yellow;"></div>',
             ['red', 'green'],
             [
                 ['blue', true, undefined!],
@@ -326,7 +326,7 @@ describe('transform to dark mode v2', () => {
 
         runTest(
             element,
-            '<div color="gray" bgcolor="brown" style="color: blue; background-color: yellow;"></div>',
+            '<div style="color: blue; background-color: yellow;"></div>',
             ['red', 'green'],
             [
                 ['blue', true, undefined!],
@@ -336,7 +336,7 @@ describe('transform to dark mode v2', () => {
     });
 });
 
-describe('transform to lgiht mode v2', () => {
+describe('transform to light mode v2', () => {
     let div: HTMLDivElement;
 
     beforeEach(() => {
@@ -377,7 +377,7 @@ describe('transform to lgiht mode v2', () => {
         expect(registerColor).toHaveBeenCalledTimes(expectedRegisterColorCalls.length);
 
         expectedParseValueCalls.forEach(v => {
-            expect(parseColorValue).toHaveBeenCalledWith(v);
+            expect(parseColorValue).toHaveBeenCalledWith(v, true);
         });
         expectedRegisterColorCalls.forEach(v => {
             expect(registerColor).toHaveBeenCalledWith(...v);
@@ -413,7 +413,7 @@ describe('transform to lgiht mode v2', () => {
 
         runTest(
             element,
-            '<div color="red" bgcolor="green" style="color: blue; background-color: yellow;"></div>',
+            '<div style="color: blue; background-color: yellow;"></div>',
             ['red', 'green'],
             [
                 ['blue', false, undefined!],
@@ -431,7 +431,7 @@ describe('transform to lgiht mode v2', () => {
 
         runTest(
             element,
-            '<div color="gray" bgcolor="brown" style="color: blue; background-color: yellow;"></div>',
+            '<div style="color: blue; background-color: yellow;"></div>',
             ['red', 'green'],
             [
                 ['blue', false, undefined!],

--- a/packages/roosterjs-editor-core/test/editor/DarkColorHandlerImplTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/DarkColorHandlerImplTest.ts
@@ -65,6 +65,42 @@ describe('DarkColorHandlerImpl.parseColorValue', () => {
             darkModeColor: 'ee',
         });
     });
+
+    function runDarkTest(input: string, expectedOutput: ColorKeyAndValue) {
+        const result = handler.parseColorValue(input, true);
+
+        expect(result).toEqual(expectedOutput);
+    }
+
+    it('simple color in dark mode', () => {
+        runDarkTest('aa', {
+            key: undefined,
+            lightModeColor: '',
+            darkModeColor: undefined,
+        });
+    });
+
+    it('var color in dark mode', () => {
+        runDarkTest('var(--aa, bb)', {
+            key: '--aa',
+            lightModeColor: 'bb',
+            darkModeColor: undefined,
+        });
+    });
+
+    it('known simple color in dark mode', () => {
+        (handler as any).knownColors = {
+            '--bb': {
+                lightModeColor: '#ff0000',
+                darkModeColor: '#00ffff',
+            },
+        };
+        runDarkTest('#00ffff', {
+            key: undefined,
+            lightModeColor: '#ff0000',
+            darkModeColor: '#00ffff',
+        });
+    });
 });
 
 describe('DarkColorHandlerImpl.registerColor', () => {

--- a/packages/roosterjs-editor-types/lib/interface/DarkColorHandler.ts
+++ b/packages/roosterjs-editor-types/lib/interface/DarkColorHandler.ts
@@ -42,8 +42,10 @@ export default interface DarkColorHandler {
      * Parse an existing color value, if it is in variable-based color format, extract color key,
      * light color and query related dark color if any
      * @param color The color string to parse
+     * @param isInDarkMode Whether current content is in dark mode. When set to true, if the color value is not in dark var format,
+     * we will treat is as a dark mode color and try to find a matched dark mode color.
      */
-    parseColorValue(color: string | null | undefined): ColorKeyAndValue;
+    parseColorValue(color: string | null | undefined, isInDarkMode?: boolean): ColorKeyAndValue;
 
     /**
      * Get a copy of known colors

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -254,6 +254,7 @@ export type SwitchShadowEdit = (core: EditorCore, isOn: boolean) => void;
  * @param direction To specify the transform direction, light to dark, or dark to light
  * @param forceTransform By default this function will only work when editor core is in dark mode.
  * Pass true to this value to force do color transformation even editor core is in light mode
+ * @param fromDarkModel Whether the given content is already in dark mode
  */
 export type TransformColor = (
     core: EditorCore,
@@ -261,7 +262,8 @@ export type TransformColor = (
     includeSelf: boolean,
     callback: (() => void) | null,
     direction: ColorTransformDirection | CompatibleColorTransformDirection,
-    forceTransform?: boolean
+    forceTransform?: boolean,
+    fromDarkMode?: boolean
 ) => void;
 
 /**
@@ -443,6 +445,7 @@ export interface CoreApiMap {
      * @param direction To specify the transform direction, light to dark, or dark to light
      * @param forceTransform By default this function will only work when editor core is in dark mode.
      * Pass true to this value to force do color transformation even editor core is in light mode
+     * @param fromDarkModel Whether the given content is already in dark mode
      */
     transformColor: TransformColor;
 


### PR DESCRIPTION
Sometimes there can be DOM element inserted programmatically into dark mode editor without light color info. In that case we can first try to match the color with known dark color to see if we can find a related light color when transform to light mode. If we can't find a color, just drop the color.

This is because:
```html
<span style="color:white">test</span>
```
The content above can be shown correctly in dark mode, but when transform to light mode, if we don't drop this color, it will become a "white on white" content. So to avoid this, we need to drop it.