### PR TITLE
Remove max-width when editing image

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -404,6 +404,7 @@ export default class ImageEdit implements EditorPlugin {
             //Clone the image and insert the clone in a entity
             this.clonedImage = this.image.cloneNode(true) as HTMLImageElement;
             this.clonedImage.removeAttribute('id');
+            this.clonedImage.style.removeProperty('max-width');
             this.wrapper = createElement(
                 KnownCreateElementDataIndex.ImageEditWrapper,
                 this.image.ownerDocument

--- a/packages/roosterjs-editor-plugins/test/imageEdit/imageEditTest.ts
+++ b/packages/roosterjs-editor-plugins/test/imageEdit/imageEditTest.ts
@@ -225,7 +225,7 @@ describe('ImageEdit | rotate and flip', () => {
     });
 });
 
-describe('ImageEdit | plugin events', () => {
+describe('ImageEdit | plugin events | quitting', () => {
     let editor: IEditor;
     const TEST_ID = 'imageEditTest';
     let plugin: ImageEdit;
@@ -309,5 +309,38 @@ describe('ImageEdit | plugin events', () => {
         plugin.onPluginEvent(keyDown('A'));
         expect(setEditingImageSpy).toHaveBeenCalled();
         expect(setEditingImageSpy).toHaveBeenCalledWith(null);
+    });
+});
+
+describe('ImageEdit | wrapper', () => {
+    let editor: IEditor;
+    const TEST_ID = 'imageEditTest';
+    let plugin: ImageEdit;
+
+    beforeEach(() => {
+        plugin = new ImageEdit();
+        editor = TestHelper.initEditor(TEST_ID, [plugin]);
+    });
+
+    afterEach(() => {
+        let element = document.getElementById(TEST_ID);
+        if (element) {
+            element.parentElement.removeChild(element);
+        }
+        editor.dispose();
+    });
+
+    it('image selection, remove max-width', () => {
+        const IMG_ID = 'IMAGE_ID';
+        const content = `<img id="${IMG_ID}" src='test'/>`;
+        editor.setContent(content);
+        const image = document.getElementById(IMG_ID) as HTMLImageElement;
+        image.style.maxWidth = '100%';
+        editor.focus();
+        editor.select(image);
+        const imageParent = image.parentElement;
+        const shadowRoot = imageParent?.shadowRoot;
+        const imageShadow = shadowRoot?.querySelector('img');
+        expect(imageShadow?.style.maxWidth).toBe('');
     });
 });


### PR DESCRIPTION
When editing image mode we restore the original image and use the wrapper to overlay the part the was cut, then we cannot use max-width in the editing image, because it will fit the whole image inside the wrapper instead of overlay it. 
So if the selected image has max-width, when create the editing image, remove max-width. 

Before:
![BeforeFixImageCrop](https://user-images.githubusercontent.com/87443959/230124518-91255739-0bc9-462b-9114-6287b978804f.gif)

After: 
![AfterFixImageCrop](https://user-images.githubusercontent.com/87443959/230124546-8ba75191-2797-4373-aab6-987e7280aedd.gif)
