### PR TITLE
Fix split cell shading for Content Model

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellHorizontally.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellHorizontally.ts
@@ -39,8 +39,7 @@ export function splitTableCellHorizontally(table: ContentModelTable) {
                             cell.format
                         );
 
-                        //Keep the background color of the original cell
-                        newCell.dataset = { editingInfo: '{"bgColorOverride":true}' };
+                        newCell.dataset = { ...cell.dataset };
 
                         if (rowIndex < sel.firstRow || rowIndex > sel.lastRow) {
                             newCell.spanLeft = true;

--- a/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellHorizontally.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellHorizontally.ts
@@ -39,6 +39,9 @@ export function splitTableCellHorizontally(table: ContentModelTable) {
                             cell.format
                         );
 
+                        //Keep the background color of the original cell
+                        newCell.dataset = { editingInfo: '{"bgColorOverride":true}' };
+
                         if (rowIndex < sel.firstRow || rowIndex > sel.lastRow) {
                             newCell.spanLeft = true;
                         } else {

--- a/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellVertically.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellVertically.ts
@@ -49,8 +49,7 @@ export function splitTableCellVertically(table: ContentModelTable) {
                             cell.format
                         );
 
-                        //Keep the background color of the original cell
-                        newCell.dataset = { editingInfo: '{"bgColorOverride":true}' };
+                        newCell.dataset = { ...cell.dataset };
 
                         if (colIndex < sel.firstCol || colIndex > sel.lastCol) {
                             newCell.spanAbove = true;

--- a/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellVertically.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/table/splitTableCellVertically.ts
@@ -49,6 +49,9 @@ export function splitTableCellVertically(table: ContentModelTable) {
                             cell.format
                         );
 
+                        //Keep the background color of the original cell
+                        newCell.dataset = { editingInfo: '{"bgColorOverride":true}' };
+
                         if (colIndex < sel.firstCol || colIndex > sel.lastCol) {
                             newCell.spanAbove = true;
                         } else {

--- a/packages/roosterjs-content-model/test/modelApi/table/splitTableCellHorizontallyTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/table/splitTableCellHorizontallyTest.ts
@@ -278,4 +278,29 @@ describe('splitTableCellHorizontally', () => {
         expect(cells[2].cachedElement).toBeUndefined();
         expect(cells[3].cachedElement).toBeUndefined();
     });
+
+    it('keep background color', () => {
+        const table = createTable(2);
+        const cells = [
+            createTableCell(false, false, false, { backgroundColor: '1' }),
+            createTableCell(false, false, false, { backgroundColor: '2' }),
+            createTableCell(false, false, false, { backgroundColor: '3' }),
+            createTableCell(false, false, false, { backgroundColor: '4' }),
+        ];
+
+        cells[0].dataset = { editingInfo: '{"bgColorOverride":true}' };
+
+        table.rows[0].cells.push(cells[0], cells[1]);
+        table.rows[1].cells.push(cells[2], cells[3]);
+        table.widths = [100, 100];
+        table.rows[0].height = 200;
+        table.rows[1].height = 200;
+
+        cells[0].isSelected = true;
+
+        splitTableCellHorizontally(table);
+
+        expect(table.rows[0].cells[1].dataset).toEqual({ editingInfo: '{"bgColorOverride":true}' });
+        expect(table.rows[0].cells[1].format).toEqual({ backgroundColor: '1' });
+    });
 });

--- a/packages/roosterjs-content-model/test/modelApi/table/splitTableCellVerticallyTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/table/splitTableCellVerticallyTest.ts
@@ -336,4 +336,29 @@ describe('splitTableCellVertically', () => {
         expect(cells[2].cachedElement).toBeUndefined();
         expect(cells[3].cachedElement).toBeUndefined();
     });
+
+    it('keep background color', () => {
+        const table = createTable(2);
+        const cells = [
+            createTableCell(false, false, false, { backgroundColor: '1' }),
+            createTableCell(false, false, false, { backgroundColor: '2' }),
+            createTableCell(false, false, false, { backgroundColor: '3' }),
+            createTableCell(false, false, false, { backgroundColor: '4' }),
+        ];
+
+        cells[0].dataset = { editingInfo: '{"bgColorOverride":true}' };
+
+        table.rows[0].cells.push(cells[0], cells[1]);
+        table.rows[1].cells.push(cells[2], cells[3]);
+        table.widths = [100, 100];
+        table.rows[0].height = 200;
+        table.rows[1].height = 200;
+
+        cells[0].isSelected = true;
+
+        splitTableCellVertically(table);
+
+        expect(table.rows[1].cells[0].dataset).toEqual({ editingInfo: '{"bgColorOverride":true}' });
+        expect(table.rows[1].cells[0].format).toEqual({ backgroundColor: '1' });
+    });
 });


### PR DESCRIPTION
### Description:

When splitting a table cell that has a background colour different that the default, the new cell will now inherit the colour too. Previously, when using content model split the new cell reverted to the default colour.

### Fix

Added to the dataset of any new cells the property `editingInfo: '{"bgColorOverride":true}'` to make it maintain the inherited shading.

### Cases tested:

* Create a table in Rooster
* Shade all table as a new colour
* Select one or all cells and use Split from the content model ribbon

**Before:** After the split, all new cells would not inherit the shading from its parent cell.

**After:** After the split, all new cells will inherit the shading from its parent cell.

### Warnings and implications

- After the split, the new cell will still not inherit other format properties from its parent, such as font size.