### PR TITLE
Content Model: Cache table step 1

### DIFF
--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBlock.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBlock.ts
@@ -12,43 +12,38 @@ export const handleBlock: ContentModelBlockHandler<ContentModelBlock> = (
     context: ModelToDomContext,
     refNode: Node | null
 ) => {
-    function callHandler<T extends ContentModelBlock>(
-        block: T,
-        handler: ContentModelBlockHandler<T>
-    ) {
-        handler(doc, parent, block, context, refNode);
-    }
-
     const handlers = context.modelHandlers;
 
     switch (block.blockType) {
         case 'Table':
-            callHandler(block, handlers.table);
+            refNode = handlers.table(doc, parent, block, context, refNode);
             break;
         case 'Paragraph':
-            callHandler(block, handlers.paragraph);
+            refNode = handlers.paragraph(doc, parent, block, context, refNode);
             break;
         case 'Entity':
-            callHandler(block, handlers.entity);
+            refNode = handlers.entity(doc, parent, block, context, refNode);
             break;
         case 'Divider':
-            callHandler(block, handlers.divider);
+            refNode = handlers.divider(doc, parent, block, context, refNode);
             break;
         case 'BlockGroup':
             switch (block.blockGroupType) {
                 case 'General':
-                    callHandler(block, handlers.general);
+                    refNode = handlers.general(doc, parent, block, context, refNode);
                     break;
 
                 case 'Quote':
-                    callHandler(block, handlers.quote);
+                    refNode = handlers.quote(doc, parent, block, context, refNode);
                     break;
 
                 case 'ListItem':
-                    callHandler(block, handlers.listItem);
+                    refNode = handlers.listItem(doc, parent, block, context, refNode);
                     break;
             }
 
             break;
     }
+
+    return refNode;
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBlockGroupChildren.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBlockGroupChildren.ts
@@ -1,11 +1,6 @@
-import { ContentModelBlock } from '../../publicTypes/block/ContentModelBlock';
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
-import { ContentModelBlockWithCache } from '../../publicTypes/block/ContentModelBlockWithCache';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
-import { getEntityFromElement } from 'roosterjs-editor-dom';
-import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
-import { NodeType } from 'roosterjs-editor-types';
 
 /**
  * @internal
@@ -34,65 +29,17 @@ export const handleBlockGroupChildren: ContentModelHandler<ContentModelBlockGrou
                 listFormat.nodeStack = [];
             }
 
-            const element = getCachedElement(childBlock);
-
-            // Check if there is cached element and if we can reuse it
-            if (element) {
-                if (element.parentNode == parent) {
-                    // Remove nodes before the one we are hitting since they don't appear in Content Model at this position.
-                    // But we don't want to touch entity since it would better to keep entity at its place unless it is removed
-                    // In that case we will remove it after we have handled all other nodes
-                    while (refNode && refNode != element && !isEntity(refNode)) {
-                        refNode = remove(refNode);
-                    }
-
-                    if (refNode && refNode == element) {
-                        refNode = refNode.nextSibling;
-                    } else {
-                        parent.insertBefore(element, refNode);
-                    }
-                } else {
-                    parent.insertBefore(element, refNode);
-                }
-
-                // No need to add entity delimiter here since entity delimiter is only for inline entity, but here we only handle block entity.
-
-                if (childBlock.blockType == 'BlockGroup') {
-                    context.modelHandlers.blockGroupChildren(doc, element, childBlock, context);
-                }
-            } else {
-                context.modelHandlers.block(doc, parent, childBlock, context, refNode);
-            }
+            refNode = context.modelHandlers.block(doc, parent, childBlock, context, refNode);
         });
 
         // Remove all rest node if any since they don't appear in content model
         while (refNode) {
-            refNode = remove(refNode);
+            const next = refNode.nextSibling;
+
+            refNode.parentNode?.removeChild(refNode);
+            refNode = next;
         }
     } finally {
         listFormat.nodeStack = nodeStack;
     }
 };
-
-function remove(node: Node) {
-    const next = node.nextSibling;
-    node.parentNode?.removeChild(node);
-
-    return next;
-}
-
-function isEntity(node: Node) {
-    return isNodeOfType(node, NodeType.Element) && !!getEntityFromElement(node);
-}
-
-function getCachedElement(block: ContentModelBlock): HTMLElement | undefined {
-    if ((block as ContentModelBlockWithCache).cachedElement) {
-        return (block as ContentModelBlockWithCache).cachedElement;
-    } else if (block.blockType == 'Entity') {
-        return block.wrapper;
-    } else if (block.blockType == 'BlockGroup' && block.blockGroupType == 'General') {
-        return block.element;
-    } else {
-        return undefined;
-    }
-}

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleDivider.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleDivider.ts
@@ -2,6 +2,7 @@ import { applyFormat } from '../utils/applyFormat';
 import { ContentModelBlockHandler } from '../../publicTypes/context/ContentModelHandler';
 import { ContentModelDivider } from '../../publicTypes/block/ContentModelDivider';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+import { reuseCachedElement } from '../utils/reuseCachedElement';
 
 /**
  * @internal
@@ -13,10 +14,18 @@ export const handleDivider: ContentModelBlockHandler<ContentModelDivider> = (
     context: ModelToDomContext,
     refNode: Node | null
 ) => {
-    const element = doc.createElement(divider.tagName);
+    const element = divider.cachedElement;
 
-    divider.cachedElement = element;
-    parent.insertBefore(element, refNode);
+    if (element) {
+        refNode = reuseCachedElement(parent, element, refNode);
+    } else {
+        const element = doc.createElement(divider.tagName);
 
-    applyFormat(element, context.formatAppliers.divider, divider.format, context);
+        divider.cachedElement = element;
+        parent.insertBefore(element, refNode);
+
+        applyFormat(element, context.formatAppliers.divider, divider.format, context);
+    }
+
+    return refNode;
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleEntity.ts
@@ -3,6 +3,7 @@ import { ContentModelBlockHandler } from '../../publicTypes/context/ContentModel
 import { ContentModelEntity } from '../../publicTypes/entity/ContentModelEntity';
 import { Entity } from 'roosterjs-editor-types';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+import { reuseCachedElement } from '../utils/reuseCachedElement';
 import {
     addDelimiters,
     commitEntity,
@@ -38,7 +39,7 @@ export const handleEntity: ContentModelBlockHandler<ContentModelEntity> = (
         commitEntity(wrapper, entity.type, entity.isReadonly, entity.id);
     }
 
-    parent.insertBefore(wrapper, refNode);
+    refNode = reuseCachedElement(parent, wrapper, refNode);
 
     if (isInlineEntity && getObjectKeys(format).length > 0) {
         const span = wrap(wrapper, 'span');
@@ -47,6 +48,10 @@ export const handleEntity: ContentModelBlockHandler<ContentModelEntity> = (
     }
 
     if (context.addDelimiterForEntity && isInlineEntity && isReadonly) {
-        addDelimiters(wrapper);
+        const [after] = addDelimiters(wrapper);
+
+        context.regularSelection.current.segment = after;
     }
+
+    return refNode;
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleGeneralModel.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleGeneralModel.ts
@@ -16,21 +16,29 @@ export const handleGeneralModel: ContentModelBlockHandler<ContentModelGeneralBlo
     context: ModelToDomContext,
     refNode: Node | null
 ) => {
-    const element = group.element.cloneNode();
+    let element: Node = group.element;
 
-    parent.insertBefore(element, refNode);
+    if (refNode == element) {
+        refNode = refNode.nextSibling;
+    } else {
+        element = element.cloneNode();
 
-    if (isGeneralSegment(group) && isNodeOfType(element, NodeType.Element)) {
-        if (!group.element.firstChild) {
-            context.regularSelection.current.segment = element;
+        parent.insertBefore(element, refNode);
+
+        if (isGeneralSegment(group) && isNodeOfType(element, NodeType.Element)) {
+            if (!group.element.firstChild) {
+                context.regularSelection.current.segment = element;
+            }
+
+            applyFormat(element, context.formatAppliers.segment, group.format, context);
+
+            context.modelHandlers.segmentDecorator(doc, element, group, context);
         }
-
-        applyFormat(element, context.formatAppliers.segment, group.format, context);
-
-        context.modelHandlers.segmentDecorator(doc, element, group, context);
     }
 
     context.modelHandlers.blockGroupChildren(doc, element, group, context);
+
+    return refNode;
 };
 
 function isGeneralSegment(block: ContentModelGeneralBlock): block is ContentModelGeneralSegment {

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleList.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleList.ts
@@ -57,6 +57,8 @@ export const handleList: ContentModelBlockHandler<ContentModelListItem> = (
 
         nodeStack.push({ node: newList, ...level });
     }
+
+    return refNode;
 };
 
 function handleMetadata(

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleListItem.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleListItem.ts
@@ -15,7 +15,7 @@ export const handleListItem: ContentModelBlockHandler<ContentModelListItem> = (
     context: ModelToDomContext,
     refNode: Node | null
 ) => {
-    context.modelHandlers.list(doc, parent, listItem, context, refNode);
+    refNode = context.modelHandlers.list(doc, parent, listItem, context, refNode);
 
     const { nodeStack } = context.listFormat;
 
@@ -41,4 +41,6 @@ export const handleListItem: ContentModelBlockHandler<ContentModelListItem> = (
 
         unwrap(li);
     }
+
+    return refNode;
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleParagraph.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleParagraph.ts
@@ -4,6 +4,7 @@ import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParag
 import { CreateElementData } from 'roosterjs-editor-types';
 import { getObjectKeys, unwrap, wrap } from 'roosterjs-editor-dom';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+import { reuseCachedElement } from '../utils/reuseCachedElement';
 import { stackFormat } from '../utils/stackFormat';
 
 const DefaultParagraphTag = 'div';
@@ -22,51 +23,59 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
     context: ModelToDomContext,
     refNode: Node | null
 ) => {
-    stackFormat(context, paragraph.decorator?.tagName || null, () => {
-        const needParagraphWrapper =
-            !paragraph.isImplicit ||
-            !!paragraph.decorator ||
-            (getObjectKeys(paragraph.format).length > 0 &&
-                paragraph.segments.some(segment => segment.segmentType != 'SelectionMarker'));
+    const element = paragraph.cachedElement;
 
-        let container = doc.createElement(paragraph.decorator?.tagName || DefaultParagraphTag);
+    if (element) {
+        refNode = reuseCachedElement(parent, element, refNode);
+    } else {
+        stackFormat(context, paragraph.decorator?.tagName || null, () => {
+            const needParagraphWrapper =
+                !paragraph.isImplicit ||
+                !!paragraph.decorator ||
+                (getObjectKeys(paragraph.format).length > 0 &&
+                    paragraph.segments.some(segment => segment.segmentType != 'SelectionMarker'));
 
-        parent.insertBefore(container, refNode);
+            let container = doc.createElement(paragraph.decorator?.tagName || DefaultParagraphTag);
 
-        if (needParagraphWrapper) {
-            applyFormat(container, context.formatAppliers.block, paragraph.format, context);
-        }
+            parent.insertBefore(container, refNode);
 
-        if (paragraph.decorator) {
-            applyFormat(
-                container,
-                context.formatAppliers.segmentOnBlock,
-                paragraph.decorator.format,
-                context
-            );
-        }
+            if (needParagraphWrapper) {
+                applyFormat(container, context.formatAppliers.block, paragraph.format, context);
+            }
 
-        let pre: HTMLElement | undefined;
+            if (paragraph.decorator) {
+                applyFormat(
+                    container,
+                    context.formatAppliers.segmentOnBlock,
+                    paragraph.decorator.format,
+                    context
+                );
+            }
 
-        // Need some special handling for PRE tag in order to cache the correct element.
-        // TODO: Consider use decorator to handle PRE tag
-        if (paragraph.format.whiteSpace == 'pre') {
-            pre = wrap(container, Pre);
-        }
+            let pre: HTMLElement | undefined;
 
-        context.regularSelection.current = {
-            block: needParagraphWrapper ? container : container.parentNode,
-            segment: null,
-        };
+            // Need some special handling for PRE tag in order to cache the correct element.
+            // TODO: Consider use decorator to handle PRE tag
+            if (paragraph.format.whiteSpace == 'pre') {
+                pre = wrap(container, Pre);
+            }
 
-        paragraph.segments.forEach(segment => {
-            context.modelHandlers.segment(doc, container, segment, context);
+            context.regularSelection.current = {
+                block: needParagraphWrapper ? container : container.parentNode,
+                segment: null,
+            };
+
+            paragraph.segments.forEach(segment => {
+                context.modelHandlers.segment(doc, container, segment, context);
+            });
+
+            if (needParagraphWrapper) {
+                paragraph.cachedElement = pre || container;
+            } else {
+                unwrap(container);
+            }
         });
+    }
 
-        if (needParagraphWrapper) {
-            paragraph.cachedElement = pre || container;
-        } else {
-            unwrap(container);
-        }
-    });
+    return refNode;
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleQuote.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleQuote.ts
@@ -3,6 +3,7 @@ import { ContentModelBlockHandler } from '../../publicTypes/context/ContentModel
 import { ContentModelQuote } from '../../publicTypes/group/ContentModelQuote';
 import { isBlockGroupEmpty } from '../../modelApi/common/isEmpty';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+import { reuseCachedElement } from '../utils/reuseCachedElement';
 import { stackFormat } from '../utils/stackFormat';
 
 const QuoteTagName = 'blockquote';
@@ -17,7 +18,13 @@ export const handleQuote: ContentModelBlockHandler<ContentModelQuote> = (
     context: ModelToDomContext,
     refNode: Node | null
 ) => {
-    if (!isBlockGroupEmpty(quote)) {
+    let element = quote.cachedElement;
+
+    if (element) {
+        refNode = reuseCachedElement(parent, element, refNode);
+
+        context.modelHandlers.blockGroupChildren(doc, element, quote, context);
+    } else if (!isBlockGroupEmpty(quote)) {
         const blockQuote = doc.createElement(QuoteTagName);
 
         quote.cachedElement = blockQuote;
@@ -35,4 +42,6 @@ export const handleQuote: ContentModelBlockHandler<ContentModelQuote> = (
 
         context.modelHandlers.blockGroupChildren(doc, blockQuote, quote, context);
     }
+
+    return refNode;
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleTable.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleTable.ts
@@ -16,7 +16,7 @@ export const handleTable: ContentModelBlockHandler<ContentModelTable> = (
 ) => {
     if (isBlockEmpty(table)) {
         // Empty table, do not create TABLE element and just return
-        return;
+        return refNode;
     }
 
     const tableNode = doc.createElement('table');
@@ -89,4 +89,6 @@ export const handleTable: ContentModelBlockHandler<ContentModelTable> = (
             }
         }
     }
+
+    return refNode;
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/utils/reuseCachedElement.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/utils/reuseCachedElement.ts
@@ -1,0 +1,48 @@
+import { getEntityFromElement } from 'roosterjs-editor-dom';
+import { isNodeOfType } from '../../domUtils/isNodeOfType';
+import { NodeType } from 'roosterjs-editor-types';
+
+/**
+ * @internal
+ */
+export function reuseCachedElement(
+    parent: Node,
+    element: HTMLElement,
+    refNode: Node | null
+): Node | null {
+    if (element.parentNode == parent) {
+        // Remove nodes before the one we are hitting since they don't appear in Content Model at this position.
+        // But we don't want to touch entity since it would better to keep entity at its place unless it is removed
+        // In that case we will remove it after we have handled all other nodes
+        while (refNode && refNode != element && !isEntity(refNode)) {
+            const next = refNode.nextSibling;
+
+            refNode.parentNode?.removeChild(refNode);
+            refNode = next;
+        }
+
+        if (refNode && refNode == element) {
+            refNode = refNode.nextSibling;
+        } else {
+            parent.insertBefore(element, refNode);
+        }
+    } else {
+        parent.insertBefore(element, refNode);
+    }
+
+    return refNode;
+}
+
+/**
+ * @internal
+ */
+export function removeNode(node: Node): Node | null {
+    const next = node.nextSibling;
+    node.parentNode?.removeChild(node);
+
+    return next;
+}
+
+function isEntity(node: Node) {
+    return isNodeOfType(node, NodeType.Element) && !!getEntityFromElement(node);
+}

--- a/packages/roosterjs-content-model/lib/publicTypes/block/ContentModelBlockWithCache.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/block/ContentModelBlockWithCache.ts
@@ -1,9 +1,9 @@
 /**
  * Represent a Content Model block with cached element
  */
-export interface ContentModelBlockWithCache {
+export interface ContentModelBlockWithCache<TElement extends HTMLElement = HTMLElement> {
     /**
      * Cached element for reuse
      */
-    cachedElement?: HTMLElement;
+    cachedElement?: TElement;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/context/ContentModelHandler.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/ContentModelHandler.ts
@@ -30,4 +30,4 @@ export type ContentModelBlockHandler<T extends ContentModelBlock | ContentModelB
     model: T,
     context: ModelToDomContext,
     refNode: Node | null
-) => void;
+) => Node | null;

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockGroupChildrenTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockGroupChildrenTest.ts
@@ -15,7 +15,7 @@ describe('handleBlockGroupChildren', () => {
     let parent: HTMLDivElement;
 
     beforeEach(() => {
-        handleBlock = jasmine.createSpy('handleBlock');
+        handleBlock = jasmine.createSpy('handleBlock').and.callFake(originalHandleBlock);
         context = createModelToDomContext(undefined, {
             modelHandlerOverride: {
                 block: handleBlock,
@@ -42,7 +42,7 @@ describe('handleBlockGroupChildren', () => {
 
         handleBlockGroupChildren(document, parent, group, context);
 
-        expect(parent.outerHTML).toBe('<div></div>');
+        expect(parent.outerHTML).toBe('<div><div></div></div>');
         expect(context.listFormat.nodeStack).toEqual([]);
         expect(handleBlock).toHaveBeenCalledTimes(1);
         expect(handleBlock).toHaveBeenCalledWith(document, parent, paragraph, context, null);
@@ -58,7 +58,7 @@ describe('handleBlockGroupChildren', () => {
 
         handleBlockGroupChildren(document, parent, group, context);
 
-        expect(parent.outerHTML).toBe('<div></div>');
+        expect(parent.outerHTML).toBe('<div><div></div></div>');
         expect(context.listFormat.nodeStack).toEqual([]);
         expect(handleBlock).toHaveBeenCalledTimes(2);
         expect(handleBlock).toHaveBeenCalledWith(document, parent, paragraph1, context, null);
@@ -73,8 +73,9 @@ describe('handleBlockGroupChildren', () => {
         group.blocks.push(paragraph);
         context.listFormat.nodeStack = nodeStack;
 
-        handleBlock.and.callFake((doc, parent, child, context) => {
+        handleBlock.and.callFake((doc, parent, child, context, refNode) => {
             expect(context.listFormat.nodeStack).toEqual([]);
+            return refNode;
         });
 
         handleBlockGroupChildren(document, parent, group, context);
@@ -98,7 +99,7 @@ describe('handleBlockGroupChildren', () => {
         group.blocks.push(paragraph2);
         context.listFormat.nodeStack = nodeStack;
 
-        handleBlock.and.callFake((doc, parent, child, context) => {
+        handleBlock.and.callFake((doc, parent, child, context, refNode) => {
             if (child == paragraph1) {
                 expect(context.listFormat.nodeStack).toEqual([]);
                 context.listFormat.nodeStack.push({ c: 'd' } as any);
@@ -109,6 +110,8 @@ describe('handleBlockGroupChildren', () => {
             } else {
                 throw new Error('Should never run to here: ' + JSON.stringify(child));
             }
+
+            return refNode;
         });
 
         handleBlockGroupChildren(document, parent, group, context);

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleBlockTest.ts
@@ -205,9 +205,10 @@ describe('handleBlockGroup', () => {
         parent = document.createElement('div');
         parent.appendChild(br);
 
-        handleBlock(document, parent, block, context, br);
+        const result = handleBlock(document, parent, block, context, br);
 
         expect(parent.innerHTML).toBe(expectedInnerHTML);
+        expect(result).toBe(br);
     }
 
     it('General block', () => {
@@ -223,9 +224,10 @@ describe('handleBlockGroup', () => {
         expect(handleGeneralModel).toHaveBeenCalledTimes(1);
         expect(handleGeneralModel).toHaveBeenCalledWith(document, parent, group, context, null);
 
-        handleGeneralModel.and.callFake((doc, parent, model, context, refNode) =>
-            parent.insertBefore(doc.createTextNode('test'), refNode)
-        );
+        handleGeneralModel.and.callFake((doc, parent, model, context, refNode) => {
+            parent.insertBefore(doc.createTextNode('test'), refNode);
+            return refNode;
+        });
 
         runTestWithRefNode(group, 'test<br>');
     });
@@ -239,9 +241,10 @@ describe('handleBlockGroup', () => {
         expect(handleQuote).toHaveBeenCalledTimes(1);
         expect(handleQuote).toHaveBeenCalledWith(document, parent, group, context, null);
 
-        handleQuote.and.callFake((doc, parent, model, context, refNode) =>
-            parent.insertBefore(doc.createTextNode('test'), refNode)
-        );
+        handleQuote.and.callFake((doc, parent, model, context, refNode) => {
+            parent.insertBefore(doc.createTextNode('test'), refNode);
+            return refNode;
+        });
 
         runTestWithRefNode(group, 'test<br>');
     });
@@ -255,9 +258,10 @@ describe('handleBlockGroup', () => {
         expect(handleListItem).toHaveBeenCalledTimes(1);
         expect(handleListItem).toHaveBeenCalledWith(document, parent, group, context, null);
 
-        handleListItem.and.callFake((doc, parent, model, context, refNode) =>
-            parent.insertBefore(doc.createTextNode('test'), refNode)
-        );
+        handleListItem.and.callFake((doc, parent, model, context, refNode) => {
+            parent.insertBefore(doc.createTextNode('test'), refNode);
+            return refNode;
+        });
 
         runTestWithRefNode(group, 'test<br>');
     });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleDividerTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleDividerTest.ts
@@ -105,9 +105,33 @@ describe('handleDivider', () => {
 
         parent.appendChild(br);
 
-        handleDivider(document, parent, hr, context, br);
+        const result = handleDivider(document, parent, hr, context, br);
 
         expect(parent.innerHTML).toBe('<hr><br>');
         expect(hr.cachedElement).toBe(parent.firstChild as HTMLElement);
+        expect(result).toBe(br);
+    });
+
+    it('HR with refNode, already in target node', () => {
+        const hrNode = document.createElement('hr');
+        const hr: ContentModelDivider = {
+            blockType: 'Divider',
+            tagName: 'hr',
+            format: {},
+            cachedElement: hrNode,
+        };
+
+        const parent = document.createElement('div');
+        const br = document.createElement('br');
+
+        parent.appendChild(hrNode);
+        parent.appendChild(br);
+
+        const result = handleDivider(document, parent, hr, context, hrNode);
+
+        expect(parent.innerHTML).toBe('<hr><br>');
+        expect(hr.cachedElement).toBe(hrNode);
+        expect(parent.firstChild).toBe(hrNode);
+        expect(result).toBe(br);
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleGeneralModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleGeneralModelTest.ts
@@ -1,7 +1,6 @@
 import * as applyFormat from '../../../lib/modelToDom/utils/applyFormat';
 import * as stackFormat from '../../../lib/modelToDom/utils/stackFormat';
 import { ContentModelBlockGroup } from '../../../lib/publicTypes/group/ContentModelBlockGroup';
-import { ContentModelHandler } from '../../../lib/publicTypes/context/ContentModelHandler';
 import { ContentModelListItem } from '../../../lib/publicTypes/group/ContentModelListItem';
 import { ContentModelQuote } from '../../../lib/publicTypes/group/ContentModelQuote';
 import { createGeneralBlock } from '../../../lib/modelApi/creators/createGeneralBlock';
@@ -9,13 +8,17 @@ import { createGeneralSegment } from '../../../lib/modelApi/creators/createGener
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { handleGeneralModel } from '../../../lib/modelToDom/handlers/handleGeneralModel';
 import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
+import {
+    ContentModelBlockHandler,
+    ContentModelHandler,
+} from '../../../lib/publicTypes/context/ContentModelHandler';
 
 describe('handleBlockGroup', () => {
     let context: ModelToDomContext;
     let parent: HTMLDivElement;
     let handleBlockGroupChildren: jasmine.Spy<ContentModelHandler<ContentModelBlockGroup>>;
-    let handleListItem: jasmine.Spy<ContentModelHandler<ContentModelListItem>>;
-    let handleQuote: jasmine.Spy<ContentModelHandler<ContentModelQuote>>;
+    let handleListItem: jasmine.Spy<ContentModelBlockHandler<ContentModelListItem>>;
+    let handleQuote: jasmine.Spy<ContentModelBlockHandler<ContentModelQuote>>;
 
     beforeEach(() => {
         handleBlockGroupChildren = jasmine.createSpy('handleBlockGroupChildren');
@@ -180,7 +183,7 @@ describe('handleBlockGroup', () => {
         const br = document.createElement('br');
         parent.appendChild(br);
 
-        handleGeneralModel(document, parent, group, context, br);
+        const result = handleGeneralModel(document, parent, group, context, br);
 
         expect(parent.outerHTML).toBe('<div><span></span><br></div>');
         expect(typeof parent.firstChild).toBe('object');
@@ -194,5 +197,24 @@ describe('handleBlockGroup', () => {
             context
         );
         expect(applyFormat.applyFormat).not.toHaveBeenCalled();
+        expect(result).toBe(br);
+    });
+
+    it('General block with refNode, already in target node', () => {
+        const node = document.createElement('span');
+        const group = createGeneralBlock(node);
+        const br = document.createElement('br');
+
+        parent.appendChild(node);
+        parent.appendChild(br);
+
+        const result = handleGeneralModel(document, parent, group, context, node);
+
+        expect(parent.outerHTML).toBe('<div><span></span><br></div>');
+        expect(parent.firstChild).toBe(node);
+        expect(context.listFormat.nodeStack).toEqual([]);
+        expect(handleBlockGroupChildren).toHaveBeenCalledTimes(1);
+        expect(handleBlockGroupChildren).toHaveBeenCalledWith(document, node, group, context);
+        expect(result).toBe(br);
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleListItemTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleListItemTest.ts
@@ -371,4 +371,27 @@ describe('handleListItem without format handler', () => {
             context
         );
     });
+
+    it('UL with refNode', () => {
+        const listItem = createListItem([{ listType: 'UL' }]);
+        const br = document.createElement('br');
+        const parent = document.createElement('div');
+
+        parent.appendChild(br);
+
+        const result = handleListItem(document, parent, listItem, context, br);
+
+        expect(parent.outerHTML).toBe('<div><ul><li></li></ul><br></div>');
+        expect(handleList).toHaveBeenCalledTimes(1);
+        expect(handleList).toHaveBeenCalledWith(document, parent, listItem, context, br);
+        expect(applyFormat.applyFormat).toHaveBeenCalled();
+        expect(handleBlockGroupChildren).toHaveBeenCalledTimes(1);
+        expect(handleBlockGroupChildren).toHaveBeenCalledWith(
+            document,
+            parent.firstChild!.firstChild as HTMLElement,
+            listItem,
+            context
+        );
+        expect(result).toBe(br);
+    });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleListTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleListTest.ts
@@ -788,7 +788,7 @@ describe('handleList handles metadata', () => {
         parent.appendChild(existingOL);
         parent.appendChild(br);
 
-        handleList(document, parent, listItem, context, br);
+        const result = handleList(document, parent, listItem, context, br);
 
         expect(parent.outerHTML).toBe('<div><ol><ol start="1"></ol></ol><br></div>');
         expect(context.listFormat).toEqual({
@@ -807,5 +807,6 @@ describe('handleList handles metadata', () => {
                 },
             ],
         });
+        expect(result).toBe(br);
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleParagraphTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleParagraphTest.ts
@@ -382,12 +382,13 @@ describe('handleParagraph', () => {
         };
         const br = document.createElement('br');
 
-        parent.appendChild(br);
+        const result = parent.appendChild(br);
 
         handleParagraph(document, parent, paragraph, context, br);
 
         expect(parent.innerHTML).toBe('<div></div><br>');
         expect(paragraph.cachedElement).toBe(parent.firstChild as HTMLElement);
+        expect(result).toBe(br);
     });
 
     it('Handle paragraph with PRE', () => {

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleQuoteTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleQuoteTest.ts
@@ -69,7 +69,7 @@ describe('handleQuote', () => {
 
         handleBlockGroupChildren.and.callFake(originalHandleBlockGroupChildren);
 
-        handleQuote(document, parent, quote, context, br);
+        const result = handleQuote(document, parent, quote, context, br);
 
         expect(parent.outerHTML).toBe(
             '<div><blockquote style="margin: 0px;"><div><span>test</span></div></blockquote><br></div>'
@@ -82,5 +82,6 @@ describe('handleQuote', () => {
             context
         );
         expect(quote.cachedElement).toBe(parent.firstChild as HTMLElement);
+        expect(result).toBe(br);
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleTableTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleTableTest.ts
@@ -235,7 +235,7 @@ describe('handleTable', () => {
 
         div.appendChild(br);
 
-        handleTable(
+        const result = handleTable(
             document,
             div,
             {
@@ -251,5 +251,6 @@ describe('handleTable', () => {
         );
 
         expect(div.innerHTML).toBe('<table><tbody><tr><td></td></tr></tbody></table><br>');
+        expect(result).toBe(br);
     });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/utils/reuseCachedElementTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/utils/reuseCachedElementTest.ts
@@ -1,0 +1,85 @@
+import { commitEntity } from 'roosterjs-editor-dom';
+import { reuseCachedElement } from '../../../lib/modelToDom/utils/reuseCachedElement';
+
+describe('reuseCachedElement', () => {
+    it('No refNode', () => {
+        const parent = document.createElement('div');
+        const element = document.createElement('span');
+
+        const result = reuseCachedElement(parent, element, null);
+
+        expect(parent.outerHTML).toBe('<div><span></span></div>');
+        expect(parent.firstChild).toBe(element);
+        expect(result).toBe(null);
+    });
+
+    it('RefNode is not current element', () => {
+        const parent = document.createElement('div');
+        const element = document.createElement('span');
+        const refNode = document.createElement('br');
+
+        parent.appendChild(refNode);
+
+        const result = reuseCachedElement(parent, element, refNode);
+
+        expect(parent.outerHTML).toBe('<div><span></span><br></div>');
+        expect(parent.firstChild).toBe(element);
+        expect(result).toBe(refNode);
+    });
+
+    it('RefNode is current element', () => {
+        const parent = document.createElement('div');
+        const element = document.createElement('span');
+        const nextNode = document.createElement('br');
+
+        parent.appendChild(element);
+        parent.appendChild(nextNode);
+
+        const result = reuseCachedElement(parent, element, element);
+
+        expect(parent.outerHTML).toBe('<div><span></span><br></div>');
+        expect(parent.firstChild).toBe(element);
+        expect(parent.firstChild?.nextSibling).toBe(nextNode);
+        expect(result).toBe(nextNode);
+    });
+
+    it('RefNode is before current element', () => {
+        const parent = document.createElement('div');
+        const refNode = document.createElement('hr');
+        const element = document.createElement('span');
+        const nextNode = document.createElement('br');
+
+        parent.appendChild(refNode);
+        parent.appendChild(element);
+        parent.appendChild(nextNode);
+
+        const result = reuseCachedElement(parent, element, refNode);
+
+        expect(parent.outerHTML).toBe('<div><span></span><br></div>');
+        expect(parent.firstChild).toBe(element);
+        expect(parent.firstChild?.nextSibling).toBe(nextNode);
+        expect(result).toBe(nextNode);
+    });
+
+    it('RefNode is entity', () => {
+        const parent = document.createElement('div');
+        const refNode = document.createElement('div');
+        const element = document.createElement('span');
+        const nextNode = document.createElement('br');
+
+        parent.appendChild(refNode);
+        parent.appendChild(element);
+        parent.appendChild(nextNode);
+
+        commitEntity(refNode, 'TestEntity', true);
+
+        const result = reuseCachedElement(parent, element, refNode);
+
+        expect(parent.outerHTML).toBe(
+            '<div><span></span><div class="_Entity _EType_TestEntity _EReadonly_1" contenteditable="false"></div><br></div>'
+        );
+        expect(parent.firstChild).toBe(element);
+        expect(parent.firstChild?.nextSibling).toBe(refNode);
+        expect(result).toBe(refNode);
+    });
+});

--- a/packages/roosterjs-editor-dom/lib/delimiter/addDelimiters.ts
+++ b/packages/roosterjs-editor-dom/lib/delimiter/addDelimiters.ts
@@ -59,12 +59,12 @@ function insertDelimiter(element: Element, delimiterClass: DelimiterClasses) {
             children: [ZERO_WIDTH_SPACE],
         },
         element.ownerDocument
-    );
+    ) as HTMLElement;
     if (span) {
         const insertPosition: InsertPosition =
             delimiterClass == DelimiterClasses.DELIMITER_AFTER ? 'afterend' : 'beforebegin';
         element.insertAdjacentElement(insertPosition, span);
     }
 
-    return element;
+    return span;
 }

--- a/packages/roosterjs-editor-dom/test/delimiter/addDelimitersTest.ts
+++ b/packages/roosterjs-editor-dom/test/delimiter/addDelimitersTest.ts
@@ -1,7 +1,7 @@
 import addDelimiters from '../../lib/delimiter/addDelimiters';
 import { DelimiterClasses } from 'roosterjs-editor-types';
 
-describe('addDelimiterstest', () => {
+describe('addDelimitersTest', () => {
     afterAll(() => {
         document.body.childNodes.forEach(node => {
             document.body.removeChild(node);
@@ -12,7 +12,7 @@ describe('addDelimiterstest', () => {
         const element = document.createElement('span');
         document.body.append(element);
 
-        addDelimiters(element);
+        const [after, before] = addDelimiters(element);
 
         expect(element.nextElementSibling).toBeDefined();
         expect(element.nextElementSibling?.className).toEqual(DelimiterClasses.DELIMITER_AFTER);
@@ -20,6 +20,8 @@ describe('addDelimiterstest', () => {
         expect(element.previousElementSibling?.className).toEqual(
             DelimiterClasses.DELIMITER_BEFORE
         );
+        expect(after.outerHTML).toBe('<span class="entityDelimiterAfter">​</span>');
+        expect(before.outerHTML).toBe('<span class="entityDelimiterBefore">​</span>');
     });
 
     it('Add between other Entity with delimiters', () => {


### PR DESCRIPTION
Allow cache table in Content Model, so that when write back, if table is not changed, no need to generate table structure again.

This is step 1: Refactor existing cache code, let each block handler decide how to handle cached element.

Then later we can let table handler handle cached table.