### PR TITLE
Always disable cache element on paste

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/coreApi/createPasteModel.ts
+++ b/packages/roosterjs-content-model/lib/editor/coreApi/createPasteModel.ts
@@ -1,5 +1,6 @@
 import ContentModelBeforePasteEvent from '../../publicTypes/event/ContentModelBeforePasteEvent';
 import domToContentModel from '../../domToModel/domToContentModel';
+import { ContentModelEditorCore, CreatePasteModel } from '../../publicTypes/ContentModelEditorCore';
 import {
     ClipboardData,
     EditorCore,
@@ -7,7 +8,6 @@ import {
     PasteType,
     PluginEventType,
 } from 'roosterjs-editor-types';
-import { ContentModelEditorCore, CreatePasteModel } from '../../publicTypes/ContentModelEditorCore';
 import {
     createDefaultHtmlSanitizerOptions,
     createFragmentFromClipboardData,
@@ -44,7 +44,10 @@ export const createPasteModel: CreatePasteModel = (
         event
     );
 
-    return domToContentModel(fragment, core.api.createEditorContext(core), event.domToModelOption);
+    return domToContentModel(fragment, core.api.createEditorContext(core), {
+        ...event.domToModelOption,
+        disableCacheElement: true,
+    });
 };
 
 /**

--- a/packages/roosterjs-content-model/lib/editor/plugins/PastePlugin/WacComponents/handleWacComponentsPaste.ts
+++ b/packages/roosterjs-content-model/lib/editor/plugins/PastePlugin/WacComponents/handleWacComponentsPaste.ts
@@ -145,7 +145,6 @@ const wacListLevelParser: FormatParser<ContentModelListItemLevelFormat> = (
  * @param ev ContentModelBeforePasteEvent
  */
 export function handleWacComponentsPaste(ev: ContentModelBeforePasteEvent) {
-    ev.domToModelOption.disableCacheElement = true;
     addParser(ev.domToModelOption, 'segment', wacSubSuperParser);
     addParser(ev.domToModelOption, 'listItem', wacListItemParser);
     addParser(ev.domToModelOption, 'listLevel', wacListLevelParser);

--- a/packages/roosterjs-content-model/test/editor/coreApi/createPasteModelTest.ts
+++ b/packages/roosterjs-content-model/test/editor/coreApi/createPasteModelTest.ts
@@ -61,10 +61,9 @@ describe('createPasteModel', () => {
     it('Execute', () => {
         createPasteModelFile.createPasteModel(core, clipboardData, null, false, false, false);
 
-        expect(domToContentModel.default).toHaveBeenCalledWith(
-            fragment,
-            mockedContext,
-            beforePasteEvent.domToModelOption
-        );
+        expect(domToContentModel.default).toHaveBeenCalledWith(fragment, mockedContext, {
+            ...beforePasteEvent.domToModelOption,
+            disableCacheElement: true,
+        });
     });
 });


### PR DESCRIPTION
We need to disable the caching of elements on paste, otherwise in some scenarios, for example for table cells, we do not apply the correct format if the editor is in dark mode.

This PR adds the disableCacheElements to the domToContentModel when invoking createPasteModel