### PR TITLE
Make mergeModel, formatWithContentModel and onDeleteEntityCallback Public

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -5,7 +5,7 @@ import { createContentModelEditorCore } from './createContentModelEditorCore';
 import { EditorBase } from 'roosterjs-editor-core';
 import { formatWithContentModel } from '../publicApi/utils/formatWithContentModel';
 import { getOnDeleteEntityCallback } from './utils/handleKeyboardEventCommon';
-import { mergeModel } from '../modelApi/common/mergeModel';
+import { mergeModel } from '../publicApi/utils/mergeModel';
 import { Position } from 'roosterjs-editor-dom';
 import {
     ChangeSource,

--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -1,11 +1,11 @@
+import formatWithContentModel from '../publicApi/utils/formatWithContentModel';
+import mergeModel from '../publicApi/utils/mergeModel';
 import { ContentModelDocument } from '../publicTypes/group/ContentModelDocument';
 import { ContentModelEditorCore } from '../publicTypes/ContentModelEditorCore';
 import { ContentModelSegmentFormat } from '../publicTypes/format/ContentModelSegmentFormat';
 import { createContentModelEditorCore } from './createContentModelEditorCore';
 import { EditorBase } from 'roosterjs-editor-core';
-import { formatWithContentModel } from '../publicApi/utils/formatWithContentModel';
 import { getOnDeleteEntityCallback } from './utils/handleKeyboardEventCommon';
-import { mergeModel } from '../publicApi/utils/mergeModel';
 import { Position } from 'roosterjs-editor-dom';
 import {
     ChangeSource,

--- a/packages/roosterjs-content-model/lib/editor/index.ts
+++ b/packages/roosterjs-content-model/lib/editor/index.ts
@@ -8,3 +8,4 @@ export {
     createContentModelEditorCore,
     promoteToContentModelEditorCore,
 } from './createContentModelEditorCore';
+export { getOnDeleteEntityCallback } from './utils/handleKeyboardEventCommon';

--- a/packages/roosterjs-content-model/lib/editor/utils/handleKeyboardEventCommon.ts
+++ b/packages/roosterjs-content-model/lib/editor/utils/handleKeyboardEventCommon.ts
@@ -5,7 +5,10 @@ import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { normalizeContentModel } from '../../modelApi/common/normalizeContentModel';
 
 /**
- * @internal
+ * Callback used when deleting an entity.
+ * @param editor editor instance
+ * @param rawEvent (Optional) keyboard event
+ * @param triggeredEntityEvents (Optional) Already triggered entity events. so the editor only triggers entity operation event when the event was not triggered before.
  */
 export function getOnDeleteEntityCallback(
     editor: IContentModelEditor,

--- a/packages/roosterjs-content-model/lib/publicApi/block/setAlignment.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setAlignment.ts
@@ -1,4 +1,4 @@
-import { formatWithContentModel } from '../utils/formatWithContentModel';
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { setModelAlignment } from '../../modelApi/block/setModelAlignment';
 

--- a/packages/roosterjs-content-model/lib/publicApi/block/setIndentation.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setIndentation.ts
@@ -1,4 +1,4 @@
-import { formatWithContentModel } from '../utils/formatWithContentModel';
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { setModelIndentation } from '../../modelApi/block/setModelIndentation';
 

--- a/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
@@ -1,5 +1,5 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { ContentModelFormatContainerFormat } from '../../publicTypes/format/ContentModelFormatContainerFormat';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { toggleModelBlockQuote } from '../../modelApi/block/toggleModelBlockQuote';
 

--- a/packages/roosterjs-content-model/lib/publicApi/editing/handleKeyDownEvent.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/editing/handleKeyDownEvent.ts
@@ -1,9 +1,9 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { Browser } from 'roosterjs-editor-dom';
 import { ChangeSource, EntityOperationEvent, Keys } from 'roosterjs-editor-types';
 import { deleteAllSegmentBefore } from '../../modelApi/edit/deleteSteps/deleteAllSegmentBefore';
 import { deleteSelection } from '../../modelApi/edit/deleteSelection';
 import { DeleteSelectionStep } from '../../modelApi/edit/utils/DeleteSelectionStep';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import {
     getOnDeleteEntityCallback,

--- a/packages/roosterjs-content-model/lib/publicApi/format/applyPendingFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/applyPendingFormat.ts
@@ -1,5 +1,5 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { createText } from '../../modelApi/creators/createText';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { iterateSelections } from '../../modelApi/selection/iterateSelections';

--- a/packages/roosterjs-content-model/lib/publicApi/format/clearFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/clearFormat.ts
@@ -1,9 +1,9 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { clearModelFormat } from '../../modelApi/common/clearModelFormat';
 import { ContentModelBlock } from '../../publicTypes/block/ContentModelBlock';
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
 import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { normalizeContentModel } from '../../modelApi/common/normalizeContentModel';
 

--- a/packages/roosterjs-content-model/lib/publicApi/format/getFormatState.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/getFormatState.ts
@@ -1,5 +1,5 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { FormatState } from 'roosterjs-editor-types';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { retrieveModelFormatState } from '../../modelApi/common/retrieveModelFormatState';

--- a/packages/roosterjs-content-model/lib/publicApi/format/getSegmentFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/getSegmentFormat.ts
@@ -1,5 +1,5 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { iterateSelections } from '../../modelApi/selection/iterateSelections';

--- a/packages/roosterjs-content-model/lib/publicApi/image/adjustImageSelection.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/adjustImageSelection.ts
@@ -1,6 +1,6 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { adjustSegmentSelection } from '../../modelApi/selection/adjustSegmentSelection';
 import { ContentModelImage } from '../../publicTypes/segment/ContentModelImage';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 
 /**

--- a/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
@@ -4,7 +4,7 @@ import { createImage } from '../../modelApi/creators/createImage';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getOnDeleteEntityCallback } from '../../editor/utils/handleKeyboardEventCommon';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
-import { mergeModel } from '../../modelApi/common/mergeModel';
+import { mergeModel } from '../utils/mergeModel';
 import { readFile } from 'roosterjs-editor-dom';
 
 /**

--- a/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
@@ -1,10 +1,10 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
+import mergeModel from '../utils/mergeModel';
 import { addSegment } from '../../modelApi/common/addSegment';
 import { createContentModelDocument } from '../../modelApi/creators/createContentModelDocument';
 import { createImage } from '../../modelApi/creators/createImage';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getOnDeleteEntityCallback } from '../../editor/utils/handleKeyboardEventCommon';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
-import { mergeModel } from '../utils/mergeModel';
 import { readFile } from 'roosterjs-editor-dom';
 
 /**

--- a/packages/roosterjs-content-model/lib/publicApi/index.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/index.ts
@@ -43,3 +43,5 @@ export { default as setImageAltText } from './image/setImageAltText';
 export { default as adjustImageSelection } from './image/adjustImageSelection';
 export { default as setParagraphMargin } from './block/setParagraphMargin';
 export { default as toggleCode } from './segment/toggleCode';
+export { default as formatWithContentModel } from './utils/formatWithContentModel';
+export { default as mergeModel } from './utils/mergeModel';

--- a/packages/roosterjs-content-model/lib/publicApi/link/adjustLinkSelection.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/adjustLinkSelection.ts
@@ -1,6 +1,6 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { adjustSegmentSelection } from '../../modelApi/selection/adjustSegmentSelection';
 import { adjustWordSelection } from '../../modelApi/selection/adjustWordSelection';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { setSelection } from '../../modelApi/selection/setSelection';

--- a/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
@@ -10,7 +10,7 @@ import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
 import { HtmlSanitizer, matchLink } from 'roosterjs-editor-dom';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
-import { mergeModel } from '../../modelApi/common/mergeModel';
+import { mergeModel } from '../utils/mergeModel';
 
 // Regex matching Uri scheme
 const URI_REGEX = /^[a-zA-Z]+:/i;

--- a/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
@@ -1,16 +1,16 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
+import mergeModel from '../utils/mergeModel';
 import { addLink } from '../../modelApi/common/addDecorators';
 import { addSegment } from '../../modelApi/common/addSegment';
 import { ChangeSource } from 'roosterjs-editor-types';
 import { ContentModelLink } from '../../publicTypes/decorator/ContentModelLink';
 import { createContentModelDocument } from '../../modelApi/creators/createContentModelDocument';
 import { createText } from '../../modelApi/creators/createText';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getOnDeleteEntityCallback } from '../../editor/utils/handleKeyboardEventCommon';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
 import { HtmlSanitizer, matchLink } from 'roosterjs-editor-dom';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
-import { mergeModel } from '../utils/mergeModel';
 
 // Regex matching Uri scheme
 const URI_REGEX = /^[a-zA-Z]+:/i;

--- a/packages/roosterjs-content-model/lib/publicApi/link/removeLink.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/removeLink.ts
@@ -1,5 +1,5 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { adjustSegmentSelection } from '../../modelApi/selection/adjustSegmentSelection';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 

--- a/packages/roosterjs-content-model/lib/publicApi/list/setListStartNumber.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/setListStartNumber.ts
@@ -1,4 +1,4 @@
-import { formatWithContentModel } from '../utils/formatWithContentModel';
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { getFirstSelectedListItem } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 

--- a/packages/roosterjs-content-model/lib/publicApi/list/setListStyle.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/setListStyle.ts
@@ -1,5 +1,5 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { findListItemsInSameThread } from '../../modelApi/list/findListItemsInSameThread';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getFirstSelectedListItem } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { ListMetadataFormat } from '../../publicTypes/format/formatParts/ListMetadataFormat';

--- a/packages/roosterjs-content-model/lib/publicApi/list/toggleBullet.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/toggleBullet.ts
@@ -1,4 +1,4 @@
-import { formatWithContentModel } from '../utils/formatWithContentModel';
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { setListType } from '../../modelApi/list/setListType';
 

--- a/packages/roosterjs-content-model/lib/publicApi/list/toggleNumbering.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/toggleNumbering.ts
@@ -1,4 +1,4 @@
-import { formatWithContentModel } from '../utils/formatWithContentModel';
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { setListType } from '../../modelApi/list/setListType';
 

--- a/packages/roosterjs-content-model/lib/publicApi/table/editTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/editTable.ts
@@ -1,10 +1,10 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { alignTable } from '../../modelApi/table/alignTable';
 import { alignTableCell } from '../../modelApi/table/alignTableCell';
 import { applyTableFormat } from '../../modelApi/table/applyTableFormat';
 import { deleteTable } from '../../modelApi/table/deleteTable';
 import { deleteTableColumn } from '../../modelApi/table/deleteTableColumn';
 import { deleteTableRow } from '../../modelApi/table/deleteTableRow';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getFirstSelectedTable } from '../../modelApi/selection/collectSelections';
 import { hasMetadata } from '../../domUtils/metadata/updateMetadata';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';

--- a/packages/roosterjs-content-model/lib/publicApi/table/formatTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/formatTable.ts
@@ -1,5 +1,5 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import { applyTableFormat } from '../../modelApi/table/applyTableFormat';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getFirstSelectedTable } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { TableMetadataFormat } from '../../publicTypes/format/formatParts/TableMetadataFormat';

--- a/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
@@ -7,7 +7,7 @@ import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getOnDeleteEntityCallback } from '../../editor/utils/handleKeyboardEventCommon';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
-import { mergeModel } from '../../modelApi/common/mergeModel';
+import { mergeModel } from '../utils/mergeModel';
 import { normalizeTable } from '../../modelApi/table/normalizeTable';
 import { setSelection } from '../../modelApi/selection/setSelection';
 import { TableMetadataFormat } from '../../publicTypes/format/formatParts/TableMetadataFormat';

--- a/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
@@ -1,13 +1,13 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
+import mergeModel from '../utils/mergeModel';
 import { applyTableFormat } from '../../modelApi/table/applyTableFormat';
 import { createContentModelDocument } from '../../modelApi/creators/createContentModelDocument';
 import { createSelectionMarker } from '../../modelApi/creators/createSelectionMarker';
 import { createTableStructure } from '../../modelApi/table/createTableStructure';
 import { deleteSelection } from '../../modelApi/edit/deleteSelection';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getOnDeleteEntityCallback } from '../../editor/utils/handleKeyboardEventCommon';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
-import { mergeModel } from '../utils/mergeModel';
 import { normalizeTable } from '../../modelApi/table/normalizeTable';
 import { setSelection } from '../../modelApi/selection/setSelection';
 import { TableMetadataFormat } from '../../publicTypes/format/formatParts/TableMetadataFormat';

--- a/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
@@ -1,5 +1,5 @@
+import formatWithContentModel from '../utils/formatWithContentModel';
 import hasSelectionInBlockGroup from '../selection/hasSelectionInBlockGroup';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getFirstSelectedTable } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { normalizeTable } from '../../modelApi/table/normalizeTable';

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatParagraphWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatParagraphWithContentModel.ts
@@ -1,5 +1,5 @@
+import formatWithContentModel from './formatWithContentModel';
 import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
-import { formatWithContentModel } from './formatWithContentModel';
 import { getSelectedParagraphs } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatSegmentWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatSegmentWithContentModel.ts
@@ -1,7 +1,7 @@
+import formatWithContentModel from './formatWithContentModel';
 import { adjustWordSelection } from '../../modelApi/selection/adjustWordSelection';
 import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
-import { formatWithContentModel } from './formatWithContentModel';
 import { getPendingFormat, setPendingFormat } from '../../modelApi/format/pendingFormat';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -49,7 +49,7 @@ export interface FormatWithContentModelOptions {
  * @param callback callback to execute to the content model representing the editor content.
  * @param options (Optional) Additional options to use when formating @see FormatWithContentModelOptions
  */
-export function formatWithContentModel(
+export default function formatWithContentModel(
     editor: IContentModelEditor,
     apiName: string,
     callback: (model: ContentModelDocument) => boolean,

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -43,7 +43,11 @@ export interface FormatWithContentModelOptions {
 }
 
 /**
- * @internal
+ * Format the current editor content model.
+ * @param editor Editor Instance
+ * @param apiName Api name that is invoking this function, will be provided to the Content Changed event when adding a undo snapshot
+ * @param callback callback to execute to the content model representing the editor content.
+ * @param options (Optional) Additional options to use when formating @see FormatWithContentModelOptions
  */
 export function formatWithContentModel(
     editor: IContentModelEditor,

--- a/packages/roosterjs-content-model/lib/publicApi/utils/mergeModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/mergeModel.ts
@@ -51,7 +51,7 @@ export interface MergeModelOption {
  * @param onDeleteEntity callback to use if an entity will be deleted if there is a entity inside of the selection
  * @param options (Optional) Additional options to use when merging the models @see MergeModelOption
  */
-export function mergeModel(
+export default function mergeModel(
     target: ContentModelDocument,
     source: ContentModelDocument,
     onDeleteEntity: OnDeleteEntity,

--- a/packages/roosterjs-content-model/lib/publicApi/utils/mergeModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/mergeModel.ts
@@ -1,5 +1,5 @@
-import { addSegment } from './addSegment';
-import { applyTableFormat } from '../table/applyTableFormat';
+import { addSegment } from '../../modelApi/common/addSegment';
+import { applyTableFormat } from '../../modelApi/table/applyTableFormat';
 import { ContentModelBlock } from '../../publicTypes/block/ContentModelBlock';
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
 import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
@@ -7,16 +7,16 @@ import { ContentModelListItem } from '../../publicTypes/group/ContentModelListIt
 import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
-import { createListItem } from '../creators/createListItem';
-import { createParagraph } from '../creators/createParagraph';
-import { createSelectionMarker } from '../creators/createSelectionMarker';
-import { createTableCell } from '../creators/createTableCell';
-import { deleteSelection } from '../edit/deleteSelection';
-import { getClosestAncestorBlockGroupIndex } from './getClosestAncestorBlockGroupIndex';
+import { createListItem } from '../../modelApi/creators/createListItem';
+import { createParagraph } from '../../modelApi/creators/createParagraph';
+import { createSelectionMarker } from '../../modelApi/creators/createSelectionMarker';
+import { createTableCell } from '../../modelApi/creators/createTableCell';
+import { deleteSelection } from '../../modelApi/edit/deleteSelection';
+import { getClosestAncestorBlockGroupIndex } from '../../modelApi/common/getClosestAncestorBlockGroupIndex';
 import { InsertPoint } from '../../publicTypes/selection/InsertPoint';
-import { normalizeContentModel } from './normalizeContentModel';
-import { normalizeTable } from '../table/normalizeTable';
-import { OnDeleteEntity } from '../edit/utils/DeleteSelectionStep';
+import { normalizeContentModel } from '../../modelApi/common/normalizeContentModel';
+import { normalizeTable } from '../../modelApi/table/normalizeTable';
+import { OnDeleteEntity } from '../../modelApi/edit/utils/DeleteSelectionStep';
 
 /**
  * @internal
@@ -45,7 +45,11 @@ export interface MergeModelOption {
 }
 
 /**
- * @internal
+ * Merges the source model into the target model.
+ * @param target Target content model
+ * @param source Source content model
+ * @param onDeleteEntity callback to use if an entity will be deleted if there is a entity inside of the selection
+ * @param options (Optional) Additional options to use when merging the models @see MergeModelOption
  */
 export function mergeModel(
     target: ContentModelDocument,

--- a/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
@@ -9,7 +9,7 @@ import { createSelectionMarker } from '../../../lib/modelApi/creators/createSele
 import { createTable } from '../../../lib/modelApi/creators/createTable';
 import { createTableCell } from '../../../lib/modelApi/creators/createTableCell';
 import { createText } from '../../../lib/modelApi/creators/createText';
-import { mergeModel } from '../../../lib/modelApi/common/mergeModel';
+import { mergeModel } from '../../../lib/publicApi/utils/mergeModel';
 
 function onDeleteEntityMock() {
     return false;

--- a/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
@@ -1,5 +1,6 @@
 import * as applyTableFormat from '../../../lib/modelApi/table/applyTableFormat';
 import * as normalizeTable from '../../../lib/modelApi/table/normalizeTable';
+import mergeModel from '../../../lib/publicApi/utils/mergeModel';
 import { ContentModelDocument } from '../../../lib/publicTypes/group/ContentModelDocument';
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
 import { createDivider } from '../../../lib/modelApi/creators/createDivider';
@@ -9,7 +10,6 @@ import { createSelectionMarker } from '../../../lib/modelApi/creators/createSele
 import { createTable } from '../../../lib/modelApi/creators/createTable';
 import { createTableCell } from '../../../lib/modelApi/creators/createTableCell';
 import { createText } from '../../../lib/modelApi/creators/createText';
-import { mergeModel } from '../../../lib/publicApi/utils/mergeModel';
 
 function onDeleteEntityMock() {
     return false;

--- a/packages/roosterjs-content-model/test/publicApi/block/setIndentationTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/block/setIndentationTest.ts
@@ -14,12 +14,12 @@ describe('setIndentation', () => {
     });
 
     it('indent', () => {
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callThrough();
+        spyOn(formatWithContentModel, 'default').and.callThrough();
         spyOn(setModelIndentation, 'setModelIndentation');
 
         setIndentation(editor, 'indent');
 
-        expect(formatWithContentModel.formatWithContentModel).toHaveBeenCalledTimes(1);
+        expect(formatWithContentModel.default).toHaveBeenCalledTimes(1);
         expect(setModelIndentation.setModelIndentation).toHaveBeenCalledTimes(1);
         expect(setModelIndentation.setModelIndentation).toHaveBeenCalledWith(
             fakeModel,
@@ -29,12 +29,12 @@ describe('setIndentation', () => {
     });
 
     it('outdent', () => {
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callThrough();
+        spyOn(formatWithContentModel, 'default').and.callThrough();
         spyOn(setModelIndentation, 'setModelIndentation');
 
         setIndentation(editor, 'outdent');
 
-        expect(formatWithContentModel.formatWithContentModel).toHaveBeenCalledTimes(1);
+        expect(formatWithContentModel.default).toHaveBeenCalledTimes(1);
         expect(setModelIndentation.setModelIndentation).toHaveBeenCalledTimes(1);
         expect(setModelIndentation.setModelIndentation).toHaveBeenCalledWith(
             fakeModel,

--- a/packages/roosterjs-content-model/test/publicApi/block/toggleBlockQuoteTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/block/toggleBlockQuoteTest.ts
@@ -14,12 +14,12 @@ describe('toggleBlockQuote', () => {
     });
 
     it('toggleBlockQuote', () => {
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callThrough();
+        spyOn(formatWithContentModel, 'default').and.callThrough();
         spyOn(toggleModelBlockQuote, 'toggleModelBlockQuote');
 
         toggleBlockQuote(editor, { a: 'b', c: 'd' } as any);
 
-        expect(formatWithContentModel.formatWithContentModel).toHaveBeenCalledTimes(1);
+        expect(formatWithContentModel.default).toHaveBeenCalledTimes(1);
         expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledTimes(1);
         expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledWith(fakeModel, {
             marginTop: '1em',
@@ -33,12 +33,12 @@ describe('toggleBlockQuote', () => {
     });
 
     it('toggleBlockQuote with real format', () => {
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callThrough();
+        spyOn(formatWithContentModel, 'default').and.callThrough();
         spyOn(toggleModelBlockQuote, 'toggleModelBlockQuote');
 
         toggleBlockQuote(editor, { lineHeight: '2', textColor: 'red' });
 
-        expect(formatWithContentModel.formatWithContentModel).toHaveBeenCalledTimes(1);
+        expect(formatWithContentModel.default).toHaveBeenCalledTimes(1);
         expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledTimes(1);
         expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledWith(fakeModel, {
             marginTop: '1em',

--- a/packages/roosterjs-content-model/test/publicApi/editing/handleKeyDownEventTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/editing/handleKeyDownEventTest.ts
@@ -376,7 +376,7 @@ describe('handleKeyDownEvent', () => {
     });
 
     it('Check parameter of formatWithContentModel, forward', () => {
-        const spy = spyOn(formatWithContentModel, 'formatWithContentModel');
+        const spy = spyOn(formatWithContentModel, 'default');
 
         const editor = 'EDITOR' as any;
         const which = Keys.DELETE;
@@ -395,7 +395,7 @@ describe('handleKeyDownEvent', () => {
     });
 
     it('Check parameter of formatWithContentModel, backward', () => {
-        const spy = spyOn(formatWithContentModel, 'formatWithContentModel');
+        const spy = spyOn(formatWithContentModel, 'default');
 
         const editor = 'EDITOR' as any;
         const which = Keys.BACKSPACE;

--- a/packages/roosterjs-content-model/test/publicApi/format/applyPendingFormatTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/format/applyPendingFormatTest.ts
@@ -39,12 +39,10 @@ describe('applyPendingFormat', () => {
             fontSize: '10px',
         });
 
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
-            (_, apiName, callback) => {
-                expect(apiName).toEqual('applyPendingFormat');
-                callback(model);
-            }
-        );
+        spyOn(formatWithContentModel, 'default').and.callFake((_, apiName, callback) => {
+            expect(apiName).toEqual('applyPendingFormat');
+            callback(model);
+        });
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
             callback([model], undefined, paragraph, [marker]);
             return false;
@@ -108,12 +106,10 @@ describe('applyPendingFormat', () => {
             fontSize: '10px',
         });
 
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
-            (_, apiName, callback) => {
-                expect(apiName).toEqual('applyPendingFormat');
-                callback(model);
-            }
-        );
+        spyOn(formatWithContentModel, 'default').and.callFake((_, apiName, callback) => {
+            expect(apiName).toEqual('applyPendingFormat');
+            callback(model);
+        });
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
             callback([model], undefined, paragraph, [marker]);
             return false;
@@ -168,12 +164,10 @@ describe('applyPendingFormat', () => {
 
         spyOn(pendingFormat, 'getPendingFormat').and.returnValue(null);
 
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
-            (_, apiName, callback) => {
-                expect(apiName).toEqual('applyPendingFormat');
-                callback(model);
-            }
-        );
+        spyOn(formatWithContentModel, 'default').and.callFake((_, apiName, callback) => {
+            expect(apiName).toEqual('applyPendingFormat');
+            callback(model);
+        });
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
             callback([model], undefined, paragraph, [marker]);
             return false;
@@ -226,12 +220,10 @@ describe('applyPendingFormat', () => {
             fontSize: '10px',
         });
 
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
-            (_, apiName, callback) => {
-                expect(apiName).toEqual('applyPendingFormat');
-                callback(model);
-            }
-        );
+        spyOn(formatWithContentModel, 'default').and.callFake((_, apiName, callback) => {
+            expect(apiName).toEqual('applyPendingFormat');
+            callback(model);
+        });
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
             callback([model], undefined, paragraph, [text]);
             return false;
@@ -271,12 +263,10 @@ describe('applyPendingFormat', () => {
         spyOn(pendingFormat, 'getPendingFormat').and.returnValue({
             fontSize: '10px',
         });
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
-            (_, apiName, callback) => {
-                expect(apiName).toEqual('applyPendingFormat');
-                callback(model);
-            }
-        );
+        spyOn(formatWithContentModel, 'default').and.callFake((_, apiName, callback) => {
+            expect(apiName).toEqual('applyPendingFormat');
+            callback(model);
+        });
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
             callback([model], undefined, paragraph, [marker]);
             return false;

--- a/packages/roosterjs-content-model/test/publicApi/format/clearFormatTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/format/clearFormatTest.ts
@@ -10,17 +10,15 @@ describe('clearFormat', () => {
         const editor = ({} as any) as IContentModelEditor;
         const model = ('Model' as any) as ContentModelDocument;
 
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
-            (_, apiName, callback) => {
-                expect(apiName).toEqual('clearFormat');
-                callback(model);
-            }
-        );
+        spyOn(formatWithContentModel, 'default').and.callFake((_, apiName, callback) => {
+            expect(apiName).toEqual('clearFormat');
+            callback(model);
+        });
         spyOn(clearModelFormat, 'clearModelFormat');
         spyOn(normalizeContentModel, 'normalizeContentModel');
 
         clearFormat(editor);
-        expect(formatWithContentModel.formatWithContentModel).toHaveBeenCalledTimes(1);
+        expect(formatWithContentModel.default).toHaveBeenCalledTimes(1);
         expect(clearModelFormat.clearModelFormat).toHaveBeenCalledTimes(1);
         expect(clearModelFormat.clearModelFormat).toHaveBeenCalledWith(model, [], [], []);
         expect(normalizeContentModel.normalizeContentModel).toHaveBeenCalledTimes(1);

--- a/packages/roosterjs-content-model/test/publicApi/list/setListStartNumberTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/list/setListStartNumberTest.ts
@@ -8,18 +8,16 @@ describe('setListStartNumber', () => {
         expectedModel: ContentModelDocument,
         expectedResult: boolean
     ) {
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
-            (editor, apiName, callback) => {
-                expect(apiName).toBe('setListStartNumber');
-                const result = callback(input);
+        spyOn(formatWithContentModel, 'default').and.callFake((editor, apiName, callback) => {
+            expect(apiName).toBe('setListStartNumber');
+            const result = callback(input);
 
-                expect(result).toBe(expectedResult);
-            }
-        );
+            expect(result).toBe(expectedResult);
+        });
 
         setListStartNumber(null!, 2);
 
-        expect(formatWithContentModel.formatWithContentModel).toHaveBeenCalledTimes(1);
+        expect(formatWithContentModel.default).toHaveBeenCalledTimes(1);
         expect(input).toEqual(expectedModel);
     }
 

--- a/packages/roosterjs-content-model/test/publicApi/list/setListStyleTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/list/setListStyleTest.ts
@@ -10,18 +10,16 @@ describe('setListStyle', () => {
         expectedModel: ContentModelDocument,
         expectedResult: boolean
     ) {
-        spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
-            (editor, apiName, callback) => {
-                expect(apiName).toBe('setListStyle');
-                const result = callback(input);
+        spyOn(formatWithContentModel, 'default').and.callFake((editor, apiName, callback) => {
+            expect(apiName).toBe('setListStyle');
+            const result = callback(input);
 
-                expect(result).toBe(expectedResult);
-            }
-        );
+            expect(result).toBe(expectedResult);
+        });
 
         setListStyle(null!, style);
 
-        expect(formatWithContentModel.formatWithContentModel).toHaveBeenCalledTimes(1);
+        expect(formatWithContentModel.default).toHaveBeenCalledTimes(1);
         expect(input).toEqual(expectedModel);
     }
 

--- a/packages/roosterjs-content-model/test/publicApi/utils/formatWithContentModelTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/utils/formatWithContentModelTest.ts
@@ -1,7 +1,7 @@
 import * as pendingFormat from '../../../lib/modelApi/format/pendingFormat';
+import formatWithContentModel from '../../../lib/publicApi/utils/formatWithContentModel';
 import { ChangeSource } from 'roosterjs-editor-types';
 import { ContentModelDocument } from '../../../lib/publicTypes/group/ContentModelDocument';
-import { formatWithContentModel } from '../../../lib/publicApi/utils/formatWithContentModel';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 
 describe('formatWithContentModel', () => {


### PR DESCRIPTION
Make the following APIs public mergeModel, formatWithContentModel and onDeleteEntityCallback.

I did the following to make them public:
- mergeModel: move it from ModelAP folder to public api folder and make it a default export.
- formatWithContentModel: Make it a default export.
- onDeleteEntityCallback: Make it a default export

Most of the file changes are due to updating the path of the files and importing the default export.
