### PR TITLE
Fix TypeError: Cannot read properties of null (reading 'getInlineElementBefore')

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
@@ -480,6 +480,10 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
 
     private tryRemoveNode(event: PluginDomEvent): boolean {
         const searcher = this.editor.getContentSearcherOfCursor(event);
+        if (!searcher) {
+            return false;
+        }
+
         const inlineElementBefore = searcher.getInlineElementBefore();
         const nodeBeforeCursor = inlineElementBefore
             ? inlineElementBefore.getContainerNode()
@@ -488,6 +492,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
         const inlineElementAfter = searcher.getInlineElementAfter();
 
         if (
+            nodeBeforeCursor &&
             nodeId &&
             nodeId.indexOf(this.pickerOptions.elementIdPrefix) == 0 &&
             (inlineElementAfter == null || !(inlineElementAfter instanceof PartialInlineElement))


### PR DESCRIPTION
Fix an error in Picker Plugin by adding some null checks:
```
TypeError: Cannot read properties of null (reading 'getInlineElementBefore')

roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts getInlineElementBefore 483 
roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts tryRemoveNode 443 
roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts onKeyDownEvent 192
```