### PR TITLE
Content Model: Fix #204225: [Format]Underline doesn't work well for subscript and superscript text, and strikethrough works as though upper/under line in Firefox

### DIFF
--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -86,11 +86,11 @@ const defaultFormatHandlerMap: FormatHandlers = {
 
 const sharedSegmentFormats: (keyof FormatHandlerTypeMap)[] = [
     'letterSpacing',
-    'superOrSubScript',
     'strike',
     'fontFamily',
     'fontSize',
     'underline',
+    'superOrSubScript',
     'italic',
     'bold',
     'textColor',

--- a/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
@@ -1319,4 +1319,31 @@ describe('End to end test for DOM => Model', () => {
         expect(createGeneralBlockSpy).toHaveBeenCalledTimes(1);
         expect(cloneNodeSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('SUB needs to be put inside S or U if any', () => {
+        runTest(
+            '<div><s><u><sub>test</sub></u></s></div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {},
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: {
+                                    strikethrough: true,
+                                    underline: true,
+                                    superOrSubScriptSequence: 'sub',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+            '<div><sub><u><s>test</s></u></sub></div>'
+        );
+    });
 });


### PR DESCRIPTION
When apply both subscript and underline/strikethrough to the same text, `SUB` tag needs to be put outside of `U` or `S` tag.

So the expected HTML should be something like:
```html
<div><sub><u><s>test</s></u></sub></div>
```

![image](https://user-images.githubusercontent.com/23065085/235544336-da23aa3c-0766-4d51-970b-c1ffaa930d6c.png)


Before the fix, it was:
```html
<div><s><u><sub>test</sub></u></s></div>
````

![image](https://user-images.githubusercontent.com/23065085/235544362-73668839-9275-4d97-953f-0270cf442693.png)
