### PR TITLE
Content Model fidelity improvement 1: Support lineHeight in list

### DIFF
--- a/demo/scripts/controls/contentModel/components/model/ContentModelListItemView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelListItemView.tsx
@@ -6,6 +6,7 @@ import { FontFamilyFormatRenderer } from '../format/formatPart/FontFamilyFormatR
 import { FontSizeFormatRenderer } from '../format/formatPart/FontSizeFormatRenderer';
 import { FormatRenderer } from '../format/utils/FormatRenderer';
 import { FormatView } from '../format/FormatView';
+import { LineHeightFormatRenderer } from '../format/formatPart/LineHeightFormatRenderer';
 import { ListMetadataFormatRenderers } from '../format/formatPart/ListMetadataFormatRenderers';
 import { ListThreadFormatRenderers } from '../format/formatPart/ListThreadFormatRenderer';
 import { ListTypeFormatRenderer } from '../format/formatPart/ListTypeFormatRenderer';
@@ -14,6 +15,7 @@ import { TextColorFormatRenderer } from '../format/formatPart/TextColorFormatRen
 import { useProperty } from '../../hooks/useProperty';
 import {
     ContentModelListItem,
+    ContentModelListItemFormat,
     ContentModelListItemLevelFormat,
     ContentModelSegmentFormat,
     hasSelectionInBlockGroup,
@@ -28,7 +30,10 @@ const ListLevelFormatRenders: FormatRenderer<ContentModelListItemLevelFormat>[] 
     ...DirectionFormatRenderers,
     MarginFormatRenderer,
 ];
-
+const ListItemFormatRenderers: FormatRenderer<ContentModelListItemFormat>[] = [
+    ...DirectionFormatRenderers,
+    LineHeightFormatRenderer,
+];
 const ListItemFormatHolderRenderers: FormatRenderer<ContentModelSegmentFormat>[] = [
     TextColorFormatRenderer,
     FontSizeFormatRenderer,
@@ -69,6 +74,10 @@ export function ContentModelListItemView(props: { listItem: ContentModelListItem
                     />
                 ))}
                 <hr className={styles.hr} />
+
+                <div>List item format:</div>
+                <FormatView format={listItem.format} renderers={ListItemFormatRenderers} />
+
                 <div>List marker format:</div>
                 <FormatView
                     format={listItem.formatHolder.format}

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -95,7 +95,7 @@ const defaultFormatKeysPerCategory: {
 } = {
     block: blockFormatHandlers,
     listItem: ['listItemThread', 'listItemMetadata'],
-    listItemElement: ['direction'],
+    listItemElement: ['direction', 'lineHeight'],
     listLevel: ['listType', 'listLevelThread', 'listLevelMetadata', 'direction', 'margin'],
     segment: [
         'superOrSubScript',

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelListItemFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelListItemFormat.ts
@@ -1,6 +1,7 @@
 import { DirectionFormat } from './formatParts/DirectionFormat';
+import { LineHeightFormat } from './formatParts/LineHeightFormat';
 
 /**
  * The format object for a list item in Content Model
  */
-export type ContentModelListItemFormat = DirectionFormat;
+export type ContentModelListItemFormat = DirectionFormat & LineHeightFormat;


### PR DESCRIPTION
I'll make a series changes to improve content model fidelity.

In this change I add lineHeight format into ContentModelListItemFormat so that if there is lineHeight style in original content, it will be preserved after content model is used.