### PR TITLE
Prevent content model from acting on undefined cell

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/selection/iterateSelections.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/selection/iterateSelections.ts
@@ -113,6 +113,9 @@ function internalIterateSelections(
 
                         for (let colIndex = 0; colIndex < row.length; colIndex++) {
                             const cell = row[colIndex];
+                            if (!cell) {
+                                continue;
+                            }
 
                             const newTable: TableSelectionContext = {
                                 table: block,


### PR DESCRIPTION
There is currently a change Rooster will receive an undefined cell within table when iterating through it while getting the format state.

Fix by not assuming a cell exists.