### PR TITLE
Remove Table temp elements from Word Online

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/officeOnlineConverter/convertPastedContentFromOfficeOnline.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/officeOnlineConverter/convertPastedContentFromOfficeOnline.ts
@@ -6,7 +6,16 @@ import convertPastedContentFromWordOnline, {
 
 const WAC_IDENTIFY_SELECTOR =
     'ul[class^="BulletListStyle"]>.OutlineElement,ol[class^="NumberListStyle"]>.OutlineElement,span.WACImageContainer';
-
+const TABLE_TEMP_ELEMENTS_QUERY = [
+    'TableInsertRowGapBlank',
+    'TableColumnResizeHandle',
+    'TableCellTopBorderHandle',
+    'TableCellLeftBorderHandle',
+    'TableHoverColumnHandle',
+    'TableHoverRowHandle',
+]
+    .map(className => `.${className}`)
+    .join(',');
 /**
  * @internal
  * Convert pasted content from Office Online
@@ -37,4 +46,8 @@ export default function convertPastedContentFromOfficeOnline(
         'border',
         (value, element) => element.tagName != 'IMG' || value != 'none'
     );
+
+    fragment
+        .querySelectorAll(TABLE_TEMP_ELEMENTS_QUERY)
+        .forEach(node => node.parentElement?.removeChild(node));
 }

--- a/packages/roosterjs-editor-plugins/test/paste/word/convertPastedContentFromOfficeOnlineTest.ts
+++ b/packages/roosterjs-editor-plugins/test/paste/word/convertPastedContentFromOfficeOnlineTest.ts
@@ -1,0 +1,32 @@
+import convertPastedContentFromOfficeOnline from '../../../lib/plugins/Paste/officeOnlineConverter/convertPastedContentFromOfficeOnline';
+import { createDefaultHtmlSanitizerOptions } from 'roosterjs-editor-dom';
+
+describe('convertPastedContentFromOfficeOnlineTest', () => {
+    function runTest(html: string, expectedInnerHtml: string) {
+        const doc = sanitizeContent(html);
+
+        expect(doc.body.innerHTML).toBe(expectedInnerHtml);
+    }
+
+    it('remove table temp elements', () => {
+        runTest(
+            '<table aria-rowcount="1" data-tablelook="1184" data-tablestyle="MsoTableGrid" border="1" class="Table TableStaticStyles Ltr TableWordWrap SCXW96211671 BCX8" id="table"><tbody><tr aria-rowindex="1" role="row"><td data-celllook="69905" role="rowheader"><div></div><div class="TableHoverColumnHandle"></div><div></div><div class="TableCellTopBorderHandle"></div><div class="TableColumnResizeHandle"></div><div class="TableInsertRowGapBlank"></div><div><div><p><span lang="EN-US" data-contrast="auto">a</span></p></div></div></td><td data-celllook="69905" role="columnheader"><div class="TableHoverColumnHandle"></div><div class="TableCellTopBorderHandle"></div><div class="TableColumnResizeHandle"></div><div class="TableInsertRowGapBlank"></div><div><p><span>asd</span></p></div></td></tr></tbody></table>',
+            '<table aria-rowcount="1" data-tablelook="1184" data-tablestyle="MsoTableGrid" border="1" class="Table TableStaticStyles Ltr TableWordWrap SCXW96211671 BCX8" id="table"><tbody><tr aria-rowindex="1" role="row"><td data-celllook="69905" role="rowheader"><div></div><div></div><div><div><p><span lang="EN-US" data-contrast="auto">a</span></p></div></div></td><td data-celllook="69905" role="columnheader"><div><p><span>asd</span></p></div></td></tr></tbody></table>'
+        );
+    });
+});
+
+function sanitizeContent(html: string) {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const fragment = doc.createDocumentFragment();
+    while (doc.body.firstChild) {
+        fragment.appendChild(doc.body.firstChild);
+    }
+
+    convertPastedContentFromOfficeOnline(fragment, createDefaultHtmlSanitizerOptions());
+
+    while (fragment.firstChild) {
+        doc.body.appendChild(fragment.firstChild);
+    }
+    return doc;
+}


### PR DESCRIPTION
In a previous I added the functionality to remove some elements that cause some layout issues on tables when pasting from Word Online.

I did not add the change to the current Paste Plugin, so I am adding it now.

Before
![image](https://github.com/microsoft/roosterjs/assets/8291124/950eebac-3167-4100-a122-98cf8dad07be)

After
![image](https://github.com/microsoft/roosterjs/assets/8291124/d49bb556-0375-4d46-a4eb-faeae960e146)
