### PR TITLE
Fix Incorrect Content removal inside of delimiter.

### DIFF
--- a/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/inlineEntityOnPluginEventTest.ts
@@ -440,6 +440,30 @@ describe('Inline Entity On Plugin Event |', () => {
             expect(rootDiv.querySelectorAll(DELIMITER_SELECTOR).length).toBe(0);
         });
 
+        it('Before CutCopyEvent, dont remove delimiter with additional content', () => {
+            const rootDiv = document.createElement('div');
+            const element1 = document.createElement('span');
+            rootDiv.appendChild(element1);
+            const [after, before]: Element[] = addDelimiters(element1);
+
+            after.appendChild(document.createTextNode('testAfter'));
+            before.appendChild(document.createTextNode('testBefore'));
+
+            inlineEntityOnPluginEvent(
+                <BeforeCutCopyEvent>{
+                    eventType: PluginEventType.BeforeCutCopy,
+                    clonedRoot: rootDiv,
+                },
+                editor
+            );
+
+            expect(rootDiv.querySelectorAll(DELIMITER_SELECTOR).length).toBe(0);
+            expect(after).toBeDefined();
+            expect(before).toBeDefined();
+            expect(after.innerHTML).toEqual('testAfter');
+            expect(before.innerHTML).toEqual('testBefore');
+        });
+
         it('ExtractContentWithDOM', () => {
             const rootDiv = document.createElement('div');
             const element1 = document.createElement('span');
@@ -455,6 +479,30 @@ describe('Inline Entity On Plugin Event |', () => {
             );
 
             expect(rootDiv.querySelectorAll(DELIMITER_SELECTOR).length).toBe(0);
+        });
+
+        it('ExtractContentWithDOM, dont remove delimiter with additional content', () => {
+            const rootDiv = document.createElement('div');
+            const element1 = document.createElement('span');
+            rootDiv.appendChild(element1);
+            const [after, before]: Element[] = addDelimiters(element1);
+
+            after.appendChild(document.createTextNode('testAfter'));
+            before.appendChild(document.createTextNode('testBefore'));
+
+            inlineEntityOnPluginEvent(
+                <ExtractContentWithDomEvent>{
+                    eventType: PluginEventType.ExtractContentWithDom,
+                    clonedRoot: rootDiv,
+                },
+                editor
+            );
+
+            expect(rootDiv.querySelectorAll(DELIMITER_SELECTOR).length).toBe(0);
+            expect(after).toBeDefined();
+            expect(before).toBeDefined();
+            expect(after.innerHTML).toEqual('testAfter');
+            expect(before.innerHTML).toEqual('testBefore');
         });
     });
 


### PR DESCRIPTION
We were removing all the Delimiters when doing BeforeCopyPaste or ExtractContentWithDOM event, but we did not check if the delimiter was actually a delimiter (textContent === ZWS && (className == DelimiterBefore || className == DelimiterAfter)).

In this PR I add a check before removing the delimiter, if it is a valid delimiter (we do the check using getDelimiterFromNode function) remove it, else just remove the classname and the ZWS