### PR TITLE
Content Model Fidelity improvment 6: list and text

### DIFF
--- a/demo/scripts/controls/contentModel/components/model/ContentModelListItemView.tsx
+++ b/demo/scripts/controls/contentModel/components/model/ContentModelListItemView.tsx
@@ -11,6 +11,7 @@ import { ListMetadataFormatRenderers } from '../format/formatPart/ListMetadataFo
 import { ListThreadFormatRenderers } from '../format/formatPart/ListThreadFormatRenderer';
 import { ListTypeFormatRenderer } from '../format/formatPart/ListTypeFormatRenderer';
 import { MarginFormatRenderer } from '../format/formatPart/MarginFormatRenderer';
+import { PaddingFormatRenderer } from '../format/formatPart/PaddingFormatRenderer';
 import { TextColorFormatRenderer } from '../format/formatPart/TextColorFormatRenderer';
 import { useProperty } from '../../hooks/useProperty';
 import {
@@ -29,10 +30,12 @@ const ListLevelFormatRenders: FormatRenderer<ContentModelListItemLevelFormat>[] 
     ...ListMetadataFormatRenderers,
     ...DirectionFormatRenderers,
     MarginFormatRenderer,
+    PaddingFormatRenderer,
 ];
 const ListItemFormatRenderers: FormatRenderer<ContentModelListItemFormat>[] = [
     ...DirectionFormatRenderers,
     LineHeightFormatRenderer,
+    MarginFormatRenderer,
 ];
 const ListItemFormatHolderRenderers: FormatRenderer<ContentModelSegmentFormat>[] = [
     TextColorFormatRenderer,

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -107,8 +107,15 @@ const defaultFormatKeysPerCategory: {
 } = {
     block: sharedBlockFormats,
     listItem: ['listItemThread', 'listItemMetadata'],
-    listItemElement: ['direction', 'lineHeight'],
-    listLevel: ['listType', 'listLevelThread', 'listLevelMetadata', 'direction', 'margin'],
+    listItemElement: ['direction', 'lineHeight', 'margin'],
+    listLevel: [
+        'listType',
+        'listLevelThread',
+        'listLevelMetadata',
+        'direction',
+        'margin',
+        'padding',
+    ],
     segment: [...sharedSegmentFormats, 'backgroundColor', 'lineHeight'],
     segmentOnBlock: sharedSegmentFormats,
     segmentOnTableCell: ['fontFamily', 'fontSize', 'underline', 'italic', 'bold'],

--- a/packages/roosterjs-content-model/lib/modelApi/common/normalizeSegment.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/normalizeSegment.ts
@@ -1,5 +1,6 @@
 import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
 import { ContentModelText } from '../../publicTypes/segment/ContentModelText';
+import { hasSpacesOnly } from 'roosterjs-content-model/lib/domUtils/hasSpacesOnly';
 
 const SPACE = '\u0020';
 const NONE_BREAK_SPACE = '\u00A0';
@@ -64,20 +65,22 @@ export function normalizeSegment(segment: ContentModelSegment, context: Normaliz
             const first = segment.text.substring(0, 1);
             const last = segment.text.substr(-1);
 
-            if (first == SPACE) {
-                // 1. Multiple leading space => single &nbsp; or empty (depends on if previous segment ends with space)
-                segment.text = segment.text.replace(
-                    LEADING_SPACE_REGEX,
-                    context.ignoreLeadingSpaces ? '' : NONE_BREAK_SPACE
-                );
-            }
+            if (!hasSpacesOnly(segment.text)) {
+                if (first == SPACE) {
+                    // 1. Multiple leading space => single &nbsp; or empty (depends on if previous segment ends with space)
+                    segment.text = segment.text.replace(
+                        LEADING_SPACE_REGEX,
+                        context.ignoreLeadingSpaces ? '' : NONE_BREAK_SPACE
+                    );
+                }
 
-            if (last == SPACE) {
-                // 2. Multiple trailing space => single space
-                segment.text = segment.text.replace(
-                    TRAILING_SPACE_REGEX,
-                    context.ignoreTrailingSpaces ? SPACE : NONE_BREAK_SPACE
-                );
+                if (last == SPACE) {
+                    // 2. Multiple trailing space => single space
+                    segment.text = segment.text.replace(
+                        TRAILING_SPACE_REGEX,
+                        context.ignoreTrailingSpaces ? SPACE : NONE_BREAK_SPACE
+                    );
+                }
             }
 
             context.ignoreLeadingSpaces = last == SPACE;

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelListItemFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelListItemFormat.ts
@@ -1,7 +1,8 @@
 import { DirectionFormat } from './formatParts/DirectionFormat';
 import { LineHeightFormat } from './formatParts/LineHeightFormat';
+import { MarginFormat } from './formatParts/MarginFormat';
 
 /**
  * The format object for a list item in Content Model
  */
-export type ContentModelListItemFormat = DirectionFormat & LineHeightFormat;
+export type ContentModelListItemFormat = DirectionFormat & LineHeightFormat & MarginFormat;

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelListItemLevelFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelListItemLevelFormat.ts
@@ -3,6 +3,7 @@ import { ListMetadataFormat } from './formatParts/ListMetadataFormat';
 import { ListThreadFormat } from './formatParts/ListThreadFormat';
 import { ListTypeFormat } from './formatParts/ListTypeFormat';
 import { MarginFormat } from './formatParts/MarginFormat';
+import { PaddingFormat } from './formatParts/PaddingFormat';
 
 /**
  * The format object for a list level in Content Model
@@ -11,4 +12,5 @@ export type ContentModelListItemLevelFormat = ListTypeFormat &
     ListThreadFormat &
     ListMetadataFormat &
     DirectionFormat &
-    MarginFormat;
+    MarginFormat &
+    PaddingFormat;

--- a/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
@@ -65,7 +65,10 @@ describe('End to end test for DOM => Model', () => {
                                 marginBottom: '0in',
                             },
                         ],
-                        format: {},
+                        format: {
+                            marginRight: '0in',
+                            marginLeft: '0in',
+                        },
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             format: {
@@ -103,7 +106,10 @@ describe('End to end test for DOM => Model', () => {
                                 marginBottom: '0in',
                             },
                         ],
-                        format: {},
+                        format: {
+                            marginRight: '0in',
+                            marginLeft: '0in',
+                        },
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             format: {
@@ -116,7 +122,7 @@ describe('End to end test for DOM => Model', () => {
                     },
                 ],
             },
-            '<ul style="flex-direction: column; display: flex; margin-bottom: 0in;"><li style="font-family: Calibri, sans-serif; font-size: 11pt; color: black;"><span style="font-family: Calibri, sans-serif; font-size: 11pt; color: black;">1</span></li><li style="font-family: Calibri, sans-serif; font-size: 11pt; color: black;"><span style="font-family: Calibri, sans-serif; font-size: 11pt; color: black;">2</span></li></ul>'
+            '<ul style="flex-direction: column; display: flex; margin-bottom: 0in;"><li style="margin-right: 0in; margin-left: 0in; font-family: Calibri, sans-serif; font-size: 11pt; color: black;"><span style="font-family: Calibri, sans-serif; font-size: 11pt; color: black;">1</span></li><li style="margin-right: 0in; margin-left: 0in; font-family: Calibri, sans-serif; font-size: 11pt; color: black;"><span style="font-family: Calibri, sans-serif; font-size: 11pt; color: black;">2</span></li></ul>'
         );
     });
 

--- a/packages/roosterjs-content-model/test/domToModel/processors/listProcessorTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/processors/listProcessorTest.ts
@@ -169,6 +169,51 @@ describe('listProcessor', () => {
 
         expect(pushSpy).toHaveBeenCalledWith({ listType: 'UL' });
     });
+
+    it('list has margin and padding', () => {
+        const ol = document.createElement('ol');
+        const li = document.createElement('li');
+        const group = createContentModelDocument();
+
+        ol.appendChild(li);
+
+        childProcessor.and.callFake(originalChildProcessor);
+
+        ol.style.margin = '1px';
+        ol.style.padding = '2px';
+
+        listProcessor(group, ol, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            marginTop: '1px',
+                            marginRight: '1px',
+                            marginBottom: '1px',
+                            marginLeft: '1px',
+                            paddingTop: '2px',
+                            paddingRight: '2px',
+                            paddingBottom: '2px',
+                            paddingLeft: '2px',
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: true,
+                    },
+                    format: {},
+                },
+            ],
+        });
+    });
 });
 
 describe('listProcessor without format handlers', () => {

--- a/packages/roosterjs-content-model/test/modelApi/common/normalizeParagraphTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/normalizeParagraphTest.ts
@@ -285,4 +285,34 @@ describe('Normalize text that contains space', () => {
             ],
         });
     });
+
+    it('Remove last space after image', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const image = createImage('test');
+        const text = createText('  ');
+
+        para.segments.push(image, text);
+        model.blocks.push(para);
+
+        normalizeContentModel(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Image',
+                            src: 'test',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleListTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleListTest.ts
@@ -358,6 +358,28 @@ describe('handleList', () => {
             ],
         });
     });
+
+    it('List with margin and padding', () => {
+        const listItem = createListItem([
+            {
+                listType: 'UL',
+                marginLeft: '1px',
+                marginRight: '2px',
+                marginTop: '3px',
+                marginBottom: '4px',
+                paddingLeft: '5px',
+                paddingRight: '6px',
+                paddingTop: '7px',
+                paddingBottom: '8px',
+            },
+        ]);
+
+        handleList(document, parent, listItem, context, null);
+
+        expect(parent.outerHTML).toBe(
+            '<div><ul style="flex-direction: column; display: flex; margin: 3px 2px 4px 1px; padding: 7px 6px 8px 5px;"></ul></div>'
+        );
+    });
 });
 
 describe('handleList without format handlers', () => {


### PR DESCRIPTION
1. For list and level, support margin and padding
2. For spaces after image if it is the last segment in a paragraph, we should remove it.