### PR TITLE
Support "No Color" for table cell shade

### DIFF
--- a/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
@@ -8,9 +8,9 @@ import { setTableCellBackgroundColor } from '../../modelApi/table/setTableCellBa
 /**
  * Set table cell shade color
  * @param editor The editor instance
- * @param color The color to set
+ * @param color The color to set. Pass null to remove existing shade color
  */
-export default function setTableCellShade(editor: IContentModelEditor, color: string) {
+export default function setTableCellShade(editor: IContentModelEditor, color: string | null) {
     formatWithContentModel(editor, 'setTableCellShade', model => {
         const table = getFirstSelectedTable(model);
 

--- a/packages/roosterjs-content-model/test/publicApi/table/setTableCellShadeTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/table/setTableCellShadeTest.ts
@@ -23,13 +23,17 @@ describe('setTableCellShade', () => {
         } as any) as IContentModelEditor;
     });
 
-    function runTest(table: ContentModelTable, expectedTable: ContentModelTable | null) {
+    function runTest(
+        table: ContentModelTable,
+        expectedTable: ContentModelTable | null,
+        colorValue: string | null = 'red'
+    ) {
         const model = createContentModelDocument();
         model.blocks.push(table);
 
         createContentModel.and.returnValue(model);
 
-        setTableCellShade(editor, 'red');
+        setTableCellShade(editor, colorValue);
 
         if (expectedTable) {
             expect(setContentModel).toHaveBeenCalledTimes(1);
@@ -344,6 +348,80 @@ describe('setTableCellShade', () => {
                 heights: [0],
                 dataset: {},
             }
+        );
+    });
+
+    it('Set to no color', () => {
+        runTest(
+            {
+                blockType: 'Table',
+                cells: [
+                    [
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {
+                                backgroundColor: 'red',
+                                textColor: 'green',
+                                direction: 'rtl',
+                            },
+                            dataset: {},
+                        },
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {
+                                backgroundColor: 'red',
+                                textColor: 'green',
+                                direction: 'rtl',
+                            },
+                            dataset: {},
+                            isSelected: true,
+                        },
+                    ],
+                ],
+                format: {},
+                widths: [0],
+                heights: [0],
+                dataset: {},
+            },
+            {
+                blockType: 'Table',
+                cells: [
+                    [
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: {
+                                backgroundColor: 'red',
+                                textColor: 'green',
+                                direction: 'rtl',
+                            },
+                            dataset: {},
+                        },
+                        {
+                            blockGroupType: 'TableCell',
+                            blocks: [],
+                            spanAbove: false,
+                            spanLeft: false,
+                            format: { direction: 'rtl' },
+                            dataset: {},
+                            isSelected: true,
+                        },
+                    ],
+                ],
+                format: {},
+                widths: [0],
+                heights: [0],
+                dataset: {},
+            },
+            null
         );
     });
 });

--- a/packages/roosterjs-editor-core/lib/coreApi/selectTable.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/selectTable.ts
@@ -153,7 +153,7 @@ function buildCss(
 
     const css = `${selectors.join(
         ','
-    )} {background-color: rgba(198,198,198,0.7) !important; caret-color: transparent}`;
+    )} {background-color: rgb(198,198,198) !important; caret-color: transparent}`;
 
     return { css, ranges };
 }


### PR DESCRIPTION
1. Allow passing "null" as parameter in API `setTableCellShade` to remove existing cell shade
2. Remove alpha value of table selection since it makes the selected text looks bad:

Before change:
![image](https://user-images.githubusercontent.com/23065085/228376182-25ce7063-a76b-4867-82ce-ecd222725fd5.png)

After change:
![image](https://user-images.githubusercontent.com/23065085/228376419-cb871a73-6436-4ff3-8168-4f596c5acd98.png)
