### PR TITLE
Content Model Edit: Improve undo

### DIFF
--- a/demo/scripts/controls/MainPane.tsx
+++ b/demo/scripts/controls/MainPane.tsx
@@ -383,20 +383,22 @@ class MainPane extends MainPaneBase {
         return (
             <div className={styles.editorContainer}>
                 <div style={editorStyles}>
-                    <Rooster
-                        className={styles.editor}
-                        plugins={allPlugins}
-                        defaultFormat={this.state.initState.defaultFormat}
-                        inDarkMode={this.state.isDarkMode}
-                        getDarkColor={getDarkColor}
-                        experimentalFeatures={this.state.initState.experimentalFeatures}
-                        undoMetadataSnapshotService={this.snapshotPlugin.getSnapshotService()}
-                        trustedHTMLHandler={trustedHTMLHandler}
-                        zoomScale={this.state.scale}
-                        initialContent={this.content}
-                        editorCreator={this.state.editorCreator}
-                        dir={this.state.isRtl ? 'rtl' : 'ltr'}
-                    />
+                    {this.state.editorCreator && (
+                        <Rooster
+                            className={styles.editor}
+                            plugins={allPlugins}
+                            defaultFormat={this.state.initState.defaultFormat}
+                            inDarkMode={this.state.isDarkMode}
+                            getDarkColor={getDarkColor}
+                            experimentalFeatures={this.state.initState.experimentalFeatures}
+                            undoMetadataSnapshotService={this.snapshotPlugin.getSnapshotService()}
+                            trustedHTMLHandler={trustedHTMLHandler}
+                            zoomScale={this.state.scale}
+                            initialContent={this.content}
+                            editorCreator={this.state.editorCreator}
+                            dir={this.state.isRtl ? 'rtl' : 'ltr'}
+                        />
+                    )}
                 </div>
             </div>
         );

--- a/demo/scripts/controls/sidePane/eventViewer/EventViewPane.tsx
+++ b/demo/scripts/controls/sidePane/eventViewer/EventViewPane.tsx
@@ -46,6 +46,7 @@ const EventTypeMap: { [key in PluginEventType]: string } = {
     [PluginEventType.BeforeSetContent]: 'BeforeSetContent',
     [PluginEventType.ZoomChanged]: 'ZoomChanged',
     [PluginEventType.SelectionChanged]: 'SelectionChanged',
+    [PluginEventType.BeforeKeyboardEditing]: 'BeforeKeyboardEditing',
 };
 
 const EntityOperationMap: { [key in EntityOperation]: string } = {
@@ -241,6 +242,9 @@ export default class EventViewPane extends React.Component<
                         Old value={event.oldZoomScale} New value={event.newZoomScale}
                     </span>
                 );
+
+            case PluginEventType.BeforeKeyboardEditing:
+                return <span>Key code={event.rawEvent.which}</span>;
 
             default:
                 return null;

--- a/packages/roosterjs-content-model/lib/editor/utils/handleKeyboardEventCommon.ts
+++ b/packages/roosterjs-content-model/lib/editor/utils/handleKeyboardEventCommon.ts
@@ -48,6 +48,10 @@ export function handleKeyboardEventResult(
         // We have deleted what we need from content model, no need to let browser keep handling the event
         rawEvent.preventDefault();
         normalizeContentModel(model);
+
+        editor.triggerPluginEvent(PluginEventType.BeforeKeyboardEditing, {
+            rawEvent,
+        });
     } else {
         // We didn't delete anything from content model, so browser will handle this event and we need to clear the cache
         editor.cacheContentModel(null);

--- a/packages/roosterjs-content-model/lib/editor/utils/handleKeyboardEventCommon.ts
+++ b/packages/roosterjs-content-model/lib/editor/utils/handleKeyboardEventCommon.ts
@@ -49,6 +49,8 @@ export function handleKeyboardEventResult(
         rawEvent.preventDefault();
         normalizeContentModel(model);
 
+        // Trigger an event to let plugins know the content is about to be changed by Content Model keyboard editing.
+        // So plugins can do proper handling. e.g. UndoPlugin can decide whether take a snapshot before this change happens.
         editor.triggerPluginEvent(PluginEventType.BeforeKeyboardEditing, {
             rawEvent,
         });

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -48,7 +48,7 @@ export interface FormatWithContentModelOptions {
 export function formatWithContentModel(
     editor: IContentModelEditor,
     apiName: string,
-    callback: (model: ContentModelDocument) => boolean,
+    formatCallback: (model: ContentModelDocument) => boolean,
     options?: FormatWithContentModelOptions
 ) {
     const {
@@ -68,8 +68,8 @@ export function formatWithContentModel(
         : undefined;
     const model = editor.createContentModel(domToModelOption);
 
-    if (callback(model)) {
-        const callback = () => {
+    if (formatCallback(model)) {
+        const applyChangeCallback = () => {
             editor.focus();
             if (model) {
                 editor.setContentModel(model, { onNodeCreated });
@@ -88,14 +88,14 @@ export function formatWithContentModel(
         };
 
         if (skipUndoSnapshot) {
-            callback();
+            applyChangeCallback();
 
             if (changeSource) {
                 editor.triggerContentChangedEvent(changeSource, getChangeData?.());
             }
         } else {
             editor.addUndoSnapshot(
-                callback,
+                applyChangeCallback,
                 changeSource || ChangeSource.Format,
                 false /*canUndoByBackspace*/,
                 {

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -48,7 +48,7 @@ export interface FormatWithContentModelOptions {
 export function formatWithContentModel(
     editor: IContentModelEditor,
     apiName: string,
-    formatCallback: (model: ContentModelDocument) => boolean,
+    callback: (model: ContentModelDocument) => boolean,
     options?: FormatWithContentModelOptions
 ) {
     const {
@@ -68,8 +68,8 @@ export function formatWithContentModel(
         : undefined;
     const model = editor.createContentModel(domToModelOption);
 
-    if (formatCallback(model)) {
-        const applyChangeCallback = () => {
+    if (callback(model)) {
+        const callback = () => {
             editor.focus();
             if (model) {
                 editor.setContentModel(model, { onNodeCreated });
@@ -88,14 +88,14 @@ export function formatWithContentModel(
         };
 
         if (skipUndoSnapshot) {
-            applyChangeCallback();
+            callback();
 
             if (changeSource) {
                 editor.triggerContentChangedEvent(changeSource, getChangeData?.());
             }
         } else {
             editor.addUndoSnapshot(
-                applyChangeCallback,
+                callback,
                 changeSource || ChangeSource.Format,
                 false /*canUndoByBackspace*/,
                 {

--- a/packages/roosterjs-content-model/test/editor/utils/handleKeyboardEventCommonTest.ts
+++ b/packages/roosterjs-content-model/test/editor/utils/handleKeyboardEventCommonTest.ts
@@ -127,15 +127,18 @@ describe('handleKeyboardEventResult', () => {
     let cacheContentModel: jasmine.Spy;
     let preventDefault: jasmine.Spy;
     let triggerContentChangedEvent: jasmine.Spy;
+    let triggerPluginEvent: jasmine.Spy;
 
     beforeEach(() => {
         cacheContentModel = jasmine.createSpy('cacheContentModel');
         preventDefault = jasmine.createSpy('preventDefault');
         triggerContentChangedEvent = jasmine.createSpy('triggerContentChangedEvent');
+        triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
 
         mockedEditor = ({
             cacheContentModel,
             triggerContentChangedEvent,
+            triggerPluginEvent,
         } as any) as IContentModelEditor;
         mockedEvent = ({
             preventDefault,
@@ -155,6 +158,9 @@ describe('handleKeyboardEventResult', () => {
         expect(normalizeContentModel.normalizeContentModel).toHaveBeenCalledWith(mockedModel);
         expect(triggerContentChangedEvent).not.toHaveBeenCalled();
         expect(cacheContentModel).not.toHaveBeenCalled();
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.BeforeKeyboardEditing, {
+            rawEvent: mockedEvent,
+        });
     });
 
     it('isChanged = false', () => {
@@ -165,5 +171,6 @@ describe('handleKeyboardEventResult', () => {
         expect(triggerContentChangedEvent).not.toHaveBeenCalled();
         expect(normalizeContentModel.normalizeContentModel).not.toHaveBeenCalled();
         expect(cacheContentModel).toHaveBeenCalledWith(null);
+        expect(triggerPluginEvent).not.toHaveBeenCalled();
     });
 });

--- a/packages/roosterjs-editor-core/test/corePlugins/undoPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/undoPluginTest.ts
@@ -800,6 +800,42 @@ describe('UndoPlugin', () => {
         expect(canUndoAutoComplete2).not.toHaveBeenCalled();
     });
 
+    it('Handle BeforeKeyboardEditing event', () => {
+        const canMove1 = jasmine.createSpy('canMove');
+        const move1 = jasmine.createSpy('move');
+        const addSnapshot1 = jasmine.createSpy('addSnapshot');
+        const clearRedo1 = jasmine.createSpy('clearRedo');
+        const canUndoAutoComplete1 = jasmine.createSpy('canUndoAutoComplete');
+        const addUndoSnapshot = jasmine.createSpy('addUndoSnapshot');
+        const plugin = new UndoPlugin({
+            undoMetadataSnapshotService: {
+                canMove: canMove1,
+                move: move1,
+                addSnapshot: addSnapshot1,
+                clearRedo: clearRedo1,
+                canUndoAutoComplete: canUndoAutoComplete1,
+            },
+        });
+
+        const mockedEditor = ({
+            isInIME: () => false,
+            addUndoSnapshot,
+        } as any) as IEditor;
+        (<any>plugin).lastKeyPress = 1;
+
+        plugin.initialize(mockedEditor);
+        plugin.onPluginEvent({
+            eventType: PluginEventType.BeforeKeyboardEditing,
+            rawEvent: {
+                which: Keys.DELETE,
+            } as any,
+        });
+
+        expect((<any>plugin).lastKeyPress).toBe(Keys.DELETE);
+        expect(addSnapshot1).not.toHaveBeenCalled();
+        expect(addUndoSnapshot).toHaveBeenCalledTimes(1);
+    });
+
     it('Handle ContentChanged event with Keyboard source', () => {
         const canMove1 = jasmine.createSpy('canMove');
         const move1 = jasmine.createSpy('move');
@@ -830,9 +866,9 @@ describe('UndoPlugin', () => {
             source: ChangeSource.Keyboard,
         });
 
-        expect((<any>plugin).lastKeyPress).toBe(Keys.DELETE);
+        expect((<any>plugin).lastKeyPress).toBe(1);
         expect(addSnapshot1).not.toHaveBeenCalled();
-        expect(addUndoSnapshot).toHaveBeenCalledTimes(1);
+        expect(addUndoSnapshot).not.toHaveBeenCalled();
     });
 
     it('Handle ContentChanged event with Keyboard source and same key code', () => {

--- a/packages/roosterjs-editor-types/lib/enum/PluginEventType.ts
+++ b/packages/roosterjs-editor-types/lib/enum/PluginEventType.ts
@@ -121,4 +121,11 @@ export const enum PluginEventType {
      * Editor changed the selection.
      */
     SelectionChanged = 22,
+
+    /**
+     * EXPERIMENTAL FEATURE
+     * Editor content is about to be changed by keyboard event.
+     * This is only used by Content Model editing
+     */
+    BeforeKeyboardEditing = 23,
 }

--- a/packages/roosterjs-editor-types/lib/event/BeforeKeyboardEditingEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/BeforeKeyboardEditingEvent.ts
@@ -1,0 +1,27 @@
+import BasePluginEvent from './BasePluginEvent';
+import { PluginEventType } from '../enum/PluginEventType';
+import type { CompatiblePluginEventType } from '../compatibleEnum/PluginEventType';
+
+/**
+ * Data of BeforeKeyboardEditing
+ */
+export interface BeforeKeyboardEditingData {
+    /**
+     * Raw DOM event
+     */
+    rawEvent: KeyboardEvent;
+}
+
+/**
+ * Provides a chance for plugin to change the content before it is copied from editor.
+ */
+export default interface BeforeKeyboardEditingEvent
+    extends BeforeKeyboardEditingData,
+        BasePluginEvent<PluginEventType.BeforeKeyboardEditing> {}
+
+/**
+ * Provides a chance for plugin to change the content before it is copied from editor.
+ */
+export interface CompatibleBeforeKeyboardEditingEvent
+    extends BeforeKeyboardEditingData,
+        BasePluginEvent<CompatiblePluginEventType.BeforeKeyboardEditing> {}

--- a/packages/roosterjs-editor-types/lib/event/PluginEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/PluginEvent.ts
@@ -1,5 +1,8 @@
 import BeforeCutCopyEvent, { CompatibleBeforeCutCopyEvent } from './BeforeCutCopyEvent';
 import BeforeDisposeEvent, { CompatibleBeforeDisposeEvent } from './BeforeDisposeEvent';
+import BeforeKeyboardEditingEvent, {
+    CompatibleBeforeKeyboardEditingEvent,
+} from './BeforeKeyboardEditingEvent';
 import BeforePasteEvent, { CompatibleBeforePasteEvent } from './BeforePasteEvent';
 import BeforeSetContentEvent, { CompatibleBeforeSetContentEvent } from './BeforeSetContentEvent';
 import ContentChangedEvent, { CompatibleContentChangedEvent } from './ContentChangedEvent';
@@ -41,6 +44,7 @@ export type PluginEvent =
     | BeforeSetContentEvent
     | ZoomChangedEvent
     | SelectionChangedEvent
+    | BeforeKeyboardEditingEvent
     | CompatibleBeforeCutCopyEvent
     | CompatibleBeforeDisposeEvent
     | CompatibleBeforePasteEvent
@@ -55,4 +59,5 @@ export type PluginEvent =
     | CompatibleEnterShadowEditEvent
     | CompatibleLeaveShadowEditEvent
     | CompatibleZoomChangedEvent
-    | CompatibleSelectionChangedEvent;
+    | CompatibleSelectionChangedEvent
+    | CompatibleBeforeKeyboardEditingEvent;

--- a/packages/roosterjs-editor-types/lib/event/index.ts
+++ b/packages/roosterjs-editor-types/lib/event/index.ts
@@ -94,3 +94,8 @@ export {
     SelectionChangedEventData,
     CompatibleSelectionChangedEvent,
 } from './SelectionChangeEvent';
+export {
+    default as BeforeKeyboardEditingEvent,
+    BeforeKeyboardEditingData,
+    CompatibleBeforeKeyboardEditingEvent,
+} from './BeforeKeyboardEditingEvent';


### PR DESCRIPTION
When press Delete/Backspace, we will add an undo snapshot before this change take effect, so that user can undo to the state before this change. However, with existing implementation there is no chance for UndoPlugin to get snapshot before change, so we need to introduce a new event `BeforeKeyboardEditingEvent`, and fire this event before we write content model back to DOM tree.

To test it:
1. Type some content
2. Press Delete or Backspace to delete some content
3. Undo, it should go back to the state before delete.