### PR TITLE
Prevent table block from passing undefined cell to normalizeContentModel

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts
@@ -22,7 +22,9 @@ export function normalizeContentModel(group: ContentModelBlockGroup) {
             case 'Table':
                 for (let r = 0; r < block.cells.length; r++) {
                     for (let c = 0; c < block.cells[r].length; c++) {
-                        normalizeContentModel(block.cells[r][c]);
+                        if (block.cells[r][c]) {
+                            normalizeContentModel(block.cells[r][c]);
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
`normalizeContentModel` can sometimes receive `undefined` and throw an exception when accessing `group.blocks`.
This is caused by attempting to normalize an `undefined` block.cells[r][c]:
https://github.com/microsoft/roosterjs/blob/332fc4d7296351faa4156bdf1ef95bd12b949806/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts#L22-L27

Mitigate by type asserting before normalization

Could be caused by table processor skipping an index and creating a longer than expected row, however that's just a theory
https://github.com/microsoft/roosterjs/blob/332fc4d7296351faa4156bdf1ef95bd12b949806/packages/roosterjs-content-model/lib/domToModel/processors/tableProcessor.ts#L87 