### PR TITLE
Improve Movement Between Delimiters

### DIFF
--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
@@ -320,7 +320,7 @@ describe('Content Edit Features |', () => {
 
                 moveBetweenDelimitersFeature.handleEvent(event, editor);
 
-                expect(extendSpy).toHaveBeenCalledWith(delimiterAfter, 1);
+                expect(extendSpy).toHaveBeenCalledWith(testContainer, 3);
                 expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
 
                 restoreSelection();


### PR DESCRIPTION
The Content Edit was not working when cursor was between Entities, this PR fixes it,

To Repro add multiple Readonly inline entities together. Without this change we had to use Arrow Key twice, now we only need to press it once