### PR TITLE
Fix #1713 Copy paste bullet list item doesn't work, copies just empty span instead of content inside.

### DIFF
--- a/packages/roosterjs-editor-dom/lib/utils/createElement.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/createElement.ts
@@ -22,7 +22,7 @@ export const KnownCreateElementData: Record<KnownCreateElementDataIndex, CreateE
     [KnownCreateElementDataIndex.CopyPasteTempDiv]: {
         tag: 'div',
         style:
-            'width: 1px; height: 1px; overflow: hidden; position: fixed; top: 0; left; 0; -webkit-user-select: text',
+            'width: 600px; height: 1px; overflow: hidden; position: fixed; top: 0; left; 0; -webkit-user-select: text',
         attributes: {
             contenteditable: 'true',
         },


### PR DESCRIPTION
This seems like a bug in Chrome, it doesn't repro in Firefox.

I found that when the width of temp DIV >=4px, it won't repro.

Let's use 600px for the temp DIV width instead. I don't have a good reason for this value, just pick whatever value that can work.