### PR TITLE
Support default format in Content Model

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/domToContentModel.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/domToContentModel.ts
@@ -21,7 +21,7 @@ export default function domToContentModel(
     editorContext: EditorContext,
     option: DomToModelOption
 ): ContentModelDocument {
-    const model = createContentModelDocument();
+    const model = createContentModelDocument(editorContext.defaultFormat);
     const context = createDomToModelContext(editorContext, option);
 
     // For root element, use computed style as initial value of segment formats

--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -1,6 +1,7 @@
 import contentModelToDom from '../modelToDom/contentModelToDom';
 import domToContentModel from '../domToModel/domToContentModel';
 import { ContentModelDocument } from '../publicTypes/group/ContentModelDocument';
+import { ContentModelSegmentFormat } from '../publicTypes/format/ContentModelSegmentFormat';
 import { Editor } from 'roosterjs-editor-core';
 import { EditorContext } from '../publicTypes/context/EditorContext';
 import { EditorOptions, ExperimentalFeatures } from 'roosterjs-editor-types';
@@ -17,6 +18,7 @@ import {
 export default class ContentModelEditor extends Editor implements IContentModelEditor {
     private cachedModel: ContentModelDocument | null;
     private reuseModel: boolean = false;
+    private defaultFormat: ContentModelSegmentFormat = {};
 
     /**
      * Creates an instance of Editor
@@ -27,6 +29,7 @@ export default class ContentModelEditor extends Editor implements IContentModelE
         super(contentDiv, options);
         this.cachedModel = null;
         this.reuseModel = this.isFeatureEnabled(ExperimentalFeatures.ReusableContentModel);
+        this.defaultFormat = this.getDefaultSegmentFormat();
     }
 
     /**
@@ -90,11 +93,27 @@ export default class ContentModelEditor extends Editor implements IContentModelE
 
         return {
             isDarkMode: this.isDarkMode(),
+            defaultFormat: this.defaultFormat,
             getDarkColor: core.lifecycle.getDarkColor,
             darkColorHandler: this.getDarkColorHandler(),
             addDelimiterForEntity: this.isFeatureEnabled(
                 ExperimentalFeatures.InlineEntityReadOnlyDelimiters
             ),
+        };
+    }
+
+    private getDefaultSegmentFormat(): ContentModelSegmentFormat {
+        const format = this.getDefaultFormat();
+
+        return {
+            fontWeight: format.bold ? 'bold' : undefined,
+            italic: format.italic || undefined,
+            underline: format.underline || undefined,
+            fontFamily: format.fontFamily || undefined,
+            fontSize: format.fontSize || undefined,
+            textColor: format.textColors?.lightModeColor || format.textColor || undefined,
+            backgroundColor:
+                format.backgroundColors?.lightModeColor || format.backgroundColor || undefined,
         };
     }
 }

--- a/packages/roosterjs-content-model/lib/modelApi/common/clearModelFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/clearModelFormat.ts
@@ -23,8 +23,7 @@ export function clearModelFormat(
     model: ContentModelDocument,
     blocksToClear: [ContentModelBlockGroup[], ContentModelBlock][],
     segmentsToClear: ContentModelSegment[],
-    tablesToClear: [ContentModelTable, boolean][],
-    defaultSegmentFormat?: ContentModelSegmentFormat
+    tablesToClear: [ContentModelTable, boolean][]
 ) {
     iterateSelections(
         [model],
@@ -44,7 +43,7 @@ export function clearModelFormat(
             // So no need to clear format of list number.
             // Otherwise, we will clear all format of selected text. And since they are under LI tag, we
             // also need to clear the format of LI (format holder) so that the format is really cleared
-            includeListFormatHolder: defaultSegmentFormat ? 'never' : 'anySegment',
+            includeListFormatHolder: model.format ? 'never' : 'anySegment',
         }
     );
 
@@ -70,7 +69,7 @@ export function clearModelFormat(
     }
 
     // 3. Finally clear format for segments
-    clearSegmentsFormat(segmentsToClear, defaultSegmentFormat);
+    clearSegmentsFormat(segmentsToClear, model.format);
 
     // 4. Clear format for table if any
     createTablesFormat(tablesToClear);

--- a/packages/roosterjs-content-model/lib/modelApi/creators/createContentModelDocument.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/creators/createContentModelDocument.ts
@@ -1,11 +1,20 @@
 import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
+import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 
 /**
  * @internal
  */
-export function createContentModelDocument(): ContentModelDocument {
-    return {
+export function createContentModelDocument(
+    defaultFormat?: ContentModelSegmentFormat
+): ContentModelDocument {
+    const result: ContentModelDocument = {
         blockGroupType: 'Document',
         blocks: [],
     };
+
+    if (defaultFormat) {
+        result.format = defaultFormat;
+    }
+
+    return result;
 }

--- a/packages/roosterjs-content-model/lib/modelApi/selection/deleteSelections.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/selection/deleteSelections.ts
@@ -1,7 +1,6 @@
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
 import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
 import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
-import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { ContentModelSelectionMarker } from '../../publicTypes/segment/ContentModelSelectionMarker';
 import { createParagraph } from '../creators/createParagraph';
 import { createSelectionMarker } from '../creators/createSelectionMarker';
@@ -29,7 +28,7 @@ export function deleteSelection(model: ContentModelDocument): InsertPosition | n
         [model],
         (path, tableContext, block, segments) => {
             let paragraph: ContentModelParagraph | undefined;
-            let markerFormat: ContentModelSegmentFormat | undefined;
+            let markerFormat = model.format;
             let insertMarkerIndex = 0;
 
             if (segments) {

--- a/packages/roosterjs-content-model/lib/publicApi/format/clearFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/clearFormat.ts
@@ -2,7 +2,6 @@ import { clearModelFormat } from '../../modelApi/common/clearModelFormat';
 import { ContentModelBlock } from '../../publicTypes/block/ContentModelBlock';
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
 import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
-import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
@@ -12,22 +11,13 @@ import { normalizeContentModel } from '../../modelApi/common/normalizeContentMod
  * Clear format of selection
  * @param editor The editor to clear format from
  */
-export default function clearFormat(
-    editor: IContentModelEditor,
-    defaultSegmentFormat?: ContentModelSegmentFormat
-) {
+export default function clearFormat(editor: IContentModelEditor) {
     formatWithContentModel(editor, 'clearFormat', model => {
         const blocksToClear: [ContentModelBlockGroup[], ContentModelBlock][] = [];
         const segmentsToClear: ContentModelSegment[] = [];
         const tablesToClear: [ContentModelTable, boolean][] = [];
 
-        clearModelFormat(
-            model,
-            blocksToClear,
-            segmentsToClear,
-            tablesToClear,
-            defaultSegmentFormat
-        );
+        clearModelFormat(model, blocksToClear, segmentsToClear, tablesToClear);
 
         normalizeContentModel(model);
 

--- a/packages/roosterjs-content-model/lib/publicTypes/context/EditorContext.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/EditorContext.ts
@@ -1,3 +1,4 @@
+import { ContentModelSegmentFormat } from '../format/ContentModelSegmentFormat';
 import { DarkColorHandler } from 'roosterjs-editor-types';
 
 /**
@@ -8,6 +9,11 @@ export interface EditorContext {
      * Whether current content is in dark mode
      */
     isDarkMode: boolean;
+
+    /**
+     * Default format of editor
+     */
+    defaultFormat?: ContentModelSegmentFormat;
 
     /**
      * Calculate color for dark mode

--- a/packages/roosterjs-content-model/lib/publicTypes/group/ContentModelDocument.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/group/ContentModelDocument.ts
@@ -1,6 +1,10 @@
 import { ContentModelBlockGroupBase } from './ContentModelBlockGroupBase';
+import { ContentModelSegmentFormat } from '../format/ContentModelSegmentFormat';
+import { ContentModelWithFormat } from '../format/ContentModelWithFormat';
 
 /**
  * Content Model document entry point
  */
-export interface ContentModelDocument extends ContentModelBlockGroupBase<'Document'> {}
+export interface ContentModelDocument
+    extends ContentModelBlockGroupBase<'Document'>,
+        Partial<ContentModelWithFormat<ContentModelSegmentFormat>> {}

--- a/packages/roosterjs-content-model/test/editor/ContentModelEditorTest.ts
+++ b/packages/roosterjs-content-model/test/editor/ContentModelEditorTest.ts
@@ -158,4 +158,37 @@ describe('ContentModelEditor', () => {
 
         expect((editor as any).cachedModel).toBe(null);
     });
+
+    it('default format', () => {
+        const div = document.createElement('div');
+        const editor = new ContentModelEditor(div, {
+            defaultFormat: {
+                bold: true,
+                italic: true,
+                underline: true,
+                fontFamily: 'Arial',
+                fontSize: '10pt',
+                textColors: {
+                    lightModeColor: 'black',
+                    darkModeColor: 'white',
+                },
+                backgroundColors: {
+                    lightModeColor: 'white',
+                    darkModeColor: 'black',
+                },
+            },
+        });
+
+        const model = editor.createContentModel();
+
+        expect(model.format).toEqual({
+            fontWeight: 'bold',
+            italic: true,
+            underline: true,
+            fontFamily: 'Arial',
+            fontSize: '10pt',
+            textColor: 'black',
+            backgroundColor: 'white',
+        });
+    });
 });

--- a/packages/roosterjs-content-model/test/modelApi/common/clearModelFormatTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/clearModelFormatTest.ts
@@ -520,7 +520,9 @@ describe('clearModelFormat', () => {
     });
 
     it('Model with selection under list, has defaultSegmentFormat', () => {
-        const model = createContentModelDocument();
+        const model = createContentModelDocument({
+            fontSize: '10px',
+        });
         const list = createListItem([{ listType: 'OL' }], { fontSize: '20px' });
         const para = createParagraph(false, { lineHeight: '10px' });
         const text = createText('test', { textColor: 'green' });
@@ -535,12 +537,13 @@ describe('clearModelFormat', () => {
         const segments: any[] = [];
         const tables: any[] = [];
 
-        clearModelFormat(model, blocks, segments, tables, {
-            fontSize: '10px',
-        });
+        clearModelFormat(model, blocks, segments, tables);
 
         expect(model).toEqual({
             blockGroupType: 'Document',
+            format: {
+                fontSize: '10px',
+            },
             blocks: [
                 {
                     blockType: 'BlockGroup',

--- a/packages/roosterjs-content-model/test/modelApi/creators/creatorsTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/creators/creatorsTest.ts
@@ -27,6 +27,20 @@ describe('Creators', () => {
         });
     });
 
+    it('createContentModelDocument with default format', () => {
+        const result = createContentModelDocument({
+            fontSize: '10pt',
+        });
+
+        expect(result).toEqual({
+            blockGroupType: 'Document',
+            blocks: [],
+            format: {
+                fontSize: '10pt',
+            },
+        });
+    });
+
     it('createGeneralBlock', () => {
         const element = document.createElement('div');
         const result = createGeneralBlock(element);

--- a/packages/roosterjs-content-model/test/modelApi/selection/deleteSelectionTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/selection/deleteSelectionTest.ts
@@ -1,3 +1,4 @@
+import { ContentModelSelectionMarker } from '../../../lib/publicTypes/segment/ContentModelSelectionMarker';
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
 import { createDivider } from '../../../lib/modelApi/creators/createDivider';
 import { createParagraph } from '../../../lib/modelApi/creators/createParagraph';
@@ -422,6 +423,48 @@ describe('deleteSelection', () => {
                     ],
                 },
             ],
+        });
+    });
+
+    it('delete with default format', () => {
+        const model = createContentModelDocument({
+            fontSize: '10pt',
+        });
+        const divider = createDivider('div');
+
+        divider.isSelected = true;
+        model.blocks.push(divider);
+
+        const result = deleteSelection(model);
+        const marker: ContentModelSelectionMarker = {
+            segmentType: 'SelectionMarker',
+            format: { fontSize: '10pt' },
+            isSelected: true,
+        };
+
+        expect(result).toEqual({
+            marker,
+            paragraph: {
+                blockType: 'Paragraph',
+                isImplicit: true,
+                segments: [marker],
+                format: {},
+            },
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    isImplicit: true,
+                    format: {},
+                    segments: [marker],
+                },
+            ],
+            format: { fontSize: '10pt' },
         });
     });
 });

--- a/packages/roosterjs-content-model/test/publicApi/domToContentModelTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/domToContentModelTest.ts
@@ -26,11 +26,19 @@ describe('domToContentModel', () => {
         const options = {
             includeRoot: false,
         };
-        const editorContext: EditorContext = { isDarkMode: false };
+        const editorContext: EditorContext = {
+            isDarkMode: false,
+            defaultFormat: {
+                fontSize: '10pt',
+            },
+        };
         const model = domToContentModel(rootElement, editorContext, options);
         const result: ContentModelDocument = {
             blockGroupType: 'Document',
             blocks: [],
+            format: {
+                fontSize: '10pt',
+            },
         };
 
         expect(model).toEqual(result);

--- a/packages/roosterjs-content-model/test/publicApi/format/clearFormatTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/format/clearFormatTest.ts
@@ -22,13 +22,7 @@ describe('clearFormat', () => {
         clearFormat(editor);
         expect(formatWithContentModel.formatWithContentModel).toHaveBeenCalledTimes(1);
         expect(clearModelFormat.clearModelFormat).toHaveBeenCalledTimes(1);
-        expect(clearModelFormat.clearModelFormat).toHaveBeenCalledWith(
-            model,
-            [],
-            [],
-            [],
-            undefined
-        );
+        expect(clearModelFormat.clearModelFormat).toHaveBeenCalledWith(model, [], [], []);
         expect(normalizeContentModel.normalizeContentModel).toHaveBeenCalledTimes(1);
         expect(normalizeContentModel.normalizeContentModel).toHaveBeenCalledWith(model);
     });

--- a/packages/roosterjs-content-model/test/publicApi/segment/changeFontSizeTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/segment/changeFontSizeTest.ts
@@ -343,15 +343,19 @@ describe('changeFontSize', () => {
 
         const editor = ({
             createContentModel: (option: any) =>
-                domToContentModel(div, null!, {
-                    selectionRange: {
-                        type: SelectionRangeTypes.Normal,
-                        areAllCollapsed: false,
-                        ranges: [createRange(sub)],
-                    },
-                    includeRoot: true,
-                    ...option,
-                }),
+                domToContentModel(
+                    div,
+                    { isDarkMode: false },
+                    {
+                        selectionRange: {
+                            type: SelectionRangeTypes.Normal,
+                            areAllCollapsed: false,
+                            ranges: [createRange(sub)],
+                        },
+                        includeRoot: true,
+                        ...option,
+                    }
+                ),
             addUndoSnapshot,
             focus: jasmine.createSpy(),
             setContentModel,


### PR DESCRIPTION
Add default format to ContentModelDocument, so that in format API (e.g. clearFormat), we don't need to pass default format separately.

Later when we handle delete/backspace key, we also need this info to create new selection marker.