### PR TITLE
Fix resize handles

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -394,7 +394,7 @@ export default class ImageEdit implements EditorPlugin {
      * quit editing mode when editor lose focus
      */
     private onBlur = () => {
-        // this.setEditingImage(null, false /* selectImage */);
+        this.setEditingImage(null, false /* selectImage */);
     };
     /**
      * Create editing wrapper for the image

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -394,7 +394,7 @@ export default class ImageEdit implements EditorPlugin {
      * quit editing mode when editor lose focus
      */
     private onBlur = () => {
-        this.setEditingImage(null, false /* selectImage */);
+        // this.setEditingImage(null, false /* selectImage */);
     };
     /**
      * Create editing wrapper for the image
@@ -679,7 +679,7 @@ function handleRadIndexCalculator(angleRad: number): number {
     return idx < 0 ? idx + DIRECTIONS : idx;
 }
 
-function rotateHandles(y: string, x: string, angleRad: number): string {
+function rotateHandles(angleRad: number, y: string = '', x: string = ''): string {
     const radIndex = handleRadIndexCalculator(angleRad);
     const originalDirection = y + x;
     const originalIndex = DirectionOrder.indexOf(originalDirection);
@@ -696,9 +696,7 @@ function updateHandleCursor(handles: HTMLElement[], angleRad: number) {
     handles.map(handle => {
         const y = handle.dataset.y;
         const x = handle.dataset.x;
-        if (y && x) {
-            handle.style.cursor = `${rotateHandles(y, x, angleRad)}-resize`;
-        }
+        handle.style.cursor = `${rotateHandles(angleRad, y, x)}-resize`;
     });
 }
 


### PR DESCRIPTION
Bug: resize handles cursor is not pointing the right direction after rotation operation. 
Cause: When data-x or data-y is undefined, the rotate handle cursor direction was not being calculated. 
Fix: when data-x or data-y is undefined, calculate the direction using the data existing value. 

Before: 
![imageHandlesBug](https://github.com/microsoft/roosterjs/assets/87443959/cb0c13af-053c-46b8-ae52-5a5ead38cb6a)

After: 
![imageHandlesFix](https://github.com/microsoft/roosterjs/assets/87443959/d32aec39-cd2b-4d71-8bb9-f06ef3f0d36e)

 