### PR TITLE
Allow Content Model API to remove image border

### DIFF
--- a/demo/scripts/controls/ribbonButtons/contentModel/ContentModelRibbon.tsx
+++ b/demo/scripts/controls/ribbonButtons/contentModel/ContentModelRibbon.tsx
@@ -18,6 +18,7 @@ import { formatTableButton } from './formatTableButton';
 import { imageBorderColorButton } from './imageBorderColorButton';
 import { imageBorderStyleButton } from './imageBorderStyleButton';
 import { imageBorderWidthButton } from './imageBorderWidthButton';
+import { imageBorderRemoveButton } from './imageBorderRemoveButton';
 import { imageBoxShadowButton } from './imageBoxShadowButton';
 import { increaseFontSizeButton } from './increaseFontSizeButton';
 import { increaseIndentButton } from './increaseIndentButton';
@@ -98,6 +99,7 @@ const buttons = [
     imageBorderColorButton,
     imageBorderWidthButton,
     imageBorderStyleButton,
+    imageBorderRemoveButton,
     changeImageButton,
     imageBoxShadowButton,
     spacingButton,

--- a/demo/scripts/controls/ribbonButtons/contentModel/imageBorderRemoveButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/imageBorderRemoveButton.ts
@@ -1,0 +1,19 @@
+import { isContentModelEditor } from 'roosterjs-content-model';
+import { RibbonButton } from 'roosterjs-react';
+import { setImageBorder } from 'roosterjs-content-model';
+
+/**
+ * @internal
+ * "Remove Image Border" button on the format ribbon
+ */
+export const imageBorderRemoveButton: RibbonButton<'buttonNameImageBorderRemove'> = {
+    key: 'buttonNameImageBorderRemove',
+    unlocalizedText: 'Remove Image Border',
+    iconName: 'Cancel',
+    isDisabled: formatState => !formatState.canAddImageAltText,
+    onClick: editor => {
+        if (isContentModelEditor(editor)) {
+            setImageBorder(editor, null);
+        }
+    },
+};

--- a/packages/roosterjs-content-model/lib/modelApi/image/applyImageBorderFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/image/applyImageBorderFormat.ts
@@ -8,46 +8,52 @@ import { parseValueWithUnit } from '../../formatHandlers/utils/parseValueWithUni
  */
 export default function applyImageBorderFormat(
     image: ContentModelImage,
-    border: Border,
+    border: Border | null,
     borderRadius?: string
 ) {
-    const format = image.format;
-    const { width, style, color } = border;
-    const borderKey = 'borderTop';
-    const extractedBorder = extractBorderValues(format[borderKey]);
-    const borderColor = extractedBorder.color;
-    const borderWidth = extractedBorder.width;
-    const borderStyle = extractedBorder.style;
-    let borderFormat = '';
+    if (border) {
+        const format = image.format;
+        const { width, style, color } = border;
+        const borderKey = 'borderTop';
+        const extractedBorder = extractBorderValues(format[borderKey]);
+        const borderColor = extractedBorder.color;
+        const borderWidth = extractedBorder.width;
+        const borderStyle = extractedBorder.style;
+        let borderFormat = '';
 
-    if (width) {
-        borderFormat = parseValueWithUnit(width) + 'px';
-    } else if (borderWidth) {
-        borderFormat = borderWidth;
+        if (width) {
+            borderFormat = parseValueWithUnit(width) + 'px';
+        } else if (borderWidth) {
+            borderFormat = borderWidth;
+        } else {
+            borderFormat = '1px';
+        }
+
+        if (style) {
+            borderFormat = `${borderFormat} ${style}`;
+        } else if (borderStyle) {
+            borderFormat = `${borderFormat} ${borderStyle}`;
+        } else {
+            borderFormat = `${borderFormat} solid`;
+        }
+
+        if (color) {
+            borderFormat = `${borderFormat} ${color}`;
+        } else if (borderColor) {
+            borderFormat = `${borderFormat} ${borderColor}`;
+        }
+        image.format.borderLeft = borderFormat;
+        image.format.borderTop = borderFormat;
+        image.format.borderBottom = borderFormat;
+        image.format.borderRight = borderFormat;
     } else {
-        borderFormat = '1px';
-    }
-
-    if (style) {
-        borderFormat = `${borderFormat} ${style}`;
-    } else if (borderStyle) {
-        borderFormat = `${borderFormat} ${borderStyle}`;
-    } else {
-        borderFormat = `${borderFormat} solid`;
-    }
-
-    if (color) {
-        borderFormat = `${borderFormat} ${color}`;
-    } else if (borderColor) {
-        borderFormat = `${borderFormat} ${borderColor}`;
+        delete image.format.borderLeft;
+        delete image.format.borderTop;
+        delete image.format.borderBottom;
+        delete image.format.borderRight;
     }
 
     if (borderRadius) {
         image.format.borderRadius = borderRadius;
     }
-
-    image.format.borderLeft = borderFormat;
-    image.format.borderTop = borderFormat;
-    image.format.borderBottom = borderFormat;
-    image.format.borderRight = borderFormat;
 }

--- a/packages/roosterjs-content-model/lib/publicApi/image/setImageBorder.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/setImageBorder.ts
@@ -8,12 +8,12 @@ import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
  * Set image border style for all selected images at selection.
  * @param editor The editor instance
  * @param border the border format object. Ex: { color: 'red', width: '10px', style: 'solid'}, if one of the value in object is undefined
- * its value will not be changed
+ * its value will not be changed. Passing null instead of an object will remove the border
  * @param borderRadius the border radius value, if undefined, the border radius will keep the actual value
  */
 export default function setImageBorder(
     editor: IContentModelEditor,
-    border: Border,
+    border: Border | null,
     borderRadius?: string
 ) {
     formatImageWithContentModel(editor, 'setImageBorder', (image: ContentModelImage) => {

--- a/packages/roosterjs-content-model/test/modelApi/image/applyImageBorderFormatTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/image/applyImageBorderFormatTest.ts
@@ -20,7 +20,11 @@ describe('applyImageBorderFormat', () => {
         };
     }
 
-    function runTest(format: Border, expectedBorder: string, previousBorder?: string) {
+    function runTest(
+        format: Border | null,
+        expectedBorder: string | undefined,
+        previousBorder?: string
+    ) {
         const image = createImage(previousBorder);
         applyImageBorderFormat(image, format, '5px');
         expect(image.format.borderBottom).toBe(expectedBorder);
@@ -154,5 +158,9 @@ describe('applyImageBorderFormat', () => {
             },
             '20px dotted'
         );
+    });
+
+    it('remove border', () => {
+        runTest(null /* remove format */, undefined /* no expected border */, '10px groove blue');
     });
 });

--- a/packages/roosterjs-content-model/test/publicApi/image/setImageBorderTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/image/setImageBorderTest.ts
@@ -12,7 +12,7 @@ describe('setImageBorder', () => {
         model: ContentModelDocument,
         result: ContentModelDocument,
         calledTimes: number,
-        border: Border,
+        border: Border | null,
         borderRadius?: string
     ) {
         segmentTestCommon(
@@ -301,6 +301,48 @@ describe('setImageBorder', () => {
             },
             1,
             { color: 'red', style: 'groove', width: '10pt' },
+            '5px'
+        );
+    });
+
+    it('Doc with selection and image - remove border', () => {
+        const doc = createContentModelDocument();
+        const img = createImage('test', {
+            borderBottom: '1px solid red',
+            borderLeft: '1px solid red',
+            borderRight: '1px solid red',
+            borderTop: '1px solid red',
+        });
+
+        img.isSelected = true;
+
+        addSegment(doc, img);
+
+        runTest(
+            doc,
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {},
+                        isImplicit: true,
+                        segments: [
+                            {
+                                segmentType: 'Image',
+                                src: 'test',
+                                isSelected: true,
+                                dataset: {},
+                                format: {
+                                    borderRadius: '5px',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+            1,
+            null /* remove */,
             '5px'
         );
     });


### PR DESCRIPTION
For `setImageBorder` content model API, allow the second parameter (`border`) to be `null`.
If this parameter is set to null, remove all border formats set, excluding border radius.

Additionally add testing and a demo ribbon button for it.

![image](https://user-images.githubusercontent.com/44042957/232664566-151423fe-c74a-41ac-ad86-247deb3b2ca5.png)

![image border remove](https://user-images.githubusercontent.com/44042957/232664732-93c46c9a-8bcb-448d-bf0f-9efa9db95bff.gif)
