### PR TITLE
Fix Tab/ShiftTab indenting for lists on Mac

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -99,22 +99,20 @@ const handleIndentationEvent = (indenting: boolean) => (
  * IndentWhenTab edit feature, provides the ability to indent current list when user press TAB
  */
 const IndentWhenTab: BuildInEditFeature<PluginKeyboardEvent> = {
-    keys: [Keys.TAB, Keys.RIGHT],
+    keys: Browser.isMac ? [Keys.TAB] : [Keys.TAB, Keys.RIGHT],
     shouldHandleEvent: shouldHandleIndentationEvent(true),
     handleEvent: handleIndentationEvent(true),
     allowFunctionKeys: true,
-    defaultDisabled: Browser.isMac,
 };
 
 /**
  * OutdentWhenShiftTab edit feature, provides the ability to outdent current list when user press Shift+TAB
  */
 const OutdentWhenShiftTab: BuildInEditFeature<PluginKeyboardEvent> = {
-    keys: [Keys.TAB, Keys.LEFT],
+    keys: Browser.isMac ? [Keys.TAB] : [Keys.TAB, Keys.LEFT],
     shouldHandleEvent: shouldHandleIndentationEvent(false),
     handleEvent: handleIndentationEvent(false),
     allowFunctionKeys: true,
-    defaultDisabled: Browser.isMac,
 };
 
 /**


### PR DESCRIPTION
Due to TAB & Shift+Alt+L/R indenting for lists being on the same features, tab indenting was being disabled on Mac
Fix by not assigning Left/Right to such features when client is Mac