### PR TITLE
Fix Uncaught TypeError: Cannot read properties of undefined (reading 'parentNode')

### DIFF
--- a/packages/roosterjs-editor-dom/lib/blockElements/getBlockElementAtNode.ts
+++ b/packages/roosterjs-editor-dom/lib/blockElements/getBlockElementAtNode.ts
@@ -35,7 +35,7 @@ export default function getBlockElementAtNode(
     rootNode: Node,
     node: Node | null
 ): BlockElement | null {
-    if (!contains(rootNode, node)) {
+    if (!node || !contains(rootNode, node)) {
         return null;
     }
 
@@ -50,12 +50,8 @@ export default function getBlockElementAtNode(
     }
 
     // Find the head and leaf node in the block
-    let headNode = findHeadTailLeafNode(node!, containerBlockNode, false /*isTail*/);
-    let tailNode = findHeadTailLeafNode(node!, containerBlockNode, true /*isTail*/);
-
-    if (!headNode || !tailNode) {
-        return null;
-    }
+    let headNode = findHeadTailLeafNode(node, containerBlockNode, false /*isTail*/);
+    let tailNode = findHeadTailLeafNode(node, containerBlockNode, true /*isTail*/);
 
     // At this point, we have the head and tail of a block, here are some examples and where head and tail point to
     // 1) &lt;root&gt;&lt;div&gt;hello&lt;br&gt;&lt;/div&gt;&lt;/root&gt;, head: hello, tail: &lt;br&gt;
@@ -63,6 +59,11 @@ export default function getBlockElementAtNode(
     // Both are actually completely and exclusively wrapped in a parent div, and can be represented with a Node block
     // So we shall try to collapse as much as we can to the nearest common ancestor
     let nodes = collapseNodes(rootNode, headNode, tailNode, false /*canSplitParent*/);
+
+    if (nodes.length === 0) {
+        return null;
+    }
+
     headNode = nodes[0];
     tailNode = nodes[nodes.length - 1];
 

--- a/packages/roosterjs-editor-dom/lib/blockElements/getBlockElementAtNode.ts
+++ b/packages/roosterjs-editor-dom/lib/blockElements/getBlockElementAtNode.ts
@@ -35,7 +35,7 @@ export default function getBlockElementAtNode(
     rootNode: Node,
     node: Node | null
 ): BlockElement | null {
-    if (!node || !contains(rootNode, node)) {
+    if (!contains(rootNode, node)) {
         return null;
     }
 
@@ -50,8 +50,12 @@ export default function getBlockElementAtNode(
     }
 
     // Find the head and leaf node in the block
-    let headNode = findHeadTailLeafNode(node, containerBlockNode, false /*isTail*/);
-    let tailNode = findHeadTailLeafNode(node, containerBlockNode, true /*isTail*/);
+    let headNode = findHeadTailLeafNode(node!, containerBlockNode, false /*isTail*/);
+    let tailNode = findHeadTailLeafNode(node!, containerBlockNode, true /*isTail*/);
+
+    if (!headNode || !tailNode) {
+        return null;
+    }
 
     // At this point, we have the head and tail of a block, here are some examples and where head and tail point to
     // 1) &lt;root&gt;&lt;div&gt;hello&lt;br&gt;&lt;/div&gt;&lt;/root&gt;, head: hello, tail: &lt;br&gt;

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
@@ -383,7 +383,10 @@ function getBlockTraverser(editor: IEditor, element: Node | null | undefined) {
         return undefined;
     }
     const blockElement = editor.getBlockElementAtNode(element)?.getStartNode();
-    return blockElement ? ContentTraverser.createBodyTraverser(blockElement, element) : undefined;
+    if (!blockElement || !isBlockElement(blockElement)) {
+        return undefined;
+    }
+    return ContentTraverser.createBodyTraverser(blockElement, element);
 }
 
 function cacheDelimiter(event: PluginEvent, checkBefore: boolean, delimiter?: HTMLElement | null) {
@@ -499,7 +502,6 @@ function getRelatedElements(delimiter: HTMLElement, checkBefore: boolean, editor
         }
         current = traverseFn(traverser);
     }
-
     return { entity, delimiterPair };
 }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
@@ -502,6 +502,7 @@ function getRelatedElements(delimiter: HTMLElement, checkBefore: boolean, editor
         }
         current = traverseFn(traverser);
     }
+
     return { entity, delimiterPair };
 }
 

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
@@ -325,7 +325,6 @@ describe('Content Edit Features |', () => {
                 );
 
                 expect(result).toBe(false);
-                return event;
             });
         }
 
@@ -578,7 +577,6 @@ describe('Content Edit Features |', () => {
                 );
 
                 expect(result).toBe(false);
-                return event;
             });
         }
 
@@ -643,13 +641,17 @@ describe('Content Edit Features |', () => {
             };
 
             const result = removeEntityBetweenDelimiters.shouldHandleEvent(
-                event,
+                <PluginKeyDownEvent>{
+                    rawEvent: <KeyboardEvent>{
+                        which: Keys.BACKSPACE,
+                        defaultPrevented: false,
+                    },
+                },
                 editor,
                 false /* ctrlOrMeta */
             );
 
             expect(result).toBe(false);
-            return event;
         });
 
         it('DelimiterAfter, Backspace, default not prevented', () => {

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
@@ -15,6 +15,7 @@ import {
     IEditor,
     Keys,
     PluginKeyDownEvent,
+    BlockElement,
 } from 'roosterjs-editor-types';
 
 describe('Content Edit Features |', () => {
@@ -302,6 +303,30 @@ describe('Content Edit Features |', () => {
 
                 runTest(delimiterAfter, true /* expected */, event);
             });
+
+            it('DelimiterAfter, should not Handle, getBlockElementAtCursor returned inline', () => {
+                const div = document.createElement('div');
+                div.appendChild(document.createTextNode('New block'));
+                testContainer.insertAdjacentElement('afterend', div);
+
+                const pos = new Position(<Node>div.firstChild!, 0);
+
+                setEditorFuncs(editor, pos, testContainer);
+                editor.getBlockElementAtNode = node => {
+                    return <BlockElement>{
+                        getStartNode: () => node,
+                    };
+                };
+
+                const result = moveBetweenDelimitersFeature.shouldHandleEvent(
+                    event,
+                    editor,
+                    false /* ctrlOrMeta */
+                );
+
+                expect(result).toBe(false);
+                return event;
+            });
         }
 
         describe('LTR |', () => {
@@ -531,6 +556,30 @@ describe('Content Edit Features |', () => {
 
                 runTest(delimiterBefore, true /* expected */, event);
             });
+
+            it('DelimiterBefore, should not Handle, getBlockElementAtCursor returned inline', () => {
+                const div = document.createElement('div');
+                div.appendChild(document.createTextNode('New block'));
+                testContainer.insertAdjacentElement('afterend', div);
+
+                const pos = new Position(<Node>div.firstChild!, 0);
+
+                setEditorFuncs(editor, pos, testContainer);
+                editor.getBlockElementAtNode = node => {
+                    return <BlockElement>{
+                        getStartNode: () => node,
+                    };
+                };
+
+                const result = moveBetweenDelimitersFeature.shouldHandleEvent(
+                    event,
+                    editor,
+                    false /* ctrlOrMeta */
+                );
+
+                expect(result).toBe(false);
+                return event;
+            });
         }
 
         describe('LTR |', () => {
@@ -578,6 +627,30 @@ describe('Content Edit Features |', () => {
             expect(result).toBe(expected);
             return event;
         }
+
+        it('removeEntityBetweenDelimiters, should not Handle, getBlockElementAtCursor returned inline', () => {
+            const div = document.createElement('div');
+            div.appendChild(document.createTextNode('New block'));
+            testContainer.insertAdjacentElement('afterend', div);
+
+            const pos = new Position(<Node>div.firstChild!, 0);
+
+            setEditorFuncs(editor, pos, testContainer);
+            editor.getBlockElementAtNode = node => {
+                return <BlockElement>{
+                    getStartNode: () => node,
+                };
+            };
+
+            const result = removeEntityBetweenDelimiters.shouldHandleEvent(
+                event,
+                editor,
+                false /* ctrlOrMeta */
+            );
+
+            expect(result).toBe(false);
+            return event;
+        });
 
         it('DelimiterAfter, Backspace, default not prevented', () => {
             let event = <PluginKeyDownEvent>{


### PR DESCRIPTION
There is an issue with delimiter when pressing Left or Right key. Seem to be related when the Entity is inserted right below the editor div and there are no more elements.

Repro 
1. Alt + A to select all text in editor
2. Delete
3. Add new Inline readonly entity
4. Press Left or Right next to the inline entity.
5. Error is thrown.

Snapshot

```
<span class="entityDelimiterBefore">​</span><span class="_Entity _EType_ _EReadonly_1" contenteditable="false" style="display: inline-block;"><span data-hydrated-html=""><a href="asas">asd</a></span></span><span class="entityDelimiterAfter">​</span><!--{"type":0,"isDarkMode":true,"start":[2,0,1],"end":[2,0,1]}-->
```

To fix, do not create the Block Traverser if the result of getBlockElementAtNode::getStartNode returns an element that is not a block