### PR TITLE
Remove max-width from insertImageWithSrc

### DIFF
--- a/packages/roosterjs-editor-api/lib/format/insertImage.ts
+++ b/packages/roosterjs-editor-api/lib/format/insertImage.ts
@@ -36,8 +36,6 @@ function insertImageWithSrc(editor: IEditor, src: string, attributes?: Record<st
                     image.setAttribute(attribute, attributes[attribute])
                 );
             }
-
-            image.style.maxWidth = '100%';
             editor.insertNode(image);
         },
         'insertImage'


### PR DESCRIPTION
Max-width is making image resize, when the image is cropped. 
Before: 
![cropIssueBefore](https://user-images.githubusercontent.com/87443959/225081085-1411015c-eb30-402d-994b-ccc49b02b2d0.gif)
After: 
![cropIssue](https://user-images.githubusercontent.com/87443959/225081154-fa817fac-721b-4c97-a79f-9d6744fb2f67.gif)
 