### PR TITLE
Content Model minor fix: Change parameter type

### DIFF
--- a/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
@@ -25,7 +25,7 @@ const BuildInQuoteFormat: ContentModelBlockFormat = {
  */
 export default function toggleBlockQuote(
     editor: IContentModelEditor,
-    quoteFormat: ContentModelBlockFormat = DefaultQuoteFormat
+    quoteFormat: ContentModelBlockFormat & ContentModelSegmentFormat = DefaultQuoteFormat
 ) {
     const fullQuoteFormat = {
         ...BuildInQuoteFormat,

--- a/packages/roosterjs-content-model/test/publicApi/block/toggleBlockQuoteTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/block/toggleBlockQuoteTest.ts
@@ -31,4 +31,23 @@ describe('toggleBlockQuote', () => {
             c: 'd',
         } as any);
     });
+
+    it('toggleBlockQuote with real format', () => {
+        spyOn(formatWithContentModel, 'formatWithContentModel').and.callThrough();
+        spyOn(toggleModelBlockQuote, 'toggleModelBlockQuote');
+
+        toggleBlockQuote(editor, { lineHeight: '2', textColor: 'red' });
+
+        expect(formatWithContentModel.formatWithContentModel).toHaveBeenCalledTimes(1);
+        expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledTimes(1);
+        expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledWith(fakeModel, {
+            marginTop: '1em',
+            marginBottom: '1em',
+            marginLeft: '40px',
+            marginRight: '40px',
+            paddingLeft: '10px',
+            lineHeight: '2',
+            textColor: 'red',
+        } as any);
+    });
 });


### PR DESCRIPTION
With the latest changes, `toggleBlockQuote` API should accept a union of Block format and Segment format, but I forgot to change the parameter type. So fix it in this change and add a test case to make sure it accepts correct format type.