### PR TITLE
Content Model: Fix #1797 Delete emoji using Content Model

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/utils/handleKeyboardEventCommon.ts
+++ b/packages/roosterjs-content-model/lib/editor/utils/handleKeyboardEventCommon.ts
@@ -2,7 +2,7 @@ import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocume
 import { EntityOperationEvent, PluginEventType } from 'roosterjs-editor-types';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { normalizeContentModel } from '../../modelApi/common/normalizeContentModel';
-import { OnDeleteEntity } from '../../modelApi/selection/deleteSelections';
+import { OnDeleteEntity } from '../../modelApi/edit/deleteSelections';
 
 /**
  * @internal

--- a/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
@@ -9,7 +9,7 @@ import { createListItem } from '../creators/createListItem';
 import { createParagraph } from '../creators/createParagraph';
 import { createSelectionMarker } from '../creators/createSelectionMarker';
 import { createTableCell } from '../creators/createTableCell';
-import { deleteSelection, InsertPoint } from '../selection/deleteSelections';
+import { deleteSelection, InsertPoint } from '../edit/deleteSelections';
 import { getClosestAncestorBlockGroupIndex } from './getClosestAncestorBlockGroupIndex';
 import { normalizeContentModel } from './normalizeContentModel';
 import { normalizeTable } from '../table/normalizeTable';

--- a/packages/roosterjs-content-model/lib/modelApi/edit/deleteSingleChar.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/edit/deleteSingleChar.ts
@@ -1,0 +1,38 @@
+/**
+ * @internal
+ */
+export function deleteSingleChar(text: string, isForward: boolean) {
+    // In case of emoji that occupies multiple characters, we need to delete the whole emoji
+    const array = [...text];
+    let deleteLength = 0;
+
+    for (
+        let i = isForward ? 0 : array.length - 1,
+            deleteState: 'notDeleted' | 'waiting' | 'done' = 'notDeleted';
+        i >= 0 && i < array.length && deleteState != 'done';
+        i += isForward ? 1 : -1
+    ) {
+        switch (array[i]) {
+            case '\u200D': // ZERO WIDTH JOINER
+            case '\u20E3': // COMBINING ENCLOSING KEYCAP
+            case '\uFE0E': // VARIATION SELECTOR-15
+            case '\uFE0F': // VARIATION SELECTOR-16
+                deleteState = 'notDeleted';
+                deleteLength++;
+                break;
+
+            default:
+                if (deleteState == 'notDeleted') {
+                    deleteState = 'waiting';
+                    deleteLength++;
+                } else if (deleteState == 'waiting') {
+                    deleteState = 'done';
+                }
+                break;
+        }
+    }
+
+    array.splice(isForward ? 0 : array.length - deleteLength, deleteLength);
+
+    return array.join('');
+}

--- a/packages/roosterjs-content-model/lib/publicApi/editing/handleBackspaceKey.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/editing/handleBackspaceKey.ts
@@ -1,5 +1,5 @@
 import { ChangeSource, EntityOperationEvent } from 'roosterjs-editor-types';
-import { deleteSelection } from '../../modelApi/selection/deleteSelections';
+import { deleteSelection } from '../../modelApi/edit/deleteSelections';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import {

--- a/packages/roosterjs-content-model/lib/publicApi/editing/handleDeleteKey.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/editing/handleDeleteKey.ts
@@ -1,5 +1,5 @@
 import { ChangeSource, EntityOperationEvent } from 'roosterjs-editor-types';
-import { deleteSelection } from '../../modelApi/selection/deleteSelections';
+import { deleteSelection } from '../../modelApi/edit/deleteSelections';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import {

--- a/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
@@ -2,7 +2,7 @@ import { applyTableFormat } from '../../modelApi/table/applyTableFormat';
 import { createContentModelDocument } from '../../modelApi/creators/createContentModelDocument';
 import { createSelectionMarker } from '../../modelApi/creators/createSelectionMarker';
 import { createTableStructure } from '../../modelApi/table/createTableStructure';
-import { deleteSelection } from '../../modelApi/selection/deleteSelections';
+import { deleteSelection } from '../../modelApi/edit/deleteSelections';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';

--- a/packages/roosterjs-content-model/test/modelApi/edit/deleteSelectionTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/edit/deleteSelectionTest.ts
@@ -13,7 +13,7 @@ import { createSelectionMarker } from '../../../lib/modelApi/creators/createSele
 import { createTable } from '../../../lib/modelApi/creators/createTable';
 import { createTableCell } from '../../../lib/modelApi/creators/createTableCell';
 import { createText } from '../../../lib/modelApi/creators/createText';
-import { deleteSelection } from '../../../lib/modelApi/selection/deleteSelections';
+import { deleteSelection } from '../../../lib/modelApi/edit/deleteSelections';
 import { EntityOperation } from 'roosterjs-editor-types';
 
 describe('deleteSelection - selectionOnly', () => {

--- a/packages/roosterjs-content-model/test/modelApi/edit/deleteSingleCharTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/edit/deleteSingleCharTest.ts
@@ -1,0 +1,48 @@
+import { deleteSingleChar } from '../../../lib/modelApi/edit/deleteSingleChar';
+
+describe('deleteSingleChar', () => {
+    const tests = ['', 'a', '\u200b', '好', '👩‍💻', '🎉', '🛏', '🎉', '👩‍❤️‍💋‍👩'];
+
+    it('Delete from start', () => {
+        tests.forEach(test => {
+            const result = deleteSingleChar(test, true);
+
+            expect(result).toBe('', test);
+        });
+    });
+
+    it('Delete from end', () => {
+        tests.forEach(test => {
+            const result = deleteSingleChar(test, false);
+
+            expect(result).toBe('', test);
+        });
+    });
+
+    it('Delete from start with another string', () => {
+        tests.forEach(test => {
+            const str = 'test';
+            const result = deleteSingleChar(test + str, true);
+
+            expect(result).toBe(test == '' ? 'est' : str, test);
+        });
+    });
+
+    it('Delete from start with another string', () => {
+        tests.forEach(test => {
+            const str = 'test';
+            const result = deleteSingleChar(str + test, false);
+
+            expect(result).toBe(test == '' ? 'tes' : str, test);
+        });
+    });
+
+    it('Delete joint emoji', () => {
+        // Temporary result: we don't have a good solution for this kind of joint emoji yet, current result seems acceptable
+        const result1 = deleteSingleChar('🇫🇷', true);
+        expect(result1).toBe('🇷');
+
+        const result2 = deleteSingleChar('🇫🇷', false);
+        expect(result2).toBe('🇫');
+    });
+});

--- a/packages/roosterjs-content-model/test/publicApi/editing/handleBackspaceKeyTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/editing/handleBackspaceKeyTest.ts
@@ -1,4 +1,4 @@
-import * as deleteSelection from '../../../lib/modelApi/selection/deleteSelections';
+import * as deleteSelection from '../../../lib/modelApi/edit/deleteSelections';
 import * as formatWithContentModel from '../../../lib/publicApi/utils/formatWithContentModel';
 import * as handleKeyboardEventResult from '../../../lib/editor/utils/handleKeyboardEventCommon';
 import handleBackspaceKey from '../../../lib/publicApi/editing/handleBackspaceKey';

--- a/packages/roosterjs-content-model/test/publicApi/editing/handleDeleteKeyTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/editing/handleDeleteKeyTest.ts
@@ -1,4 +1,4 @@
-import * as deleteSelection from '../../../lib/modelApi/selection/deleteSelections';
+import * as deleteSelection from '../../../lib/modelApi/edit/deleteSelections';
 import * as formatWithContentModel from '../../../lib/publicApi/utils/formatWithContentModel';
 import * as handleKeyboardEventResult from '../../../lib/editor/utils/handleKeyboardEventCommon';
 import handleDeleteKey from '../../../lib/publicApi/editing/handleDeleteKey';

--- a/packages/tsconfig.build.json
+++ b/packages/tsconfig.build.json
@@ -9,6 +9,7 @@
         "noImplicitAny": true,
         "preserveConstEnums": false,
         "noUnusedLocals": true,
+        "downlevelIteration": true,
         "baseUrl": ".",
         "paths": {
             "*": ["*"]

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -10,6 +10,7 @@
         "noImplicitAny": true,
         "preserveConstEnums": true,
         "noUnusedLocals": true,
+        "downlevelIteration": true,
         "baseUrl": ".",
         "paths": {
             "*": ["*"]

--- a/tools/buildTools/buildDemo.js
+++ b/tools/buildTools/buildDemo.js
@@ -8,7 +8,6 @@ const {
     packagesPath,
     deployPath,
     roosterJsDistPath,
-    mainPackageJson,
     packagesUiPath,
     roosterJsUiDistPath,
     runWebPack,
@@ -35,6 +34,11 @@ async function buildDemoSite() {
                 {
                     test: /\.tsx?$/,
                     loader: 'ts-loader',
+                    options: {
+                        compilerOptions: {
+                            downlevelIteration: true,
+                        },
+                    },
                 },
                 {
                     test: /\.svg$/,

--- a/tools/buildTools/pack.js
+++ b/tools/buildTools/pack.js
@@ -39,6 +39,7 @@ async function pack(isProduction, isAmd, isUi, filename) {
                             rootDir: rootPath,
                             strict: false,
                             declaration: false,
+                            downlevelIteration: true,
                         },
                     },
                 },

--- a/tools/tsconfig.doc.json
+++ b/tools/tsconfig.doc.json
@@ -9,6 +9,7 @@
             "*": ["packages/*", "packages-ui/*"]
         },
         "rootDir": "..",
+        "downlevelIteration": true,
         "lib": ["es6", "dom"]
     },
     "include": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,11 @@ module.exports = {
             {
                 test: /\.tsx?$/,
                 loader: 'ts-loader',
+                options: {
+                    compilerOptions: {
+                        downlevelIteration: true,
+                    },
+                },
             },
             {
                 test: /\.svg$/,


### PR DESCRIPTION
Emoji can be multiple-character. So we need to detect if we need to delete all of them.

The idea comes from here https://cestoliv.com/blog/how-to-count-emojis-with-javascript/

I'm not using the ultimate fix since it doesn't work for Firefox. The remaining issue is to delete emoji such as "🇫🇷". I think the current behavior is still acceptable, so just use it.