### PR TITLE
Content Model: Merge format when merge model

### DIFF
--- a/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
@@ -1,9 +1,11 @@
 import { addSegment } from './addSegment';
 import { applyTableFormat } from '../table/applyTableFormat';
 import { ContentModelBlock } from '../../publicTypes/block/ContentModelBlock';
+import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
 import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
 import { ContentModelListItem } from '../../publicTypes/group/ContentModelListItem';
 import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
+import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { createListItem } from '../creators/createListItem';
 import { createParagraph } from '../creators/createParagraph';
@@ -31,6 +33,13 @@ export interface MergeModelOption {
      * @default undefined
      */
     insertPosition?: InsertPoint;
+
+    /**
+     * When set to true, segment format of the insert position will be merged into the content that is merged into current model.
+     * If the source model already has some format, it will not be overwritten.
+     * @default false
+     */
+    mergeCurrentFormat?: boolean;
 }
 
 /**
@@ -44,6 +53,15 @@ export function mergeModel(
     const insertPosition = options?.insertPosition ?? deleteSelection(target).insertPoint;
 
     if (insertPosition) {
+        if (options?.mergeCurrentFormat) {
+            const newFormat: ContentModelSegmentFormat = {
+                ...(target.format || {}),
+                ...insertPosition.marker.format,
+            };
+
+            applyDefaultFormat(source, newFormat);
+        }
+
         for (let i = 0; i < source.blocks.length; i++) {
             const block = source.blocks[i];
 
@@ -231,4 +249,32 @@ function insertBlock(markerPosition: InsertPoint, block: ContentModelBlock) {
     if (blockIndex >= 0) {
         path[0].blocks.splice(blockIndex, 0, block);
     }
+}
+
+function applyDefaultFormat(group: ContentModelBlockGroup, format: ContentModelSegmentFormat) {
+    group.blocks.forEach(block => {
+        switch (block.blockType) {
+            case 'BlockGroup':
+                applyDefaultFormat(block, format);
+                break;
+
+            case 'Table':
+                block.rows.forEach(row =>
+                    row.cells.forEach(cell => {
+                        applyDefaultFormat(cell, format);
+                    })
+                );
+                break;
+
+            case 'Paragraph':
+                block.segments.forEach(segment => {
+                    if (segment.segmentType == 'General') {
+                        applyDefaultFormat(segment, format);
+                    }
+
+                    segment.format = { ...format, ...segment.format };
+                });
+                break;
+        }
+    });
 }

--- a/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
@@ -29,7 +29,7 @@ function insertImageWithSrc(editor: IContentModelEditor, src: string) {
         const doc = createContentModelDocument();
 
         addSegment(doc, image);
-        mergeModel(model, doc);
+        mergeModel(model, doc, { mergeCurrentFormat: true });
 
         return true;
     });

--- a/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
@@ -92,7 +92,7 @@ export default function insertLink(
                         links.push(segment.link);
                     }
 
-                    mergeModel(model, doc);
+                    mergeModel(model, doc, { mergeCurrentFormat: true });
                 }
 
                 return segments.length > 0;

--- a/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
@@ -37,6 +37,7 @@ export default function insertTable(
             applyTableFormat(table, format);
             mergeModel(model, doc, {
                 insertPosition,
+                mergeCurrentFormat: true,
             });
 
             const firstBlock = table.rows[0]?.cells[0]?.blocks[0];

--- a/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
@@ -1,5 +1,6 @@
 import * as applyTableFormat from '../../../lib/modelApi/table/applyTableFormat';
 import * as normalizeTable from '../../../lib/modelApi/table/normalizeTable';
+import { ContentModelDocument } from '../../../lib/publicTypes/group/ContentModelDocument';
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
 import { createDivider } from '../../../lib/modelApi/creators/createDivider';
 import { createListItem } from '../../../lib/modelApi/creators/createListItem';
@@ -1368,6 +1369,59 @@ describe('mergeModel', () => {
                     format: {},
                 },
             ],
+        });
+    });
+
+    it('Merge with default format', () => {
+        const MockedFormat = {
+            formatName: 'mocked',
+        } as any;
+        const majorModel = createContentModelDocument(MockedFormat);
+        const sourceModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+        };
+        const para1 = createParagraph();
+        const marker = createSelectionMarker();
+
+        para1.segments.push(marker);
+        majorModel.blocks.push(para1);
+
+        mergeModel(majorModel, sourceModel, { mergeCurrentFormat: true });
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: MockedFormat,
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: MockedFormat,
         });
     });
 });

--- a/packages/roosterjs-content-model/test/publicApi/image/insertImageTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/image/insertImageTest.ts
@@ -146,4 +146,55 @@ describe('insertImage', () => {
             1
         );
     });
+
+    it('Insert image with current format', () => {
+        const model = createContentModelDocument({
+            fontFamily: 'Test',
+        });
+        const marker = createSelectionMarker({
+            fontSize: '20px',
+        });
+
+        addSegment(model, marker);
+
+        runTest(
+            'insertImage',
+            editor => {
+                insertImage(editor, testUrl);
+            },
+            model,
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {},
+                        isImplicit: true,
+                        segments: [
+                            {
+                                segmentType: 'Image',
+                                src: testUrl,
+                                format: {
+                                    fontFamily: 'Test',
+                                    fontSize: '20px',
+                                },
+                                dataset: {},
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
+                                format: {
+                                    fontSize: '20px',
+                                },
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+                format: {
+                    fontFamily: 'Test',
+                },
+            },
+            1
+        );
+    });
 });

--- a/packages/roosterjs-content-model/test/publicApi/link/insertLinkTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/link/insertLinkTest.ts
@@ -323,7 +323,9 @@ describe('insertLink', () => {
 
         const a = div.querySelector('a');
 
-        expect(a!.outerHTML).toBe('<a href="http://test.com" title="title">http://test.com</a>');
+        expect(a!.outerHTML).toBe(
+            '<a href="http://test.com" title="title"><span style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt;">http://test.com</span></a>'
+        );
         expect(onPluginEvent).toHaveBeenCalledTimes(4);
         expect(onPluginEvent).toHaveBeenCalledWith({
             eventType: PluginEventType.ContentChanged,


### PR DESCRIPTION
For Content Model API `mergeModel`, adding an option `mergeCurrentFormat`. When pass to true, it will merge a combination of default format and current format into the merged model.

For example:
```ts
defaultFormat = { fontFamily: 'Arial' };

currentFormat = { fontSize: '20px', textColor: 'red' }

mergedModelFormat = { textColor: 'blue' }
```

After merge, the format will be:

```ts
{
  fontFamily: 'Arial',
  fontSize: '20px',
  textColor: 'blue'
}
```

This is because from the source model, it already has format `textColor: blue`, so it will not be overwritten, but other formats like fontFamily, fontSize will be merged into the model segment format.

With this change, when insert image or other content, we can merge the existing format to make sure the merged model always has a format. Later we can also use this for paste.