### PR TITLE
Handle not collapsed selection & Delimiter selected

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/utils/InlineEntityHandlers/inlineEntityOnPluginEvent.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/utils/InlineEntityHandlers/inlineEntityOnPluginEvent.ts
@@ -47,9 +47,7 @@ export function inlineEntityOnPluginEvent(event: PluginEvent, editor: IEditor) {
 
         case PluginEventType.ExtractContentWithDom:
         case PluginEventType.BeforeCutCopy:
-            event.clonedRoot.querySelectorAll(DELIMITER_SELECTOR).forEach(node => {
-                node.parentElement?.removeChild(node);
-            });
+            event.clonedRoot.querySelectorAll(DELIMITER_SELECTOR).forEach(removeNode);
             break;
 
         case PluginEventType.KeyDown:

--- a/packages/roosterjs-editor-core/lib/corePlugins/utils/InlineEntityHandlers/inlineEntityOnPluginEvent.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/utils/InlineEntityHandlers/inlineEntityOnPluginEvent.ts
@@ -62,7 +62,7 @@ export function inlineEntityOnPluginEvent(event: PluginEvent, editor: IEditor) {
                 rangeEx.areAllCollapsed &&
                 (isCharacterValue(rawEvent) || rawEvent.which === Keys.ENTER)
             ) {
-                let position = editor.getFocusedPosition()?.normalize();
+                const position = editor.getFocusedPosition();
 
                 if (!position) {
                     return;

--- a/packages/roosterjs-editor-core/lib/corePlugins/utils/InlineEntityHandlers/inlineEntityOnPluginEvent.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/utils/InlineEntityHandlers/inlineEntityOnPluginEvent.ts
@@ -72,14 +72,9 @@ export function inlineEntityOnPluginEvent(event: PluginEvent, editor: IEditor) {
                         ? position.element.childNodes.item(position.offset)
                         : position.element;
 
-                const elementAtCursor = editor.getElementAtCursor(DELIMITER_SELECTOR, refNode);
-                const delimiter = getDelimiterFromElement(elementAtCursor);
+                const delimiter = editor.getElementAtCursor(DELIMITER_SELECTOR, refNode);
 
                 if (!delimiter) {
-                    // If the element exists but it is not a delimiter, example the text content is not ZWS, remove the classes
-                    if (elementAtCursor) {
-                        removeDelimiterAttr(elementAtCursor);
-                    }
                     return;
                 }
 
@@ -163,6 +158,7 @@ export function inlineEntityOnPluginEvent(event: PluginEvent, editor: IEditor) {
                     });
                 }
             }
+            break;
     }
 }
 
@@ -179,7 +175,7 @@ function getDelimiters(entityWrapper: HTMLElement): (HTMLElement | undefined)[] 
 
 function addDelimitersIfNeeded(nodes: Element[] | NodeListOf<Element>) {
     nodes.forEach(node => {
-        if (safeInstanceOf(node, 'HTMLElement') && isReadOnly(getEntityFromElement(node))) {
+        if (tryGetEntityFromNode(node)) {
             const [delimiterAfter, delimiterBefore] = getDelimiters(node);
 
             if (!delimiterAfter) {
@@ -190,6 +186,14 @@ function addDelimitersIfNeeded(nodes: Element[] | NodeListOf<Element>) {
             }
         }
     });
+}
+
+function tryGetEntityFromNode(node: Element | null): node is HTMLElement {
+    return !!(
+        node &&
+        safeInstanceOf(node, 'HTMLElement') &&
+        isReadOnly(getEntityFromElement(node))
+    );
 }
 
 function removeNode(el: Node | undefined) {

--- a/packages/roosterjs-editor-core/lib/corePlugins/utils/InlineEntityHandlers/inlineEntityOnPluginEvent.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/utils/InlineEntityHandlers/inlineEntityOnPluginEvent.ts
@@ -129,9 +129,9 @@ export function inlineEntityOnPluginEvent(event: PluginEvent, editor: IEditor) {
                         });
                     }
                 } else if (delimiter.firstChild?.nodeType == NodeType.Text) {
-                    delimiter.normalize();
-                    const textNode = delimiter.firstChild as Node;
                     editor.runAsync(() => {
+                        delimiter.normalize();
+                        const textNode = delimiter.firstChild as Node;
                         const index = textNode.nodeValue?.indexOf(ZERO_WIDTH_SPACE) ?? -1;
                         if (index >= 0) {
                             splitTextNode(

--- a/packages/roosterjs-editor-core/lib/corePlugins/utils/InlineEntityHandlers/inlineEntityOnPluginEvent.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/utils/InlineEntityHandlers/inlineEntityOnPluginEvent.ts
@@ -2,6 +2,7 @@ import {
     ChangeSource,
     DelimiterClasses,
     IEditor,
+    Keys,
     NodeType,
     PluginEventType,
     PositionType,
@@ -10,6 +11,7 @@ import {
 import {
     addDelimiterAfter,
     addDelimiterBefore,
+    createElement,
     createRange,
     getDelimiterFromElement,
     getEntityFromElement,
@@ -26,6 +28,7 @@ const DELIMITER_SELECTOR =
     '.' + DelimiterClasses.DELIMITER_AFTER + ',.' + DelimiterClasses.DELIMITER_BEFORE;
 const ZERO_WIDTH_SPACE = '\u200B';
 const INLINE_ENTITY_SELECTOR = 'span' + getEntitySelector();
+const NBSP = '\u00A0';
 
 export function inlineEntityOnPluginEvent(event: PluginEvent, editor: IEditor) {
     switch (event.eventType) {
@@ -51,10 +54,14 @@ export function inlineEntityOnPluginEvent(event: PluginEvent, editor: IEditor) {
 
         case PluginEventType.KeyDown:
             const range = editor.getSelectionRangeEx();
+            const { rawEvent } = event;
+            if (range.type != SelectionRangeTypes.Normal) {
+                return;
+            }
+
             if (
-                range.type == SelectionRangeTypes.Normal &&
                 range.areAllCollapsed &&
-                isCharacterValue(event.rawEvent)
+                (isCharacterValue(rawEvent) || rawEvent.which === Keys.ENTER)
             ) {
                 const position = editor.getFocusedPosition();
 
@@ -62,19 +69,68 @@ export function inlineEntityOnPluginEvent(event: PluginEvent, editor: IEditor) {
                     return;
                 }
 
-                const delimiter = editor.getElementAtCursor(DELIMITER_SELECTOR, position.element);
+                const refNode =
+                    position.element == position.node
+                        ? position.element.childNodes.item(position.offset)
+                        : position.element;
 
-                if (
-                    !delimiter ||
-                    (!delimiter.classList.contains(DelimiterClasses.DELIMITER_AFTER) &&
-                        !delimiter.classList.contains(DelimiterClasses.DELIMITER_BEFORE))
-                ) {
+                const elementAtCursor = editor.getElementAtCursor(DELIMITER_SELECTOR, refNode);
+                const delimiter = getDelimiterFromElement(elementAtCursor);
+
+                if (!delimiter) {
+                    // If the element exists but it is not a delimiter, example the text content is not ZWS, remove the classes
+                    if (elementAtCursor) {
+                        removeDelimiterAttr(elementAtCursor);
+                    }
                     return;
                 }
 
-                delimiter.normalize();
-                const textNode = delimiter.firstChild as Node;
-                if (textNode?.nodeType == NodeType.Text) {
+                if (rawEvent.which === Keys.ENTER) {
+                    const isAfter = delimiter.classList.contains(DelimiterClasses.DELIMITER_AFTER);
+                    const sibling = isAfter ? delimiter.nextSibling : delimiter.previousSibling;
+                    let positionToUse: Position | undefined;
+                    let element: Element | null;
+
+                    if (sibling) {
+                        positionToUse = new Position(
+                            sibling,
+                            isAfter ? PositionType.Begin : PositionType.End
+                        );
+                    } else {
+                        element = delimiter.insertAdjacentElement(
+                            isAfter ? 'afterend' : 'beforebegin',
+                            createElement(
+                                {
+                                    tag: 'span',
+                                    children: [NBSP],
+                                },
+                                editor.getDocument()
+                            )!
+                        );
+
+                        if (!element) {
+                            return;
+                        }
+
+                        positionToUse = new Position(element, PositionType.Begin);
+                    }
+
+                    if (positionToUse) {
+                        editor.select(positionToUse);
+
+                        editor.runAsync(asyncEditor => {
+                            if (isAfter) {
+                                const elAfter = asyncEditor.getElementAtCursor();
+                                removeDelimiterAttr(elAfter);
+                            }
+                            if (element) {
+                                removeNode(element);
+                            }
+                        });
+                    }
+                } else if (delimiter.firstChild?.nodeType == NodeType.Text) {
+                    delimiter.normalize();
+                    const textNode = delimiter.firstChild as Node;
                     editor.runAsync(() => {
                         const index = textNode.nodeValue?.indexOf(ZERO_WIDTH_SPACE) ?? -1;
                         if (index >= 0) {
@@ -160,18 +216,19 @@ function removeInvalidDelimiters(nodes: Element[]) {
                 removeNode(node);
             }
         } else {
-            node?.classList.remove(
-                DelimiterClasses.DELIMITER_BEFORE,
-                DelimiterClasses.DELIMITER_AFTER
-            );
+            removeDelimiterAttr(node);
+        }
+    });
+}
 
-            node.normalize();
-            node.childNodes.forEach(cn => {
-                const index = cn.textContent?.indexOf(ZERO_WIDTH_SPACE) ?? -1;
-                if (index >= 0) {
-                    createRange(cn, index, cn, index + 1)?.deleteContents();
-                }
-            });
+function removeDelimiterAttr(node: Element | undefined | null) {
+    node?.classList.remove(DelimiterClasses.DELIMITER_BEFORE, DelimiterClasses.DELIMITER_AFTER);
+
+    node?.normalize();
+    node?.childNodes.forEach(cn => {
+        const index = cn.textContent?.indexOf(ZERO_WIDTH_SPACE) ?? -1;
+        if (index >= 0) {
+            createRange(cn, index, cn, index + 1)?.deleteContents();
         }
     });
 }

--- a/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
@@ -41,6 +41,7 @@ describe('Inline Entity On Plugin Event |', () => {
         testContainer.appendChild(wrapper);
         document.body.appendChild(testContainer);
         spyOn(splitTextNode, 'default').and.callThrough();
+        selectSpy = jasmine.createSpy('select');
 
         editor = <IEditor>(<any>{
             getDocument: () => document,
@@ -60,7 +61,7 @@ describe('Inline Entity On Plugin Event |', () => {
                     type: SelectionRangeTypes.Normal,
                 };
             },
-            select: selectSpy = jasmine.createSpy('select'),
+            select: selectSpy,
         });
     });
 
@@ -139,21 +140,6 @@ describe('Inline Entity On Plugin Event |', () => {
                 expect(splitTextNode.default).not.toHaveBeenCalled();
             });
 
-            it('Selection not collapsed', () => {
-                editor.getSelectionRangeEx = () => {
-                    return <NormalSelectionRange>(<any>{
-                        areAllCollapsed: false,
-                        type: SelectionRangeTypes.Normal,
-                    });
-                };
-                spyOn(editor, 'getElementAtCursor').and.returnValue(delimiterAfter as HTMLElement);
-
-                arrangeAndAct();
-
-                expect(editor.getElementAtCursor).not.toHaveBeenCalled();
-                expect(splitTextNode.default).not.toHaveBeenCalled();
-            });
-
             it('Selection collapsed and not Normal Selection', () => {
                 editor.getSelectionRangeEx = () => {
                     return <NormalSelectionRange>(<any>{
@@ -199,6 +185,54 @@ describe('Inline Entity On Plugin Event |', () => {
 
                 expect(selectSpy).toHaveBeenCalled();
                 expect(delimiterBefore?.previousElementSibling).not.toBeNull();
+            });
+
+            it('Key press when selection is not collapsed, delimiter before is the endContainer', () => {
+                const testElement = document.createElement('span');
+                testElement.appendChild(document.createTextNode('Test'));
+                delimiterBefore?.parentElement?.insertBefore(testElement, delimiterBefore);
+
+                const range = new Range();
+                range.setStart(testElement, 0);
+                range.setEnd(delimiterBefore!, 0);
+
+                editor.getSelectionRangeEx = () => {
+                    return <NormalSelectionRange>{
+                        areAllCollapsed: false,
+                        type: SelectionRangeTypes.Normal,
+                        ranges: [range],
+                    };
+                };
+                arrangeAndAct(13 /* ENTER */, false /* addElementOnRunAsync */);
+
+                expect(selectSpy).toHaveBeenCalledWith(
+                    new Position(testElement, 0),
+                    new Position(testContainer, 1)
+                );
+            });
+
+            it('Key press when selection is not collapsed, delimiter before is the startContainer', () => {
+                const testElement = document.createElement('span');
+                testElement.appendChild(document.createTextNode('Test'));
+                delimiterBefore?.parentElement?.insertBefore(testElement, null);
+
+                const range = new Range();
+                range.setStart(delimiterBefore!, 0);
+                range.setEnd(testElement, 0);
+
+                editor.getSelectionRangeEx = () => {
+                    return <NormalSelectionRange>{
+                        areAllCollapsed: false,
+                        type: SelectionRangeTypes.Normal,
+                        ranges: [range],
+                    };
+                };
+                arrangeAndAct(13 /* ENTER */, false /* addElementOnRunAsync */);
+
+                expect(selectSpy).toHaveBeenCalledWith(
+                    new Position(testContainer, 1),
+                    new Position(testElement, 0)
+                );
             });
         });
 
@@ -259,21 +293,6 @@ describe('Inline Entity On Plugin Event |', () => {
                 expect(splitTextNode.default).not.toHaveBeenCalled();
             });
 
-            it('Selection not collapsed', () => {
-                editor.getSelectionRangeEx = () => {
-                    return <NormalSelectionRange>(<any>{
-                        areAllCollapsed: false,
-                        type: SelectionRangeTypes.Normal,
-                    });
-                };
-                spyOn(editor, 'getElementAtCursor').and.returnValue(delimiterAfter as HTMLElement);
-
-                arrangeAndAct();
-
-                expect(editor.getElementAtCursor).not.toHaveBeenCalled();
-                expect(splitTextNode.default).not.toHaveBeenCalled();
-            });
-
             it('Selection collapsed and not Normal Selection', () => {
                 editor.getSelectionRangeEx = () => {
                     return <NormalSelectionRange>(<any>{
@@ -319,6 +338,54 @@ describe('Inline Entity On Plugin Event |', () => {
 
                 expect(selectSpy).toHaveBeenCalled();
                 expect(delimiterAfter?.nextElementSibling).not.toBeNull();
+            });
+
+            it('Key press when selection is not collapsed, delimiter after is the endContainer', () => {
+                const testElement = document.createElement('span');
+                testElement.appendChild(document.createTextNode('Test'));
+                delimiterBefore?.parentElement?.insertBefore(testElement, delimiterBefore);
+
+                const range = new Range();
+                range.setStart(testElement, 0);
+                range.setEnd(delimiterAfter!, 0);
+
+                editor.getSelectionRangeEx = () => {
+                    return <NormalSelectionRange>{
+                        areAllCollapsed: false,
+                        type: SelectionRangeTypes.Normal,
+                        ranges: [range],
+                    };
+                };
+                arrangeAndAct(13 /* ENTER */, false /* addElementOnRunAsync */);
+
+                expect(selectSpy).toHaveBeenCalledWith(
+                    new Position(testElement, 0),
+                    new Position(testContainer, 4)
+                );
+            });
+
+            it('Key press when selection is not collapsed, delimiter after is the startContainer', () => {
+                const testElement = document.createElement('span');
+                testElement.appendChild(document.createTextNode('Test'));
+                delimiterBefore?.parentElement?.insertBefore(testElement, null);
+
+                const range = new Range();
+                range.setStart(delimiterAfter!, 0);
+                range.setEnd(testElement, 0);
+
+                editor.getSelectionRangeEx = () => {
+                    return <NormalSelectionRange>{
+                        areAllCollapsed: false,
+                        type: SelectionRangeTypes.Normal,
+                        ranges: [range],
+                    };
+                };
+                arrangeAndAct(13 /* ENTER */, false /* addElementOnRunAsync */);
+
+                expect(selectSpy).toHaveBeenCalledWith(
+                    new Position(testContainer, 3),
+                    new Position(testElement, 0)
+                );
             });
         });
     });

--- a/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
@@ -184,14 +184,6 @@ describe('Inline Entity On Plugin Event |', () => {
                 expect(splitTextNode.default).not.toHaveBeenCalled();
             });
 
-            it('Delimiter Classes but contains different text content', () => {
-                delimiterBefore?.insertBefore(textToAdd, delimiterBefore.firstChild);
-
-                arrangeAndAct();
-
-                expect(splitTextNode.default).not.toHaveBeenCalled();
-            });
-
             it('Enter on delimiter before, no previous sibling', () => {
                 arrangeAndAct(13 /* ENTER */, false /* addElementOnRunAsync */);
 

--- a/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
@@ -29,11 +29,16 @@ const DELIMITER_SELECTOR =
 describe('Inline Entity On Plugin Event |', () => {
     let wrapper: HTMLElement;
     let editor: IEditor;
+    let testContainer: HTMLElement;
+    let selectSpy: jasmine.Spy;
 
     beforeEach(() => {
         wrapper = document.createElement('span');
         wrapper.innerHTML = 'Test';
-        document.body.appendChild(wrapper);
+
+        testContainer = document.createElement('div');
+        testContainer.appendChild(wrapper);
+        document.body.appendChild(testContainer);
 
         editor = <IEditor>(<any>{
             getDocument: () => document,
@@ -53,6 +58,7 @@ describe('Inline Entity On Plugin Event |', () => {
                     type: SelectionRangeTypes.Normal,
                 };
             },
+            select: selectSpy = jasmine.createSpy('select'),
         });
     });
 


### PR DESCRIPTION
Handle a scenario where the delimiter is removed when user selects the text + delimiter.

Repro
1. Add Entity
2. type Next and Before the Entity
3. Select the text after/before the entity  
4. press a key the modified the content

Actual:
The delimiter is removed in some scenarios

Expected:
Do not remove the delimiter

To fix modify the selection and prevent the user typing inside of the delimiter when selection is not collapsed