### PR TITLE
Add a experimental feature for paste with ContentModel

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
@@ -26,6 +26,7 @@ const FeatureNames: Partial<Record<ExperimentalFeatures, string>> = {
     [ExperimentalFeatures.InlineEntityReadOnlyDelimiters]:
         'Add read entities around read only entities to handle browser edge cases.',
     [ExperimentalFeatures.DefaultFormatOnContainer]: 'Apply default format on editor container',
+    [ExperimentalFeatures.ContentModelPaste]: 'Paste with content model',
 };
 
 export default class ExperimentalFeaturesPane extends React.Component<

--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -1,4 +1,3 @@
-import { ChangeSource, ClipboardData, GetContentMode } from 'roosterjs-editor-types';
 import { ContentModelDocument } from '../publicTypes/group/ContentModelDocument';
 import { ContentModelEditorCore } from '../publicTypes/ContentModelEditorCore';
 import { createContentModelEditorCore } from './createContentModelEditorCore';
@@ -6,6 +5,12 @@ import { EditorBase } from 'roosterjs-editor-core';
 import { formatWithContentModel } from '../publicApi/utils/formatWithContentModel';
 import { mergeModel } from '../modelApi/common/mergeModel';
 import { Position } from 'roosterjs-editor-dom';
+import {
+    ChangeSource,
+    ClipboardData,
+    ExperimentalFeatures,
+    GetContentMode,
+} from 'roosterjs-editor-types';
 import {
     ContentModelEditorOptions,
     DomToModelOption,
@@ -86,6 +91,11 @@ export default class ContentModelEditor
         applyCurrentFormat: boolean = false,
         pasteAsImage: boolean = false
     ) {
+        if (!this.isFeatureEnabled(ExperimentalFeatures.ContentModelPaste)) {
+            super.paste(clipboardData, pasteAsText, applyCurrentFormat, pasteAsImage);
+            return;
+        }
+
         const core = this.getCore();
         if (!clipboardData) {
             return;

--- a/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
@@ -157,4 +157,9 @@ export const enum ExperimentalFeatures {
      * Add entities around a Read Only  Inline entity to prevent cursor to be hidden when cursor is next of it.
      */
     InlineEntityReadOnlyDelimiters = 'InlineEntityReadOnlyDelimiters',
+
+    /**
+     * Paste with Content model
+     */
+    ContentModelPaste = 'ContentModelPaste',
 }


### PR DESCRIPTION
This PR adds a Experimental Feature to be used in the ContentModelEditor class. When enabled will use content model to insert the content in the editor