### PR TITLE
Fix dialog can't be closed through pressing esc key

### DIFF
--- a/packages-ui/roosterjs-react/lib/ribbon/component/Ribbon.tsx
+++ b/packages-ui/roosterjs-react/lib/ribbon/component/Ribbon.tsx
@@ -101,7 +101,7 @@ export default function Ribbon<T extends string>(props: RibbonProps<T>) {
                     result.subMenuProps = {
                         shouldFocusOnMount: true,
                         focusZoneProps: { direction: FocusZoneDirection.bidirectional },
-                        onDismiss: onDismiss,
+                        onMenuDismissed: onDismiss,
                         onItemClick: onClick,
                         onRenderContextualMenuItem: dropDownMenu.allowLivePreview
                             ? contextMenuItemRenderer


### PR DESCRIPTION
Rooterjs dialog is not getting closed through "Esc" key.