### PR TITLE
Fix Arrow Keys + Delimiter bug

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
@@ -321,6 +321,7 @@ function getIsDelimiterAtCursor(event: PluginKeyboardEvent, editor: IEditor, che
             ? position.element.childNodes.item(position.offset)
             : position.element;
 
+    const searcher = editor.getContentSearcherOfCursor(event);
     const data = checkBefore
         ? {
               class: DelimiterClasses.DELIMITER_BEFORE,
@@ -328,18 +329,7 @@ function getIsDelimiterAtCursor(event: PluginKeyboardEvent, editor: IEditor, che
               getDelimiterPair: (element: HTMLElement) =>
                   element.nextElementSibling?.nextElementSibling,
               getNextSibling: () => {
-                  if (position.node.nodeType == NodeType.Text) {
-                      return position.node.nextSibling != null
-                          ? position.node.nextSibling
-                          : (position.node.parentNode as HTMLElement).className ===
-                            DelimiterClasses.DELIMITER_BEFORE
-                          ? position.node.parentElement
-                          : null;
-                  } else if (position.node == position.element) {
-                      return position.element.childNodes.item(position.offset);
-                  } else {
-                      return null;
-                  }
+                  return searcher.getInlineElementAfter()?.getContainerNode();
               },
               isAtEndOrBeginning: position.isAtEnd,
           }
@@ -349,18 +339,7 @@ function getIsDelimiterAtCursor(event: PluginKeyboardEvent, editor: IEditor, che
               getDelimiterPair: (element: HTMLElement) =>
                   element.previousElementSibling?.previousElementSibling,
               getNextSibling: () => {
-                  if (position.node.nodeType == NodeType.Text) {
-                      return position.node.previousSibling != null
-                          ? position.node.previousSibling
-                          : (position.node.parentNode as HTMLElement).className ===
-                            DelimiterClasses.DELIMITER_AFTER
-                          ? position.node.parentElement
-                          : null;
-                  } else if (position.node == position.element) {
-                      return position.element.childNodes.item(position.offset);
-                  } else {
-                      return null;
-                  }
+                  return searcher.getInlineElementBefore()?.getContainerNode();
               },
               isAtEndOrBeginning: position.offset == 0,
           };

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
@@ -82,12 +82,12 @@ describe('Content Edit Features |', () => {
     });
 
     describe('Move Before |', () => {
-        function runTest(element: Element | null, expected: boolean, event: PluginKeyDownEvent) {
-            editor.getFocusedPosition = () => (element ? new Position(element, 0) : null)!;
-            editor.getContentSearcherOfCursor = () =>
-                element
-                    ? new PositionContentSearcher(testContainer, new Position(element, 0))
-                    : null!;
+        function runTest(
+            element: Element | Position | null,
+            expected: boolean,
+            event: PluginKeyDownEvent
+        ) {
+            setEditorFuncs(editor, element, testContainer);
 
             const result = moveBetweenDelimitersFeature.shouldHandleEvent(
                 event,
@@ -197,6 +197,45 @@ describe('Content Edit Features |', () => {
             it('Null', () => {
                 runTest(null, false /* expected */, event);
             });
+
+            it('Feature not enabled, do not handle', () => {
+                editor.isFeatureEnabled = () => false;
+                runTest(null, false /* expected */, event);
+            });
+
+            it('Selection not collapsed. do not handle', () => {
+                (editor.getSelectionRange = () =>
+                    <Range>{
+                        collapsed: false,
+                    }),
+                    runTest(null, false /* expected */, event);
+            });
+
+            it('DelimiterAfter, shouldHandle and Handle, cursor at start of element after delimiter after', () => {
+                const bold = document.createElement('b');
+                bold.append(document.createTextNode('Bold'));
+                testContainer.insertBefore(bold, null);
+
+                event = runTest(new Position(bold.firstChild!, 0), true /* expected */, event);
+
+                spyOnSelection();
+
+                moveBetweenDelimitersFeature.handleEvent(event, editor);
+
+                expect(select).toHaveBeenCalledWith(new Position(testContainer, 0));
+                expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+                expect(extendSpy).toHaveBeenCalledTimes(0);
+
+                restoreSelection();
+            });
+
+            it('DelimiterAfter, should not Handle, cursor is not not at the start of the element after delimiter after', () => {
+                const bold = document.createElement('b');
+                bold.append(document.createTextNode('Bold'));
+                testContainer.insertBefore(bold, null);
+
+                event = runTest(new Position(bold.firstChild!, 1), false /* expected */, event);
+            });
         }
 
         describe('LTR |', () => {
@@ -232,13 +271,12 @@ describe('Content Edit Features |', () => {
     describe('Move After |', () => {
         let event: PluginKeyDownEvent;
 
-        function runTest(element: Element | null, expected: boolean, event: PluginKeyDownEvent) {
-            editor.getFocusedPosition = () => (element ? new Position(element, 0) : null)!;
-
-            editor.getContentSearcherOfCursor = () =>
-                element
-                    ? new PositionContentSearcher(testContainer, new Position(element, 0))
-                    : null!;
+        function runTest(
+            element: Element | Position | null,
+            expected: boolean,
+            event: PluginKeyDownEvent
+        ) {
+            setEditorFuncs(editor, element, testContainer);
 
             const result = moveBetweenDelimitersFeature.shouldHandleEvent(
                 event,
@@ -326,6 +364,45 @@ describe('Content Edit Features |', () => {
             it('Null', () => {
                 runTest(null, false /* expected */, event);
             });
+
+            it('Feature not enabled, do not handle', () => {
+                editor.isFeatureEnabled = () => false;
+                runTest(null, false /* expected */, event);
+            });
+
+            it('Selection not collapsed. do not handle', () => {
+                (editor.getSelectionRange = () =>
+                    <Range>{
+                        collapsed: false,
+                    }),
+                    runTest(null, false /* expected */, event);
+            });
+
+            it('DelimiterBefore, shouldHandle and Handle, cursor at end of element before delimiter before', () => {
+                const bold = document.createElement('b');
+                bold.append(document.createTextNode('Bold'));
+                testContainer.insertBefore(bold, delimiterBefore);
+
+                event = runTest(new Position(bold.firstChild!, 4), true /* expected */, event);
+
+                spyOnSelection();
+
+                moveBetweenDelimitersFeature.handleEvent(event, editor);
+
+                expect(select).toHaveBeenCalledWith(new Position(delimiterAfter!, 1));
+                expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+                expect(extendSpy).toHaveBeenCalledTimes(0);
+
+                restoreSelection();
+            });
+
+            it('DelimiterBefore, should not Handle, cursor is not not at the start of the element after delimiter after', () => {
+                const bold = document.createElement('b');
+                bold.append(document.createTextNode('Bold'));
+                testContainer.insertBefore(bold, null);
+
+                event = runTest(new Position(bold.firstChild!, 1), false /* expected */, event);
+            });
         }
 
         describe('LTR |', () => {
@@ -362,11 +439,7 @@ describe('Content Edit Features |', () => {
 
     describe('Remove Entity Between delimiters', () => {
         function runTest(element: Element | null, expected: boolean, event: PluginKeyDownEvent) {
-            editor.getFocusedPosition = () => (element ? new Position(element, 0) : null)!;
-            editor.getContentSearcherOfCursor = () =>
-                element
-                    ? new PositionContentSearcher(testContainer, new Position(element, 0))
-                    : null!;
+            setEditorFuncs(editor, element, testContainer);
 
             const result = removeEntityBetweenDelimiters.shouldHandleEvent(
                 event,
@@ -443,6 +516,18 @@ describe('Content Edit Features |', () => {
     }
 });
 
+function setEditorFuncs(
+    editor: IEditor,
+    element: Element | Position | null,
+    testContainer: HTMLDivElement
+) {
+    editor.getFocusedPosition = () => getPos(element);
+    editor.getContentSearcherOfCursor = () => {
+        const pos = getPos(element);
+        return pos ? new PositionContentSearcher(testContainer, pos) : null!;
+    };
+}
+
 function cleanUp() {
     document.body.childNodes.forEach(cn => {
         document.body.removeChild(cn);
@@ -466,3 +551,11 @@ function addEntityBeforeEach(entity: Entity, wrapper: HTMLElement) {
         delimiterBefore: wrapper.previousElementSibling,
     };
 }
+
+const getPos = (element: Element | Position | null) => {
+    return (element
+        ? (element as Position).element
+            ? (element as Position)
+            : new Position(element as Element, 0)
+        : null)!;
+};

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
@@ -11,6 +11,7 @@ import {
     addDelimiters,
     commitEntity,
     findClosestElementAncestor,
+    PositionContentSearcher,
     Position,
 } from 'roosterjs-editor-dom';
 
@@ -83,6 +84,10 @@ describe('Content Edit Features |', () => {
     describe('Move Before |', () => {
         function runTest(element: Element | null, expected: boolean, event: PluginKeyDownEvent) {
             editor.getFocusedPosition = () => (element ? new Position(element, 0) : null)!;
+            editor.getContentSearcherOfCursor = () =>
+                element
+                    ? new PositionContentSearcher(testContainer, new Position(element, 0))
+                    : null!;
 
             const result = moveBetweenDelimitersFeature.shouldHandleEvent(
                 event,
@@ -230,6 +235,11 @@ describe('Content Edit Features |', () => {
         function runTest(element: Element | null, expected: boolean, event: PluginKeyDownEvent) {
             editor.getFocusedPosition = () => (element ? new Position(element, 0) : null)!;
 
+            editor.getContentSearcherOfCursor = () =>
+                element
+                    ? new PositionContentSearcher(testContainer, new Position(element, 0))
+                    : null!;
+
             const result = moveBetweenDelimitersFeature.shouldHandleEvent(
                 event,
                 editor,
@@ -353,6 +363,10 @@ describe('Content Edit Features |', () => {
     describe('Remove Entity Between delimiters', () => {
         function runTest(element: Element | null, expected: boolean, event: PluginKeyDownEvent) {
             editor.getFocusedPosition = () => (element ? new Position(element, 0) : null)!;
+            editor.getContentSearcherOfCursor = () =>
+                element
+                    ? new PositionContentSearcher(testContainer, new Position(element, 0))
+                    : null!;
 
             const result = removeEntityBetweenDelimiters.shouldHandleEvent(
                 event,


### PR DESCRIPTION
**Describe the bug**
Cursor stuck in a delimiter

**To Reproduce**
Steps to reproduce the behavior:

1. Add a readonly inline entity
2. select text around it a bold it
3. place cursor before text
4. user RIGHT arrow Keys
5. Notice that you need to do Right twice because of the zws
6. Expected should only one right key press to move after entity

To fix, use ContentSearcher to get the next/previous Inline element

Before
![DelimiterMoveBefore](https://user-images.githubusercontent.com/8291124/223184093-a126587e-447d-4cbc-857f-38f6b37348d0.gif)

After
![DelimiterMoveAfter](https://user-images.githubusercontent.com/8291124/223184128-c5d57f03-736f-4a14-99f0-04e98647c230.gif)
