### PR TITLE
Content Model fidelity improvement 2: Support size in divider

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/hrProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/hrProcessor.ts
@@ -18,6 +18,10 @@ export const hrProcessor: ElementProcessor<HTMLHRElement> = (group, element, con
 
             const hr = createDivider('hr', context.blockFormat);
 
+            if (element.size) {
+                hr.size = element.size;
+            }
+
             if (context.isInSelection) {
                 hr.isSelected = true;
             }

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleDivider.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleDivider.ts
@@ -25,6 +25,10 @@ export const handleDivider: ContentModelBlockHandler<ContentModelDivider> = (
         parent.insertBefore(element, refNode);
 
         applyFormat(element, context.formatAppliers.divider, divider.format, context);
+
+        if (divider.size) {
+            element.setAttribute('size', divider.size);
+        }
     }
 
     context.onNodeCreated?.(divider, element);

--- a/packages/roosterjs-content-model/lib/publicTypes/block/ContentModelDivider.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/block/ContentModelDivider.ts
@@ -14,4 +14,9 @@ export interface ContentModelDivider
      * Tag name of this element, either HR or DIV
      */
     tagName: 'hr' | 'div';
+
+    /**
+     * Size property for HR
+     */
+    size?: string;
 }

--- a/packages/roosterjs-content-model/test/domToModel/processors/hrProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/hrProcessorTest.ts
@@ -73,12 +73,13 @@ describe('hrProcessor', () => {
         });
     });
 
-    it('HR with width and display', () => {
+    it('HR with width, size and display', () => {
         const doc = createContentModelDocument();
         const hr = document.createElement('hr');
 
         hr.style.display = 'inline-block';
         hr.style.width = '98%';
+        hr.size = '2';
 
         hrProcessor(doc, hr, context);
 
@@ -88,6 +89,7 @@ describe('hrProcessor', () => {
                 {
                     blockType: 'Divider',
                     tagName: 'hr',
+                    size: '2',
                     format: {
                         display: 'inline-block',
                         width: '98%',

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleDividerTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleDividerTest.ts
@@ -55,7 +55,7 @@ describe('handleDivider', () => {
         expect(hr.cachedElement).toBe(parent.firstChild as HTMLElement);
     });
 
-    it('HR with size and display', () => {
+    it('HR with width, size and display', () => {
         const hr: ContentModelDivider = {
             blockType: 'Divider',
             tagName: 'hr',
@@ -63,13 +63,14 @@ describe('handleDivider', () => {
                 display: 'inline-block',
                 width: '98%',
             },
+            size: '2',
         };
 
         const parent = document.createElement('div');
 
         handleDivider(document, parent, hr, context, null);
 
-        expect(parent.innerHTML).toBe('<hr style="display: inline-block; width: 98%;">');
+        expect(parent.innerHTML).toBe('<hr size="2" style="display: inline-block; width: 98%;">');
         expect(hr.cachedElement).toBe(parent.firstChild as HTMLElement);
     });
 

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleDividerTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleDividerTest.ts
@@ -70,7 +70,12 @@ describe('handleDivider', () => {
 
         handleDivider(document, parent, hr, context, null);
 
-        expect(parent.innerHTML).toBe('<hr size="2" style="display: inline-block; width: 98%;">');
+        expect(
+            [
+                '<hr size="2" style="display: inline-block; width: 98%;">',
+                '<hr style="display: inline-block; width: 98%;" size="2">',
+            ].indexOf(parent.innerHTML) >= 0
+        ).toBeTrue();
         expect(hr.cachedElement).toBe(parent.firstChild as HTMLElement);
     });
 


### PR DESCRIPTION
I'll make a series changes to improve content model fidelity.

In this change I add size property to ContentModelDivider so that if "size" is specified in HR element, it can be preserved.