### PR TITLE
Fix VSO 207180 Inline image pasted from Word Online disappears when you try to edit it

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/Paste.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/Paste.ts
@@ -89,7 +89,7 @@ export default class Paste implements EditorPlugin {
                     convertPastedContentFromPowerPoint(event, trustedHTMLHandler);
                     break;
                 case KnownPasteSourceType.WacComponents:
-                    convertPastedContentFromOfficeOnline(fragment);
+                    convertPastedContentFromOfficeOnline(fragment, sanitizingOption);
                     break;
                 case KnownPasteSourceType.GoogleSheets:
                     sanitizingOption.additionalTagReplacements[GOOGLE_SHEET_NODE_NAME] = '*';

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/officeOnlineConverter/convertPastedContentFromOfficeOnline.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/officeOnlineConverter/convertPastedContentFromOfficeOnline.ts
@@ -1,3 +1,5 @@
+import { chainSanitizerCallback } from 'roosterjs-editor-dom';
+import { HtmlSanitizerOptions } from 'roosterjs-editor-types';
 import convertPastedContentFromWordOnline, {
     isWordOnlineWithList,
 } from './convertPastedContentFromWordOnline';
@@ -12,7 +14,10 @@ const WAC_IDENTIFY_SELECTOR =
  * We need to remove the display property and margin from all the list item
  * @param event The BeforePaste event
  */
-export default function convertPastedContentFromOfficeOnline(fragment: DocumentFragment) {
+export default function convertPastedContentFromOfficeOnline(
+    fragment: DocumentFragment,
+    sanitizingOption: Required<HtmlSanitizerOptions>
+) {
     fragment.querySelectorAll(WAC_IDENTIFY_SELECTOR).forEach((el: Element) => {
         const element = el as HTMLElement;
         element.style.removeProperty('display');
@@ -23,4 +28,13 @@ export default function convertPastedContentFromOfficeOnline(fragment: DocumentF
     if (isWordOnlineWithList(fragment)) {
         convertPastedContentFromWordOnline(fragment);
     }
+
+    // Remove "border:none" for image to fix image resize behavior
+    // We found a problem that when paste an image with "border:none" then the resize border will be
+    // displayed incorrectly when resize it. So we need to drop this style
+    chainSanitizerCallback(
+        sanitizingOption.cssStyleCallbacks,
+        'border',
+        (value, element) => element.tagName != 'IMG' || value != 'none'
+    );
 }


### PR DESCRIPTION
I have no idea why, but the symptom is, if the image has style "border:none", then it will not show correctly when resize. The resize border actually shrink into 0*0.

So the fix is to remove "border: none" when paste.