### PR TITLE
Show correct font when jump between table cells

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/tableFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/tableFeatures.ts
@@ -51,7 +51,8 @@ const TabInTable: BuildInEditFeature<PluginKeyboardEvent> = {
             }
             let cell = vtable.getCell(row, col);
             if (cell.td) {
-                editor.select(cell.td, PositionType.Begin);
+                const newPos = new Position(cell.td, PositionType.Begin).normalize();
+                editor.select(newPos);
                 break;
             }
         }
@@ -143,7 +144,7 @@ const UpDownInTable: BuildInEditFeature<PluginKeyboardEvent> = {
                             newPos.offset
                         );
                     } else {
-                        editor.select(newPos);
+                        editor.select(newPos.normalize());
                     }
                 }
             });


### PR DESCRIPTION
1. set a font, type something
2. insert a table using content model
3. put cursor in table, and use Up/Down/Left/Right/Tab to move cursor between cells, see the current font

The existing code always set focus to the beginning of a table, where there is no font info there since the font is declared in the SPAN inside a TD:
```html
<td>
  [CURSOR]<span style="..."><br></span>
</td>
```

After this change, we will set focus into the SPAN:
```html
<td>
  <span style="...">[CURSOR]<br></span>
</td>
```
So that font can show correctly.