### PR TITLE
Remove the support of ShadowDOM entity

### DIFF
--- a/demo/scripts/controls/sidePane/apiPlayground/insertEntity/InsertEntityPane.tsx
+++ b/demo/scripts/controls/sidePane/apiPlayground/insertEntity/InsertEntityPane.tsx
@@ -14,7 +14,6 @@ interface InsertEntityPaneState {
 export default class InsertEntityPane extends React.Component<ApiPaneProps, InsertEntityPaneState> {
     private entityType = React.createRef<HTMLInputElement>();
     private html = React.createRef<HTMLTextAreaElement>();
-    private hydratedHtml = React.createRef<HTMLTextAreaElement>();
     private styleInline = React.createRef<HTMLInputElement>();
     private styleBlock = React.createRef<HTMLInputElement>();
     private isReadonly = React.createRef<HTMLInputElement>();
@@ -36,10 +35,6 @@ export default class InsertEntityPane extends React.Component<ApiPaneProps, Inse
                 </div>
                 <div>
                     HTML: <textarea className={styles.textarea} ref={this.html}></textarea>
-                </div>
-                <div>
-                    Hydrated HTML:
-                    <textarea className={styles.textarea} ref={this.hydratedHtml}></textarea>
                 </div>
                 <div>
                     Style:
@@ -85,7 +80,6 @@ export default class InsertEntityPane extends React.Component<ApiPaneProps, Inse
         const entityType = this.entityType.current.value;
         const node = document.createElement('span');
         node.innerHTML = trustedHTMLHandler(this.html.current.value);
-        node.dataset.hydratedHtml = this.hydratedHtml.current.value.trim();
         const isBlock = this.styleBlock.current.checked;
         const isReadonly = this.isReadonly.current.checked;
         const insertAtRoot = this.insertAtRoot.current.checked;
@@ -138,9 +132,6 @@ function EntityButton({ entity }: { entity: Entity }) {
             Id: {entity.id}
             <br />
             Readonly: {entity.isReadonly ? 'True' : 'False'}
-            <br />
-            IsShadowEntity: {!!entity.wrapper.shadowRoot}
-            <br />
             <br />
         </div>
     );

--- a/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/newEditorTest.ts
@@ -73,7 +73,6 @@ describe('Editor', () => {
         }
         expect(core.entity).toEqual({
             knownEntityElements: [],
-            shadowEntityCache: {},
         });
         expect(core.lifecycle.customData).toEqual({});
         expect(core.lifecycle.isDarkMode).toBeFalse();
@@ -183,7 +182,6 @@ describe('Editor', () => {
         }
         expect(core.entity).toEqual({
             knownEntityElements: [],
-            shadowEntityCache: {},
         });
         expect(core.lifecycle.customData).toEqual({});
         expect(core.lifecycle.isDarkMode).toBeTrue();

--- a/packages/roosterjs-editor-types/lib/corePluginState/EntityPluginState.ts
+++ b/packages/roosterjs-editor-types/lib/corePluginState/EntityPluginState.ts
@@ -14,9 +14,7 @@ export default interface EntityPluginState {
     knownEntityElements: HTMLElement[];
 
     /**
-     * Cache for the hydrated content of shadow DOM entity.
-     * When set content to replace the whole editor, we will cache the hydrated content
-     * before it is gone, then after that we can use the cached content to rehydrate entity
+     * @deprecated
      */
-    shadowEntityCache: Record<string, HTMLElement>;
+    shadowEntityCache?: Record<string, HTMLElement>;
 }

--- a/packages/roosterjs-editor-types/lib/enum/EntityOperation.ts
+++ b/packages/roosterjs-editor-types/lib/enum/EntityOperation.ts
@@ -59,14 +59,12 @@ export const enum EntityOperation {
     ReplaceTemporaryContent,
 
     /**
-     * Notify plugins that editor has attached shadow root for an entity.
-     * Plugins can handle this event to do extra operations to the shadow root
+     * @deprecated
      */
     AddShadowRoot,
 
     /**
-     * Notify plugins that editor has removed the shadow root of an entity
-     * Plugins can handle this event to do any necessary clean up for shadow root
+     * @deprecated
      */
     RemoveShadowRoot,
 }

--- a/packages/roosterjs-editor-types/lib/event/EntityOperationEvent.ts
+++ b/packages/roosterjs-editor-types/lib/event/EntityOperationEvent.ts
@@ -25,15 +25,7 @@ export interface EntityOperationEventData {
     rawEvent?: Event;
 
     /**
-     * A document fragment for entity based on Shadow DOM. This property is only available for NewEntity operation.
-     * Putting DOM nodes under this fragment will cause a shadow root to be attached to the entity wrapper
-     * with these DOM nodes under it.
-     *
-     * If there is already cached DOM nodes, they will also be put under this fragment.
-     * Plugin need to decide:
-     * 1. Apply the cache: do nothing and the DOM nodes will be appended as shadow DOM entity content
-     * 2. Discard the cache and use new content instead: clear the fragment and append new DOM nodes, then new DOM nodes will be used
-     * 3. Dehydrate this entity: clear the fragment, and leave it empty
+     * @deprecated
      */
     contentForShadowEntity?: DocumentFragment;
 }


### PR DESCRIPTION
Shadow DOM entity has never been really used, and it still has a lot of problem. So let's remove the support of Shadow DOM entity. In the future we can consider add this feature back using Content Model.