### PR TITLE
Remove shadow wrapper

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -418,14 +418,8 @@ export default class ImageEdit implements EditorPlugin {
      * Remove the temp wrapper of the image
      */
     private removeWrapper = () => {
-        if (
-            this.editor &&
-            this.image &&
-            this.image.parentNode &&
-            this.editor.contains(this.image) &&
-            this.wrapper
-        ) {
-            unwrap(this.image.parentNode);
+        if (this.shadowSpan) {
+            unwrap(this.shadowSpan);
         }
         this.wrapper = null;
         this.shadowSpan = null;


### PR DESCRIPTION
Sometimes the selected image can be wrapped by a element while in editing mode, such as a hyperlink. 
To avoid removed the element that wrappers the image, do not remove image parent element, but the shadow span. 
![imageHyperlink](https://user-images.githubusercontent.com/87443959/224829394-c3bff7b3-21ac-4ca5-97f1-73ee33c78abc.gif)
