### PR TITLE
Fix Copy/Paste on lost focus in Safari

### DIFF
--- a/demo/scripts/controls/MainPane.tsx
+++ b/demo/scripts/controls/MainPane.tsx
@@ -26,6 +26,7 @@ import { registerWindowForCss, unregisterWindowForCss } from '../utils/cssMonito
 import { trustedHTMLHandler } from '../utils/trustedHTMLHandler';
 import { WindowProvider } from '@fluentui/react/lib/WindowProvider';
 import { zoom, ZoomButtonStringKey } from './ribbonButtons/zoom';
+import { clipboard, CopyButtonStringKey } from './ribbonButtons/clipboard';
 import {
     AllButtonStringKeys,
     createRibbonPlugin,
@@ -108,7 +109,8 @@ type RibbonStringKeys =
     | DarkModeButtonStringKey
     | ZoomButtonStringKey
     | ExportButtonStringKey
-    | PopoutButtonStringKey;
+    | PopoutButtonStringKey
+    | CopyButtonStringKey;
 
 class MainPane extends MainPaneBase {
     private mouseX: number;
@@ -158,6 +160,7 @@ class MainPane extends MainPaneBase {
             zoom,
             exportContent,
             popout,
+            clipboard,
         ]);
         this.popoutWindowButtons = getButtons([...AllButtonKeys, darkMode, zoom, exportContent]);
         this.state = {

--- a/demo/scripts/controls/ribbonButtons/clipboard.ts
+++ b/demo/scripts/controls/ribbonButtons/clipboard.ts
@@ -1,0 +1,36 @@
+import { DocumentCommand } from 'roosterjs-editor-types';
+import { RibbonButton } from 'roosterjs-react';
+
+export type CopyButtonStringKey = 'buttonNameClipboard';
+
+export const clipboard: RibbonButton<CopyButtonStringKey> = {
+    key: 'buttonNameClipboard',
+    unlocalizedText: 'Perform copy action',
+    iconName: 'Clipboard',
+    dropDownMenu: {
+        items: {
+            copy: 'Copy',
+            cut: 'Cut',
+            paste: 'Paste',
+        },
+    },
+    onClick: (editor, key) => {
+        const doc = editor.getDocument();
+        let command: DocumentCommand;
+        if (!doc) {
+            return;
+        }
+        switch (<string>key) {
+            case 'copy':
+                command = DocumentCommand.Copy;
+                break;
+            case 'cut':
+                command = DocumentCommand.Cut;
+                break;
+            case 'paste':
+                command = DocumentCommand.Paste;
+                break;
+        }
+        doc.execCommand(command);
+    },
+};

--- a/packages/roosterjs-editor-core/test/corePlugins/copyPastePluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/copyPastePluginTest.ts
@@ -1,7 +1,7 @@
 import * as addRangeToSelection from 'roosterjs-editor-dom/lib/selection/addRangeToSelection';
 import * as extractClipboardEvent from 'roosterjs-editor-dom/lib/clipboard/extractClipboardEvent';
 import CopyPastePlugin from '../../lib/corePlugins/CopyPastePlugin';
-import { Position } from 'roosterjs-editor-dom';
+import { Position, Browser } from 'roosterjs-editor-dom';
 import {
     ClipboardData,
     DOMEventHandlerFunction,
@@ -117,6 +117,8 @@ describe('CopyPastePlugin copy', () => {
     let plugin: CopyPastePlugin;
     let handler: Record<string, DOMEventHandlerFunction>;
     let editor: IEditor;
+    let rangeEx = {};
+    let select: jasmine.Spy;
     let tempNode: HTMLElement = null;
     let addDomEventHandler: jasmine.Spy;
     let triggerPluginEvent: jasmine.Spy;
@@ -153,11 +155,13 @@ describe('CopyPastePlugin copy', () => {
                 }
             );
         spyOn(addRangeToSelection, 'default');
+        select = jasmine.createSpy('select');
 
         editor = <IEditor>(<any>{
             addDomEventHandler,
             triggerPluginEvent,
             getSelectionRange: () => <Range>{ collapsed: false },
+            getSelectionRangeEx: () => rangeEx,
             getContent: () => '<div>test</div><!--{"start":[0,0],"end":[0,1]}-->',
             getCustomData: (key: string, getter: () => any) => {
                 tempNode = getter();
@@ -168,7 +172,7 @@ describe('CopyPastePlugin copy', () => {
                 document.body.appendChild(node);
             },
             getDocument: () => document,
-            select: () => {},
+            select,
             addUndoSnapshot: (f: () => void) => f(),
             focus: () => {},
             getTrustedHTMLHandler: (html: string) => html,
@@ -294,5 +298,13 @@ describe('CopyPastePlugin copy', () => {
         expect(contentDiv.innerHTML).toBe(
             '<ol><li>line1</li><li><div>line2</div><div>lin</div></li></ol><div>ne5</div>'
         );
+    });
+
+    it('restores pre-blur selection when copying on Safari', () => {
+        Browser.isSafari = true;
+        handler.blur();
+        expect(g);
+        handler.copy(<Event>{});
+        expect(select).toHaveBeenCalledWith(rangeEx);
     });
 });


### PR DESCRIPTION
Safari entirely loses selection when switching focus away from editor, so externally triggering a copy event will result in nothing being copied.
Same with Cut and Paste