### PR TITLE
Do not had BR when pasting two LI blocks.

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/lineMerge/handleLineMerge.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/lineMerge/handleLineMerge.ts
@@ -1,6 +1,7 @@
 import {
     changeElementTag,
     ContentTraverser,
+    findClosestElementAncestor,
     getBlockElementAtNode,
     getNextLeafSibling,
     getPreviousLeafSibling,
@@ -85,7 +86,10 @@ function checkAndAddBr(
         // If the first block and the last block are Siblings, add a BR before so the only two
         // lines that are being pasted are not merged.
         const previousSibling = getPreviousLeafSibling(root, block.start);
-        if (firstBlock.end.contains(previousSibling) && getTagOfNode(block.start) !== 'LI') {
+        if (
+            firstBlock.end.contains(previousSibling) &&
+            !findClosestElementAncestor(block.start, root, 'li')
+        ) {
             const br = block.start.ownerDocument?.createElement('br');
             if (br) {
                 block.start.parentNode?.insertBefore(br, block.start);

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/lineMerge/handleLineMerge.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/lineMerge/handleLineMerge.ts
@@ -85,7 +85,7 @@ function checkAndAddBr(
         // If the first block and the last block are Siblings, add a BR before so the only two
         // lines that are being pasted are not merged.
         const previousSibling = getPreviousLeafSibling(root, block.start);
-        if (firstBlock.end.contains(previousSibling)) {
+        if (firstBlock.end.contains(previousSibling) && getTagOfNode(block.start) !== 'LI') {
             const br = block.start.ownerDocument?.createElement('br');
             if (br) {
                 block.start.parentNode?.insertBefore(br, block.start);

--- a/packages/roosterjs-editor-plugins/test/paste/handleLineMergeTest.ts
+++ b/packages/roosterjs-editor-plugins/test/paste/handleLineMergeTest.ts
@@ -135,4 +135,11 @@ describe('handleLineMerge', () => {
             '<span><span>asdsad</span><span>asdsadsa</span></span><br><span><span>asdsad</span></span>'
         );
     });
+
+    it('Do not had BR when pasting two list items.', () => {
+        runTest(
+            '<span><ul><li><div><span>asdf</span></div></li><li><span><span>asdf&nbsp;</span></span></li></ul></span>',
+            '<span><ul><li><span><span>asdf</span></span></li><li><span><span>asdf&nbsp;</span></span></li></ul></span>'
+        );
+    });
 });


### PR DESCRIPTION
When pasting two LI elements we are adding a BR in the last block, we should not do that. Issue instroduced here:

To repro:

1. Restore snapshot:

```
<span><ul><li><div><span>asdf</span></div></li><li><span><span>asdf&nbsp;</span></span></li></ul></span><!--{"type":0,"isDarkMode":true,"start":[0,0,1,0,0,0,5],"end":[0,0,1,0,0,0,5]}-->
```
2. Copy the two LI elements
3. Paste them again.

Before:
A br element is added to the pasted content.
![image](https://user-images.githubusercontent.com/8291124/225734324-0139f7f2-206d-43fd-8dd8-cc4f83d97120.png)

After
We do not add the BR element
![image](https://user-images.githubusercontent.com/8291124/225734392-6c2e3caa-4384-43e9-84a4-3f91937ea9d7.png)
