### PR TITLE
Content Model: Fix a bug in normalization

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts
@@ -48,14 +48,17 @@ function normalizeParagraph(block: ContentModelParagraph) {
 
         if (segments.length == 1 && segments[0].segmentType == 'SelectionMarker') {
             segments.push(createBr(segments[0].format));
-        } else if (
-            segments.length > 1 &&
-            segments[segments.length - 1].segmentType == 'Br' &&
-            segments.some(
-                segment => segment.segmentType != 'SelectionMarker' && segment.segmentType != 'Br'
-            )
-        ) {
-            segments.pop();
+        } else if (segments.length > 1 && segments[segments.length - 1].segmentType == 'Br') {
+            const noMarkerSegments = segments.filter(x => x.segmentType != 'SelectionMarker');
+
+            // When there is content with a <BR> tag at the end, we can remove the BR.
+            // But if there are more than one <BR> at the end, do not remove them.
+            if (
+                noMarkerSegments.length > 1 &&
+                noMarkerSegments[noMarkerSegments.length - 2].segmentType != 'Br'
+            ) {
+                segments.pop();
+            }
         }
     }
 }

--- a/packages/roosterjs-content-model/test/modelApi/common/normalizeContentModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/normalizeContentModelTest.ts
@@ -117,6 +117,62 @@ describe('normalizeContentModel', () => {
         });
     });
 
+    it('Normalize paragraph with multiple BRs', () => {
+        const model = createContentModelDocument();
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const br1 = createBr();
+        const marker = createSelectionMarker();
+        const br2 = createBr();
+        const br3 = createBr();
+        const br4 = createBr();
+
+        para1.segments.push(br1, marker, br2);
+        para2.segments.push(br3, br4);
+        model.blocks.push(para1, para2);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
     it('Do not normalize implicit paragraph', () => {
         const model = createContentModelDocument();
         const para1 = createParagraph(true /*isImplicit*/);


### PR DESCRIPTION
When call normalizeContentModel and recreate DOM,
Case 1:
input: 
```html
<div>text<br></div>
```
Output:
```html
<div>text</div>
```
This is correct

Case 2:
input: 
```html
<div>text<br><br></div>
```
Output:
```html
<div>text<br></div>
```
This is wrong. Because we need the two BR at the end to make sure there is an empty line below "text".

Fix: check there must be only one BR at the end then we can remove it.
