### PR TITLE
Enter on Delimiter change and Add classes to sanitizing option

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/utils/inlineEntityOnPluginEvent.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/utils/inlineEntityOnPluginEvent.ts
@@ -1,12 +1,12 @@
 import {
     addDelimiters,
-    createElement,
     createRange,
     getDelimiterFromElement,
     getEntityFromElement,
     getEntitySelector,
     isBlockElement,
     isCharacterValue,
+    matchesSelector,
     Position,
     safeInstanceOf,
     splitTextNode,
@@ -29,21 +29,17 @@ const DELIMITER_SELECTOR =
     '.' + DelimiterClasses.DELIMITER_AFTER + ',.' + DelimiterClasses.DELIMITER_BEFORE;
 const ZERO_WIDTH_SPACE = '\u200B';
 const INLINE_ENTITY_SELECTOR = 'span' + getEntitySelector();
-const NBSP = '\u00A0';
+const CHANGE_SOURCES_TO_HANDLE: string[] = [ChangeSource.SetContent, ChangeSource.Paste];
 
 export function inlineEntityOnPluginEvent(event: PluginEvent, editor: IEditor) {
     switch (event.eventType) {
         case PluginEventType.ContentChanged:
-            if (event.source === ChangeSource.SetContent) {
+            if (CHANGE_SOURCES_TO_HANDLE.indexOf(event.source) >= 0) {
                 normalizeDelimitersInEditor(editor);
             }
             break;
         case PluginEventType.EditorReady:
             normalizeDelimitersInEditor(editor);
-            break;
-
-        case PluginEventType.BeforePaste:
-            addDelimitersIfNeeded(event.fragment.querySelectorAll(INLINE_ENTITY_SELECTOR));
             break;
 
         case PluginEventType.ExtractContentWithDom:
@@ -98,13 +94,13 @@ export function normalizeDelimitersInEditor(editor: IEditor) {
 
 function addDelimitersIfNeeded(nodes: Element[] | NodeListOf<Element>) {
     nodes.forEach(node => {
-        if (tryGetEntityFromNode(node)) {
+        if (isEntityElement(node)) {
             addDelimiters(node);
         }
     });
 }
 
-function tryGetEntityFromNode(node: Element | null): node is HTMLElement {
+function isEntityElement(node: Node | null): node is HTMLElement {
     return !!(
         node &&
         safeInstanceOf(node, 'HTMLElement') &&
@@ -124,7 +120,7 @@ function isReadOnly(entity: Entity | null) {
     );
 }
 
-function removeInvalidDelimiters(nodes: Element[]) {
+function removeInvalidDelimiters(nodes: Element[] | NodeListOf<Element>) {
     nodes.forEach(node => {
         if (getDelimiterFromElement(node)) {
             const sibling = node.classList.contains(DelimiterClasses.DELIMITER_BEFORE)
@@ -139,14 +135,14 @@ function removeInvalidDelimiters(nodes: Element[]) {
     });
 }
 
-function removeDelimiterAttr(node: Element | undefined | null) {
+function removeDelimiterAttr(node: Element | undefined | null, checkEntity: boolean = true) {
     if (!node) {
         return;
     }
 
     const isAfter = node.classList.contains(DelimiterClasses.DELIMITER_AFTER);
     const entitySibling = isAfter ? node.previousElementSibling : node.nextElementSibling;
-    if (entitySibling && tryGetEntityFromNode(entitySibling)) {
+    if (checkEntity && entitySibling && isEntityElement(entitySibling)) {
         return;
     }
 
@@ -163,39 +159,34 @@ function removeDelimiterAttr(node: Element | undefined | null) {
 
 function handleCollapsedEnter(editor: IEditor, delimiter: HTMLElement) {
     const isAfter = delimiter.classList.contains(DelimiterClasses.DELIMITER_AFTER);
-    const sibling = isAfter ? delimiter.nextSibling : delimiter.previousSibling;
-    let positionToUse: Position | undefined;
-    let element: Element | null;
+    const entity = !isAfter ? delimiter.nextSibling : delimiter.previousSibling;
+    const block = editor.getBlockElementAtNode(delimiter)?.getStartNode();
 
-    if (sibling) {
-        positionToUse = new Position(sibling, isAfter ? PositionType.Begin : PositionType.End);
-    } else {
-        element = delimiter.insertAdjacentElement(
-            isAfter ? 'afterend' : 'beforebegin',
-            createElement(
-                {
-                    tag: 'span',
-                    children: [NBSP],
-                },
-                editor.getDocument()
-            )!
-        );
-
-        if (!element) {
+    editor.runAsync(() => {
+        if (!block) {
             return;
         }
+        const blockToCheck = isAfter ? block.nextSibling : block.previousSibling;
+        if (blockToCheck && safeInstanceOf(blockToCheck, 'HTMLElement')) {
+            const delimiters = blockToCheck.querySelectorAll(DELIMITER_SELECTOR);
+            // Check if the last or first delimiter still contain the delimiter class and remove it.
+            const delimiterToCheck = delimiters.item(isAfter ? 0 : delimiters.length - 1);
+            removeDelimiterAttr(delimiterToCheck);
+        }
 
-        positionToUse = new Position(element, PositionType.Begin);
-    }
-
-    if (positionToUse) {
-        editor.select(positionToUse);
-        editor.runAsync(aEditor => {
-            const elAfter = aEditor.getElementAtCursor();
-            removeDelimiterAttr(elAfter);
-            removeNode(element);
-        });
-    }
+        if (isEntityElement(entity)) {
+            const { nextElementSibling, previousElementSibling } = entity;
+            [nextElementSibling, previousElementSibling].forEach(el => {
+                // Check if after Enter the ZWS got removed but we still have a element with the class
+                // Remove the attributes of the element if it is invalid now.
+                if (el && matchesSelector(el, DELIMITER_SELECTOR) && !getDelimiterFromElement(el)) {
+                    removeDelimiterAttr(el, false /* checkEntity */);
+                }
+            });
+            // Add delimiters to the entity if needed because on Enter we can sometimes lose the ZWS of the element.
+            addDelimiters(entity);
+        }
+    });
 }
 
 const getPosition = (container: HTMLElement | null) => {

--- a/packages/roosterjs-editor-core/lib/corePlugins/utils/inlineEntityOnPluginEvent.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/utils/inlineEntityOnPluginEvent.ts
@@ -1,5 +1,6 @@
 import {
     addDelimiters,
+    arrayPush,
     createRange,
     getDelimiterFromElement,
     getEntityFromElement,
@@ -29,17 +30,28 @@ const DELIMITER_SELECTOR =
     '.' + DelimiterClasses.DELIMITER_AFTER + ',.' + DelimiterClasses.DELIMITER_BEFORE;
 const ZERO_WIDTH_SPACE = '\u200B';
 const INLINE_ENTITY_SELECTOR = 'span' + getEntitySelector();
-const CHANGE_SOURCES_TO_HANDLE: string[] = [ChangeSource.SetContent, ChangeSource.Paste];
 
 export function inlineEntityOnPluginEvent(event: PluginEvent, editor: IEditor) {
     switch (event.eventType) {
         case PluginEventType.ContentChanged:
-            if (CHANGE_SOURCES_TO_HANDLE.indexOf(event.source) >= 0) {
+            if (event.source === ChangeSource.SetContent) {
                 normalizeDelimitersInEditor(editor);
             }
             break;
         case PluginEventType.EditorReady:
             normalizeDelimitersInEditor(editor);
+            break;
+
+        case PluginEventType.BeforePaste:
+            const { fragment, sanitizingOption } = event;
+            addDelimitersIfNeeded(fragment.querySelectorAll(INLINE_ENTITY_SELECTOR));
+
+            if (sanitizingOption.additionalAllowedCssClasses) {
+                arrayPush(sanitizingOption.additionalAllowedCssClasses, [
+                    DelimiterClasses.DELIMITER_AFTER,
+                    DelimiterClasses.DELIMITER_BEFORE,
+                ]);
+            }
             break;
 
         case PluginEventType.ExtractContentWithDom:

--- a/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
@@ -1,4 +1,5 @@
 import * as splitTextNode from 'roosterjs-editor-dom/lib/utils/splitTextNode';
+import { inlineEntityOnPluginEvent } from '../../lib/corePlugins/utils/inlineEntityOnPluginEvent';
 import {
     BeforeCutCopyEvent,
     BeforePasteEvent,
@@ -15,7 +16,6 @@ import {
     PluginKeyDownEvent,
     SelectionRangeTypes,
 } from 'roosterjs-editor-types';
-import { inlineEntityOnPluginEvent } from '../../lib/corePlugins/utils/inlineEntityOnPluginEvent';
 import {
     addDelimiters,
     commitEntity,
@@ -608,20 +608,21 @@ describe('Inline Entity On Plugin Event |', () => {
             if (elementToUse) {
                 rootDiv.appendChild(elementToUse);
             }
-
+            const additionalAllowedCssClasses: string[] = [];
             inlineEntityOnPluginEvent(
                 <BeforePasteEvent>(<any>{
                     eventType: PluginEventType.BeforePaste,
                     clipboardData: {},
                     fragment: rootDiv,
                     sanitizingOption: {
-                        additionalAllowedCssClasses: [],
+                        additionalAllowedCssClasses,
                     },
                 }),
                 editor
             );
-
             expect(rootDiv.querySelectorAll(DELIMITER_SELECTOR).length).toBe(expectedDelimiters);
+            expect(additionalAllowedCssClasses).toContain(DelimiterClasses.DELIMITER_AFTER);
+            expect(additionalAllowedCssClasses).toContain(DelimiterClasses.DELIMITER_BEFORE);
         }
 
         it('Before Paste with Read only Inline Entity in content', () => {

--- a/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
@@ -1,4 +1,20 @@
 import * as splitTextNode from 'roosterjs-editor-dom/lib/utils/splitTextNode';
+import {
+    BeforeCutCopyEvent,
+    BeforePasteEvent,
+    ChangeSource,
+    ContentChangedEvent,
+    DelimiterClasses,
+    EditorReadyEvent,
+    Entity,
+    ExtractContentWithDomEvent,
+    IEditor,
+    NormalSelectionRange,
+    PluginEvent,
+    PluginEventType,
+    PluginKeyDownEvent,
+    SelectionRangeTypes,
+} from 'roosterjs-editor-types';
 import { inlineEntityOnPluginEvent } from '../../lib/corePlugins/utils/inlineEntityOnPluginEvent';
 import {
     addDelimiters,
@@ -7,21 +23,6 @@ import {
     getBlockElementAtNode,
     Position,
 } from 'roosterjs-editor-dom';
-import {
-    BeforeCutCopyEvent,
-    EditorReadyEvent,
-    DelimiterClasses,
-    Entity,
-    ExtractContentWithDomEvent,
-    IEditor,
-    NormalSelectionRange,
-    PluginEventType,
-    ContentChangedEvent,
-    PluginEvent,
-    SelectionRangeTypes,
-    PluginKeyDownEvent,
-    ChangeSource,
-} from 'roosterjs-editor-types';
 
 const ZERO_WIDTH_SPACE = '\u200B';
 const DELIMITER_SELECTOR =
@@ -601,55 +602,68 @@ describe('Inline Entity On Plugin Event |', () => {
         });
     });
 
-    describe('Content Change, Paste Source |', () => {
-        let event: ContentChangedEvent;
+    describe('Before Paste |', () => {
+        function runTest(expectedDelimiters: number, elementToUse?: Node) {
+            const rootDiv = document.createElement('div');
+            if (elementToUse) {
+                rootDiv.appendChild(elementToUse);
+            }
 
-        beforeEach(() => {
-            event = <ContentChangedEvent>{
-                eventType: PluginEventType.ContentChanged,
-                source: ChangeSource.Paste,
-            };
-        });
+            inlineEntityOnPluginEvent(
+                <BeforePasteEvent>(<any>{
+                    eventType: PluginEventType.BeforePaste,
+                    clipboardData: {},
+                    fragment: rootDiv,
+                    sanitizingOption: {
+                        additionalAllowedCssClasses: [],
+                    },
+                }),
+                editor
+            );
 
-        it('Content Change, Paste Source with Read only Inline Entity in content', () => {
+            expect(rootDiv.querySelectorAll(DELIMITER_SELECTOR).length).toBe(expectedDelimiters);
+        }
+
+        it('Before Paste with Read only Inline Entity in content', () => {
             const element = document.createElement('span');
             commitEntity(element, '123', true /* ReadOnly */, '1');
 
-            runEditorReadyContentChangedTest(2, element, event);
+            runTest(2, element);
         });
 
-        it('Content Change, Paste Source with Read only Block Entity in content', () => {
+        it('Before Paste with Read only Block Entity in content', () => {
             const element = document.createElement('div');
             commitEntity(element, '123', true /* ReadOnly */, '1');
 
-            runEditorReadyContentChangedTest(0, element, event);
+            runTest(0, element);
         });
 
-        it('Content Change, Paste Source with Editable Inline Entity in content', () => {
+        it('Before Paste with Editable Inline Entity in content', () => {
             const element = document.createElement('span');
             commitEntity(element, '123', false /* ReadOnly */, '1');
 
-            runEditorReadyContentChangedTest(0, element, event);
+            runTest(0, element);
         });
 
-        it('Content Change, Paste Source with Editable Block Entity in content', () => {
+        it('Before Paste with Editable Block Entity in content', () => {
             const element = document.createElement('div');
             commitEntity(element, '123', false /* ReadOnly */, '1');
 
-            runEditorReadyContentChangedTest(0, element, event);
+            runTest(0, element);
         });
 
-        it('Content Change, Paste Source with Normal Element', () => {
+        it('Before Paste with Normal Element', () => {
             const element = document.createElement('div');
-            runEditorReadyContentChangedTest(0, element, event);
+            runTest(0, element);
         });
 
-        it('Content Change, Paste Source with no elements', () => {
+        it('Before Paste with no elements', () => {
             const element = document.createElement('div');
-            runEditorReadyContentChangedTest(0, element, event);
+            runTest(0, element);
         });
     });
 });
+
 function addEntityBeforeEach(entity: Entity, wrapper: HTMLElement) {
     entity = <Entity>{
         id: 'test',


### PR DESCRIPTION
Change the way we are handling Enter on a delimiter due to an issue. Instead of removing the node, just remove the class and the ZWS
Add the delimiter classes to the sanitizing option so they do not get removed on paste