### PR TITLE
Fix unexpected error in getBlockElementAtNode.ts

### DIFF
--- a/packages/roosterjs-editor-dom/lib/blockElements/getBlockElementAtNode.ts
+++ b/packages/roosterjs-editor-dom/lib/blockElements/getBlockElementAtNode.ts
@@ -53,6 +53,10 @@ export default function getBlockElementAtNode(
     let headNode = findHeadTailLeafNode(node!, containerBlockNode, false /*isTail*/);
     let tailNode = findHeadTailLeafNode(node!, containerBlockNode, true /*isTail*/);
 
+    if (!headNode || !tailNode) {
+        return null;
+    }
+
     // At this point, we have the head and tail of a block, here are some examples and where head and tail point to
     // 1) &lt;root&gt;&lt;div&gt;hello&lt;br&gt;&lt;/div&gt;&lt;/root&gt;, head: hello, tail: &lt;br&gt;
     // 2) &lt;root&gt;&lt;div&gt;hello&lt;span style="font-family: Arial"&gt;world&lt;/span&gt;&lt;/div&gt;&lt;/root&gt;, head: hello, tail: world


### PR DESCRIPTION
If the head node or the tail node is undefined, the block element at node cannot be returned, so return null. 

Fix for error: 
Uncaught TypeError: Cannot read properties of undefined (reading 'parentNode');

Call stack: 
at webpack://owa/packages/roosterjs-editor-dom/lib/blockElements/getBlockElementAtNode.ts:65
at webpack://owa/packages/roosterjs-editor-dom/lib/inlineElements/getInlineElementAtNode.ts:31
at webpack://owa/packages/roosterjs-editor-dom/lib/contentTraverser/BodyScoper.ts:39
at webpack://owa/packages/roosterjs-editor-dom/lib/contentTraverser/ContentTraverser.ts:146
at webpack://owa/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts:374
at webpack://owa/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts:337
at webpack://owa/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts:237
at webpack://owa/packages/roosterjs-editor-core/lib/corePlugins/EditPlugin.ts:86