### PR TITLE
Content Model: Improve edit plugin

### DIFF
--- a/packages/roosterjs-content-model/lib/publicApi/editing/handleBackspaceKey.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/editing/handleBackspaceKey.ts
@@ -1,3 +1,4 @@
+import { ChangeSource, EntityOperationEvent } from 'roosterjs-editor-types';
 import { deleteSelection } from '../../modelApi/selection/deleteSelections';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
@@ -9,14 +10,18 @@ import {
 /**
  * Handle Backspace key event
  */
-export default function handleBackspaceKey(editor: IContentModelEditor, rawEvent: KeyboardEvent) {
+export default function handleBackspaceKey(
+    editor: IContentModelEditor,
+    rawEvent: KeyboardEvent,
+    triggeredEntityEvents: EntityOperationEvent[]
+) {
     formatWithContentModel(
         editor,
         'handleBackspaceKey',
         model => {
             const { isChanged } = deleteSelection(model, {
                 direction: 'backward',
-                onDeleteEntity: getOnDeleteEntityCallback(editor, rawEvent),
+                onDeleteEntity: getOnDeleteEntityCallback(editor, rawEvent, triggeredEntityEvents),
             });
 
             handleKeyboardEventResult(editor, model, rawEvent, isChanged);
@@ -25,6 +30,8 @@ export default function handleBackspaceKey(editor: IContentModelEditor, rawEvent
         },
         {
             skipUndoSnapshot: true, // No need to add undo snapshot for each key down event. We will trigger a ContentChanged event and let UndoPlugin decide when to add undo snapshot
+            changeSource: ChangeSource.Keyboard,
+            getChangeData: () => rawEvent.which,
         }
     );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/editing/handleDeleteKey.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/editing/handleDeleteKey.ts
@@ -1,3 +1,4 @@
+import { ChangeSource, EntityOperationEvent } from 'roosterjs-editor-types';
 import { deleteSelection } from '../../modelApi/selection/deleteSelections';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
@@ -9,14 +10,18 @@ import {
 /**
  * Handle Delete key event
  */
-export default function handleDeleteKey(editor: IContentModelEditor, rawEvent: KeyboardEvent) {
+export default function handleDeleteKey(
+    editor: IContentModelEditor,
+    rawEvent: KeyboardEvent,
+    triggeredEntityEvents: EntityOperationEvent[]
+) {
     formatWithContentModel(
         editor,
         'handleDeleteKey',
         model => {
             const { isChanged } = deleteSelection(model, {
                 direction: 'forward',
-                onDeleteEntity: getOnDeleteEntityCallback(editor, rawEvent),
+                onDeleteEntity: getOnDeleteEntityCallback(editor, rawEvent, triggeredEntityEvents),
             });
 
             handleKeyboardEventResult(editor, model, rawEvent, isChanged);
@@ -25,6 +30,8 @@ export default function handleDeleteKey(editor: IContentModelEditor, rawEvent: K
         },
         {
             skipUndoSnapshot: true, // No need to add undo snapshot for each key down event. We will trigger a ContentChanged event and let UndoPlugin decide when to add undo snapshot
+            changeSource: ChangeSource.Keyboard,
+            getChangeData: () => rawEvent.which,
         }
     );
 }

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -89,6 +89,10 @@ export function formatWithContentModel(
 
         if (skipUndoSnapshot) {
             callback();
+
+            if (changeSource) {
+                editor.triggerContentChangedEvent(changeSource, getChangeData?.());
+            }
         } else {
             editor.addUndoSnapshot(
                 callback,

--- a/packages/roosterjs-content-model/test/editor/plugins/ContentModelEditPluginTest.ts
+++ b/packages/roosterjs-content-model/test/editor/plugins/ContentModelEditPluginTest.ts
@@ -1,199 +1,14 @@
 import * as handleBackspaceKey from '../../../lib/publicApi/editing/handleBackspaceKey';
 import * as handleDeleteKey from '../../../lib/publicApi/editing/handleDeleteKey';
 import ContentModelEditPlugin from '../../../lib/editor/plugins/ContentModelEditPlugin';
+import { EntityOperation, Keys, PluginEventType } from 'roosterjs-editor-types';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
-import { Keys, PluginEventType } from 'roosterjs-editor-types';
 
 describe('ContentModelEditPlugin', () => {
     let editor: IContentModelEditor;
 
     beforeEach(() => {
         editor = ({} as any) as IContentModelEditor;
-    });
-
-    describe('willHandleEventExclusively', () => {
-        it('Handle other events', () => {
-            const plugin = new ContentModelEditPlugin();
-
-            plugin.initialize(editor);
-
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.EditorReady,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.KeyPress,
-                    rawEvent: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.KeyUp,
-                    rawEvent: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.Input,
-                    rawEvent: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.CompositionEnd,
-                    rawEvent: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.MouseDown,
-                    rawEvent: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.MouseUp,
-                    rawEvent: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.ContentChanged,
-                    source: '',
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.ExtractContentWithDom,
-                    clonedRoot: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.BeforeCutCopy,
-                    rawEvent: {} as any,
-                    clonedRoot: {} as any,
-                    range: {} as any,
-                    isCut: false,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.BeforePaste,
-                    clipboardData: {} as any,
-                    fragment: {} as any,
-                    sanitizingOption: {} as any,
-                    htmlBefore: {} as any,
-                    htmlAfter: {} as any,
-                    htmlAttributes: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.BeforeDispose,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.PendingFormatStateChanged,
-                    formatState: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.Scroll,
-                    scrollContainer: {} as any,
-                    rawEvent: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.EntityOperation,
-                    operation: {} as any,
-                    entity: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.ContextMenu,
-                    items: {} as any,
-                    rawEvent: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.EnteredShadowEdit,
-                    fragment: {} as any,
-                    selectionPath: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.LeavingShadowEdit,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.EditImage,
-                    image: {} as any,
-                    originalSrc: {} as any,
-                    previousSrc: {} as any,
-                    newSrc: {} as any,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.BeforeSetContent,
-                    newContent: '',
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.ZoomChanged,
-                    oldZoomScale: 1,
-                    newZoomScale: 2,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.SelectionChanged,
-                    selectionRangeEx: {} as any,
-                })
-            ).toBeFalse();
-        });
-
-        it('Handle KeyDown events', () => {
-            const plugin = new ContentModelEditPlugin();
-
-            plugin.initialize(editor);
-
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.KeyDown,
-                    rawEvent: ({
-                        which: Keys.ESCAPE,
-                    } as any) as KeyboardEvent,
-                })
-            ).toBeFalse();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.KeyDown,
-                    rawEvent: ({
-                        which: Keys.DELETE,
-                    } as any) as KeyboardEvent,
-                })
-            ).toBeTrue();
-            expect(
-                plugin.willHandleEventExclusively({
-                    eventType: PluginEventType.KeyDown,
-                    rawEvent: ({
-                        which: Keys.BACKSPACE,
-                    } as any) as KeyboardEvent,
-                })
-            ).toBeTrue();
-        });
     });
 
     describe('onPluginEvent', () => {
@@ -216,7 +31,7 @@ describe('ContentModelEditPlugin', () => {
                 rawEvent,
             });
 
-            expect(handleBackspaceKeySpy).toHaveBeenCalledWith(editor, rawEvent);
+            expect(handleBackspaceKeySpy).toHaveBeenCalledWith(editor, rawEvent, []);
             expect(handleDeleteKeySpy).not.toHaveBeenCalled();
         });
 
@@ -232,7 +47,7 @@ describe('ContentModelEditPlugin', () => {
             });
 
             expect(handleBackspaceKeySpy).not.toHaveBeenCalled();
-            expect(handleDeleteKeySpy).toHaveBeenCalledWith(editor, rawEvent);
+            expect(handleDeleteKeySpy).toHaveBeenCalledWith(editor, rawEvent, []);
         });
 
         it('Other key', () => {
@@ -248,6 +63,67 @@ describe('ContentModelEditPlugin', () => {
 
             expect(handleBackspaceKeySpy).not.toHaveBeenCalled();
             expect(handleDeleteKeySpy).not.toHaveBeenCalled();
+        });
+
+        it('Default prevented', () => {
+            const plugin = new ContentModelEditPlugin();
+            const rawEvent = { which: Keys.DELETE, defaultPrevented: true } as any;
+
+            plugin.initialize(editor);
+
+            plugin.onPluginEvent({
+                eventType: PluginEventType.KeyDown,
+                rawEvent,
+            });
+
+            expect(handleBackspaceKeySpy).not.toHaveBeenCalled();
+            expect(handleDeleteKeySpy).not.toHaveBeenCalled();
+        });
+
+        it('Trigger entity event first', () => {
+            const plugin = new ContentModelEditPlugin();
+            const wrapper = 'WRAPPER' as any;
+
+            plugin.initialize(editor);
+
+            plugin.onPluginEvent({
+                eventType: PluginEventType.EntityOperation,
+                operation: EntityOperation.Overwrite,
+                rawEvent: {
+                    type: 'keydown',
+                } as any,
+                entity: wrapper,
+            });
+
+            plugin.onPluginEvent({
+                eventType: PluginEventType.KeyDown,
+                rawEvent: { which: Keys.DELETE } as any,
+            });
+
+            expect(handleBackspaceKeySpy).not.toHaveBeenCalled();
+            expect(handleDeleteKeySpy).toHaveBeenCalledTimes(1);
+            expect(handleDeleteKeySpy).toHaveBeenCalledWith(editor, { which: Keys.DELETE } as any, [
+                {
+                    eventType: PluginEventType.EntityOperation,
+                    operation: EntityOperation.Overwrite,
+                    rawEvent: {
+                        type: 'keydown',
+                    } as any,
+                    entity: wrapper,
+                },
+            ]);
+
+            plugin.onPluginEvent({
+                eventType: PluginEventType.KeyDown,
+                rawEvent: { which: Keys.DELETE } as any,
+            });
+
+            expect(handleDeleteKeySpy).toHaveBeenCalledTimes(2);
+            expect(handleDeleteKeySpy).toHaveBeenCalledWith(
+                editor,
+                { which: Keys.DELETE } as any,
+                []
+            );
         });
     });
 });

--- a/packages/roosterjs-content-model/test/editor/utils/handleKeyboardEventCommonTest.ts
+++ b/packages/roosterjs-content-model/test/editor/utils/handleKeyboardEventCommonTest.ts
@@ -1,5 +1,5 @@
 import * as normalizeContentModel from '../../../lib/modelApi/common/normalizeContentModel';
-import { ChangeSource, EntityOperation, PluginEventType } from 'roosterjs-editor-types';
+import { EntityOperation, PluginEventType } from 'roosterjs-editor-types';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 import {
     getOnDeleteEntityCallback,
@@ -22,7 +22,7 @@ describe('getOnDeleteEntityCallback', () => {
     });
 
     it('Entity without id', () => {
-        const func = getOnDeleteEntityCallback(mockedEditor, mockedEvent);
+        const func = getOnDeleteEntityCallback(mockedEditor, mockedEvent, []);
 
         const result = func(
             {
@@ -40,7 +40,7 @@ describe('getOnDeleteEntityCallback', () => {
     });
 
     it('Entity with id and type', () => {
-        const func = getOnDeleteEntityCallback(mockedEditor, mockedEvent);
+        const func = getOnDeleteEntityCallback(mockedEditor, mockedEvent, []);
 
         const result = func(
             {
@@ -73,7 +73,7 @@ describe('getOnDeleteEntityCallback', () => {
             param.rawEvent.defaultPrevented = true;
         });
 
-        const func = getOnDeleteEntityCallback(mockedEditor, mockedEvent);
+        const func = getOnDeleteEntityCallback(mockedEditor, mockedEvent, []);
 
         const result = func(
             {
@@ -99,6 +99,25 @@ describe('getOnDeleteEntityCallback', () => {
             operation: EntityOperation.RemoveFromStart,
             rawEvent: mockedEvent,
         });
+    });
+
+    it('Call with triggeredEntityEvents', () => {
+        const wrapper = 'WRAPPER';
+        const entity = {
+            wrapper,
+        } as any;
+        const func = getOnDeleteEntityCallback(mockedEditor, mockedEvent, [
+            {
+                eventType: PluginEventType.EntityOperation,
+                operation: EntityOperation.Overwrite,
+                entity,
+            },
+        ]);
+
+        const result = func({ wrapper } as any, EntityOperation.Overwrite);
+
+        expect(result).toBeFalse();
+        expect(triggerPluginEvent).not.toHaveBeenCalled();
     });
 });
 
@@ -134,7 +153,7 @@ describe('handleKeyboardEventResult', () => {
 
         expect(preventDefault).toHaveBeenCalled();
         expect(normalizeContentModel.normalizeContentModel).toHaveBeenCalledWith(mockedModel);
-        expect(triggerContentChangedEvent).toHaveBeenCalledWith(ChangeSource.Keyboard, which);
+        expect(triggerContentChangedEvent).not.toHaveBeenCalled();
         expect(cacheContentModel).not.toHaveBeenCalled();
     });
 

--- a/packages/roosterjs-content-model/test/publicApi/editing/editingTestCommon.ts
+++ b/packages/roosterjs-content-model/test/publicApi/editing/editingTestCommon.ts
@@ -13,6 +13,8 @@ export function editingTestCommon(
     spyOn(pendingFormat, 'setPendingFormat');
     spyOn(pendingFormat, 'getPendingFormat').and.returnValue(null);
 
+    const triggerContentChangedEvent = jasmine.createSpy('triggerContentChangedEvent');
+
     const addUndoSnapshot = jasmine
         .createSpy('addUndoSnapshot')
         .and.callFake((callback: () => void, source: string, _, param: any) => {
@@ -32,6 +34,7 @@ export function editingTestCommon(
         setContentModel,
         isDisposed: () => false,
         getFocusedPosition: () => null as NodePosition,
+        triggerContentChangedEvent,
     } as any) as IContentModelEditor;
 
     executionCallback(editor);

--- a/packages/roosterjs-content-model/test/publicApi/editing/handleBackspaceKeyTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/editing/handleBackspaceKeyTest.ts
@@ -1,6 +1,8 @@
 import * as deleteSelection from '../../../lib/modelApi/selection/deleteSelections';
+import * as formatWithContentModel from '../../../lib/publicApi/utils/formatWithContentModel';
 import * as handleKeyboardEventResult from '../../../lib/editor/utils/handleKeyboardEventCommon';
 import handleBackspaceKey from '../../../lib/publicApi/editing/handleBackspaceKey';
+import { ChangeSource } from 'roosterjs-editor-types';
 import { ContentModelDocument } from '../../../lib/publicTypes/group/ContentModelDocument';
 import { editingTestCommon } from './editingTestCommon';
 
@@ -33,7 +35,7 @@ describe('handleBackspaceKey', () => {
             'handleBackspaceKey',
             newEditor => {
                 editor = newEditor;
-                handleBackspaceKey(editor, mockedEvent);
+                handleBackspaceKey(editor, mockedEvent, []);
             },
             input,
             expectedResult,
@@ -42,7 +44,8 @@ describe('handleBackspaceKey', () => {
 
         expect(handleKeyboardEventResult.getOnDeleteEntityCallback).toHaveBeenCalledWith(
             editor,
-            mockedEvent
+            mockedEvent,
+            []
         );
         expect(deleteSelectionSpy).toHaveBeenCalledWith(input, {
             direction: 'backward',
@@ -157,5 +160,24 @@ describe('handleBackspaceKey', () => {
             true,
             1
         );
+    });
+
+    it('Check parameter of formatWithContentModel', () => {
+        const spy = spyOn(formatWithContentModel, 'formatWithContentModel');
+
+        const editor = 'EDITOR' as any;
+        const which = 'WHICH';
+        const event = {
+            which,
+        } as any;
+        const triggeredEvents = 'EVENTS' as any;
+
+        handleBackspaceKey(editor, event, triggeredEvents);
+
+        expect(spy.calls.argsFor(0)[0]).toBe(editor);
+        expect(spy.calls.argsFor(0)[1]).toBe('handleBackspaceKey');
+        expect(spy.calls.argsFor(0)[3]?.skipUndoSnapshot).toBe(true);
+        expect(spy.calls.argsFor(0)[3]?.changeSource).toBe(ChangeSource.Keyboard);
+        expect(spy.calls.argsFor(0)[3]?.getChangeData?.()).toBe(which);
     });
 });

--- a/packages/roosterjs-content-model/test/publicApi/editing/handleDeleteKeyTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/editing/handleDeleteKeyTest.ts
@@ -1,6 +1,8 @@
 import * as deleteSelection from '../../../lib/modelApi/selection/deleteSelections';
+import * as formatWithContentModel from '../../../lib/publicApi/utils/formatWithContentModel';
 import * as handleKeyboardEventResult from '../../../lib/editor/utils/handleKeyboardEventCommon';
 import handleDeleteKey from '../../../lib/publicApi/editing/handleDeleteKey';
+import { ChangeSource } from 'roosterjs-editor-types';
 import { ContentModelDocument } from '../../../lib/publicTypes/group/ContentModelDocument';
 import { editingTestCommon } from './editingTestCommon';
 
@@ -33,7 +35,7 @@ describe('handleDeleteKey', () => {
             'handleBackspaceKey',
             newEditor => {
                 editor = newEditor;
-                handleDeleteKey(editor, mockedEvent);
+                handleDeleteKey(editor, mockedEvent, []);
             },
             input,
             expectedResult,
@@ -42,7 +44,8 @@ describe('handleDeleteKey', () => {
 
         expect(handleKeyboardEventResult.getOnDeleteEntityCallback).toHaveBeenCalledWith(
             editor,
-            mockedEvent
+            mockedEvent,
+            []
         );
         expect(deleteSelectionSpy).toHaveBeenCalledWith(input, {
             direction: 'forward',
@@ -157,5 +160,24 @@ describe('handleDeleteKey', () => {
             true,
             1
         );
+    });
+
+    it('Check parameter of formatWithContentModel', () => {
+        const spy = spyOn(formatWithContentModel, 'formatWithContentModel');
+
+        const editor = 'EDITOR' as any;
+        const which = 'WHICH';
+        const event = {
+            which,
+        } as any;
+        const triggeredEvents = 'EVENTS' as any;
+
+        handleDeleteKey(editor, event, triggeredEvents);
+
+        expect(spy.calls.argsFor(0)[0]).toBe(editor);
+        expect(spy.calls.argsFor(0)[1]).toBe('handleDeleteKey');
+        expect(spy.calls.argsFor(0)[3]?.skipUndoSnapshot).toBe(true);
+        expect(spy.calls.argsFor(0)[3]?.changeSource).toBe(ChangeSource.Keyboard);
+        expect(spy.calls.argsFor(0)[3]?.getChangeData?.()).toBe(which);
     });
 });

--- a/packages/roosterjs-content-model/test/publicApi/utils/formatWithContentModelTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/utils/formatWithContentModelTest.ts
@@ -13,6 +13,7 @@ describe('formatWithContentModel', () => {
     let mockedModel: ContentModelDocument;
     let cacheContentModel: jasmine.Spy;
     let getFocusedPosition: jasmine.Spy;
+    let triggerContentChangedEvent: jasmine.Spy;
 
     const apiName = 'mockedApi';
     const mockedPos = 'POS' as any;
@@ -26,6 +27,7 @@ describe('formatWithContentModel', () => {
         focus = jasmine.createSpy('focus');
         cacheContentModel = jasmine.createSpy('cacheContentModel');
         getFocusedPosition = jasmine.createSpy('getFocusedPosition').and.returnValue(mockedPos);
+        triggerContentChangedEvent = jasmine.createSpy('triggerContentChangedEvent');
 
         editor = ({
             focus,
@@ -34,6 +36,7 @@ describe('formatWithContentModel', () => {
             setContentModel,
             cacheContentModel,
             getFocusedPosition,
+            triggerContentChangedEvent,
         } as any) as IContentModelEditor;
     });
 
@@ -119,6 +122,21 @@ describe('formatWithContentModel', () => {
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).toHaveBeenCalled();
         expect(addUndoSnapshot.calls.argsFor(0)[1]).toBe('TEST');
+    });
+
+    it('Customize change source and skip undo snapshot', () => {
+        const callback = jasmine.createSpy('callback').and.returnValue(true);
+
+        formatWithContentModel(editor, apiName, callback, {
+            changeSource: 'TEST',
+            skipUndoSnapshot: true,
+            getChangeData: () => 'DATA',
+        });
+
+        expect(callback).toHaveBeenCalledWith(mockedModel);
+        expect(createContentModel).toHaveBeenCalledTimes(1);
+        expect(addUndoSnapshot).not.toHaveBeenCalled();
+        expect(triggerContentChangedEvent).toHaveBeenCalledWith('TEST', 'DATA');
     });
 
     it('Has onNodeCreated', () => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -1,5 +1,6 @@
 import { isCharacterValue, isCtrlOrMetaPressed, matchLink } from 'roosterjs-editor-dom';
 import {
+    ChangeSource,
     DOMEventHandler,
     EditorPlugin,
     IEditor,
@@ -105,6 +106,18 @@ export default class HyperLink implements EditorPlugin {
                 (anchor && anchor !== this.trackedLink) ||
                 event.eventType == PluginEventType.KeyUp ||
                 event.eventType == PluginEventType.ContentChanged;
+
+            if (
+                event.eventType == PluginEventType.ContentChanged &&
+                event.source == ChangeSource.Keyboard &&
+                this.trackedLink != anchor &&
+                anchor
+            ) {
+                // For Keyboard event that causes content change (mostly come from Content Model), this tracked list may be staled.
+                // So we need to get an up-to-date link element
+                // TODO: This is a temporary solution. Later when Content Model can fully take over this behavior, we can remove this code.
+                this.trackedLink = anchor;
+            }
 
             if (
                 this.trackedLink &&


### PR DESCRIPTION
This is a part of #1664.

At beginning, I was planning to replace all content edit features with content model (ContentModelEditPlugin). However, I found there will be too many things to work on. Given that the main goal of this plugin for now is to take over editing behavior from browser, but not replace existing edit features, and those features are working well, I changed the plan to be:
1. When there is a keydown event, let other plugins handle first
2. After other plugins, if the default behavior of the raw event is not prevented, it means we want to rely on browser's editing behavior. So the new ContentModelEditPlugin can handle this event (for now, only handle DELETE and BACKSPACE key)
3. Later we can start to port existing edit features to Content Model one by one.

With this plan, we can enable the content model editing plugin earlier, and do change incrementally.

To do this, we need to remove "willHandleEventExclusively" from ContentModelEditPlugin so that all other plugins can handle the event. We also need to fix those known conflict behavior between old code and Content Model, including:
1. Hyperlink plugin, we need to let this plugin handle url change when delete/backspace within a link
2. Entity events: sometimes a single delete will trigger EntityOperation event twice, one from old code and one from Content Model. We will remember event triggered from old code then skip triggering same event from Content Model.

Related test cases fixed and added.