### PR TITLE
Fixed plus sign position on table handle

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
@@ -108,7 +108,7 @@ function getInsertElementData(
     backgroundColor: string
 ): CreateElementData {
     const inserterColor = isDark ? INSERTER_COLOR_DARK_MODE : INSERTER_COLOR;
-    const outerDivStyle = `position: fixed; width: ${INSERTER_SIDE_LENGTH}px; height: ${INSERTER_SIDE_LENGTH}px; font-size: 16px; color: ${inserterColor}; line-height: 10px; vertical-align: middle; text-align: center; cursor: pointer; border: solid ${INSERTER_BORDER_SIZE}px ${inserterColor}; border-radius: 50%; background-color: ${backgroundColor}`;
+    const outerDivStyle = `position: fixed; width: ${INSERTER_SIDE_LENGTH}px; height: ${INSERTER_SIDE_LENGTH}px; font-size: 16px; color: ${inserterColor}; line-height: 8px; vertical-align: middle; text-align: center; cursor: pointer; border: solid ${INSERTER_BORDER_SIZE}px ${inserterColor}; border-radius: 50%; background-color: ${backgroundColor}`;
     const leftOrRight = isRTL ? 'right' : 'left';
     const childBaseStyles = `position: absolute; box-sizing: border-box; background-color: ${backgroundColor};`;
     const childInfo: CreateElementData = {


### PR DESCRIPTION
### Description:

The plus sign in the table handle used to add more rows and columns is misaligned with the circle.

### Fix

Modified the value on line-height to rise by 2 pixels the position of the plus sign on the table handler. This was done to better center its position, especially when the handle is on a horizontal position.

### Cases tested:

Observed the handle in vertical and horizontal position.

**Before:**

<img width="139" alt="image" src="https://user-images.githubusercontent.com/107568016/227658817-5b76da7d-ff22-4033-a468-452fecf7ec23.png">

**After:**

<img width="143" alt="image" src="https://user-images.githubusercontent.com/107568016/227658881-3cc9add0-3c20-4556-9861-9d8f2c8c1a46.png">

### Warnings and implications

- There is still some misalignment of the overall handle top and stick.