### PR TITLE
Content Model: Fix #1738 delete space issue

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -22,7 +22,7 @@ const initialState: BuildInPluginState = {
         contextMenu: true,
         autoFormat: true,
         contentModelFormat: true,
-        contentModelEdit: false,
+        contentModelEdit: true,
     },
     contentEditFeatures: getDefaultContentEditFeatureSettings(),
     defaultFormat: {},

--- a/packages/roosterjs-content-model/lib/editor/plugins/ContentModelEditPlugin.ts
+++ b/packages/roosterjs-content-model/lib/editor/plugins/ContentModelEditPlugin.ts
@@ -82,12 +82,21 @@ export default class ContentModelEditPlugin implements EditorPlugin {
                                 this.triggeredEntityEvents
                             );
                             break;
+
+                        default:
+                            this.editor.cacheContentModel(null);
+                            break;
                     }
                 }
 
                 if (this.triggeredEntityEvents.length > 0) {
                     this.triggeredEntityEvents = [];
                 }
+            } else if (
+                event.eventType == PluginEventType.ContentChanged ||
+                event.eventType == PluginEventType.MouseUp
+            ) {
+                this.editor.cacheContentModel(null);
             }
         }
     }

--- a/packages/roosterjs-content-model/lib/editor/plugins/ContentModelFormatPlugin.ts
+++ b/packages/roosterjs-content-model/lib/editor/plugins/ContentModelFormatPlugin.ts
@@ -64,18 +64,13 @@ export default class ContentModelFormatPlugin implements EditorPlugin {
 
             case PluginEventType.KeyDown:
                 if (event.rawEvent.which >= Keys.PAGEUP && event.rawEvent.which <= Keys.DOWN) {
-                    this.editor.cacheContentModel(null);
                     clearPendingFormat(this.editor);
-                } else {
-                    this.editor.cacheContentModel(null);
                 }
 
                 break;
 
             case PluginEventType.MouseUp:
             case PluginEventType.ContentChanged:
-                this.editor.cacheContentModel(null);
-
                 if (!canApplyPendingFormat(this.editor)) {
                     clearPendingFormat(this.editor);
                 }

--- a/packages/roosterjs-content-model/lib/modelApi/common/isWhiteSpacePreserved.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/isWhiteSpacePreserved.ts
@@ -1,0 +1,15 @@
+import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
+
+// According to https://developer.mozilla.org/en-US/docs/Web/CSS/white-space, these style values will need to preserve white spaces
+const WHITESPACE_PRE_VALUES = ['pre', 'pre-wrap', 'break-spaces'];
+
+/**
+ * @internal
+ */
+export function isWhiteSpacePreserved(paragraph: ContentModelParagraph): boolean {
+    return (
+        (paragraph.format.whiteSpace &&
+            WHITESPACE_PRE_VALUES.indexOf(paragraph.format.whiteSpace) >= 0) ||
+        false
+    );
+}

--- a/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts
@@ -1,7 +1,7 @@
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
 import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
-import { createBr } from '../creators/createBr';
 import { isBlockEmpty, isSegmentEmpty } from './isEmpty';
+import { normalizeParagraph } from './normalizeParagraph';
 import { unwrapBlock } from './unwrapBlock';
 
 /**
@@ -46,27 +46,6 @@ function removeEmptySegments(block: ContentModelParagraph) {
     for (let j = block.segments.length - 1; j >= 0; j--) {
         if (isSegmentEmpty(block.segments[j])) {
             block.segments.splice(j, 1);
-        }
-    }
-}
-
-function normalizeParagraph(block: ContentModelParagraph) {
-    if (!block.isImplicit) {
-        const segments = block.segments;
-
-        if (segments.length == 1 && segments[0].segmentType == 'SelectionMarker') {
-            segments.push(createBr(segments[0].format));
-        } else if (segments.length > 1 && segments[segments.length - 1].segmentType == 'Br') {
-            const noMarkerSegments = segments.filter(x => x.segmentType != 'SelectionMarker');
-
-            // When there is content with a <BR> tag at the end, we can remove the BR.
-            // But if there are more than one <BR> at the end, do not remove them.
-            if (
-                noMarkerSegments.length > 1 &&
-                noMarkerSegments[noMarkerSegments.length - 2].segmentType != 'Br'
-            ) {
-                segments.pop();
-            }
         }
     }
 }

--- a/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/normalizeContentModel.ts
@@ -1,13 +1,11 @@
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
-import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
-import { isBlockEmpty, isSegmentEmpty } from './isEmpty';
+import { isBlockEmpty } from './isEmpty';
 import { normalizeParagraph } from './normalizeParagraph';
 import { unwrapBlock } from './unwrapBlock';
 
 /**
  * @internal
- */
-export function normalizeContentModel(group: ContentModelBlockGroup) {
+ */ export function normalizeContentModel(group: ContentModelBlockGroup) {
     for (let i = group.blocks.length - 1; i >= 0; i--) {
         const block = group.blocks[i];
 
@@ -21,8 +19,6 @@ export function normalizeContentModel(group: ContentModelBlockGroup) {
                 }
                 break;
             case 'Paragraph':
-                removeEmptySegments(block);
-
                 normalizeParagraph(block);
                 break;
             case 'Table':
@@ -38,14 +34,6 @@ export function normalizeContentModel(group: ContentModelBlockGroup) {
 
         if (isBlockEmpty(block)) {
             group.blocks.splice(i, 1);
-        }
-    }
-}
-
-function removeEmptySegments(block: ContentModelParagraph) {
-    for (let j = block.segments.length - 1; j >= 0; j--) {
-        if (isSegmentEmpty(block.segments[j])) {
-            block.segments.splice(j, 1);
         }
     }
 }

--- a/packages/roosterjs-content-model/lib/modelApi/common/normalizeParagraph.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/normalizeParagraph.ts
@@ -1,0 +1,82 @@
+import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
+import { ContentModelText } from '../../publicTypes/segment/ContentModelText';
+import { createBr } from '../creators/createBr';
+import { isWhiteSpacePreserved } from './isWhiteSpacePreserved';
+
+const SPACE = '\u0020';
+const NONE_BREAK_SPACE = '\u00A0';
+const LEADING_SPACE_REGEX = /^\u0020+/;
+const TRAILING_SPACE_REGEX = /\u0020+$/;
+
+/**
+ * @internal
+ */
+export function normalizeParagraph(paragraph: ContentModelParagraph) {
+    const segments = paragraph.segments;
+
+    if (!paragraph.isImplicit) {
+        if (segments.length == 1 && segments[0].segmentType == 'SelectionMarker') {
+            segments.push(createBr(segments[0].format));
+        } else if (segments.length > 1 && segments[segments.length - 1].segmentType == 'Br') {
+            const noMarkerSegments = segments.filter(x => x.segmentType != 'SelectionMarker');
+
+            // When there is content with a <BR> tag at the end, we can remove the BR.
+            // But if there are more than one <BR> at the end, do not remove them.
+            if (
+                noMarkerSegments.length > 1 &&
+                noMarkerSegments[noMarkerSegments.length - 2].segmentType != 'Br'
+            ) {
+                segments.pop();
+            }
+        }
+    }
+
+    let ignoreLeadingSpaces = true;
+
+    if (!isWhiteSpacePreserved(paragraph)) {
+        let lastTextSegment: ContentModelText | undefined;
+
+        segments.forEach(segment => {
+            if (segment.segmentType == 'Text') {
+                lastTextSegment = segment;
+
+                const first = segment.text.substring(0, 1);
+                const last = segment.text.substr(-1);
+
+                if (first == SPACE) {
+                    // 1. Multiple leading space => single &nbsp; or empty (depends on if previous segment ends with space)
+                    segment.text = segment.text.replace(
+                        LEADING_SPACE_REGEX,
+                        ignoreLeadingSpaces ? '' : NONE_BREAK_SPACE
+                    );
+                }
+
+                if (last == SPACE) {
+                    // 2. Multiple trailing space => single space
+                    segment.text = segment.text.replace(TRAILING_SPACE_REGEX, SPACE);
+                }
+
+                ignoreLeadingSpaces = last == SPACE;
+            } else if (segment.segmentType != 'SelectionMarker') {
+                ignoreLeadingSpaces = true;
+            }
+        });
+
+        segments.forEach(segment => {
+            // 3. Segment ends with &nbsp; replace it with space if the previous char is not space so that next segment can wrap
+            // Only do this for segments that is not the last one since the last space will be removed in step 4
+            if (segment.segmentType == 'Text' && segment != lastTextSegment) {
+                const text = segment.text;
+
+                if (text.substr(-1) == NONE_BREAK_SPACE && text.substr(-2, 1) != SPACE) {
+                    segment.text = text.substring(0, text.length - 1) + SPACE;
+                }
+            }
+        });
+
+        if (lastTextSegment?.text.substr(-1) == SPACE) {
+            // 4. last text segment of the paragraph, remove trailing space
+            lastTextSegment.text = lastTextSegment.text.replace(TRAILING_SPACE_REGEX, '');
+        }
+    }
+}

--- a/packages/roosterjs-content-model/lib/modelApi/common/normalizeSegment.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/normalizeSegment.ts
@@ -1,0 +1,118 @@
+import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
+import { ContentModelText } from '../../publicTypes/segment/ContentModelText';
+
+const SPACE = '\u0020';
+const NONE_BREAK_SPACE = '\u00A0';
+const LEADING_SPACE_REGEX = /^\u0020+/;
+const TRAILING_SPACE_REGEX = /\u0020+$/;
+
+/**
+ * @internal
+ */
+export interface NormalizeSegmentContext {
+    textSegments: ContentModelText[];
+    ignoreLeadingSpaces: boolean;
+    ignoreTrailingSpaces: boolean;
+    lastTextSegment: ContentModelText | undefined;
+    lastInlineSegment: ContentModelSegment | undefined;
+}
+
+export function createNormalizeSegmentContext(): NormalizeSegmentContext {
+    return resetNormalizeSegmentContext();
+}
+
+function resetNormalizeSegmentContext(
+    context?: Partial<NormalizeSegmentContext>
+): NormalizeSegmentContext {
+    return Object.assign(context ?? {}, {
+        textSegments: [],
+        ignoreLeadingSpaces: true,
+        ignoreTrailingSpaces: true,
+        lastInlineSegment: undefined,
+        lastTextSegment: undefined,
+    });
+}
+
+/**
+ * @internal
+ */
+export function normalizeSegment(segment: ContentModelSegment, context: NormalizeSegmentContext) {
+    switch (segment.segmentType) {
+        case 'Br':
+            normalizeTextSegments(context.textSegments, context.lastInlineSegment);
+            normalizeLastTextSegment(context.lastTextSegment, context.lastInlineSegment);
+
+            // Line ends, reset all states
+            resetNormalizeSegmentContext(context);
+            break;
+
+        case 'Entity':
+        case 'General':
+        case 'Image':
+            // Here "inline segment" means a segment showing some content inline such as text, image, or other inline HTML elements
+            // BR will end current line, so it is not treated as "inline" here.
+            // We will do some normalization to the trailing spaces for non-inline-segments
+            context.lastInlineSegment = segment;
+            context.ignoreLeadingSpaces = false;
+            break;
+
+        case 'Text':
+            context.textSegments.push(segment);
+            context.lastInlineSegment = segment;
+            context.lastTextSegment = segment;
+
+            const first = segment.text.substring(0, 1);
+            const last = segment.text.substr(-1);
+
+            if (first == SPACE) {
+                // 1. Multiple leading space => single &nbsp; or empty (depends on if previous segment ends with space)
+                segment.text = segment.text.replace(
+                    LEADING_SPACE_REGEX,
+                    context.ignoreLeadingSpaces ? '' : NONE_BREAK_SPACE
+                );
+            }
+
+            if (last == SPACE) {
+                // 2. Multiple trailing space => single space
+                segment.text = segment.text.replace(
+                    TRAILING_SPACE_REGEX,
+                    context.ignoreTrailingSpaces ? SPACE : NONE_BREAK_SPACE
+                );
+            }
+
+            context.ignoreLeadingSpaces = last == SPACE;
+
+            break;
+    }
+}
+
+export function normalizeTextSegments(
+    segments: ContentModelText[],
+    lastInlineSegment: ContentModelSegment | undefined
+) {
+    segments.forEach(segment => {
+        // 3. Segment ends with &nbsp; replace it with space if the previous char is not space so that next segment can wrap
+        // Only do this for segments that is not the last one since the last space will be removed in step 4
+        if (segment != lastInlineSegment) {
+            const text = segment.text;
+
+            if (
+                text.substr(-1) == NONE_BREAK_SPACE &&
+                text.length > 1 &&
+                text.substr(-2, 1) != SPACE
+            ) {
+                segment.text = text.substring(0, text.length - 1) + SPACE;
+            }
+        }
+    });
+}
+
+export function normalizeLastTextSegment(
+    segment: ContentModelText | undefined,
+    lastInlineSegment: ContentModelSegment | undefined
+) {
+    if (segment && segment == lastInlineSegment && segment?.text.substr(-1) == SPACE) {
+        // 4. last text segment of the paragraph, remove trailing space
+        segment.text = segment.text.replace(TRAILING_SPACE_REGEX, '');
+    }
+}

--- a/packages/roosterjs-content-model/lib/modelApi/selection/deleteSelections.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/selection/deleteSelections.ts
@@ -10,6 +10,7 @@ import { createBr } from '../creators/createBr';
 import { createParagraph } from '../creators/createParagraph';
 import { createSelectionMarker } from '../creators/createSelectionMarker';
 import { EntityOperation } from 'roosterjs-editor-types';
+import { isWhiteSpacePreserved } from '../common/isWhiteSpacePreserved';
 import { setParagraphNotImplicit } from '../block/setParagraphNotImplicit';
 import {
     iterateSelections,
@@ -137,7 +138,7 @@ const deleteSelectionStep1: DeleteSelectionStep = (context, options, model) => {
                             );
                         } else {
                             context.isChanged =
-                                deleteSegment(block.segments, segment, isForward, onDeleteEntity) ||
+                                deleteSegment(block, segment, isForward, onDeleteEntity) ||
                                 context.isChanged;
                         }
                     });
@@ -189,7 +190,12 @@ const deleteSelectionStep2: DeleteSelectionStep = (context, options) => {
         let blockToDelete: BlockAndPath | null;
 
         if (segmentToDelete) {
-            context.isChanged = deleteSegment(segments, segmentToDelete, isForward, onDeleteEntity);
+            context.isChanged = deleteSegment(
+                paragraph,
+                segmentToDelete,
+                isForward,
+                onDeleteEntity
+            );
         } else if ((blockToDelete = getLeafSiblingBlock(path, paragraph, isForward))) {
             const { block, path, siblingSegment } = blockToDelete;
 
@@ -197,7 +203,7 @@ const deleteSelectionStep2: DeleteSelectionStep = (context, options) => {
                 if (siblingSegment) {
                     // When selection is under general segment, need to check if it has a sibling sibling, and delete from it
                     context.isChanged = deleteSegment(
-                        block.segments,
+                        block,
                         siblingSegment,
                         isForward,
                         onDeleteEntity
@@ -264,11 +270,12 @@ function fixupBr(segments: ContentModelSegment[]) {
 }
 
 function deleteSegment(
-    segments: ContentModelSegment[],
+    paragraph: ContentModelParagraph,
     segmentToDelete: ContentModelSegment,
     isForward: boolean,
     onDeleteEntity: OnDeleteEntity
 ): boolean {
+    const segments = paragraph.segments;
     const index = segments.indexOf(segmentToDelete);
 
     switch (segmentToDelete.segmentType) {
@@ -300,9 +307,13 @@ function deleteSegment(
             if (text.length == 0 || segmentToDelete.isSelected) {
                 segments.splice(index, 1);
             } else {
-                segmentToDelete.text = isForward
-                    ? text.substring(1)
-                    : text.substring(0, text.length - 1);
+                text = isForward ? text.substring(1) : text.substring(0, text.length - 1);
+
+                if (!isWhiteSpacePreserved(paragraph)) {
+                    text = text.replace(isForward ? /^\u0020+/ : /\u0020+$/, '\u00A0');
+                }
+
+                segmentToDelete.text = text;
             }
 
             return true;

--- a/packages/roosterjs-content-model/test/editor/plugins/ContentModelEditPluginTest.ts
+++ b/packages/roosterjs-content-model/test/editor/plugins/ContentModelEditPluginTest.ts
@@ -6,9 +6,12 @@ import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEdito
 
 describe('ContentModelEditPlugin', () => {
     let editor: IContentModelEditor;
+    let cacheContentModel: jasmine.Spy;
 
     beforeEach(() => {
-        editor = ({} as any) as IContentModelEditor;
+        cacheContentModel = jasmine.createSpy('cacheContentModel');
+
+        editor = ({ cacheContentModel } as any) as IContentModelEditor;
     });
 
     describe('onPluginEvent', () => {

--- a/packages/roosterjs-content-model/test/modelApi/common/isWhiteSpacePreservedTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/isWhiteSpacePreservedTest.ts
@@ -1,0 +1,29 @@
+import { ContentModelParagraph } from '../../../lib/publicTypes/block/ContentModelParagraph';
+import { isWhiteSpacePreserved } from '../../../lib/modelApi/common/isWhiteSpacePreserved';
+
+describe('isWhiteSpacePreserved', () => {
+    function runTest(style: string | undefined, expected: boolean) {
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            format: {},
+            segments: [],
+        };
+
+        if (style) {
+            paragraph.format.whiteSpace = style;
+        }
+
+        const result = isWhiteSpacePreserved(paragraph);
+        expect(result).toBe(expected);
+    }
+
+    it('isWhiteSpacePreserved', () => {
+        runTest(undefined, false);
+        runTest('normal', false);
+        runTest('nowrap', false);
+        runTest('pre', true);
+        runTest('pre-wrap', true);
+        runTest('pre-line', false);
+        runTest('break-spaces', true);
+    });
+});

--- a/packages/roosterjs-content-model/test/modelApi/common/normalizeParagraphTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/normalizeParagraphTest.ts
@@ -1,0 +1,111 @@
+import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
+import { createImage } from '../../../lib/modelApi/creators/createImage';
+import { createParagraph } from '../../../lib/modelApi/creators/createParagraph';
+import { createSelectionMarker } from '../../../lib/modelApi/creators/createSelectionMarker';
+import { createText } from '../../../lib/modelApi/creators/createText';
+import { normalizeContentModel } from '../../../lib/modelApi/common/normalizeContentModel';
+
+describe('Normalize text that contains space', () => {
+    function runTest(texts: string[], expected: string[], whiteSpace?: string) {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        texts.forEach(t => {
+            para.segments.push(t ? createText(t) : createSelectionMarker());
+        });
+
+        if (whiteSpace) {
+            para.format.whiteSpace = whiteSpace;
+        }
+
+        model.blocks.push(para);
+        normalizeContentModel(model);
+
+        const result = para.segments.map(s => (s.segmentType == 'Text' ? s.text : ''));
+
+        expect(result).toEqual(expected);
+    }
+
+    it('Text without space', () => {
+        runTest(['a', '', 'b'], ['a', '', 'b']);
+    });
+
+    it('Text with space', () => {
+        runTest([' a ', '', ' b '], ['a ', '', 'b']);
+    });
+
+    it('Text with space in middle', () => {
+        runTest([' a   b '], ['a   b']);
+    });
+
+    it('Only first text with space', () => {
+        runTest([' a ', '', 'b'], ['a ', '', 'b']);
+    });
+
+    it('Only second text with space', () => {
+        runTest(['a', '', '  b '], ['a', '', '\u00A0b']);
+    });
+
+    it('Text with multiple spaces', () => {
+        runTest(['   a   ', '', '   b   '], ['a ', '', 'b']);
+    });
+
+    it('Text with &nbsp;', () => {
+        runTest(['\u00A0a\u00A0', '', '\u00A0b\u00A0'], ['\u00A0a ', '', '\u00A0b\u00A0']);
+    });
+
+    it('Text with &nbsp; and space', () => {
+        runTest(
+            [' \u00A0 a \u00A0 ', '', ' \u00A0 b \u00A0 '],
+            ['\u00A0 a \u00A0 ', '', '\u00A0 b \u00A0']
+        );
+    });
+
+    it('Text with multiple spaces and whitespace=pre', () => {
+        runTest(['   a   ', '', '   b   '], ['   a   ', '', '   b   '], 'pre');
+    });
+
+    it('Text ends with &nbsp;', () => {
+        runTest(['a\u00A0', 'b'], ['a ', 'b']);
+        runTest(['a\u00A0\u00A0', 'b'], ['a\u00A0 ', 'b']);
+        runTest(['a \u00A0', 'b'], ['a \u00A0', 'b']);
+    });
+
+    it('with other type of segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createText('  a  '), createImage('test'), createText('  b  '));
+        model.blocks.push(para);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'a ',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Image',
+                            format: {},
+                            src: 'test',
+                            dataset: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'b',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/packages/roosterjs-content-model/test/modelApi/common/normalizeParagraphTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/normalizeParagraphTest.ts
@@ -1,3 +1,4 @@
+import { createBr } from '../../../lib/modelApi/creators/createBr';
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
 import { createImage } from '../../../lib/modelApi/creators/createImage';
 import { createParagraph } from '../../../lib/modelApi/creators/createParagraph';
@@ -100,8 +101,184 @@ describe('Normalize text that contains space', () => {
                         },
                         {
                             segmentType: 'Text',
+                            text: '\u00A0b',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('with BR', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createText('  a  '), createBr(), createText('  b  '));
+        model.blocks.push(para);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'a',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
                             text: 'b',
                             format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Remove empty', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createText('  a  '), createText(''), createText('  b  '));
+        model.blocks.push(para);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'a ',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\u00A0b',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Add Br for empty paragraph', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+
+        para.segments.push(marker);
+        model.blocks.push(para);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Add Br after Br', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const br = createBr();
+        const marker = createSelectionMarker();
+
+        para.segments.push(br, marker);
+        model.blocks.push(para);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Do not add Br after text', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const br = createBr();
+        const text = createText('test');
+        const marker = createSelectionMarker();
+
+        para.segments.push(br, text, marker);
+        model.blocks.push(para);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test',
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
                         },
                     ],
                 },

--- a/packages/roosterjs-content-model/test/modelApi/common/normalizeSegmentTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/normalizeSegmentTest.ts
@@ -1,0 +1,181 @@
+import { createBr } from '../../../lib/modelApi/creators/createBr';
+import { createImage } from '../../../lib/modelApi/creators/createImage';
+import { createText } from '../../../lib/modelApi/creators/createText';
+import {
+    createNormalizeSegmentContext,
+    normalizeSegment,
+} from '../../../lib/modelApi/common/normalizeSegment';
+
+describe('normalizeSegment', () => {
+    it('With initial context, image', () => {
+        const context = createNormalizeSegmentContext();
+        const image = createImage('test');
+
+        normalizeSegment(image, context);
+
+        expect(image).toEqual({
+            segmentType: 'Image',
+            src: 'test',
+            format: {},
+            dataset: {},
+        });
+
+        expect(context).toEqual({
+            textSegments: [],
+            ignoreLeadingSpaces: false,
+            ignoreTrailingSpaces: true,
+            lastInlineSegment: image,
+            lastTextSegment: undefined,
+        });
+    });
+
+    it('With initial context, regular text', () => {
+        const context = createNormalizeSegmentContext();
+        const text = createText('test');
+
+        normalizeSegment(text, context);
+
+        expect(text).toEqual({
+            segmentType: 'Text',
+            text: 'test',
+            format: {},
+        });
+
+        expect(context).toEqual({
+            textSegments: [text],
+            ignoreLeadingSpaces: false,
+            ignoreTrailingSpaces: true,
+            lastInlineSegment: text,
+            lastTextSegment: text,
+        });
+    });
+
+    it('With initial context, br', () => {
+        const context = createNormalizeSegmentContext();
+        const br = createBr();
+
+        normalizeSegment(br, context);
+
+        expect(br).toEqual({
+            segmentType: 'Br',
+            format: {},
+        });
+
+        expect(context).toEqual({
+            textSegments: [],
+            ignoreLeadingSpaces: true,
+            ignoreTrailingSpaces: true,
+            lastInlineSegment: undefined,
+            lastTextSegment: undefined,
+        });
+    });
+
+    it('Normalize an empty string', () => {
+        const context = createNormalizeSegmentContext();
+        const text = createText('');
+
+        normalizeSegment(text, context);
+
+        expect(text).toEqual({
+            segmentType: 'Text',
+            format: {},
+            text: '',
+        });
+
+        expect(context).toEqual({
+            textSegments: [text],
+            ignoreLeadingSpaces: false,
+            ignoreTrailingSpaces: true,
+            lastInlineSegment: text,
+            lastTextSegment: text,
+        });
+    });
+
+    it('Normalize an string with spaces', () => {
+        const context = createNormalizeSegmentContext();
+        const text = createText('   aa   ');
+
+        normalizeSegment(text, context);
+
+        expect(text).toEqual({
+            segmentType: 'Text',
+            format: {},
+            text: 'aa ',
+        });
+
+        expect(context).toEqual({
+            textSegments: [text],
+            ignoreLeadingSpaces: true,
+            ignoreTrailingSpaces: true,
+            lastInlineSegment: text,
+            lastTextSegment: text,
+        });
+    });
+
+    it('Normalize an string with &nbsp;', () => {
+        const context = createNormalizeSegmentContext();
+        const text = createText('\u00A0\u00A0aa\u00A0\u00A0');
+
+        normalizeSegment(text, context);
+
+        expect(text).toEqual({
+            segmentType: 'Text',
+            format: {},
+            text: '\u00A0\u00A0aa\u00A0\u00A0',
+        });
+
+        expect(context).toEqual({
+            textSegments: [text],
+            ignoreLeadingSpaces: false,
+            ignoreTrailingSpaces: true,
+            lastInlineSegment: text,
+            lastTextSegment: text,
+        });
+    });
+
+    it('Normalize an string space and ignoreLeadingSpaces = false', () => {
+        const context = createNormalizeSegmentContext();
+        const text = createText('  aa  ');
+
+        context.ignoreLeadingSpaces = false;
+
+        normalizeSegment(text, context);
+
+        expect(text).toEqual({
+            segmentType: 'Text',
+            format: {},
+            text: '\u00A0aa ',
+        });
+
+        expect(context).toEqual({
+            textSegments: [text],
+            ignoreLeadingSpaces: true,
+            ignoreTrailingSpaces: true,
+            lastInlineSegment: text,
+            lastTextSegment: text,
+        });
+    });
+
+    it('Normalize an string space and ignoreTrailingSpaces = false', () => {
+        const context = createNormalizeSegmentContext();
+        const text = createText('  aa  ');
+
+        context.ignoreTrailingSpaces = false;
+
+        normalizeSegment(text, context);
+
+        expect(text).toEqual({
+            segmentType: 'Text',
+            format: {},
+            text: 'aa\u00A0',
+        });
+
+        expect(context).toEqual({
+            textSegments: [text],
+            ignoreLeadingSpaces: true,
+            ignoreTrailingSpaces: false,
+            lastInlineSegment: text,
+            lastTextSegment: text,
+        });
+    });
+});

--- a/packages/roosterjs-content-model/test/modelApi/selection/deleteSelectionTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/selection/deleteSelectionTest.ts
@@ -823,6 +823,47 @@ describe('deleteSelection - selectionOnly', () => {
             ],
         });
     });
+
+    it('Normalize spaces before deleted segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const text = createText('test ');
+        const image = createImage('test');
+
+        image.isSelected = true;
+        para.segments.push(text, image);
+        model.blocks.push(para);
+
+        const result = deleteSelection(model);
+        const marker: ContentModelSelectionMarker = {
+            segmentType: 'SelectionMarker',
+            format: {},
+            isSelected: true,
+        };
+
+        expect(result.isChanged).toBeTrue();
+        expect(result.insertPoint).toEqual({
+            marker,
+            paragraph: {
+                blockType: 'Paragraph',
+                segments: [{ segmentType: 'Text', text: 'test\u00A0', format: {} }, marker],
+                format: {},
+            },
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [{ segmentType: 'Text', text: 'test\u00A0', format: {} }, marker],
+                },
+            ],
+        });
+    });
 });
 
 describe('deleteSelection - forward', () => {
@@ -2311,6 +2352,99 @@ describe('deleteSelection - forward', () => {
             ],
         });
     });
+
+    it('Normalize text and space before deleted content', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        const text1 = createText('test1  ');
+        const text2 = createText('test2');
+
+        para.segments.push(text1, marker, text2);
+        model.blocks.push(para);
+
+        const result = deleteSelection(model, { direction: 'forward' });
+
+        expect(result.isChanged).toBeTrue();
+
+        expect(result.insertPoint).toEqual({
+            marker: marker,
+            paragraph: para,
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test1\u00A0',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'est2',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Normalize text and space before deleted content, delete empty text', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        const text1 = createText('test1  ');
+        const text2 = createText('a');
+
+        para.segments.push(text1, marker, text2);
+        model.blocks.push(para);
+
+        const result = deleteSelection(model, { direction: 'forward' });
+
+        expect(result.isChanged).toBeTrue();
+
+        expect(result.insertPoint).toEqual({
+            marker: marker,
+            paragraph: para,
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test1\u00A0',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });
 
 describe('deleteSelection - backward', () => {
@@ -3786,6 +3920,99 @@ describe('deleteSelection - backward', () => {
                         {
                             segmentType: 'Text',
                             text: 'test  ',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Normalize text and space before deleted content', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        const text1 = createText('test1  ');
+        const text2 = createText('test2');
+
+        para.segments.push(text1, text2, marker);
+        model.blocks.push(para);
+
+        const result = deleteSelection(model, { direction: 'backward' });
+
+        expect(result.isChanged).toBeTrue();
+
+        expect(result.insertPoint).toEqual({
+            marker: marker,
+            paragraph: para,
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test1\u00A0',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Normalize text and space before deleted content, delete empty text', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        const text1 = createText('test1  ');
+        const text2 = createText('a');
+
+        para.segments.push(text1, text2, marker);
+        model.blocks.push(para);
+
+        const result = deleteSelection(model, { direction: 'backward' });
+
+        expect(result.isChanged).toBeTrue();
+
+        expect(result.insertPoint).toEqual({
+            marker: marker,
+            paragraph: para,
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test1\u00A0',
                             format: {},
                         },
                         {

--- a/packages/roosterjs-content-model/test/modelApi/selection/deleteSelectionTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/selection/deleteSelectionTest.ts
@@ -2222,6 +2222,95 @@ describe('deleteSelection - forward', () => {
             ],
         });
     });
+
+    it('Delete text and need to convert space to &nbsp;', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        const text = createText('   test');
+
+        para.segments.push(marker, text);
+        model.blocks.push(para);
+
+        const result = deleteSelection(model, { direction: 'forward' });
+
+        expect(result.isChanged).toBeTrue();
+
+        expect(result.insertPoint).toEqual({
+            marker: marker,
+            paragraph: para,
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\u00A0test',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Delete text and no need to convert space to &nbsp; when preserve white space', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        const text = createText('   test');
+
+        para.format.whiteSpace = 'pre';
+        para.segments.push(marker, text);
+        model.blocks.push(para);
+
+        const result = deleteSelection(model, { direction: 'forward' });
+
+        expect(result.isChanged).toBeTrue();
+
+        expect(result.insertPoint).toEqual({
+            marker: marker,
+            paragraph: para,
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {
+                        whiteSpace: 'pre',
+                    },
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '  test',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });
 
 describe('deleteSelection - backward', () => {
@@ -3614,6 +3703,95 @@ describe('deleteSelection - backward', () => {
                                 },
                             ],
                             element: null!,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Delete text and need to convert space to &nbsp;', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        const text = createText('test   ');
+
+        para.segments.push(text, marker);
+        model.blocks.push(para);
+
+        const result = deleteSelection(model, { direction: 'backward' });
+
+        expect(result.isChanged).toBeTrue();
+
+        expect(result.insertPoint).toEqual({
+            marker: marker,
+            paragraph: para,
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test\u00A0',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Delete text and no need to convert space to &nbsp; when preserve white space', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        const text = createText('test   ');
+
+        para.format.whiteSpace = 'pre';
+        para.segments.push(text, marker);
+        model.blocks.push(para);
+
+        const result = deleteSelection(model, { direction: 'backward' });
+
+        expect(result.isChanged).toBeTrue();
+
+        expect(result.insertPoint).toEqual({
+            marker: marker,
+            paragraph: para,
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {
+                        whiteSpace: 'pre',
+                    },
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test  ',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
                         },
                     ],
                 },


### PR DESCRIPTION
This change addresses 3 issues:
1. For content such as "a b", and backspace after "b", we should not delete the space. This is done in deleteSelections.ts by changing the space after "a" to be `&nbsp;` when delete. Similar for DELETE key case
2. For content such as "a[SPACE][SPACE]b", when put cursor right before "b", browser will leave the second space after cursor so Content Model need to recognize this space and ignore it since it isn't rendering anything. This is done by creating a new model API `normalizeParagraph` and call it from `normalizeContentModel`. There are bunch of cases of spaces need to be handled there, see comments in code for more info
3. For `&nbsp;` at then end of a segment (not the last text segment), we need to replace it to be a normal space if the second last char is not space so that if there is another long segment after it (e.g. a hyperlink), browser can wrap before the link.

Related test cases added. And in this change I also enabled `ContentModelEditPlugin` in demo site by default.