### PR TITLE
Support context menu in ImageSelection Plugin

### DIFF
--- a/packages-ui/roosterjs-react/lib/contextMenu/menus/createImageEditMenuProvider.tsx
+++ b/packages-ui/roosterjs-react/lib/contextMenu/menus/createImageEditMenuProvider.tsx
@@ -1,7 +1,7 @@
 import ContextMenuItem from '../types/ContextMenuItem';
 import createContextMenuProvider from '../utils/createContextMenuProvider';
 import showInputDialog from '../../inputDialog/utils/showInputDialog';
-import { EditorPlugin, IEditor, ImageEditOperation } from 'roosterjs-editor-types';
+import { DocumentCommand, EditorPlugin, IEditor, ImageEditOperation } from 'roosterjs-editor-types';
 import { ImageEditMenuItemStringKey } from '../types/ContextMenuItemStringKeys';
 import { LocalizedStrings } from '../../common/type/LocalizedStrings';
 import { safeInstanceOf } from 'roosterjs-editor-dom';
@@ -163,6 +163,30 @@ const ImageRemoveMenuItem: ContextMenuItem<ImageEditMenuItemStringKey, ImageEdit
     },
 };
 
+const ImageCopyMenuItem: ContextMenuItem<ImageEditMenuItemStringKey, ImageEdit> = {
+    key: 'menuNameImageCopy',
+    unlocalizedText: 'Copy image',
+    onClick: (_, editor, node, strings, uiUtilities, imageEdit) => {
+        if (editor.contains(node)) {
+            editor.addUndoSnapshot(() => {
+                editor.getDocument()?.execCommand(DocumentCommand.Copy);
+            }, 'DeleteImage');
+        }
+    },
+};
+
+const ImageCutMenuItem: ContextMenuItem<ImageEditMenuItemStringKey, ImageEdit> = {
+    key: 'menuNameImageCut',
+    unlocalizedText: 'Cut image',
+    onClick: (_, editor, node, strings, uiUtilities, imageEdit) => {
+        if (editor.contains(node)) {
+            editor.addUndoSnapshot(() => {
+                editor.getDocument()?.execCommand(DocumentCommand.Cut);
+            }, 'DeleteImage');
+        }
+    },
+};
+
 function shouldShowImageEditItems(editor: IEditor, node: Node) {
     return safeInstanceOf(node, 'HTMLImageElement') && node.isContentEditable;
 }
@@ -184,6 +208,8 @@ export default function createImageEditMenuProvider(
             ImageRemoveMenuItem,
             ImageRotateMenuItem,
             ImageFlipMenuItem,
+            ImageCopyMenuItem,
+            ImageCutMenuItem,
         ],
         strings,
         shouldShowImageEditItems,

--- a/packages-ui/roosterjs-react/lib/contextMenu/menus/createImageEditMenuProvider.tsx
+++ b/packages-ui/roosterjs-react/lib/contextMenu/menus/createImageEditMenuProvider.tsx
@@ -170,7 +170,7 @@ const ImageCopyMenuItem: ContextMenuItem<ImageEditMenuItemStringKey, ImageEdit> 
         if (editor.contains(node)) {
             editor.addUndoSnapshot(() => {
                 editor.getDocument()?.execCommand(DocumentCommand.Copy);
-            }, 'DeleteImage');
+            }, 'CopyImage');
         }
     },
 };
@@ -182,7 +182,7 @@ const ImageCutMenuItem: ContextMenuItem<ImageEditMenuItemStringKey, ImageEdit> =
         if (editor.contains(node)) {
             editor.addUndoSnapshot(() => {
                 editor.getDocument()?.execCommand(DocumentCommand.Cut);
-            }, 'DeleteImage');
+            }, 'CutImage');
         }
     },
 };

--- a/packages-ui/roosterjs-react/lib/contextMenu/types/ContextMenuItemStringKeys.ts
+++ b/packages-ui/roosterjs-react/lib/contextMenu/types/ContextMenuItemStringKeys.ts
@@ -46,6 +46,8 @@ export type ImageEditMenuItemStringKey =
     | 'menuNameImageRotateRight'
     | 'menuNameImageRotateFlipHorizontally'
     | 'menuNameImageRotateFlipVertically'
+    | 'menuNameImageCopy'
+    | 'menuNameImageCut'
     | OkButtonStringKey
     | CancelButtonStringKey;
 

--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -1,4 +1,4 @@
-import { createRange, safeInstanceOf } from 'roosterjs-editor-dom';
+import { safeInstanceOf } from 'roosterjs-editor-dom';
 
 import {
     EditorPlugin,
@@ -11,7 +11,6 @@ import {
 
 const Escape = 'Escape';
 const Delete = 'Delete';
-const mouseRightButton = 2;
 const mouseLeftButton = 0;
 
 /**
@@ -57,10 +56,7 @@ export default class ImageSelection implements EditorPlugin {
                 case PluginEventType.MouseUp:
                     const target = event.rawEvent.target;
                     if (safeInstanceOf(target, 'HTMLImageElement')) {
-                        if (event.rawEvent.button === mouseRightButton) {
-                            const imageRange = createRange(target);
-                            this.editor.select(imageRange);
-                        } else if (event.rawEvent.button === mouseLeftButton) {
+                        if (event.rawEvent.button === mouseLeftButton) {
                             this.editor.select(target);
                         }
                     }
@@ -94,7 +90,13 @@ export default class ImageSelection implements EditorPlugin {
                     break;
                 case PluginEventType.ContextMenu:
                     const contextMenuTarget = event.rawEvent.target;
-                    if (safeInstanceOf(contextMenuTarget, 'HTMLImageElement')) {
+                    const actualSelection = this.editor.getSelectionRangeEx();
+                    if (
+                        safeInstanceOf(contextMenuTarget, 'HTMLImageElement') &&
+                        (actualSelection.type !== SelectionRangeTypes.ImageSelection ||
+                            (actualSelection.type === SelectionRangeTypes.ImageSelection &&
+                                actualSelection.image !== contextMenuTarget))
+                    ) {
                         this.editor.select(contextMenuTarget);
                     }
             }

--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -55,10 +55,11 @@ export default class ImageSelection implements EditorPlugin {
 
                 case PluginEventType.MouseUp:
                     const target = event.rawEvent.target;
-                    if (safeInstanceOf(target, 'HTMLImageElement')) {
-                        if (event.rawEvent.button === mouseLeftButton) {
-                            this.editor.select(target);
-                        }
+                    if (
+                        safeInstanceOf(target, 'HTMLImageElement') &&
+                        event.rawEvent.button === mouseLeftButton
+                    ) {
+                        this.editor.select(target);
                     }
                     break;
                 case PluginEventType.MouseDown:

--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -92,6 +92,11 @@ export default class ImageSelection implements EditorPlugin {
                         }
                     }
                     break;
+                case PluginEventType.ContextMenu:
+                    const contextMenuTarget = event.rawEvent.target;
+                    if (safeInstanceOf(contextMenuTarget, 'HTMLImageElement')) {
+                        this.editor.select(contextMenuTarget);
+                    }
             }
         }
     }

--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -95,8 +95,7 @@ export default class ImageSelection implements EditorPlugin {
                     if (
                         safeInstanceOf(contextMenuTarget, 'HTMLImageElement') &&
                         (actualSelection.type !== SelectionRangeTypes.ImageSelection ||
-                            (actualSelection.type === SelectionRangeTypes.ImageSelection &&
-                                actualSelection.image !== contextMenuTarget))
+                            actualSelection.image !== contextMenuTarget)
                     ) {
                         this.editor.select(contextMenuTarget);
                     }

--- a/packages/roosterjs-editor-core/test/corePlugins/imageSelectionTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/imageSelectionTest.ts
@@ -141,6 +141,18 @@ describe('ImageSelectionPlugin |', () => {
         expect(selection.areAllCollapsed).toBe(false);
     });
 
+    it('should handle contextMenu', () => {
+        editor.setContent(`<img id=${imageId}></img>`);
+        const target = document.getElementById(imageId);
+        editorIsFeatureEnabled.and.returnValue(true);
+        editor.focus();
+        const contextMenuEvent = contextMenu(target!);
+        imageSelection.onPluginEvent(contextMenuEvent);
+        const selection = editor.getSelectionRangeEx();
+        expect(selection.type).toBe(SelectionRangeTypes.ImageSelection);
+        expect(selection.areAllCollapsed).toBe(false);
+    });
+
     const keyDown = (key: string): PluginEvent => {
         return {
             eventType: PluginEventType.KeyDown,
@@ -160,6 +172,16 @@ describe('ImageSelectionPlugin |', () => {
                 preventDefault: () => {},
                 stopPropagation: () => {},
             },
+        };
+    };
+
+    const contextMenu = (target: HTMLElement): PluginEvent => {
+        return {
+            eventType: PluginEventType.ContextMenu,
+            rawEvent: <any>{
+                target: target,
+            },
+            items: [],
         };
     };
 

--- a/packages/roosterjs-editor-core/test/corePlugins/imageSelectionTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/imageSelectionTest.ts
@@ -4,6 +4,7 @@ import {
     IEditor,
     EditorOptions,
     SelectionRangeTypes,
+    ImageSelectionRange,
     PluginEvent,
     PluginEventType,
 } from 'roosterjs-editor-types';
@@ -17,6 +18,7 @@ describe('ImageSelectionPlugin |', () => {
     let editor: IEditor;
     let id = 'imageSelectionContainerId';
     let imageId = 'imageSelectionId';
+    let imageId2 = 'imageSelectionId2';
     let imageSelection: ImageSelection;
     let editorIsFeatureEnabled: any;
 
@@ -62,19 +64,6 @@ describe('ImageSelectionPlugin |', () => {
 
         const selection = editor.getSelectionRangeEx();
         expect(selection.type).toBe(SelectionRangeTypes.ImageSelection);
-        expect(selection.areAllCollapsed).toBe(false);
-    });
-
-    it('should be triggered in mouse up right click', () => {
-        editor.setContent(`<img id=${imageId}></img>`);
-        const target = document.getElementById(imageId);
-        editorIsFeatureEnabled.and.returnValue(true);
-        simulateMouseEvent('mousedown', target!, 2);
-        simulateMouseEvent('mouseup', target!, 2);
-        editor.focus();
-
-        const selection = editor.getSelectionRangeEx();
-        expect(selection.type).toBe(SelectionRangeTypes.Normal);
         expect(selection.areAllCollapsed).toBe(false);
     });
 
@@ -151,6 +140,33 @@ describe('ImageSelectionPlugin |', () => {
         const selection = editor.getSelectionRangeEx();
         expect(selection.type).toBe(SelectionRangeTypes.ImageSelection);
         expect(selection.areAllCollapsed).toBe(false);
+    });
+
+    it('should change image selection contextMenu', () => {
+        editor.setContent(`<img id=${imageId}></img><img id=${imageId2}></img>`);
+        const target = document.getElementById(imageId);
+        const secondTarget = document.getElementById(imageId2);
+        editorIsFeatureEnabled.and.returnValue(true);
+        editor.focus();
+        editor.select(secondTarget);
+        const contextMenuEvent = contextMenu(target!);
+        imageSelection.onPluginEvent(contextMenuEvent);
+        const selection = editor.getSelectionRangeEx() as ImageSelectionRange;
+        expect(selection.type).toBe(SelectionRangeTypes.ImageSelection);
+
+        expect(selection.image.id).toBe(imageId);
+    });
+
+    it('should not change image selection contextMenu', () => {
+        editor.setContent(`<img id=${imageId}></img>`);
+        const target = document.getElementById(imageId);
+        editorIsFeatureEnabled.and.returnValue(true);
+        editor.focus();
+        editor.select(target);
+        const contextMenuEvent = contextMenu(target!);
+        imageSelection.onPluginEvent(contextMenuEvent);
+        spyOn(editor, 'select');
+        expect(editor.select).not.toHaveBeenCalled();
     });
 
     const keyDown = (key: string): PluginEvent => {


### PR DESCRIPTION
Instead of select the image when right click, use Context Menu event to select the image when right click a image. 
Add copy/cut options to the image context menu to test image selection. 

**Before:**
![contextMenuSelectionBlue](https://github.com/microsoft/roosterjs/assets/87443959/19e9f3de-96c4-4216-8265-e451260965d9)

**After:**
![contextMenuSelection](https://github.com/microsoft/roosterjs/assets/87443959/eed78ec7-6832-487c-8528-db3cad11122b)
