### PR TITLE
Paste as image feature

### DIFF
--- a/packages-ui/roosterjs-react/lib/pasteOptions/plugin/createPasteOptionPlugin.ts
+++ b/packages-ui/roosterjs-react/lib/pasteOptions/plugin/createPasteOptionPlugin.ts
@@ -142,6 +142,13 @@ class PasteOptionPlugin implements ReactEditorPlugin {
                         true /*applyCurrentFormat*/
                     );
                     break;
+                case 'pasteOptionPasteAsImage':
+                    this.editor.paste(
+                        this.clipboardData,
+                        false /*pasteAsText*/,
+                        false /*applyCurrentFormat*/,
+                        true /** pasteAsImage **/
+                    );
             }
 
             this.pasteOptionRef.current?.setSelectedKey(key);

--- a/packages-ui/roosterjs-react/lib/pasteOptions/type/PasteOptionStringKeys.ts
+++ b/packages-ui/roosterjs-react/lib/pasteOptions/type/PasteOptionStringKeys.ts
@@ -4,7 +4,8 @@
 export type PasteOptionButtonKeys =
     | 'pasteOptionPasteAsIs'
     | 'pasteOptionPasteText'
-    | 'pasteOptionMergeFormat';
+    | 'pasteOptionMergeFormat'
+    | 'pasteOptionPasteAsImage';
 
 /**
  * Localized string keys for Paste Option buttons and its UI component

--- a/packages-ui/roosterjs-react/lib/pasteOptions/utils/buttons.ts
+++ b/packages-ui/roosterjs-react/lib/pasteOptions/utils/buttons.ts
@@ -28,6 +28,11 @@ export const Buttons: Record<PasteOptionButtonKeys, PasteOptionButtonType> = {
         shortcut: 'M',
         icon: 'ClipboardList',
     },
+    pasteOptionPasteAsImage: {
+        unlocalizedText: 'Paste as image',
+        shortcut: 'I',
+        icon: 'PictureFill',
+    },
 };
 
 /**

--- a/packages/roosterjs-editor-core/lib/coreApi/createPasteFragment.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/createPasteFragment.ts
@@ -40,7 +40,8 @@ export const createPasteFragment: CreatePasteFragment = (
     clipboardData: ClipboardData,
     position: NodePosition | null,
     pasteAsText: boolean,
-    applyCurrentStyle: boolean
+    applyCurrentStyle: boolean,
+    pasteAsImage: boolean = false
 ) => {
     if (!clipboardData) {
         return null;
@@ -108,7 +109,7 @@ export const createPasteFragment: CreatePasteFragment = (
     }
 
     // Step 3: Fill the BeforePasteEvent object, especially the fragment for paste
-    if (!pasteAsText && !text && imageDataUri) {
+    if ((pasteAsImage && imageDataUri) || (!pasteAsText && !text && imageDataUri)) {
         // Paste image
         const img = document.createElement('img');
         img.style.maxWidth = '100%';
@@ -158,7 +159,6 @@ export const createPasteFragment: CreatePasteFragment = (
 
     // Step 5. Sanitize the fragment before paste to make sure the content is safe
     const sanitizer = new HtmlSanitizer(event.sanitizingOption);
-
     sanitizer.convertGlobalCssToInlineCss(fragment);
     sanitizer.sanitize(fragment, position ? getInheritableStyles(position.element) : undefined);
 

--- a/packages/roosterjs-editor-core/lib/editor/EditorBase.ts
+++ b/packages/roosterjs-editor-core/lib/editor/EditorBase.ts
@@ -332,7 +332,8 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
     public paste(
         clipboardData: ClipboardData,
         pasteAsText: boolean = false,
-        applyCurrentFormat: boolean = false
+        applyCurrentFormat: boolean = false,
+        pasteAsImage: boolean = false
     ) {
         const core = this.getCore();
         if (!clipboardData) {
@@ -355,7 +356,8 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
             clipboardData,
             pos,
             pasteAsText,
-            applyCurrentFormat
+            applyCurrentFormat,
+            pasteAsImage
         );
         if (fragment) {
             this.addUndoSnapshot(() => {

--- a/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
@@ -18,7 +18,7 @@ describe('createPasteFragment', () => {
 
     it('null input', () => {
         const core = createEditorCore(div, {});
-        const fragment = createPasteFragment(core, null, null, false, false);
+        const fragment = createPasteFragment(core, null, null, false, false, false);
         expect(fragment).toBeNull();
     });
 
@@ -38,7 +38,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('This is a test');
     });
@@ -59,7 +59,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('This is a test<br>this is line 2');
     });
@@ -80,7 +80,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('This is a test<div>this is line 2</div>this is line 3');
     });
@@ -101,7 +101,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('<br>this is line 2');
     });
@@ -122,7 +122,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('this is line 1<br>');
     });
@@ -143,7 +143,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('<div>this is line 2</div>this is line 3');
     });
@@ -164,7 +164,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('this is line 1<div><br></div>this is line 3');
     });
@@ -185,7 +185,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('this is line 1<div>this is line 2</div>');
     });
@@ -206,7 +206,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, true, false);
+        const fragment = createPasteFragment(core, clipboardData, null, true, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('This is a test<div>this is line 2</div>this is line 3');
     });
@@ -227,7 +227,7 @@ describe('createPasteFragment', () => {
             imageDataUri: 'test',
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('<img style="max-width:100%" src="test">');
     });
@@ -248,7 +248,7 @@ describe('createPasteFragment', () => {
             imageDataUri: 'test',
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('test');
     });
@@ -269,9 +269,30 @@ describe('createPasteFragment', () => {
             imageDataUri: 'test',
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, true, false);
+        const fragment = createPasteFragment(core, clipboardData, null, true, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('');
+    });
+
+    it('create image fragment', () => {
+        const triggerEvent = jasmine.createSpy();
+        const core = createEditorCore(div, {
+            coreApiOverride: {
+                triggerEvent,
+            },
+        });
+        const clipboardData: ClipboardData = {
+            types: [],
+            text: '',
+            rawHtml: null,
+            image: null,
+            snapshotBeforePaste: null,
+            imageDataUri: 'test',
+            customValues: {},
+        };
+        const fragment = createPasteFragment(core, clipboardData, null, true, false, true);
+        const html = getHTML(fragment);
+        expect(html).toBe('<img src="test" style="max-width:100%">');
     });
 
     it('html input, html output', () => {
@@ -290,7 +311,7 @@ describe('createPasteFragment', () => {
             imageDataUri: 'test',
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('<div>test html</div>');
     });
@@ -311,7 +332,7 @@ describe('createPasteFragment', () => {
             imageDataUri: 'test',
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, true, false);
+        const fragment = createPasteFragment(core, clipboardData, null, true, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('test text');
     });
@@ -338,7 +359,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
 
         expect(triggerEvent).toHaveBeenCalledWith(
             core,
@@ -382,7 +403,7 @@ describe('createPasteFragment', () => {
             imageDataUri: null,
             customValues: {},
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
 
         expect(getHTML(fragment)).toBe('<div>test</div>');
         expect(sanitizingOption.additionalGlobalStyleNodes.length).toBe(2);
@@ -410,7 +431,7 @@ describe('createPasteFragment', () => {
             customValues: {},
             imageDataUri: null,
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html).toBe('<img src="">');
         expect(clipboardData.htmlFirstLevelChildTags).toEqual(['IMG']);
@@ -432,7 +453,7 @@ describe('createPasteFragment', () => {
             customValues: {},
             imageDataUri: null,
         };
-        const fragment = createPasteFragment(core, clipboardData, null, false, false);
+        const fragment = createPasteFragment(core, clipboardData, null, false, false, false);
         const html = getHTML(fragment);
         expect(html.trim()).toBe('teststring<img src="">teststring');
         expect(clipboardData.htmlFirstLevelChildTags).toEqual(['', 'IMG', '']);

--- a/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
+++ b/packages/roosterjs-editor-core/test/coreApi/createPasteFragmentTest.ts
@@ -2,7 +2,7 @@ import * as createDefaultHtmlSanitizerOptions from 'roosterjs-editor-dom/lib/htm
 import createEditorCore from './createMockEditorCore';
 import { ClipboardData, PluginEventType } from 'roosterjs-editor-types';
 import { createPasteFragment, transformTabCharacters } from '../../lib/coreApi/createPasteFragment';
-import { itFirefoxOnly } from '../TestHelper';
+import { itChromeOnly, itFirefoxOnly } from '../TestHelper';
 
 describe('createPasteFragment', () => {
     let div: HTMLDivElement;
@@ -274,7 +274,7 @@ describe('createPasteFragment', () => {
         expect(html).toBe('');
     });
 
-    it('create image fragment', () => {
+    itChromeOnly('create image fragment', () => {
         const triggerEvent = jasmine.createSpy();
         const core = createEditorCore(div, {
             coreApiOverride: {
@@ -293,6 +293,27 @@ describe('createPasteFragment', () => {
         const fragment = createPasteFragment(core, clipboardData, null, true, false, true);
         const html = getHTML(fragment);
         expect(html).toBe('<img src="test" style="max-width:100%">');
+    });
+
+    itFirefoxOnly('create image fragment', () => {
+        const triggerEvent = jasmine.createSpy();
+        const core = createEditorCore(div, {
+            coreApiOverride: {
+                triggerEvent,
+            },
+        });
+        const clipboardData: ClipboardData = {
+            types: [],
+            text: '',
+            rawHtml: null,
+            image: null,
+            snapshotBeforePaste: null,
+            imageDataUri: 'test',
+            customValues: {},
+        };
+        const fragment = createPasteFragment(core, clipboardData, null, true, false, true);
+        const html = getHTML(fragment);
+        expect(html).toBe('<img style="max-width:100%" src="test">');
     });
 
     it('html input, html output', () => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/excelConverter/convertPastedContentFromExcel.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/excelConverter/convertPastedContentFromExcel.ts
@@ -17,9 +17,9 @@ export default function convertPastedContentFromExcel(
     trustedHTMLHandler: TrustedHTMLHandler
 ) {
     const { fragment, sanitizingOption, htmlBefore, clipboardData } = event;
-    const html = clipboardData.html ? excelHandler(clipboardData.html, htmlBefore) : undefined;
-
-    if (html && clipboardData.html != html) {
+    const fragmentHTML = fragment.firstElementChild?.outerHTML ?? clipboardData.html;
+    const html = fragmentHTML ? excelHandler(fragmentHTML, htmlBefore) : undefined;
+    if (html && fragmentHTML != html) {
         const doc = new DOMParser().parseFromString(trustedHTMLHandler(html), 'text/html');
         moveChildNodes(fragment, doc?.body);
     }

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -124,7 +124,8 @@ export type CreatePasteFragment = (
     clipboardData: ClipboardData,
     position: NodePosition | null,
     pasteAsText: boolean,
-    applyCurrentStyle: boolean
+    applyCurrentStyle: boolean,
+    pasteAsImage: boolean
 ) => DocumentFragment | null;
 
 /**

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -210,7 +210,12 @@ export default interface IEditor {
      * @param applyCurrentStyle True if apply format of current selection to the pasted content,
      * false to keep original format.  Default value is false. When pasteAsText is true, this parameter is ignored
      */
-    paste(clipboardData: ClipboardData, pasteAsText?: boolean, applyCurrentFormat?: boolean): void;
+    paste(
+        clipboardData: ClipboardData,
+        pasteAsText?: boolean,
+        applyCurrentFormat?: boolean,
+        pasteAsImage?: boolean
+    ): void;
 
     //#endregion
 


### PR DESCRIPTION
Add the `pasteAsImage` parameter to the editor paste, so if the content has image in base64 we can paste it as image. 

![pasteAsImage](https://user-images.githubusercontent.com/87443959/230488195-77e659c4-e1d4-45b8-b620-d0c0458f8f7c.gif)


