### PR TITLE
Content Model: Fix fidelity issue of list

### DIFF
--- a/demo/scripts/controls/contentModel/components/model/ContentModelListItemView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelListItemView.tsx
@@ -9,6 +9,7 @@ import { FormatView } from '../format/FormatView';
 import { ListMetadataFormatRenderers } from '../format/formatPart/ListMetadataFormatRenderers';
 import { ListThreadFormatRenderers } from '../format/formatPart/ListThreadFormatRenderer';
 import { ListTypeFormatRenderer } from '../format/formatPart/ListTypeFormatRenderer';
+import { MarginFormatRenderer } from '../format/formatPart/MarginFormatRenderer';
 import { TextColorFormatRenderer } from '../format/formatPart/TextColorFormatRenderer';
 import { useProperty } from '../../hooks/useProperty';
 import {
@@ -25,6 +26,7 @@ const ListLevelFormatRenders: FormatRenderer<ContentModelListItemLevelFormat>[] 
     ...ListThreadFormatRenderers,
     ...ListMetadataFormatRenderers,
     ...DirectionFormatRenderers,
+    MarginFormatRenderer,
 ];
 
 const ListItemFormatHolderRenderers: FormatRenderer<ContentModelSegmentFormat>[] = [

--- a/packages/roosterjs-content-model/lib/domToModel/processors/listItemProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/listItemProcessor.ts
@@ -1,6 +1,5 @@
 import { createListItem } from '../../modelApi/creators/createListItem';
 import { ElementProcessor } from '../../publicTypes/context/ElementProcessor';
-import { getDefaultStyle } from '../utils/getDefaultStyle';
 import { parseFormat } from '../utils/parseFormat';
 import { stackFormat } from '../utils/stackFormat';
 
@@ -10,11 +9,7 @@ import { stackFormat } from '../utils/stackFormat';
 export const listItemProcessor: ElementProcessor<HTMLLIElement> = (group, element, context) => {
     const { listFormat } = context;
 
-    if (
-        listFormat.listParent &&
-        listFormat.levels.length > 0 &&
-        (element.style.display || getDefaultStyle(element, context).display) == 'list-item'
-    ) {
+    if (listFormat.listParent && listFormat.levels.length > 0) {
         stackFormat(
             context,
             {

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -95,7 +95,7 @@ const defaultFormatKeysPerCategory: {
 } = {
     block: blockFormatHandlers,
     listItem: ['listItemThread', 'listItemMetadata'],
-    listLevel: ['listType', 'listLevelThread', 'listLevelMetadata', 'direction'],
+    listLevel: ['listType', 'listLevelThread', 'listLevelMetadata', 'direction', 'margin'],
     segment: [
         'superOrSubScript',
         'strike',

--- a/packages/roosterjs-content-model/lib/formatHandlers/list/listItemThreadFormatHandler.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/list/listItemThreadFormatHandler.ts
@@ -6,11 +6,14 @@ import { safeInstanceOf } from 'roosterjs-editor-dom';
  * @internal
  */
 export const listItemThreadFormatHandler: FormatHandler<ListThreadFormat> = {
-    parse: (format, element, context) => {
+    parse: (format, element, context, defaultStyles) => {
         const { listFormat } = context;
         const depth = listFormat.levels.length;
+        const display = element.style.display || defaultStyles.display;
 
-        if (isLiUnderOl(element) && depth > 0) {
+        if (display && display != 'list-item') {
+            format.displayForDummyItem = display;
+        } else if (isLiUnderOl(element) && depth > 0) {
             listFormat.threadItemCounts[depth - 1]++;
             listFormat.threadItemCounts.splice(depth);
             listFormat.levels.forEach(level => {
@@ -21,7 +24,9 @@ export const listItemThreadFormatHandler: FormatHandler<ListThreadFormat> = {
         }
     },
     apply: (format, element, context) => {
-        if (isLiUnderOl(element)) {
+        if (format.displayForDummyItem) {
+            element.style.display = format.displayForDummyItem;
+        } else if (isLiUnderOl(element)) {
             const { listFormat } = context;
             const { threadItemCounts } = listFormat;
             const index = listFormat.nodeStack.length - 2; // The first one is always the parent of list, then minus another 1 to convert length to index

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelListItemLevelFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelListItemLevelFormat.ts
@@ -2,6 +2,7 @@ import { DirectionFormat } from './formatParts/DirectionFormat';
 import { ListMetadataFormat } from './formatParts/ListMetadataFormat';
 import { ListThreadFormat } from './formatParts/ListThreadFormat';
 import { ListTypeFormat } from './formatParts/ListTypeFormat';
+import { MarginFormat } from './formatParts/MarginFormat';
 
 /**
  * The format object for a list level in Content Model
@@ -9,4 +10,5 @@ import { ListTypeFormat } from './formatParts/ListTypeFormat';
 export type ContentModelListItemLevelFormat = ListTypeFormat &
     ListThreadFormat &
     ListMetadataFormat &
-    DirectionFormat;
+    DirectionFormat &
+    MarginFormat;

--- a/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/ListThreadFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/formatParts/ListThreadFormat.ts
@@ -7,4 +7,12 @@ export type ListThreadFormat = {
      * Otherwise, leave it undefined to continue last list
      */
     startNumberOverride?: number;
+
+    /**
+     * For a list item, it should have "list-item" (default value) for display style. In those case,
+     * we will leave displayForDummyItem as undefined.
+     * But if there is other value than "list-item" in display style, we store it here and treat this item
+     * as a dummy item. Dummy item won't have list bullet or number, and we won't add 1 for list number for such items
+     */
+    displayForDummyItem?: string;
 };

--- a/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
@@ -1,0 +1,201 @@
+import contentModelToDom from '../../lib/modelToDom/contentModelToDom';
+import domToContentModel from '../../lib/domToModel/domToContentModel';
+import { ContentModelDocument } from '../../lib/publicTypes/group/ContentModelDocument';
+import { EditorContext } from '../../lib/publicTypes/context/EditorContext';
+
+describe('End to end test for DOM => Model', () => {
+    function runTest(html: string, expectedModel: ContentModelDocument, expectedHtml: string) {
+        const context: EditorContext = {
+            isDarkMode: false,
+        };
+
+        const div1 = document.createElement('div');
+        div1.innerHTML = html;
+
+        const model = domToContentModel(div1, context, {});
+
+        expect(model).toEqual(expectedModel);
+
+        const div2 = document.createElement('div');
+
+        contentModelToDom(document, div2, model, context);
+
+        expect(div2.innerHTML).toEqual(expectedHtml);
+    }
+
+    it('List with margin', () => {
+        runTest(
+            '<ul type="disc" style="margin-bottom: 0in;"><li style="margin-right: 0in; margin-left: 0in; font-size: 11pt; font-family: Calibri, sans-serif;color:black; background:white">1</li><li style="margin-right: 0in; margin-left: 0in; font-size: 11pt; font-family: Calibri, sans-serif;color:black; background:white">2</li></ul>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockGroupType: 'ListItem',
+                        blockType: 'BlockGroup',
+                        blocks: [
+                            {
+                                blockType: 'Paragraph',
+                                format: {},
+                                segments: [
+                                    {
+                                        segmentType: 'Text',
+                                        text: '1',
+                                        format: {
+                                            fontFamily: 'Calibri, sans-serif',
+                                            fontSize: '11pt',
+                                            textColor: 'black',
+                                        },
+                                    },
+                                ],
+                                isImplicit: true,
+                            },
+                        ],
+                        levels: [
+                            {
+                                listType: 'UL',
+                                marginBottom: '0in',
+                            },
+                        ],
+                        format: {},
+                        formatHolder: {
+                            segmentType: 'SelectionMarker',
+                            format: {
+                                fontFamily: 'Calibri, sans-serif',
+                                fontSize: '11pt',
+                                textColor: 'black',
+                            },
+                            isSelected: true,
+                        },
+                    },
+                    {
+                        blockGroupType: 'ListItem',
+                        blockType: 'BlockGroup',
+                        blocks: [
+                            {
+                                blockType: 'Paragraph',
+                                format: {},
+                                segments: [
+                                    {
+                                        segmentType: 'Text',
+                                        text: '2',
+                                        format: {
+                                            fontFamily: 'Calibri, sans-serif',
+                                            fontSize: '11pt',
+                                            textColor: 'black',
+                                        },
+                                    },
+                                ],
+                                isImplicit: true,
+                            },
+                        ],
+                        levels: [
+                            {
+                                listType: 'UL',
+                                marginBottom: '0in',
+                            },
+                        ],
+                        format: {},
+                        formatHolder: {
+                            segmentType: 'SelectionMarker',
+                            format: {
+                                fontFamily: 'Calibri, sans-serif',
+                                fontSize: '11pt',
+                                textColor: 'black',
+                            },
+                            isSelected: true,
+                        },
+                    },
+                ],
+            },
+            '<ul style="margin-bottom: 0in;"><li style="font-family: Calibri, sans-serif; font-size: 11pt; color: black;"><span style="font-family: Calibri, sans-serif; font-size: 11pt; color: black;">1</span></li><li style="font-family: Calibri, sans-serif; font-size: 11pt; color: black;"><span style="font-family: Calibri, sans-serif; font-size: 11pt; color: black;">2</span></li></ul>'
+        );
+    });
+
+    it('list with dummy item', () => {
+        runTest(
+            '<ol><li>1</li><ol><li>a</li></ol><li style="display:block">b</li><li>2</li></ol>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'BlockGroup',
+                        blockGroupType: 'ListItem',
+                        blocks: [
+                            {
+                                blockType: 'Paragraph',
+                                segments: [{ segmentType: 'Text', text: '1', format: {} }],
+                                format: {},
+                                isImplicit: true,
+                            },
+                        ],
+                        levels: [{ listType: 'OL' }],
+                        formatHolder: {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        format: {},
+                    },
+                    {
+                        blockType: 'BlockGroup',
+                        blockGroupType: 'ListItem',
+                        blocks: [
+                            {
+                                blockType: 'Paragraph',
+                                segments: [{ segmentType: 'Text', text: 'a', format: {} }],
+                                format: {},
+                                isImplicit: true,
+                            },
+                        ],
+                        levels: [{ listType: 'OL' }, { listType: 'OL' }],
+                        formatHolder: {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        format: {},
+                    },
+                    {
+                        blockType: 'BlockGroup',
+                        blockGroupType: 'ListItem',
+                        blocks: [
+                            {
+                                blockType: 'Paragraph',
+                                segments: [{ segmentType: 'Text', text: 'b', format: {} }],
+                                format: {},
+                                isImplicit: true,
+                            },
+                        ],
+                        levels: [{ listType: 'OL', displayForDummyItem: 'block' }],
+                        formatHolder: {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        format: {},
+                    },
+                    {
+                        blockType: 'BlockGroup',
+                        blockGroupType: 'ListItem',
+                        blocks: [
+                            {
+                                blockType: 'Paragraph',
+                                segments: [{ segmentType: 'Text', text: '2', format: {} }],
+                                format: {},
+                                isImplicit: true,
+                            },
+                        ],
+                        levels: [{ listType: 'OL' }],
+                        formatHolder: {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        format: {},
+                    },
+                ],
+            },
+            '<ol start="1"><li>1</li><ol start="1"><li style="list-style-type: lower-alpha;">a</li></ol><li style="display: block;">b</li><li>2</li></ol>'
+        );
+    });
+});

--- a/packages/roosterjs-content-model/test/domToModel/processors/listItemProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/listItemProcessorTest.ts
@@ -49,13 +49,13 @@ describe('listItemProcessor', () => {
 
         expect(group).toEqual({
             blockGroupType: 'Document',
-
             blocks: [
                 {
                     blockType: 'BlockGroup',
-                    blockGroupType: 'General',
-                    element: li,
+                    blockGroupType: 'ListItem',
                     blocks: [],
+                    levels: [{ listType: 'UL', displayForDummyItem: 'block' }],
+                    formatHolder: { segmentType: 'SelectionMarker', isSelected: true, format: {} },
                     format: {},
                 },
             ],
@@ -233,13 +233,13 @@ describe('listItemProcessor without format handlers', () => {
 
         expect(group).toEqual({
             blockGroupType: 'Document',
-
             blocks: [
                 {
                     blockType: 'BlockGroup',
-                    blockGroupType: 'General',
-                    element: li,
+                    blockGroupType: 'ListItem',
                     blocks: [],
+                    levels: [{ listType: 'UL' }],
+                    formatHolder: { segmentType: 'SelectionMarker', isSelected: true, format: {} },
                     format: {},
                 },
             ],

--- a/packages/roosterjs-content-model/test/formatHandlers/list/listItemThreadFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model/test/formatHandlers/list/listItemThreadFormatHandlerTest.ts
@@ -153,6 +153,36 @@ describe('listItemThreadFormatHandler.parse', () => {
             ],
         });
     });
+
+    it('LI under OL with display: block', () => {
+        const ol = document.createElement('ol');
+        const li = document.createElement('li');
+
+        ol.appendChild(li);
+        li.style.display = 'block';
+        context.listFormat.levels = [
+            {},
+            {
+                listType: 'OL',
+            },
+        ];
+        context.listFormat.threadItemCounts = [1];
+
+        listItemThreadFormatHandler.parse(format, li, context, {});
+
+        expect(format).toEqual({
+            displayForDummyItem: 'block',
+        });
+        expect(context.listFormat).toEqual({
+            threadItemCounts: [1],
+            levels: [
+                {},
+                {
+                    listType: 'OL',
+                },
+            ],
+        });
+    });
 });
 
 describe('listItemThreadFormatHandler.parse', () => {
@@ -317,6 +347,34 @@ describe('listItemThreadFormatHandler.parse', () => {
                 {
                     node: {} as Node,
                 },
+                {
+                    node: {} as Node,
+                },
+            ],
+        });
+    });
+
+    it('LI under OL with display: block', () => {
+        const ol = document.createElement('ol');
+        const li = document.createElement('li');
+
+        ol.appendChild(li);
+
+        context.listFormat.nodeStack = [
+            {
+                node: {} as Node,
+            },
+        ];
+
+        context.listFormat.threadItemCounts = [1];
+        format.displayForDummyItem = 'block';
+
+        listItemThreadFormatHandler.apply(format, li, context);
+
+        expect(li.outerHTML).toBe('<li style="display: block;"></li>');
+        expect(context.listFormat).toEqual({
+            threadItemCounts: [1],
+            nodeStack: [
                 {
                     node: {} as Node,
                 },


### PR DESCRIPTION
1. For list item with style: display = block, we need to still treat it as a list item but mark it as dummy so we won't show list bullet/number for it and no need to add list number with 1.
2. For list with margins, need to remember the margin value.