### PR TITLE
Content Model: Fix format change while editing

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/ContentModelPlugin.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelPlugin.ts
@@ -80,10 +80,14 @@ export default class ContentModelPlugin implements EditorPlugin {
                     if (format && pos) {
                         setPendingFormat(this.editor, format, pos);
                     }
-                } else if (event.rawEvent.which == Keys.BACKSPACE) {
-                    handleDelete(this.editor, 'backspace');
-                } else if (event.rawEvent.which == Keys.DELETE) {
-                    handleDelete(this.editor, 'delete');
+                } else if (
+                    event.rawEvent.which == Keys.BACKSPACE ||
+                    event.rawEvent.which == Keys.DELETE
+                ) {
+                    handleDelete(
+                        this.editor,
+                        event.rawEvent.which == Keys.DELETE ? 'delete' : 'backspace'
+                    );
                 }
 
                 break;

--- a/packages/roosterjs-content-model/lib/editor/ContentModelPlugin.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelPlugin.ts
@@ -1,7 +1,13 @@
 import applyPendingFormat from '../publicApi/format/applyPendingFormat';
-import { canApplyPendingFormat, clearPendingFormat } from '../modelApi/format/pendingFormat';
+import getSegmentFormat from '../publicApi/format/getSegmentFormat';
+import handleDelete from '../publicApi/editing/handleDelete';
 import { EditorPlugin, IEditor, Keys, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import { IContentModelEditor } from '../publicTypes/IContentModelEditor';
+import {
+    canApplyPendingFormat,
+    clearPendingFormat,
+    setPendingFormat,
+} from '../modelApi/format/pendingFormat';
 
 /**
  * ContentModel plugins helps editor to do editing operation on top of content model.
@@ -67,6 +73,17 @@ export default class ContentModelPlugin implements EditorPlugin {
 
                 if (event.rawEvent.which >= Keys.PAGEUP && event.rawEvent.which <= Keys.DOWN) {
                     clearPendingFormat(this.editor);
+                } else if (event.rawEvent.which == Keys.ENTER) {
+                    const format = getSegmentFormat(this.editor);
+                    const pos = this.editor.getFocusedPosition();
+
+                    if (format && pos) {
+                        setPendingFormat(this.editor, format, pos);
+                    }
+                } else if (event.rawEvent.which == Keys.BACKSPACE) {
+                    handleDelete(this.editor, 'backspace');
+                } else if (event.rawEvent.which == Keys.DELETE) {
+                    handleDelete(this.editor, 'delete');
                 }
 
                 break;

--- a/packages/roosterjs-content-model/lib/publicApi/block/setIndentation.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setIndentation.ts
@@ -17,7 +17,8 @@ export default function setIndentation(
         editor,
         'setIndentation',
         model => setModelIndentation(model, indentation, length),
-        undefined /*options*/,
-        true /*preservePendingFormat*/
+        {
+            preservePendingFormat: true,
+        }
     );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
@@ -40,7 +40,8 @@ export default function toggleBlockQuote(
         editor,
         'toggleBlockQuote',
         model => toggleModelBlockQuote(model, fullQuoteFormat, segmentFormat),
-        undefined /*options*/,
-        true /*preservePendingFormat*/
+        {
+            preservePendingFormat: true,
+        }
     );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/editing/handleDelete.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/editing/handleDelete.ts
@@ -1,0 +1,46 @@
+import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
+import { formatWithContentModel } from '../utils/formatWithContentModel';
+import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
+import { iterateSelections } from '../../modelApi/selection/iterateSelections';
+import { setPendingFormat } from '../../modelApi/format/pendingFormat';
+
+/**
+ * @internal
+ * This is a temporary solution to handle format change when backspace/delete. This is not completed yet.
+ */
+export default function handleDelete(editor: IContentModelEditor, key: 'delete' | 'backspace') {
+    let pos = editor.getFocusedPosition();
+    let format: ContentModelSegmentFormat | undefined;
+
+    formatWithContentModel(editor, 'backspace', model => {
+        iterateSelections([model], (_1, _2, block, segments) => {
+            if (block?.blockType == 'Paragraph') {
+                if (
+                    key == 'backspace' &&
+                    segments?.length == 1 &&
+                    segments[0].segmentType == 'SelectionMarker'
+                ) {
+                    // Backspace with a collapsed selection, set pending format to the format of previous segment
+                    const index = block.segments.indexOf(segments[0]);
+
+                    format = index > 0 ? block.segments[index - 1].format : undefined;
+                } else if (
+                    segments &&
+                    segments.length > 0 &&
+                    block.segments.every(x => x.isSelected)
+                ) {
+                    // Delete everything of a paragraph, set pending format to the format of the first segment
+                    format = segments[0].format;
+                }
+            }
+
+            return true;
+        });
+
+        return false;
+    });
+
+    if (format && pos) {
+        setPendingFormat(editor, format, pos);
+    }
+}

--- a/packages/roosterjs-content-model/lib/publicApi/format/applyPendingFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/applyPendingFormat.ts
@@ -25,7 +25,8 @@ export default function applyPendingFormat(editor: IContentModelEditor, data: st
                     segments?.length == 1 &&
                     segments[0].segmentType == 'SelectionMarker'
                 ) {
-                    const index = block.segments.indexOf(segments[0]);
+                    const marker = segments[0];
+                    const index = block.segments.indexOf(marker);
                     const previousSegment = block.segments[index - 1];
 
                     if (previousSegment?.segmentType == 'Text') {
@@ -34,6 +35,7 @@ export default function applyPendingFormat(editor: IContentModelEditor, data: st
 
                         // For space, there can be &#32 (space) or &#160 (&nbsp;), we treat them as the same
                         if (subStr == data || (data == ANSI_SPACE && subStr == NON_BREAK_SPACE)) {
+                            marker.format = { ...format };
                             previousSegment.text = text.substring(0, text.length - data.length);
 
                             const newText = createText(

--- a/packages/roosterjs-content-model/lib/publicApi/format/getFormatState.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/getFormatState.ts
@@ -2,7 +2,6 @@ import { FormatState } from 'roosterjs-editor-types';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
-import { reducedModelChildProcessor } from '../../domToModel/processors/reducedModelChildProcessor';
 import { retrieveModelFormatState } from '../../modelApi/common/retrieveModelFormatState';
 
 /**
@@ -28,10 +27,7 @@ export default function getFormatState(editor: IContentModelEditor): FormatState
             return false;
         },
         {
-            processorOverride: {
-                // Create a "reduced" Content Model that only scan a sub DOM tree that contains the selection.
-                child: reducedModelChildProcessor,
-            },
+            useReducedModel: true,
         }
     );
 

--- a/packages/roosterjs-content-model/lib/publicApi/format/getSegmentFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/getSegmentFormat.ts
@@ -3,7 +3,6 @@ import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { iterateSelections } from '../../modelApi/selection/iterateSelections';
-import { reducedModelChildProcessor } from '../../domToModel/processors/reducedModelChildProcessor';
 
 /**
  * Get current segment format. This is usually used by format painter
@@ -33,10 +32,7 @@ export default function getSegmentFormat(
                 return false;
             },
             {
-                processorOverride: {
-                    // Create a "reduced" Content Model that only scan a sub DOM tree that contains the selection.
-                    child: reducedModelChildProcessor,
-                },
+                useReducedModel: true,
             }
         );
     }

--- a/packages/roosterjs-content-model/lib/publicApi/list/toggleBullet.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/toggleBullet.ts
@@ -9,11 +9,7 @@ import { setListType } from '../../modelApi/list/setListType';
  * @param editor The editor to operate on
  */
 export default function toggleBullet(editor: IContentModelEditor) {
-    formatWithContentModel(
-        editor,
-        'toggleBullet',
-        model => setListType(model, 'UL'),
-        undefined /*options*/,
-        true /*preservePendingFormat*/
-    );
+    formatWithContentModel(editor, 'toggleBullet', model => setListType(model, 'UL'), {
+        preservePendingFormat: true,
+    });
 }

--- a/packages/roosterjs-content-model/lib/publicApi/list/toggleNumbering.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/toggleNumbering.ts
@@ -9,11 +9,7 @@ import { setListType } from '../../modelApi/list/setListType';
  * @param editor The editor to operate on
  */
 export default function toggleNumbering(editor: IContentModelEditor) {
-    formatWithContentModel(
-        editor,
-        'toggleNumbering',
-        model => setListType(model, 'OL'),
-        undefined /*options*/,
-        true /*preservePendingFormat*/
-    );
+    formatWithContentModel(editor, 'toggleNumbering', model => setListType(model, 'OL'), {
+        preservePendingFormat: true,
+    });
 }

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatParagraphWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatParagraphWithContentModel.ts
@@ -21,7 +21,8 @@ export function formatParagraphWithContentModel(
 
             return paragraphs.length > 0;
         },
-        undefined /*options*/,
-        true /*preservePendingFormat*/
+        {
+            preservePendingFormat: true,
+        }
     );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatSegmentWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatSegmentWithContentModel.ts
@@ -1,10 +1,10 @@
 import { adjustWordSelection } from '../../modelApi/selection/adjustWordSelection';
 import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
-import { DomToModelOption, IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { formatWithContentModel } from './formatWithContentModel';
 import { getPendingFormat, setPendingFormat } from '../../modelApi/format/pendingFormat';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
+import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 /**
  * @internal
  */
@@ -20,57 +20,51 @@ export function formatSegmentWithContentModel(
         format: ContentModelSegmentFormat,
         segment: ContentModelSegment | null
     ) => boolean,
-    includingFormatHolder?: boolean,
-    domToModelOptions?: DomToModelOption
+    includingFormatHolder?: boolean
 ) {
-    formatWithContentModel(
-        editor,
-        apiName,
-        model => {
-            let segments = getSelectedSegments(model, !!includingFormatHolder);
-            const pendingFormat = getPendingFormat(editor);
-            let isCollapsedSelection =
-                segments.length == 1 && segments[0].segmentType == 'SelectionMarker';
+    formatWithContentModel(editor, apiName, model => {
+        let segments = getSelectedSegments(model, !!includingFormatHolder);
+        const pendingFormat = getPendingFormat(editor);
+        let isCollapsedSelection =
+            segments.length == 1 && segments[0].segmentType == 'SelectionMarker';
 
-            if (isCollapsedSelection) {
-                segments = adjustWordSelection(model, segments[0]);
-                if (segments.length > 1) {
-                    isCollapsedSelection = false;
-                }
+        if (isCollapsedSelection) {
+            segments = adjustWordSelection(model, segments[0]);
+            if (segments.length > 1) {
+                isCollapsedSelection = false;
             }
+        }
 
-            const formatsAndSegments: [
-                ContentModelSegmentFormat,
-                ContentModelSegment | null
-            ][] = pendingFormat
-                ? [[pendingFormat, null]]
-                : segments.map(segment => [segment.format, segment]);
+        const formatsAndSegments: [
+            ContentModelSegmentFormat,
+            ContentModelSegment | null
+        ][] = pendingFormat
+            ? [[pendingFormat, null]]
+            : segments.map(segment => [segment.format, segment]);
 
-            const isTurningOff = segmentHasStyleCallback
-                ? formatsAndSegments.every(([format, segment]) =>
-                      segmentHasStyleCallback(format, segment)
-                  )
-                : false;
+        const isTurningOff = segmentHasStyleCallback
+            ? formatsAndSegments.every(([format, segment]) =>
+                  segmentHasStyleCallback(format, segment)
+              )
+            : false;
 
-            formatsAndSegments.forEach(([format, segment]) =>
-                toggleStyleCallback(format, !isTurningOff, segment)
-            );
+        formatsAndSegments.forEach(([format, segment]) =>
+            toggleStyleCallback(format, !isTurningOff, segment)
+        );
 
-            if (!pendingFormat && isCollapsedSelection) {
-                const pos = editor.getFocusedPosition();
+        if (!pendingFormat && isCollapsedSelection) {
+            const pos = editor.getFocusedPosition();
 
-                if (pos) {
-                    setPendingFormat(editor, segments[0].format, pos);
-                }
+            if (pos) {
+                setPendingFormat(editor, segments[0].format, pos);
             }
+        }
 
-            if (isCollapsedSelection) {
-                editor.focus();
-                return false;
-            } else {
-                return formatsAndSegments.length > 0;
-            }
-        },
-        domToModelOptions
-    );
+        if (isCollapsedSelection) {
+            editor.focus();
+            return false;
+        } else {
+            return formatsAndSegments.length > 0;
+        }
+    });
 }

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -2,6 +2,22 @@ import { ChangeSource } from 'roosterjs-editor-types';
 import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
 import { DomToModelOption, IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { getPendingFormat, setPendingFormat } from '../../modelApi/format/pendingFormat';
+import { reducedModelChildProcessor } from '../../domToModel/processors/reducedModelChildProcessor';
+
+/**
+ * @internal
+ */
+export interface FormatWithContentModelOptions {
+    /**
+     * When set to true, it will only create Content Model for selected content
+     */
+    useReducedModel?: boolean;
+
+    /**
+     * When set to true, if there is pending format, it will be preserved after this format operation is done
+     */
+    preservePendingFormat?: boolean;
+}
 
 /**
  * @internal
@@ -10,10 +26,16 @@ export function formatWithContentModel(
     editor: IContentModelEditor,
     apiName: string,
     callback: (model: ContentModelDocument) => boolean,
-    domToModelOptions?: DomToModelOption,
-    preservePendingFormat?: boolean
+    options?: FormatWithContentModelOptions
 ) {
-    const model = editor.createContentModel(domToModelOptions);
+    const domToModelOption: DomToModelOption | undefined = options?.useReducedModel
+        ? {
+              processorOverride: {
+                  child: reducedModelChildProcessor,
+              },
+          }
+        : undefined;
+    const model = editor.createContentModel(domToModelOption);
 
     if (callback(model)) {
         editor.addUndoSnapshot(
@@ -23,7 +45,7 @@ export function formatWithContentModel(
                     editor.setContentModel(model);
                 }
 
-                if (preservePendingFormat) {
+                if (options?.preservePendingFormat) {
                     const pendingFormat = getPendingFormat(editor);
                     const pos = editor.getFocusedPosition();
 

--- a/packages/roosterjs-content-model/test/editor/ContentModelPluginTest.ts
+++ b/packages/roosterjs-content-model/test/editor/ContentModelPluginTest.ts
@@ -1,3 +1,4 @@
+import * as deleteContent from '../../lib/publicApi/editing/handleDelete';
 import * as pendingFormat from '../../lib/modelApi/format/pendingFormat';
 import ContentModelPlugin from '../../lib/editor/ContentModelPlugin';
 import { addSegment } from '../../lib/modelApi/common/addSegment';
@@ -5,6 +6,7 @@ import { createContentModelDocument } from '../../lib/modelApi/creators/createCo
 import { createSelectionMarker } from '../../lib/modelApi/creators/createSelectionMarker';
 import { createText } from '../../lib/modelApi/creators/createText';
 import { IContentModelEditor } from '../../lib/publicTypes/IContentModelEditor';
+import { Keys } from 'roosterjs-editor-types';
 import { PluginEventType } from 'roosterjs-editor-types';
 
 describe('ContentModelPlugin', () => {
@@ -369,5 +371,47 @@ describe('ContentModelPlugin', () => {
         expect(setContentModel).toHaveBeenCalledTimes(0);
         expect(pendingFormat.clearPendingFormat).not.toHaveBeenCalled();
         expect(pendingFormat.canApplyPendingFormat).toHaveBeenCalledTimes(1);
+    });
+
+    it('Delete key', () => {
+        spyOn(deleteContent, 'default');
+
+        const editor = ({
+            cacheContentModel: () => {},
+        } as any) as IContentModelEditor;
+        const plugin = new ContentModelPlugin();
+
+        plugin.initialize(editor);
+        plugin.onPluginEvent({
+            eventType: PluginEventType.KeyDown,
+            rawEvent: ({
+                which: Keys.DELETE,
+            } as any) as KeyboardEvent,
+        });
+        plugin.dispose();
+
+        expect(deleteContent.default).toHaveBeenCalledTimes(1);
+        expect(deleteContent.default).toHaveBeenCalledWith(editor, 'delete');
+    });
+
+    it('Backspace key', () => {
+        spyOn(deleteContent, 'default');
+
+        const editor = ({
+            cacheContentModel: () => {},
+        } as any) as IContentModelEditor;
+        const plugin = new ContentModelPlugin();
+
+        plugin.initialize(editor);
+        plugin.onPluginEvent({
+            eventType: PluginEventType.KeyDown,
+            rawEvent: ({
+                which: Keys.BACKSPACE,
+            } as any) as KeyboardEvent,
+        });
+        plugin.dispose();
+
+        expect(deleteContent.default).toHaveBeenCalledTimes(1);
+        expect(deleteContent.default).toHaveBeenCalledWith(editor, 'backspace');
     });
 });

--- a/packages/roosterjs-content-model/test/editor/ContentModelPluginTest.ts
+++ b/packages/roosterjs-content-model/test/editor/ContentModelPluginTest.ts
@@ -176,7 +176,7 @@ describe('ContentModelPlugin', () => {
                         },
                         {
                             segmentType: 'SelectionMarker',
-                            format: {},
+                            format: { fontSize: '10px' },
                             isSelected: true,
                         },
                     ],
@@ -240,7 +240,7 @@ describe('ContentModelPlugin', () => {
                         },
                         {
                             segmentType: 'SelectionMarker',
-                            format: {},
+                            format: { fontSize: '10px' },
                             isSelected: true,
                         },
                     ],

--- a/packages/roosterjs-content-model/test/publicApi/editing/handleDeleteTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/editing/handleDeleteTest.ts
@@ -1,0 +1,130 @@
+import * as pendingFormat from '../../../lib/modelApi/format/pendingFormat';
+import deleteContent from '../../../lib/publicApi/editing/handleDelete';
+import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
+
+describe('handleDelete', () => {
+    let editor: IContentModelEditor;
+    const mockedPos = 'POS' as any;
+
+    beforeEach(() => {
+        editor = ({
+            getFocusedPosition: () => mockedPos,
+        } as any) as IContentModelEditor;
+
+        spyOn(pendingFormat, 'setPendingFormat');
+    });
+
+    it('delete without selection', () => {
+        editor.createContentModel = () => ({
+            blockGroupType: 'Document',
+            blocks: [],
+        });
+
+        deleteContent(editor, 'delete');
+
+        expect(pendingFormat.setPendingFormat).toHaveBeenCalledTimes(0);
+    });
+
+    it('delete with expanded selection', () => {
+        editor.createContentModel = () => ({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            isSelected: true,
+                            format: {
+                                fontSize: '10pt',
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        deleteContent(editor, 'delete');
+
+        expect(pendingFormat.setPendingFormat).toHaveBeenCalledTimes(1);
+        expect(pendingFormat.setPendingFormat).toHaveBeenCalledWith(
+            editor,
+            {
+                fontSize: '10pt',
+            },
+            mockedPos
+        );
+    });
+
+    it('backspace with expanded selection', () => {
+        editor.createContentModel = () => ({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            isSelected: true,
+                            format: {
+                                fontSize: '10pt',
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        deleteContent(editor, 'backspace');
+
+        expect(pendingFormat.setPendingFormat).toHaveBeenCalledTimes(1);
+        expect(pendingFormat.setPendingFormat).toHaveBeenCalledWith(
+            editor,
+            {
+                fontSize: '10pt',
+            },
+            mockedPos
+        );
+    });
+
+    it('backspace with collapsed selection', () => {
+        editor.createContentModel = () => ({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {
+                                fontSize: '10pt',
+                            },
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+
+        deleteContent(editor, 'backspace');
+
+        expect(pendingFormat.setPendingFormat).toHaveBeenCalledTimes(1);
+        expect(pendingFormat.setPendingFormat).toHaveBeenCalledWith(
+            editor,
+            {
+                fontSize: '10pt',
+            },
+            mockedPos
+        );
+    });
+});

--- a/packages/roosterjs-content-model/test/publicApi/format/applyPendingFormatTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/format/applyPendingFormatTest.ts
@@ -69,7 +69,7 @@ describe('applyPendingFormat', () => {
                         },
                         {
                             segmentType: 'SelectionMarker',
-                            format: {},
+                            format: { fontSize: '10px' },
                             isSelected: true,
                         },
                     ],

--- a/packages/roosterjs-content-model/test/publicApi/utils/formatWithContentModelTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/utils/formatWithContentModelTest.ts
@@ -1,3 +1,4 @@
+import * as pendingFormat from '../../../lib/modelApi/format/pendingFormat';
 import { ChangeSource } from 'roosterjs-editor-types';
 import { ContentModelDocument } from '../../../lib/publicTypes/group/ContentModelDocument';
 import { formatWithContentModel } from '../../../lib/publicApi/utils/formatWithContentModel';
@@ -10,8 +11,11 @@ describe('formatWithContentModel', () => {
     let setContentModel: jasmine.Spy;
     let focus: jasmine.Spy;
     let mockedModel: ContentModelDocument;
+    let cacheContentModel: jasmine.Spy;
+    let getFocusedPosition: jasmine.Spy;
 
     const apiName = 'mockedApi';
+    const mockedPos = 'POS' as any;
 
     beforeEach(() => {
         mockedModel = ({} as any) as ContentModelDocument;
@@ -20,12 +24,16 @@ describe('formatWithContentModel', () => {
         createContentModel = jasmine.createSpy('createContentModel').and.returnValue(mockedModel);
         setContentModel = jasmine.createSpy('setContentModel');
         focus = jasmine.createSpy('focus');
+        cacheContentModel = jasmine.createSpy('cacheContentModel');
+        getFocusedPosition = jasmine.createSpy('getFocusedPosition').and.returnValue(mockedPos);
 
         editor = ({
             focus,
             addUndoSnapshot,
             createContentModel,
             setContentModel,
+            cacheContentModel,
+            getFocusedPosition,
         } as any) as IContentModelEditor;
     });
 
@@ -57,5 +65,26 @@ describe('formatWithContentModel', () => {
         expect(setContentModel).toHaveBeenCalledTimes(1);
         expect(setContentModel).toHaveBeenCalledWith(mockedModel);
         expect(focus).toHaveBeenCalledTimes(1);
+    });
+
+    it('Preserve pending format', () => {
+        const callback = jasmine.createSpy('callback').and.returnValue(true);
+        const mockedFormat = 'FORMAT' as any;
+
+        spyOn(pendingFormat, 'getPendingFormat').and.returnValue(mockedFormat);
+        spyOn(pendingFormat, 'setPendingFormat');
+
+        formatWithContentModel(editor, apiName, callback, {
+            preservePendingFormat: true,
+        });
+
+        expect(callback).toHaveBeenCalledWith(mockedModel);
+        expect(createContentModel).toHaveBeenCalledTimes(1);
+        expect(pendingFormat.setPendingFormat).toHaveBeenCalledTimes(1);
+        expect(pendingFormat.setPendingFormat).toHaveBeenCalledWith(
+            editor,
+            mockedFormat,
+            mockedPos
+        );
     });
 });


### PR DESCRIPTION
When edit with Enter, Backspace, Delete keys, it is possible to cause the current content lose format especially when all content inside a paragraph is removed.

To finally fix this issue, we need to let Content Model handle all these editing operations and generate modified content for us.

This is just a first step. It will not change the content using Content Model, but just save a pending format so if user keep editing, the correct format will be applied.

This can't fix the case when user do Enter/Delete/Backspace then move the cursor away. That need a full fix later.