### PR TITLE
Make deleteSelections function return the deleted content

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/common/cloneModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/cloneModel.ts
@@ -36,7 +36,10 @@ export function cloneModel(model: ContentModelDocument): ContentModelDocument {
     return newModel;
 }
 
-function cloneBlock(block: ContentModelBlock): ContentModelBlock {
+/**
+ * @internal
+ */
+export function cloneBlock(block: ContentModelBlock): ContentModelBlock {
     switch (block.blockType) {
         case 'BlockGroup':
             switch (block.blockGroupType) {

--- a/packages/roosterjs-content-model/lib/modelApi/selection/deleteSelections.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/selection/deleteSelections.ts
@@ -8,7 +8,7 @@ import { ContentModelEntity } from '../../publicTypes/entity/ContentModelEntity'
 import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
 import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
 import { ContentModelSelectionMarker } from '../../publicTypes/segment/ContentModelSelectionMarker';
-import { ContentModelTable } from '../../publicTypes';
+import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { createBr } from '../creators/createBr';
 import { createContentModelDocument } from '../creators/createContentModelDocument';
 import { createNormalizeSegmentContext, normalizeSegment } from '../common/normalizeSegment';

--- a/packages/roosterjs-content-model/lib/modelApi/selection/deleteSelections.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/selection/deleteSelections.ts
@@ -156,7 +156,6 @@ const deleteSelectionStep1: DeleteSelectionStep = (context, options, model, dele
             } else if (block) {
                 // Delete a whole block (divider, table, ...)
                 const blocks = path[0].blocks;
-
                 context.isChanged =
                     deleteBlock(blocks, block, isForward, onDeleteEntity, paragraph) ||
                     context.isChanged;
@@ -281,12 +280,10 @@ function saveDeletedElements(
 
         addBlock(deleteResult, newBlock);
     } else if (tableContext) {
-        // Delete a whole table cell
-        const { table } = tableContext;
-
         const isInserted = tableContext == context.lastTableContext;
-
         if (!isInserted) {
+            const { table } = tableContext;
+
             const deletedTable = cloneBlock(table) as ContentModelTable;
             deletedTable.cells = deletedTable.cells.map(row =>
                 row.filter(cell => !!cell.isSelected)
@@ -405,6 +402,7 @@ function deleteBlock(
     replacement?: ContentModelBlock
 ): boolean {
     const index = blocks.indexOf(blockToDelete);
+
     switch (blockToDelete.blockType) {
         case 'Table':
         case 'Divider':

--- a/packages/roosterjs-content-model/test/modelApi/selection/deleteSelectionTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/selection/deleteSelectionTest.ts
@@ -38,6 +38,7 @@ describe('deleteSelection - selectionOnly', () => {
 
         expect(result.isChanged).toBeFalse();
         expect(result.insertPoint).toBeNull();
+        expect(result.deletedModel).toEqual({ blockGroupType: 'Document', blocks: [] });
     });
 
     it('Single selection marker', () => {
@@ -74,6 +75,24 @@ describe('deleteSelection - selectionOnly', () => {
                             isSelected: true,
                         },
                     ],
+                },
+            ],
+        });
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                    segments: [
+                        {
+                            isSelected: true,
+                            segmentType: 'SelectionMarker',
+                            format: Object({ fontSize: '10px' }),
+                        },
+                    ],
+                    blockType: 'Paragraph',
+                    format: Object({}),
                 },
             ],
         });
@@ -114,6 +133,25 @@ describe('deleteSelection - selectionOnly', () => {
                             isSelected: true,
                         },
                     ],
+                },
+            ],
+        });
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                    segments: [
+                        {
+                            text: 'test1',
+                            segmentType: 'Text',
+                            isSelected: true,
+                            format: Object({ fontSize: '10px' }),
+                        },
+                    ],
+                    blockType: 'Paragraph',
+                    format: Object({}),
                 },
             ],
         });
@@ -176,6 +214,39 @@ describe('deleteSelection - selectionOnly', () => {
                 },
             ],
         });
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                Object({
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                    segments: [
+                        Object({
+                            text: 'test1',
+                            segmentType: 'Text',
+                            isSelected: true,
+                            format: Object({ fontSize: '11px' }),
+                        }),
+                    ],
+                    blockType: 'Paragraph',
+                    format: Object({}),
+                }),
+                Object({
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                    segments: [
+                        Object({
+                            text: 'test2',
+                            segmentType: 'Text',
+                            isSelected: true,
+                            format: Object({ fontSize: '12px' }),
+                        }),
+                    ],
+                    blockType: 'Paragraph',
+                    format: Object({}),
+                }),
+            ],
+        });
     });
 
     it('Divider selection', () => {
@@ -223,6 +294,18 @@ describe('deleteSelection - selectionOnly', () => {
                         },
                     ],
                     isImplicit: false,
+                },
+            ],
+        });
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    isSelected: true,
+                    tagName: 'div',
+                    cachedElement: undefined,
+                    blockType: 'Divider',
+                    format: {},
                 },
             ],
         });
@@ -293,6 +376,25 @@ describe('deleteSelection - selectionOnly', () => {
                     blockType: 'Paragraph',
                     format: {},
                     segments: [],
+                },
+            ],
+        });
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    isSelected: true,
+                    tagName: 'div',
+                    cachedElement: undefined,
+                    blockType: 'Divider',
+                    format: {},
+                },
+                {
+                    isSelected: true,
+                    tagName: 'hr',
+                    cachedElement: undefined,
+                    blockType: 'Divider',
+                    format: {},
                 },
             ],
         });
@@ -395,6 +497,34 @@ describe('deleteSelection - selectionOnly', () => {
                 },
             ],
         });
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    cachedElement: undefined,
+                    widths: [],
+                    heights: [],
+                    cells: [
+                        [
+                            {
+                                cachedElement: undefined,
+                                isSelected: true,
+                                spanAbove: false,
+                                spanLeft: false,
+                                isHeader: false,
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                dataset: {},
+                            },
+                        ],
+                    ],
+                    blockType: 'Table',
+                    format: {},
+                    dataset: {},
+                },
+            ],
+        });
     });
 
     it('All table cell selection', () => {
@@ -449,6 +579,34 @@ describe('deleteSelection - selectionOnly', () => {
                 },
             ],
         });
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    cachedElement: undefined,
+                    widths: [],
+                    heights: [],
+                    cells: [
+                        [
+                            {
+                                cachedElement: undefined,
+                                isSelected: true,
+                                spanAbove: false,
+                                spanLeft: false,
+                                isHeader: false,
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                dataset: {},
+                            },
+                        ],
+                    ],
+                    blockType: 'Table',
+                    format: {},
+                    dataset: {},
+                },
+            ],
+        });
     });
 
     it('Entity selection, no callback', () => {
@@ -498,6 +656,21 @@ describe('deleteSelection - selectionOnly', () => {
                         },
                     ],
                     isImplicit: false,
+                },
+            ],
+        });
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    wrapper: 'WRAPPER' as any,
+                    isReadonly: true,
+                    type: undefined,
+                    id: undefined,
+                    blockType: 'Entity',
+                    format: {},
+                    segmentType: 'Entity',
+                    isSelected: true,
                 },
             ],
         });
@@ -556,6 +729,21 @@ describe('deleteSelection - selectionOnly', () => {
         });
 
         expect(onDeleteEntity).toHaveBeenCalledWith(entity, EntityOperation.Overwrite);
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    wrapper: 'WRAPPER' as any,
+                    isReadonly: true,
+                    type: undefined,
+                    id: undefined,
+                    blockType: 'Entity',
+                    format: Object({}),
+                    segmentType: 'Entity',
+                    isSelected: true,
+                },
+            ],
+        });
     });
 
     it('Entity selection, callback returns true', () => {
@@ -609,6 +797,21 @@ describe('deleteSelection - selectionOnly', () => {
         });
 
         expect(onDeleteEntity).toHaveBeenCalledWith(entity, EntityOperation.Overwrite);
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    wrapper: 'WRAPPER' as any,
+                    isReadonly: true,
+                    type: undefined,
+                    id: undefined,
+                    blockType: 'Entity',
+                    format: Object({}),
+                    segmentType: 'Entity',
+                    isSelected: true,
+                },
+            ],
+        });
     });
 
     it('delete with default format', () => {
@@ -652,6 +855,18 @@ describe('deleteSelection - selectionOnly', () => {
             ],
             format: { fontSize: '10pt' },
         });
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    isSelected: true,
+                    tagName: 'div',
+                    cachedElement: undefined,
+                    blockType: 'Divider',
+                    format: {},
+                },
+            ],
+        });
     });
 
     it('delete with general block', () => {
@@ -689,6 +904,19 @@ describe('deleteSelection - selectionOnly', () => {
                     format: {},
                     segments: [marker],
                     isImplicit: false,
+                },
+            ],
+        });
+
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    element: null as any,
+                    blockType: 'BlockGroup',
+                    format: {},
+                    blockGroupType: 'General',
+                    blocks: [],
                 },
             ],
         });
@@ -740,6 +968,26 @@ describe('deleteSelection - selectionOnly', () => {
                 },
             ],
         });
+
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    isSelected: true,
+                    tagName: 'div',
+                    cachedElement: undefined,
+                    blockType: 'Divider',
+                    format: {},
+                },
+                {
+                    element: null as any,
+                    blockType: 'BlockGroup',
+                    format: {},
+                    blockGroupType: 'General',
+                    blocks: [],
+                },
+            ],
+        });
     });
 
     it('delete with general segment', () => {
@@ -777,6 +1025,29 @@ describe('deleteSelection - selectionOnly', () => {
                     blockType: 'Paragraph',
                     format: {},
                     segments: [marker],
+                },
+            ],
+        });
+
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                    segments: [
+                        {
+                            element: null as any,
+                            blockType: 'BlockGroup',
+                            format: {},
+                            blockGroupType: 'General',
+                            blocks: [],
+                            segmentType: 'General',
+                            isSelected: true,
+                        },
+                    ],
+                    blockType: 'Paragraph',
+                    format: {},
                 },
             ],
         });
@@ -822,6 +1093,34 @@ describe('deleteSelection - selectionOnly', () => {
                 },
             ],
         });
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                    segments: [
+                        {
+                            element: null,
+                            blockType: 'BlockGroup',
+                            format: {},
+                            blockGroupType: 'General',
+                            blocks: [],
+                            segmentType: 'General',
+                            isSelected: true,
+                        },
+                        {
+                            text: 'test',
+                            segmentType: 'Text',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+        });
     });
 
     it('Normalize spaces before deleted segment', () => {
@@ -860,6 +1159,30 @@ describe('deleteSelection - selectionOnly', () => {
                     blockType: 'Paragraph',
                     format: {},
                     segments: [{ segmentType: 'Text', text: 'test\u00A0', format: {} }, marker],
+                },
+            ],
+        });
+
+        expect(result.deletedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                    segments: [
+                        {
+                            src: 'test',
+                            alt: undefined,
+                            title: undefined,
+                            isSelectedAsImageSelection: undefined,
+                            segmentType: 'Image',
+                            isSelected: true,
+                            format: {},
+                            dataset: {},
+                        },
+                    ],
+                    blockType: 'Paragraph',
+                    format: {},
                 },
             ],
         });


### PR DESCRIPTION
In order to support copy, cut and paste with content model, I am updating the `deleteSelections` function to return the deleted blocks or segments.
Using that data we can update the tempDiv using contentModelToDom function. To perform the copy or cut operation. Which will be done in a future PR