### PR TITLE
Content Model: Improve default format state

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -36,6 +36,7 @@ const initialState: BuildInPluginState = {
         ExperimentalFeatures.VariableBasedDarkColor,
         ExperimentalFeatures.ReusableContentModel,
         ExperimentalFeatures.InlineEntityReadOnlyDelimiters,
+        ExperimentalFeatures.DefaultFormatOnContainer,
     ],
     isRtl: false,
 };

--- a/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
@@ -25,6 +25,7 @@ const FeatureNames: Partial<Record<ExperimentalFeatures, string>> = {
         'Delete a table selected with the table selector pressing Backspace key',
     [ExperimentalFeatures.InlineEntityReadOnlyDelimiters]:
         'Add read entities around read only entities to handle browser edge cases.',
+    [ExperimentalFeatures.DefaultFormatOnContainer]: 'Apply default format on editor container',
 };
 
 export default class ExperimentalFeaturesPane extends React.Component<

--- a/packages/roosterjs-content-model/lib/domToModel/domToContentModel.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/domToContentModel.ts
@@ -24,8 +24,10 @@ export default function domToContentModel(
     const model = createContentModelDocument(editorContext.defaultFormat);
     const context = createDomToModelContext(editorContext, option);
 
-    // For root element, use computed style as initial value of segment formats
-    parseFormat(root, [computedSegmentFormatHandler.parse], context.segmentFormat, context);
+    if (!context.defaultFormatOnContainer) {
+        // For root element, use computed style as initial value of segment formats
+        parseFormat(root, [computedSegmentFormatHandler.parse], context.segmentFormat, context);
+    }
 
     // Need to calculate direction (ltr or rtl), use it as initial value
     parseFormat(root, [rootDirectionFormatHandler.parse], context.blockFormat, context);

--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -25,6 +25,17 @@ export default class ContentModelEditor
         super(contentDiv, options, createContentModelEditorCore);
     }
 
+    dispose() {
+        const { contentDiv, originalContainerFormat, defaultFormatOnContainer } = this.getCore();
+
+        if (defaultFormatOnContainer) {
+            contentDiv.style.setProperty('font-family', originalContainerFormat.fontFamily || null);
+            contentDiv.style.setProperty('font-size', originalContainerFormat.fontSize || null);
+        }
+
+        super.dispose();
+    }
+
     /**
      * Create Content Model from DOM tree in this editor
      * @param option The option to customize the behavior of DOM to Content Model conversion

--- a/packages/roosterjs-content-model/lib/editor/coreApi/createEditorContext.ts
+++ b/packages/roosterjs-content-model/lib/editor/coreApi/createEditorContext.ts
@@ -11,5 +11,6 @@ export const createEditorContext: CreateEditorContext = core => {
         getDarkColor: core.lifecycle.getDarkColor,
         darkColorHandler: core.darkColorHandler,
         addDelimiterForEntity: core.addDelimiterForEntity,
+        defaultFormatOnContainer: core.defaultFormatOnContainer,
     };
 };

--- a/packages/roosterjs-content-model/lib/editor/createContentModelEditorCore.ts
+++ b/packages/roosterjs-content-model/lib/editor/createContentModelEditorCore.ts
@@ -1,12 +1,22 @@
 import { ContentModelEditorCore } from '../publicTypes/ContentModelEditorCore';
 import { ContentModelEditorOptions } from '../publicTypes/IContentModelEditor';
 import { ContentModelSegmentFormat } from '../publicTypes/format/ContentModelSegmentFormat';
-import { CoreCreator, EditorCore, ExperimentalFeatures } from 'roosterjs-editor-types';
 import { createContentModel } from './coreApi/createContentModel';
 import { createEditorContext } from './coreApi/createEditorContext';
 import { createEditorCore, isFeatureEnabled } from 'roosterjs-editor-core';
 import { setContentModel } from './coreApi/setContentModel';
 import { switchShadowEdit } from './coreApi/switchShadowEdit';
+import {
+    CoreCreator,
+    DefaultFormat,
+    EditorCore,
+    ExperimentalFeatures,
+} from 'roosterjs-editor-types';
+
+const DEFAULT_FORMAT: DefaultFormat = {
+    fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+    fontSize: '12pt',
+};
 
 /**
  * Editor Core creator for Content Model editor
@@ -31,26 +41,71 @@ export function promoteToContentModelEditorCore(
     core: EditorCore,
     options: ContentModelEditorOptions
 ) {
-    const experimentalFeatures = core.lifecycle.experimentalFeatures;
-    const reuseModel = isFeatureEnabled(
-        experimentalFeatures,
-        ExperimentalFeatures.ReusableContentModel
-    );
     const cmCore = core as ContentModelEditorCore;
+
+    promoteDefaultFormat(cmCore);
+    promoteContentModelInfo(cmCore, options);
+    promoteCoreApi(cmCore);
+}
+
+function promoteDefaultFormat(cmCore: ContentModelEditorCore) {
+    cmCore.defaultFormatOnContainer = isFeatureEnabled(
+        cmCore.lifecycle.experimentalFeatures,
+        ExperimentalFeatures.DefaultFormatOnContainer
+    );
+    cmCore.lifecycle.defaultFormat = {
+        ...(cmCore.defaultFormatOnContainer ? DEFAULT_FORMAT : {}),
+        ...(cmCore.lifecycle.defaultFormat || {}),
+    };
+    cmCore.defaultFormat = getDefaultSegmentFormat(cmCore);
+    cmCore.originalContainerFormat = {};
+
+    if (cmCore.defaultFormatOnContainer) {
+        const { contentDiv, defaultFormat } = cmCore;
+        const { fontFamily, fontSize } = defaultFormat;
+
+        cmCore.originalContainerFormat.fontFamily = contentDiv.style.fontFamily;
+        cmCore.originalContainerFormat.fontSize = contentDiv.style.fontSize;
+
+        if (fontFamily) {
+            contentDiv.style.fontFamily = fontFamily;
+        }
+
+        if (fontSize) {
+            contentDiv.style.fontSize = fontSize;
+        }
+    }
+}
+
+function promoteContentModelInfo(
+    cmCore: ContentModelEditorCore,
+    options: ContentModelEditorOptions
+) {
+    const experimentalFeatures = cmCore.lifecycle.experimentalFeatures;
 
     cmCore.defaultDomToModelOptions = options.defaultDomToModelOptions || {};
     cmCore.defaultModelToDomOptions = options.defaultModelToDomOptions || {};
-    cmCore.defaultFormat = getDefaultSegmentFormat(core);
-    cmCore.reuseModel = reuseModel;
-    (cmCore.addDelimiterForEntity = isFeatureEnabled(
+    cmCore.reuseModel = isFeatureEnabled(
+        experimentalFeatures,
+        ExperimentalFeatures.ReusableContentModel
+    );
+    cmCore.addDelimiterForEntity = isFeatureEnabled(
         experimentalFeatures,
         ExperimentalFeatures.InlineEntityReadOnlyDelimiters
-    )),
-        (cmCore.api.createEditorContext = createEditorContext);
+    );
+}
+
+function promoteCoreApi(cmCore: ContentModelEditorCore) {
+    cmCore.api.createEditorContext = createEditorContext;
     cmCore.api.createContentModel = createContentModel;
     cmCore.api.setContentModel = setContentModel;
 
-    if (reuseModel) {
+    if (
+        isFeatureEnabled(
+            cmCore.lifecycle.experimentalFeatures,
+            ExperimentalFeatures.ReusableContentModel
+        )
+    ) {
         // Only use Content Model shadow edit when reuse model is enabled because it relies on cached model for the original model
         cmCore.api.switchShadowEdit = switchShadowEdit;
     }
@@ -67,9 +122,10 @@ function getDefaultSegmentFormat(core: EditorCore): ContentModelSegmentFormat {
         fontWeight: format.bold ? 'bold' : undefined,
         italic: format.italic || undefined,
         underline: format.underline || undefined,
-        fontFamily: format.fontFamily || undefined,
-        fontSize: format.fontSize || undefined,
-        textColor: format.textColors?.lightModeColor || format.textColor || undefined,
+        fontFamily: format.fontFamily || DEFAULT_FORMAT.fontFamily,
+        fontSize: format.fontSize || DEFAULT_FORMAT.fontSize,
+        textColor:
+            format.textColors?.lightModeColor || format.textColor || DEFAULT_FORMAT.textColor,
         backgroundColor:
             format.backgroundColors?.lightModeColor || format.backgroundColor || undefined,
     };

--- a/packages/roosterjs-content-model/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/retrieveModelFormatState.ts
@@ -30,7 +30,13 @@ export function retrieveModelFormatState(
 
     if (pendingFormat) {
         // Pending format
-        retrieveSegmentFormat(formatState, pendingFormat, isFirst);
+        retrieveSegmentFormat(
+            formatState,
+            pendingFormat,
+            isFirst,
+            undefined /*segment*/,
+            model.format
+        );
     }
 
     iterateSelections(
@@ -56,7 +62,13 @@ export function retrieveModelFormatState(
                 segments?.forEach(segment => {
                     if (!pendingFormat) {
                         if (isFirstSegment || segment.segmentType != 'SelectionMarker') {
-                            retrieveSegmentFormat(formatState, segment.format, isFirst, segment);
+                            retrieveSegmentFormat(
+                                formatState,
+                                segment.format,
+                                isFirst,
+                                segment,
+                                model.format
+                            );
                         }
 
                         // We only care the format of selection marker when it is the first selected segment. This is because when selection marker
@@ -117,7 +129,8 @@ function retrieveSegmentFormat(
     result: ContentModelFormatState,
     format: ContentModelSegmentFormat,
     isFirst: boolean,
-    segment?: ContentModelSegment
+    segment?: ContentModelSegment,
+    defaultFormat?: ContentModelSegmentFormat
 ) {
     const superOrSubscript = format.superOrSubScriptSequence?.split(' ')?.pop();
     mergeValue(result, 'isBold', isBold(format.fontWeight), isFirst);
@@ -135,12 +148,18 @@ function retrieveSegmentFormat(
     mergeValue(
         result,
         'fontName',
-        segment?.code ? segment.code.format.fontFamily : format.fontFamily,
+        (segment?.code ? segment.code.format.fontFamily : format.fontFamily) ||
+            defaultFormat?.fontFamily,
         isFirst
     );
-    mergeValue(result, 'fontSize', format.fontSize, isFirst);
-    mergeValue(result, 'backgroundColor', format.backgroundColor, isFirst);
-    mergeValue(result, 'textColor', format.textColor, isFirst);
+    mergeValue(result, 'fontSize', format.fontSize || defaultFormat?.fontSize, isFirst);
+    mergeValue(
+        result,
+        'backgroundColor',
+        format.backgroundColor || defaultFormat?.backgroundColor,
+        isFirst
+    );
+    mergeValue(result, 'textColor', format.textColor || defaultFormat?.textColor, isFirst);
 
     //TODO: handle block owning segments with different line-heights
     mergeValue(result, 'lineHeight', format.lineHeight, isFirst);

--- a/packages/roosterjs-content-model/lib/publicTypes/ContentModelEditorCore.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/ContentModelEditorCore.ts
@@ -102,4 +102,14 @@ export interface ContentModelEditorCore extends EditorCore {
      * Whether adding delimiter for entity is allowed
      */
     addDelimiterForEntity: boolean;
+
+    /**
+     * Apply default format to editor container
+     */
+    defaultFormatOnContainer: boolean;
+
+    /**
+     * Original format on container DIV
+     */
+    originalContainerFormat: ContentModelSegmentFormat;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/context/EditorContext.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/context/EditorContext.ts
@@ -31,4 +31,9 @@ export interface EditorContext {
      * Whether to handle delimiters in Content Model
      */
     addDelimiterForEntity?: boolean;
+
+    /**
+     * Apply default format to editor container
+     */
+    defaultFormatOnContainer?: boolean;
 }

--- a/packages/roosterjs-content-model/test/editor/ContentModelEditorTest.ts
+++ b/packages/roosterjs-content-model/test/editor/ContentModelEditorTest.ts
@@ -228,4 +228,23 @@ describe('ContentModelEditor', () => {
 
         expect(div.style.fontFamily).toBe('Arial');
     });
+
+    it('dispose with DefaultFormatOnContainer and customized default format', () => {
+        const div = document.createElement('div');
+        div.style.fontFamily = 'Arial';
+
+        const editor = new ContentModelEditor(div, {
+            experimentalFeatures: [ExperimentalFeatures.DefaultFormatOnContainer],
+            defaultFormat: {
+                fontFamily: 'Tahoma',
+                fontSize: '20pt',
+            },
+        });
+
+        expect(div.style.fontFamily).toBe('Tahoma');
+
+        editor.dispose();
+
+        expect(div.style.fontFamily).toBe('Arial');
+    });
 });

--- a/packages/roosterjs-content-model/test/editor/ContentModelEditorTest.ts
+++ b/packages/roosterjs-content-model/test/editor/ContentModelEditorTest.ts
@@ -127,8 +127,8 @@ describe('ContentModelEditor', () => {
                 fontWeight: undefined,
                 italic: undefined,
                 underline: undefined,
-                fontFamily: undefined,
-                fontSize: undefined,
+                fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                fontSize: '12pt',
                 textColor: undefined,
                 backgroundColor: undefined,
             },
@@ -199,5 +199,33 @@ describe('ContentModelEditor', () => {
             textColor: 'black',
             backgroundColor: 'white',
         });
+    });
+
+    it('dispose', () => {
+        const div = document.createElement('div');
+        div.style.fontFamily = 'Arial';
+
+        const editor = new ContentModelEditor(div);
+
+        expect(div.style.fontFamily).toBe('Arial');
+
+        editor.dispose();
+
+        expect(div.style.fontFamily).toBe('Arial');
+    });
+
+    it('dispose with DefaultFormatOnContainer', () => {
+        const div = document.createElement('div');
+        div.style.fontFamily = 'Arial';
+
+        const editor = new ContentModelEditor(div, {
+            experimentalFeatures: [ExperimentalFeatures.DefaultFormatOnContainer],
+        });
+
+        expect(div.style.fontFamily).toBe('Calibri, Arial, Helvetica, sans-serif');
+
+        editor.dispose();
+
+        expect(div.style.fontFamily).toBe('Arial');
     });
 });

--- a/packages/roosterjs-content-model/test/editor/coreApi/createEditorContextTest.ts
+++ b/packages/roosterjs-content-model/test/editor/coreApi/createEditorContextTest.ts
@@ -27,6 +27,37 @@ describe('createEditorContext', () => {
             defaultFormat,
             getDarkColor,
             addDelimiterForEntity,
+            defaultFormatOnContainer: undefined,
+        });
+    });
+
+    it('create a context when DefaultFormatOnContainer is true', () => {
+        const isDarkMode = 'DARKMODE' as any;
+        const defaultFormat = 'DEFAULTFORMAT' as any;
+        const getDarkColor = 'GETDARKCOLOR' as any;
+        const darkColorHandler = 'DARKHANDLER' as any;
+        const addDelimiterForEntity = 'ADDDELIMITER' as any;
+
+        const core = ({
+            lifecycle: {
+                isDarkMode,
+                getDarkColor,
+            },
+            defaultFormat,
+            darkColorHandler,
+            addDelimiterForEntity,
+            defaultFormatOnContainer: true,
+        } as any) as ContentModelEditorCore;
+
+        const context = createEditorContext(core);
+
+        expect(context).toEqual({
+            isDarkMode,
+            darkColorHandler,
+            defaultFormat,
+            getDarkColor,
+            addDelimiterForEntity,
+            defaultFormatOnContainer: true,
         });
     });
 });

--- a/packages/roosterjs-content-model/test/editor/createContentModelEditorCoreTest.ts
+++ b/packages/roosterjs-content-model/test/editor/createContentModelEditorCoreTest.ts
@@ -7,13 +7,17 @@ import { setContentModel } from '../../lib/editor/coreApi/setContentModel';
 import { switchShadowEdit } from '../../lib/editor/coreApi/switchShadowEdit';
 
 const mockedSwitchShadowEdit = 'SHADOWEDIT' as any;
-const contentDiv = 'DIV' as any;
 
 describe('createContentModelEditorCore', () => {
     let createEditorCoreSpy: jasmine.Spy;
     let mockedCore: any;
+    let contentDiv: any;
 
     beforeEach(() => {
+        contentDiv = {
+            style: {},
+        } as any;
+
         mockedCore = {
             lifecycle: {
                 experimentalFeatures: [],
@@ -24,6 +28,7 @@ describe('createContentModelEditorCore', () => {
             originalApi: {
                 a: 'b',
             },
+            contentDiv,
         } as any;
 
         createEditorCoreSpy = spyOn(createEditorCore, 'createEditorCore').and.returnValue(
@@ -39,6 +44,7 @@ describe('createContentModelEditorCore', () => {
         expect(core).toEqual({
             lifecycle: {
                 experimentalFeatures: [],
+                defaultFormat: {},
             },
             api: {
                 switchShadowEdit: mockedSwitchShadowEdit,
@@ -58,13 +64,18 @@ describe('createContentModelEditorCore', () => {
                 fontWeight: undefined,
                 italic: undefined,
                 underline: undefined,
-                fontFamily: undefined,
-                fontSize: undefined,
+                fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                fontSize: '12pt',
                 textColor: undefined,
                 backgroundColor: undefined,
             },
             reuseModel: false,
             addDelimiterForEntity: false,
+            contentDiv: {
+                style: {},
+            },
+            defaultFormatOnContainer: false,
+            originalContainerFormat: {},
         } as any);
     });
 
@@ -80,6 +91,7 @@ describe('createContentModelEditorCore', () => {
         expect(core).toEqual({
             lifecycle: {
                 experimentalFeatures: [],
+                defaultFormat: {},
             },
             api: {
                 switchShadowEdit: mockedSwitchShadowEdit,
@@ -99,13 +111,18 @@ describe('createContentModelEditorCore', () => {
                 fontWeight: undefined,
                 italic: undefined,
                 underline: undefined,
-                fontFamily: undefined,
-                fontSize: undefined,
+                fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                fontSize: '12pt',
                 textColor: undefined,
                 backgroundColor: undefined,
             },
             reuseModel: false,
             addDelimiterForEntity: false,
+            contentDiv: {
+                style: {},
+            },
+            defaultFormatOnContainer: false,
+            originalContainerFormat: {},
         } as any);
     });
 
@@ -162,6 +179,11 @@ describe('createContentModelEditorCore', () => {
             },
             reuseModel: false,
             addDelimiterForEntity: false,
+            contentDiv: {
+                style: {},
+            },
+            defaultFormatOnContainer: false,
+            originalContainerFormat: {},
         } as any);
     });
 
@@ -175,6 +197,7 @@ describe('createContentModelEditorCore', () => {
         expect(core).toEqual({
             lifecycle: {
                 experimentalFeatures: [ExperimentalFeatures.ReusableContentModel],
+                defaultFormat: {},
             },
             api: {
                 switchShadowEdit: switchShadowEdit,
@@ -194,13 +217,18 @@ describe('createContentModelEditorCore', () => {
                 fontWeight: undefined,
                 italic: undefined,
                 underline: undefined,
-                fontFamily: undefined,
-                fontSize: undefined,
+                fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                fontSize: '12pt',
                 textColor: undefined,
                 backgroundColor: undefined,
             },
             reuseModel: true,
             addDelimiterForEntity: false,
+            contentDiv: {
+                style: {},
+            },
+            defaultFormatOnContainer: false,
+            originalContainerFormat: {},
         } as any);
     });
 
@@ -216,6 +244,7 @@ describe('createContentModelEditorCore', () => {
         expect(core).toEqual({
             lifecycle: {
                 experimentalFeatures: [ExperimentalFeatures.InlineEntityReadOnlyDelimiters],
+                defaultFormat: {},
             },
             api: {
                 switchShadowEdit: mockedSwitchShadowEdit,
@@ -235,13 +264,360 @@ describe('createContentModelEditorCore', () => {
                 fontWeight: undefined,
                 italic: undefined,
                 underline: undefined,
-                fontFamily: undefined,
-                fontSize: undefined,
+                fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                fontSize: '12pt',
                 textColor: undefined,
                 backgroundColor: undefined,
             },
             reuseModel: false,
             addDelimiterForEntity: true,
+            contentDiv: {
+                style: {},
+            },
+            defaultFormatOnContainer: false,
+            originalContainerFormat: {},
+        } as any);
+    });
+});
+
+describe('createContentModelEditorCore with experimental feature "DefaultFormatOnContainer', () => {
+    let createEditorCoreSpy: jasmine.Spy;
+    let mockedCore: any;
+    let contentDiv: any;
+
+    beforeEach(() => {
+        contentDiv = {
+            style: {},
+        } as any;
+
+        mockedCore = {
+            lifecycle: {
+                experimentalFeatures: [ExperimentalFeatures.DefaultFormatOnContainer],
+            },
+            api: {
+                switchShadowEdit: mockedSwitchShadowEdit,
+            },
+            originalApi: {
+                a: 'b',
+            },
+            contentDiv,
+        } as any;
+
+        createEditorCoreSpy = spyOn(createEditorCore, 'createEditorCore').and.returnValue(
+            mockedCore
+        );
+    });
+
+    it('No additional option', () => {
+        const options = {};
+        const core = createContentModelEditorCore(contentDiv, options);
+
+        expect(createEditorCoreSpy).toHaveBeenCalledWith(contentDiv, options);
+        expect(core).toEqual({
+            lifecycle: {
+                experimentalFeatures: [ExperimentalFeatures.DefaultFormatOnContainer],
+                defaultFormat: {
+                    fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                    fontSize: '12pt',
+                },
+            },
+            api: {
+                switchShadowEdit: mockedSwitchShadowEdit,
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            originalApi: {
+                a: 'b',
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            defaultDomToModelOptions: {},
+            defaultModelToDomOptions: {},
+            defaultFormat: {
+                fontWeight: undefined,
+                italic: undefined,
+                underline: undefined,
+                fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                fontSize: '12pt',
+                textColor: undefined,
+                backgroundColor: undefined,
+            },
+            reuseModel: false,
+            addDelimiterForEntity: false,
+            contentDiv: {
+                style: { fontFamily: 'Calibri, Arial, Helvetica, sans-serif', fontSize: '12pt' },
+            },
+            defaultFormatOnContainer: true,
+            originalContainerFormat: { fontFamily: undefined, fontSize: undefined },
+        } as any);
+    });
+
+    it('With additional option', () => {
+        const defaultDomToModelOptions = { a: '1' } as any;
+        const defaultModelToDomOptions = { b: '2' } as any;
+
+        const options = { defaultDomToModelOptions, defaultModelToDomOptions };
+        const core = createContentModelEditorCore(contentDiv, options);
+
+        expect(createEditorCoreSpy).toHaveBeenCalledWith(contentDiv, options);
+
+        expect(core).toEqual({
+            lifecycle: {
+                experimentalFeatures: [ExperimentalFeatures.DefaultFormatOnContainer],
+                defaultFormat: {
+                    fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                    fontSize: '12pt',
+                },
+            },
+            api: {
+                switchShadowEdit: mockedSwitchShadowEdit,
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            originalApi: {
+                a: 'b',
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            defaultDomToModelOptions,
+            defaultModelToDomOptions,
+            defaultFormat: {
+                fontWeight: undefined,
+                italic: undefined,
+                underline: undefined,
+                fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                fontSize: '12pt',
+                textColor: undefined,
+                backgroundColor: undefined,
+            },
+            reuseModel: false,
+            addDelimiterForEntity: false,
+            contentDiv: {
+                style: { fontFamily: 'Calibri, Arial, Helvetica, sans-serif', fontSize: '12pt' },
+            },
+            defaultFormatOnContainer: true,
+            originalContainerFormat: { fontFamily: undefined, fontSize: undefined },
+        } as any);
+    });
+
+    it('With default format', () => {
+        mockedCore.lifecycle.defaultFormat = {
+            bold: true,
+            italic: true,
+            underline: true,
+            fontFamily: 'Arial',
+            fontSize: '10pt',
+            textColor: 'red',
+            backgroundColor: 'blue',
+        };
+
+        const options = {};
+        const core = createContentModelEditorCore(contentDiv, options);
+
+        expect(createEditorCoreSpy).toHaveBeenCalledWith(contentDiv, options);
+        expect(core).toEqual({
+            lifecycle: {
+                experimentalFeatures: [ExperimentalFeatures.DefaultFormatOnContainer],
+                defaultFormat: {
+                    bold: true,
+                    italic: true,
+                    underline: true,
+                    fontFamily: 'Arial',
+                    fontSize: '10pt',
+                    textColor: 'red',
+                    backgroundColor: 'blue',
+                },
+            },
+            api: {
+                switchShadowEdit: mockedSwitchShadowEdit,
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            originalApi: {
+                a: 'b',
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            defaultDomToModelOptions: {},
+            defaultModelToDomOptions: {},
+            defaultFormat: {
+                fontWeight: 'bold',
+                italic: true,
+                underline: true,
+                fontFamily: 'Arial',
+                fontSize: '10pt',
+                textColor: 'red',
+                backgroundColor: 'blue',
+            },
+            reuseModel: false,
+            addDelimiterForEntity: false,
+            contentDiv: {
+                style: { fontFamily: 'Arial', fontSize: '10pt' },
+            },
+            defaultFormatOnContainer: true,
+            originalContainerFormat: { fontFamily: undefined, fontSize: undefined },
+        } as any);
+    });
+
+    it('Reuse model', () => {
+        mockedCore.lifecycle.experimentalFeatures.push(ExperimentalFeatures.ReusableContentModel);
+
+        const options = {};
+        const core = createContentModelEditorCore(contentDiv, options);
+
+        expect(createEditorCoreSpy).toHaveBeenCalledWith(contentDiv, options);
+        expect(core).toEqual({
+            lifecycle: {
+                experimentalFeatures: [
+                    ExperimentalFeatures.DefaultFormatOnContainer,
+                    ExperimentalFeatures.ReusableContentModel,
+                ],
+                defaultFormat: {
+                    fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                    fontSize: '12pt',
+                },
+            },
+            api: {
+                switchShadowEdit: switchShadowEdit,
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            originalApi: {
+                a: 'b',
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            defaultDomToModelOptions: {},
+            defaultModelToDomOptions: {},
+            defaultFormat: {
+                fontWeight: undefined,
+                italic: undefined,
+                underline: undefined,
+                fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                fontSize: '12pt',
+                textColor: undefined,
+                backgroundColor: undefined,
+            },
+            reuseModel: true,
+            addDelimiterForEntity: false,
+            contentDiv: {
+                style: { fontFamily: 'Calibri, Arial, Helvetica, sans-serif', fontSize: '12pt' },
+            },
+            defaultFormatOnContainer: true,
+            originalContainerFormat: { fontFamily: undefined, fontSize: undefined },
+        } as any);
+    });
+
+    it('Allow entity delimiters', () => {
+        mockedCore.lifecycle.experimentalFeatures.push(
+            ExperimentalFeatures.InlineEntityReadOnlyDelimiters
+        );
+
+        const options = {};
+        const core = createContentModelEditorCore(contentDiv, options);
+
+        expect(createEditorCoreSpy).toHaveBeenCalledWith(contentDiv, options);
+        expect(core).toEqual({
+            lifecycle: {
+                experimentalFeatures: [
+                    ExperimentalFeatures.DefaultFormatOnContainer,
+                    ExperimentalFeatures.InlineEntityReadOnlyDelimiters,
+                ],
+                defaultFormat: {
+                    fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                    fontSize: '12pt',
+                },
+            },
+            api: {
+                switchShadowEdit: mockedSwitchShadowEdit,
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            originalApi: {
+                a: 'b',
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            defaultDomToModelOptions: {},
+            defaultModelToDomOptions: {},
+            defaultFormat: {
+                fontWeight: undefined,
+                italic: undefined,
+                underline: undefined,
+                fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                fontSize: '12pt',
+                textColor: undefined,
+                backgroundColor: undefined,
+            },
+            reuseModel: false,
+            addDelimiterForEntity: true,
+            contentDiv: {
+                style: { fontFamily: 'Calibri, Arial, Helvetica, sans-serif', fontSize: '12pt' },
+            },
+            defaultFormatOnContainer: true,
+            originalContainerFormat: { fontFamily: undefined, fontSize: undefined },
+        } as any);
+    });
+
+    it('Content Div already has style', () => {
+        const options = {};
+        const core = createContentModelEditorCore(contentDiv, options);
+
+        contentDiv.style.fontFamily = 'AAAA';
+        contentDiv.style.fontSize = 'BBBB';
+
+        expect(createEditorCoreSpy).toHaveBeenCalledWith(contentDiv, options);
+        expect(core).toEqual({
+            lifecycle: {
+                experimentalFeatures: [ExperimentalFeatures.DefaultFormatOnContainer],
+                defaultFormat: {
+                    fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                    fontSize: '12pt',
+                },
+            },
+            api: {
+                switchShadowEdit: mockedSwitchShadowEdit,
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            originalApi: {
+                a: 'b',
+                createEditorContext,
+                createContentModel,
+                setContentModel,
+            },
+            defaultDomToModelOptions: {},
+            defaultModelToDomOptions: {},
+            defaultFormat: {
+                fontWeight: undefined,
+                italic: undefined,
+                underline: undefined,
+                fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                fontSize: '12pt',
+                textColor: undefined,
+                backgroundColor: undefined,
+            },
+            reuseModel: false,
+            addDelimiterForEntity: false,
+            contentDiv: {
+                style: {
+                    fontFamily: 'AAAA',
+                    fontSize: 'BBBB',
+                },
+            },
+            defaultFormatOnContainer: true,
+            originalContainerFormat: { fontFamily: undefined, fontSize: undefined },
         } as any);
     });
 });

--- a/packages/roosterjs-content-model/test/modelApi/common/retrieveModelFormatStateTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/retrieveModelFormatStateTest.ts
@@ -668,4 +668,67 @@ describe('retrieveModelFormatState', () => {
             imageFormat: undefined,
         });
     });
+
+    it('With default format but no format in body', () => {
+        const model = createContentModelDocument({
+            fontFamily: 'Arial',
+            fontSize: '12px',
+        });
+        const result: ContentModelFormatState = {};
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        para.segments.push(marker);
+
+        spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
+            callback(path, undefined, para, [marker]);
+            return false;
+        });
+
+        retrieveModelFormatState(model, null, result);
+
+        expect(result).toEqual({
+            isBlockQuote: false,
+            isBold: false,
+            isSuperscript: false,
+            isSubscript: false,
+            fontName: 'Arial',
+            fontSize: '12px',
+            isCodeInline: false,
+            canUnlink: false,
+            canAddImageAltText: false,
+        });
+    });
+
+    it('With default format and other different format', () => {
+        const model = createContentModelDocument({
+            fontFamily: 'Arial',
+            fontSize: '12px',
+        });
+        const result: ContentModelFormatState = {};
+        const para = createParagraph();
+        const text1 = createText('test1');
+        const text2 = createText('test2', { fontFamily: 'Tahoma', fontSize: '12px' });
+        para.segments.push(text1, text2);
+
+        text1.isSelected = true;
+        text2.isSelected = true;
+
+        spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
+            callback(path, undefined, para, [text1, text2]);
+            return false;
+        });
+
+        retrieveModelFormatState(model, null, result);
+
+        expect(result).toEqual({
+            isBlockQuote: false,
+            isBold: false,
+            isSuperscript: false,
+            isSubscript: false,
+            fontSize: '12px',
+            isCodeInline: false,
+            canUnlink: false,
+            canAddImageAltText: false,
+        });
+    });
 });

--- a/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
@@ -144,6 +144,11 @@ export const enum ExperimentalFeatures {
     ReusableContentModel = 'ReusableContentModel',
 
     /**
+     * Apply default format on editor container
+     */
+    DefaultFormatOnContainer = 'DefaultFormatOnContainer',
+
+    /**
      * Delete table with Backspace key with the whole was selected with table selector
      */
     DeleteTableWithBackspace = 'DeleteTableWithBackspace',


### PR DESCRIPTION
Today when we create content model, we always read font name and font size using "getComputedStyle" from root container as root level format. This causes two problems:
1. If we load content that doesn't have font info, Content Model will always add font from root container into the content. This is not right. Content should keep its style unless user changes it.
2. When clear content from current line, format state will show font from root container (in most cases, Segoe UI) which will confuse user because when keep typing, TypeInContainerPlugin will force the new content in default format.

To fix this, we are doing:
1. Remove the code that reads format from root container
2. When retrieve format, if there is no font info (as well as color), use the format from defaultFormat instead
3. Content Model will not magically add those format into content, it is the job of TypeInContainerPlugin. (but in the future we may change it)
4. Apply default format to editor root container to make sure it looks right
5. If no default format specified, we should give it a default one.

All these changes are protected by an experimental feature `DefaultFormatOnContainer`.