### PR TITLE
Content Model: Fix #1684

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/listProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/listProcessor.ts
@@ -14,15 +14,16 @@ export const listProcessor: ElementProcessor<HTMLOListElement | HTMLUListElement
     element,
     context
 ) => {
-    const level: ContentModelListItemLevelFormat = {};
-    const { listFormat } = context;
-
     stackFormat(
         context,
         {
             segment: 'shallowCloneForBlock',
+            paragraph: 'shallowCopyInherit',
         },
         () => {
+            const level: ContentModelListItemLevelFormat = { ...context.blockFormat };
+            const { listFormat } = context;
+
             processMetadata(element, context, level);
             parseFormat(element, context.formatParsers.listLevel, level, context);
             parseFormat(element, context.formatParsers.segment, context.segmentFormat, context);

--- a/packages/roosterjs-content-model/test/domToModel/processors/listProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/listProcessorTest.ts
@@ -484,4 +484,41 @@ describe('listProcessor process metadata', () => {
 
         expect(childProcessor).toHaveBeenCalledTimes(1);
     });
+
+    it('Context has block formats', () => {
+        const ol = document.createElement('ol');
+        const li = document.createElement('li');
+        const group = createContentModelDocument();
+
+        ol.appendChild(li);
+
+        context.blockFormat.direction = 'rtl';
+
+        childProcessor.and.callFake(originalChildProcessor);
+
+        listProcessor(group, ol, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            direction: 'rtl',
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: true,
+                    },
+                    format: {},
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
#1684 We need to respect direction style from parent container when process List.

To fix it, clone the block format for list level and use it as initial value of list level format.

There is a known issue after this fix: #1729 LTR/RTL command won't work for OL/UL element with direction specified. We need a separate fix for this issue.