### PR TITLE
Fix Movement Between Entity Delimiter issue

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
@@ -220,7 +220,7 @@ const MoveBetweenDelimitersFeature: BuildInEditFeature<PluginKeyboardEvent> = {
     allowFunctionKeys: true,
     shouldHandleEvent: (event: PluginKeyboardEvent, editor: IEditor) => {
         if (
-            event.rawEvent.altKey &&
+            event.rawEvent.altKey ||
             !editor.isFeatureEnabled(ExperimentalFeatures.InlineEntityReadOnlyDelimiters)
         ) {
             return false;

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
@@ -5,6 +5,7 @@ import {
     commitEntity,
     ContentTraverser,
     findClosestElementAncestor,
+    getBlockElementAtNode,
     Position,
     PositionContentSearcher,
 } from 'roosterjs-editor-dom';
@@ -70,6 +71,7 @@ describe('Content Edit Features |', () => {
                 feature === ExperimentalFeatures.InlineEntityReadOnlyDelimiters,
             getBodyTraverser: (startNode?: Node) =>
                 ContentTraverser.createBodyTraverser(testContainer, startNode),
+            getBlockElementAtNode: (node: Node) => getBlockElementAtNode(document.body, node),
         });
 
         ({ entity, delimiterAfter, delimiterBefore } = addEntityBeforeEach(entity, wrapper));
@@ -278,6 +280,13 @@ describe('Content Edit Features |', () => {
 
                 event = runTest(new Position(bold.firstChild!, 1), false /* expected */, event);
             });
+
+            it('DelimiterAfter, should not Handle, cursor is at start of next block', () => {
+                const div = document.createElement('div');
+                testContainer.insertAdjacentElement('afterend', div);
+
+                runTest(new Position(div, 0), false /* expected */, event);
+            });
         }
 
         describe('LTR |', () => {
@@ -485,6 +494,13 @@ describe('Content Edit Features |', () => {
                 testContainer.insertBefore(bold, null);
 
                 event = runTest(new Position(bold.firstChild!, 1), false /* expected */, event);
+            });
+
+            it('DelimiterBefore, should not Handle, cursor is at end of previous block', () => {
+                const div = document.createElement('div');
+                testContainer.insertAdjacentElement('beforeend', div);
+
+                runTest(new Position(div, 0), false /* expected */, event);
             });
         }
 

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
@@ -283,9 +283,24 @@ describe('Content Edit Features |', () => {
 
             it('DelimiterAfter, should not Handle, cursor is at start of next block', () => {
                 const div = document.createElement('div');
+                div.appendChild(document.createTextNode('New block'));
                 testContainer.insertAdjacentElement('afterend', div);
 
-                runTest(new Position(div, 0), false /* expected */, event);
+                runTest(new Position(<Node>div.firstChild!, 0), false /* expected */, event);
+            });
+
+            it('Delimiter After, Inline Readonly Entity with multiple Inline Elements', () => {
+                const b = document.createElement('b');
+                b.appendChild(document.createTextNode('Bold'));
+
+                entity.wrapper.appendChild(b);
+                entity.wrapper.appendChild(b.cloneNode(true));
+
+                wrapElementInB(delimiterBefore);
+                wrapElementInB(entity.wrapper);
+                wrapElementInB(delimiterAfter);
+
+                runTest(delimiterAfter, true /* expected */, event);
             });
         }
 
@@ -501,6 +516,20 @@ describe('Content Edit Features |', () => {
                 testContainer.insertAdjacentElement('beforeend', div);
 
                 runTest(new Position(div, 0), false /* expected */, event);
+            });
+
+            it('DelimiterBefore, Inline Readonly Entity with multiple Inline Elements', () => {
+                const b = document.createElement('b');
+                b.appendChild(document.createTextNode('Bold'));
+
+                entity.wrapper.appendChild(b);
+                entity.wrapper.appendChild(b.cloneNode(true));
+
+                wrapElementInB(delimiterBefore);
+                wrapElementInB(entity.wrapper);
+                wrapElementInB(delimiterAfter);
+
+                runTest(delimiterBefore, true /* expected */, event);
             });
         }
 


### PR DESCRIPTION
When trying to move between the delimiters after using the Format API without Content Model and a delimiter element in the selection, The cursor is stuck in the ZWS so use the arrow key twice is needed.

The root cause of the issue is that we are using (Next/Previous)ElementSibling and since the delimiter element is wrapped in a new element it is returning null
To fix this intead use ContentTraverser to get the next sibling.

