### PR TITLE
Add formatWithContentModel and paste to EditorCore and as a member in ContentModelEditor

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/coreApi/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/editor/coreApi/formatWithContentModel.ts
@@ -1,0 +1,97 @@
+import { ChangeSource, PluginEventType } from 'roosterjs-editor-types';
+import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
+import { DomToModelOption } from '../../publicTypes/IContentModelEditor';
+import { FormatWithContentModelOptions } from '../../publicApi/utils/formatWithContentModel';
+import { reducedModelChildProcessor } from '../../domToModel/processors/reducedModelChildProcessor';
+import {
+    getPendingFormatFromCore,
+    setPendingFormatFromCore,
+} from '../../modelApi/format/pendingFormat';
+import {
+    ContentModelEditorCore,
+    FormatWithContentModel,
+} from '../../publicTypes/ContentModelEditorCore';
+
+/**
+ * @internal
+ * Create content model from clipboard data
+ * @param core The EditorCore object.
+ * @param clipboardData Clipboard data retrieved from clipboard
+ * @param position The position to paste to
+ * @param pasteAsText True to force use plain text as the content to paste, false to choose HTML or Image if any
+ * @param applyCurrentStyle True if apply format of current selection to the pasted content,
+ * false to keep original format
+ */
+export const formatWithContentModel: FormatWithContentModel = (
+    core: ContentModelEditorCore,
+    apiName: string,
+    callback: (model: ContentModelDocument) => boolean,
+    options?: FormatWithContentModelOptions
+) => {
+    const {
+        useReducedModel,
+        onNodeCreated,
+        preservePendingFormat,
+        getChangeData,
+        skipUndoSnapshot,
+        changeSource,
+    } = options || {};
+    const domToModelOption: DomToModelOption | undefined = useReducedModel
+        ? {
+              processorOverride: {
+                  child: reducedModelChildProcessor,
+              },
+          }
+        : undefined;
+    const model = core.api.createContentModel(core, domToModelOption);
+
+    if (callback(model)) {
+        const undoSnapshotCallback = () => {
+            core.api.focus(core);
+            if (model) {
+                core.api.setContentModel(core, model, { onNodeCreated });
+            }
+
+            if (preservePendingFormat) {
+                const pendingFormat = getPendingFormatFromCore(core);
+                const pos = core.api.getFocusedPosition(core);
+
+                if (pendingFormat && pos) {
+                    setPendingFormatFromCore(core, pendingFormat, pos);
+                }
+            }
+
+            return getChangeData?.();
+        };
+
+        if (skipUndoSnapshot) {
+            undoSnapshotCallback();
+
+            if (changeSource) {
+                core.api.triggerEvent(
+                    core,
+                    {
+                        eventType: PluginEventType.ContentChanged,
+                        source: ChangeSource.Format,
+                        data: getChangeData?.(),
+                    },
+                    false /* broadcast */
+                );
+            }
+        } else {
+            core.api.addUndoSnapshot(
+                core,
+                undoSnapshotCallback,
+                changeSource || ChangeSource.Format,
+                false /*canUndoByBackspace*/,
+                {
+                    formatApiName: apiName,
+                }
+            );
+        }
+
+        if (core.reuseModel && !core.lifecycle.shadowEditFragment) {
+            core.cachedModel = model || undefined;
+        }
+    }
+};

--- a/packages/roosterjs-content-model/lib/editor/coreApi/paste.ts
+++ b/packages/roosterjs-content-model/lib/editor/coreApi/paste.ts
@@ -1,0 +1,62 @@
+import { ContentModelEditorCore } from '../../publicTypes/ContentModelEditorCore';
+import { mergeModel } from '../../modelApi/common/mergeModel';
+import { Position } from 'roosterjs-editor-dom';
+import {
+    ChangeSource,
+    ClipboardData,
+    EditorCore,
+    GetContentMode,
+    PasteApi,
+} from 'roosterjs-editor-types';
+
+export const paste: PasteApi = (
+    core: EditorCore,
+    clipboardData: ClipboardData,
+    pasteAsText: boolean,
+    applyCurrentFormat: boolean,
+    pasteAsImage: boolean
+) => {
+    if (!clipboardData) {
+        return;
+    }
+    const cmCore = core as ContentModelEditorCore;
+
+    if (clipboardData.snapshotBeforePaste) {
+        // Restore original content before paste a new one
+        cmCore.api.setContent(
+            core,
+            clipboardData.snapshotBeforePaste,
+            true /* triggerContentChangedEvent */
+        );
+    } else {
+        clipboardData.snapshotBeforePaste = cmCore.api.getContent(
+            cmCore,
+            GetContentMode.RawHTMLWithSelection
+        );
+    }
+
+    const range = cmCore.api.getSelectionRange(core, true);
+    const pos = range && Position.getStart(range);
+    const pasteModel = cmCore.api.createPasteModel(
+        cmCore,
+        clipboardData,
+        pos,
+        pasteAsText,
+        applyCurrentFormat,
+        pasteAsImage
+    );
+
+    if (pasteModel) {
+        cmCore.api.formatWithContentModel(
+            cmCore,
+            'Paste',
+            model => {
+                mergeModel(model, pasteModel, cmCore.onDeleteEntityCallback(cmCore));
+                return true;
+            },
+            {
+                changeSource: ChangeSource.Paste,
+            }
+        );
+    }
+};

--- a/packages/roosterjs-content-model/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages/roosterjs-content-model/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -1,9 +1,9 @@
 import contentModelToDom from '../../modelToDom/contentModelToDom';
 import { cloneModel } from '../../modelApi/common/cloneModel';
 import { deleteSelection } from '../../modelApi/edit/deleteSelection';
-import { getOnDeleteEntityCallback } from '../utils/handleKeyboardEventCommon';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { iterateSelections } from '../../modelApi/selection/iterateSelections';
+
 import {
     addRangeToSelection,
     createElement,
@@ -143,10 +143,7 @@ export default class ContentModelCopyPastePlugin implements PluginWithState<Copy
                     }
                     if (isCut) {
                         editor.addUndoSnapshot(() => {
-                            deleteSelection(
-                                model,
-                                getOnDeleteEntityCallback(editor as IContentModelEditor)
-                            );
+                            deleteSelection(model, this.editor!.getOnDeleteEntityCallback());
                             this.editor?.setContentModel(model);
                         }, ChangeSource.Cut);
                     }
@@ -214,7 +211,7 @@ function isClipboardEvent(event: Event): event is ClipboardEvent {
 function removeContentForAndroid(editor: IContentModelEditor) {
     if (Browser.isAndroid) {
         const model = editor.createContentModel();
-        deleteSelection(model, getOnDeleteEntityCallback(editor));
+        deleteSelection(model, editor.getOnDeleteEntityCallback());
         editor.setContentModel(model);
     }
 }

--- a/packages/roosterjs-content-model/lib/editor/createContentModelEditorCore.ts
+++ b/packages/roosterjs-content-model/lib/editor/createContentModelEditorCore.ts
@@ -10,6 +10,9 @@ import { createContentModel } from './coreApi/createContentModel';
 import { createEditorContext } from './coreApi/createEditorContext';
 import { createEditorCore, isFeatureEnabled } from 'roosterjs-editor-core';
 import { createPasteModel } from './coreApi/createPasteModel';
+import { formatWithContentModel } from './coreApi/formatWithContentModel';
+import { getOnDeleteEntityCallback } from './utils/handleKeyboardEventCommon';
+import { paste } from './coreApi/paste';
 import { setContentModel } from './coreApi/setContentModel';
 import { switchShadowEdit } from './coreApi/switchShadowEdit';
 
@@ -78,6 +81,8 @@ function promoteContentModelInfo(
         experimentalFeatures,
         ExperimentalFeatures.InlineEntityReadOnlyDelimiters
     );
+
+    cmCore.onDeleteEntityCallback = getOnDeleteEntityCallback;
 }
 
 function promoteCoreApi(cmCore: ContentModelEditorCore) {
@@ -85,6 +90,7 @@ function promoteCoreApi(cmCore: ContentModelEditorCore) {
     cmCore.api.createContentModel = createContentModel;
     cmCore.api.setContentModel = setContentModel;
     cmCore.api.createPasteModel = createPasteModel;
+    cmCore.api.formatWithContentModel = formatWithContentModel;
 
     if (
         isFeatureEnabled(
@@ -95,10 +101,20 @@ function promoteCoreApi(cmCore: ContentModelEditorCore) {
         // Only use Content Model shadow edit when reuse model is enabled because it relies on cached model for the original model
         cmCore.api.switchShadowEdit = switchShadowEdit;
     }
+
+    if (
+        isFeatureEnabled(
+            cmCore.lifecycle.experimentalFeatures,
+            ExperimentalFeatures.ContentModelPaste
+        )
+    ) {
+        cmCore.api.paste = paste;
+    }
     cmCore.originalApi.createEditorContext = createEditorContext;
     cmCore.originalApi.createContentModel = createContentModel;
     cmCore.originalApi.setContentModel = setContentModel;
     cmCore.originalApi.createPasteModel = createPasteModel;
+    cmCore.originalApi.formatWithContentModel = formatWithContentModel;
 }
 
 function getDefaultSegmentFormat(core: EditorCore): ContentModelSegmentFormat {

--- a/packages/roosterjs-content-model/lib/modelApi/format/pendingFormat.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/format/pendingFormat.ts
@@ -1,3 +1,4 @@
+import { ContentModelEditorCore } from '../../publicTypes/ContentModelEditorCore';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { NodePosition } from 'roosterjs-editor-types';
@@ -71,4 +72,40 @@ function getPendingFormatHolder(editor: IContentModelEditor): PendingFormatHolde
         format: null,
         position: null,
     }));
+}
+
+/**
+ * @internal
+ * Get pending segment format from editor if any, otherwise null
+ * @param editor The editor to get format from
+ */
+export function getPendingFormatFromCore(
+    core: ContentModelEditorCore
+): ContentModelSegmentFormat | null {
+    return getPendingFormatHolderFromCore(core).format;
+}
+
+/**
+ * @internal
+ * Set pending segment format to editor
+ * @param editor The editor to set pending format to
+ * @param format The format to set.
+ * @param position Cursor position when set this format
+ */
+export function setPendingFormatFromCore(
+    core: ContentModelEditorCore,
+    format: ContentModelSegmentFormat,
+    position: NodePosition
+) {
+    const holder = getPendingFormatHolderFromCore(core);
+
+    holder.format = format;
+    holder.position = position;
+}
+
+function getPendingFormatHolderFromCore(core: ContentModelEditorCore): PendingFormatHolder {
+    return core.api.getCustomData(core, PendingFormatHolderKey, () => ({
+        format: null,
+        position: null,
+    })) as PendingFormatHolder;
 }

--- a/packages/roosterjs-content-model/lib/publicApi/block/setAlignment.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setAlignment.ts
@@ -1,4 +1,3 @@
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { setModelAlignment } from '../../modelApi/block/setModelAlignment';
 
@@ -11,5 +10,5 @@ export default function setAlignment(
     editor: IContentModelEditor,
     alignment: 'left' | 'center' | 'right'
 ) {
-    formatWithContentModel(editor, 'setAlignment', model => setModelAlignment(model, alignment));
+    editor.formatWithContentModel('setAlignment', model => setModelAlignment(model, alignment));
 }

--- a/packages/roosterjs-content-model/lib/publicApi/block/setIndentation.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setIndentation.ts
@@ -1,4 +1,3 @@
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { setModelIndentation } from '../../modelApi/block/setModelIndentation';
 
@@ -13,8 +12,7 @@ export default function setIndentation(
     indentation: 'indent' | 'outdent',
     length?: number
 ) {
-    formatWithContentModel(
-        editor,
+    editor.formatWithContentModel(
         'setIndentation',
         model => setModelIndentation(model, indentation, length),
         {

--- a/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/toggleBlockQuote.ts
@@ -1,5 +1,4 @@
 import { ContentModelFormatContainerFormat } from '../../publicTypes/format/ContentModelFormatContainerFormat';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { toggleModelBlockQuote } from '../../modelApi/block/toggleModelBlockQuote';
 
@@ -31,8 +30,7 @@ export default function toggleBlockQuote(
         ...quoteFormat,
     };
 
-    formatWithContentModel(
-        editor,
+    editor.formatWithContentModel(
         'toggleBlockQuote',
         model => toggleModelBlockQuote(model, fullQuoteFormat),
         {

--- a/packages/roosterjs-content-model/lib/publicApi/editing/handleKeyDownEvent.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/editing/handleKeyDownEvent.ts
@@ -3,10 +3,8 @@ import { ChangeSource, EntityOperationEvent, Keys } from 'roosterjs-editor-types
 import { deleteAllSegmentBefore } from '../../modelApi/edit/deleteSteps/deleteAllSegmentBefore';
 import { deleteSelection } from '../../modelApi/edit/deleteSelection';
 import { DeleteSelectionStep } from '../../modelApi/edit/utils/DeleteSelectionStep';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import {
-    getOnDeleteEntityCallback,
     handleKeyboardEventResult,
     shouldDeleteAllSegmentsBefore,
     shouldDeleteWord,
@@ -43,8 +41,7 @@ export default function handleKeyDownEvent(
                 : backwardDeleteWordSelection
             : null;
 
-        formatWithContentModel(
-            editor,
+        editor.formatWithContentModel(
             apiName,
             model => {
                 const steps: (DeleteSelectionStep | null)[] = [
@@ -57,7 +54,7 @@ export default function handleKeyDownEvent(
 
                 const result = deleteSelection(
                     model,
-                    getOnDeleteEntityCallback(editor, rawEvent, triggeredEntityEvents),
+                    editor.getOnDeleteEntityCallback(rawEvent, triggeredEntityEvents),
                     steps
                 ).deleteResult;
 

--- a/packages/roosterjs-content-model/lib/publicApi/format/applyPendingFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/applyPendingFormat.ts
@@ -1,5 +1,4 @@
 import { createText } from '../../modelApi/creators/createText';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { iterateSelections } from '../../modelApi/selection/iterateSelections';
@@ -19,8 +18,7 @@ export default function applyPendingFormat(editor: IContentModelEditor, data: st
     if (format) {
         let isChanged = false;
 
-        formatWithContentModel(
-            editor,
+        editor.formatWithContentModel(
             'applyPendingFormat',
             model => {
                 iterateSelections([model], (_, __, block, segments) => {

--- a/packages/roosterjs-content-model/lib/publicApi/format/clearFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/clearFormat.ts
@@ -3,7 +3,6 @@ import { ContentModelBlock } from '../../publicTypes/block/ContentModelBlock';
 import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBlockGroup';
 import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { normalizeContentModel } from '../../modelApi/common/normalizeContentModel';
 
@@ -12,7 +11,7 @@ import { normalizeContentModel } from '../../modelApi/common/normalizeContentMod
  * @param editor The editor to clear format from
  */
 export default function clearFormat(editor: IContentModelEditor) {
-    formatWithContentModel(editor, 'clearFormat', model => {
+    editor.formatWithContentModel('clearFormat', model => {
         const blocksToClear: [ContentModelBlockGroup[], ContentModelBlock][] = [];
         const segmentsToClear: ContentModelSegment[] = [];
         const tablesToClear: [ContentModelTable, boolean][] = [];

--- a/packages/roosterjs-content-model/lib/publicApi/format/getFormatState.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/getFormatState.ts
@@ -1,5 +1,4 @@
 import { FormatState } from 'roosterjs-editor-types';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { retrieveModelFormatState } from '../../modelApi/common/retrieveModelFormatState';
@@ -16,8 +15,7 @@ export default function getFormatState(editor: IContentModelEditor): FormatState
         zoomScale: editor.getZoomScale(),
     };
 
-    formatWithContentModel(
-        editor,
+    editor.formatWithContentModel(
         'getFormatState',
         model => {
             const pendingFormat = getPendingFormat(editor);

--- a/packages/roosterjs-content-model/lib/publicApi/format/getSegmentFormat.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/format/getSegmentFormat.ts
@@ -1,5 +1,4 @@
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { iterateSelections } from '../../modelApi/selection/iterateSelections';
@@ -14,8 +13,7 @@ export default function getSegmentFormat(
     let result = getPendingFormat(editor);
 
     if (!result) {
-        formatWithContentModel(
-            editor,
+        editor.formatWithContentModel(
             'getSegmentFormat',
             model => {
                 iterateSelections(

--- a/packages/roosterjs-content-model/lib/publicApi/image/adjustImageSelection.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/adjustImageSelection.ts
@@ -1,6 +1,5 @@
 import { adjustSegmentSelection } from '../../modelApi/selection/adjustSegmentSelection';
 import { ContentModelImage } from '../../publicTypes/segment/ContentModelImage';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 
 /**
@@ -12,7 +11,7 @@ export default function adjustImageSelection(
 ): ContentModelImage | null {
     let image: ContentModelImage | null = null;
 
-    formatWithContentModel(editor, 'adjustImageSelection', model =>
+    editor.formatWithContentModel('adjustImageSelection', model =>
         adjustSegmentSelection(
             model,
             target => {

--- a/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
@@ -1,8 +1,6 @@
 import { addSegment } from '../../modelApi/common/addSegment';
 import { createContentModelDocument } from '../../modelApi/creators/createContentModelDocument';
 import { createImage } from '../../modelApi/creators/createImage';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
-import { getOnDeleteEntityCallback } from '../../editor/utils/handleKeyboardEventCommon';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { mergeModel } from '../../modelApi/common/mergeModel';
 import { readFile } from 'roosterjs-editor-dom';
@@ -25,12 +23,12 @@ export default function insertImage(editor: IContentModelEditor, imageFileOrSrc:
 }
 
 function insertImageWithSrc(editor: IContentModelEditor, src: string) {
-    formatWithContentModel(editor, 'insertImage', model => {
+    editor.formatWithContentModel('insertImage', model => {
         const image = createImage(src);
         const doc = createContentModelDocument();
 
         addSegment(doc, image);
-        mergeModel(model, doc, getOnDeleteEntityCallback(editor), { mergeCurrentFormat: true });
+        mergeModel(model, doc, editor.getOnDeleteEntityCallback(), { mergeCurrentFormat: true });
 
         return true;
     });

--- a/packages/roosterjs-content-model/lib/publicApi/link/adjustLinkSelection.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/adjustLinkSelection.ts
@@ -1,6 +1,5 @@
 import { adjustSegmentSelection } from '../../modelApi/selection/adjustSegmentSelection';
 import { adjustWordSelection } from '../../modelApi/selection/adjustWordSelection';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { setSelection } from '../../modelApi/selection/setSelection';
@@ -13,7 +12,7 @@ export default function adjustLinkSelection(editor: IContentModelEditor): [strin
     let text = '';
     let url: string | null = null;
 
-    formatWithContentModel(editor, 'adjustLinkSelection', model => {
+    editor.formatWithContentModel('adjustLinkSelection', model => {
         let changed = adjustSegmentSelection(
             model,
             target => !!target.isSelected && !!target.link,

--- a/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
@@ -4,8 +4,6 @@ import { ChangeSource } from 'roosterjs-editor-types';
 import { ContentModelLink } from '../../publicTypes/decorator/ContentModelLink';
 import { createContentModelDocument } from '../../modelApi/creators/createContentModelDocument';
 import { createText } from '../../modelApi/creators/createText';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
-import { getOnDeleteEntityCallback } from '../../editor/utils/handleKeyboardEventCommon';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
 import { HtmlSanitizer, matchLink } from 'roosterjs-editor-dom';
@@ -55,8 +53,7 @@ export default function insertLink(
         const links: ContentModelLink[] = [];
         let anchorNode: Node | undefined;
 
-        formatWithContentModel(
-            editor,
+        editor.formatWithContentModel(
             'insertLink',
             model => {
                 const segments = getSelectedSegments(model, false /*includingFormatHolder*/);
@@ -93,7 +90,7 @@ export default function insertLink(
                         links.push(segment.link);
                     }
 
-                    mergeModel(model, doc, getOnDeleteEntityCallback(editor), {
+                    mergeModel(model, doc, editor.getOnDeleteEntityCallback(), {
                         mergeCurrentFormat: true,
                     });
                 }

--- a/packages/roosterjs-content-model/lib/publicApi/link/removeLink.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/removeLink.ts
@@ -1,5 +1,4 @@
 import { adjustSegmentSelection } from '../../modelApi/selection/adjustSegmentSelection';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 
@@ -10,7 +9,7 @@ import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
  * @param editor The editor instance
  */
 export default function removeLink(editor: IContentModelEditor) {
-    formatWithContentModel(editor, 'removeLink', model => {
+    editor.formatWithContentModel('removeLink', model => {
         adjustSegmentSelection(
             model,
             target => !!target.isSelected && !!target.link,

--- a/packages/roosterjs-content-model/lib/publicApi/list/setListStartNumber.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/setListStartNumber.ts
@@ -1,4 +1,3 @@
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getFirstSelectedListItem } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 
@@ -8,7 +7,7 @@ import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
  * @param value The number to set to, must be equal or greater than 1
  */
 export default function setListStartNumber(editor: IContentModelEditor, value: number) {
-    formatWithContentModel(editor, 'setListStartNumber', model => {
+    editor.formatWithContentModel('setListStartNumber', model => {
         const listItem = getFirstSelectedListItem(model);
         const level = listItem?.levels[listItem?.levels.length - 1];
 

--- a/packages/roosterjs-content-model/lib/publicApi/list/setListStyle.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/setListStyle.ts
@@ -1,5 +1,4 @@
 import { findListItemsInSameThread } from '../../modelApi/list/findListItemsInSameThread';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getFirstSelectedListItem } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { ListMetadataFormat } from '../../publicTypes/format/formatParts/ListMetadataFormat';
@@ -10,7 +9,7 @@ import { ListMetadataFormat } from '../../publicTypes/format/formatParts/ListMet
  * @param style The target list item style to set
  */
 export default function setListStyle(editor: IContentModelEditor, style: ListMetadataFormat) {
-    formatWithContentModel(editor, 'setListStyle', model => {
+    editor.formatWithContentModel('setListStyle', model => {
         const listItem = getFirstSelectedListItem(model);
 
         if (listItem) {

--- a/packages/roosterjs-content-model/lib/publicApi/list/toggleBullet.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/toggleBullet.ts
@@ -1,4 +1,3 @@
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { setListType } from '../../modelApi/list/setListType';
 
@@ -9,7 +8,7 @@ import { setListType } from '../../modelApi/list/setListType';
  * @param editor The editor to operate on
  */
 export default function toggleBullet(editor: IContentModelEditor) {
-    formatWithContentModel(editor, 'toggleBullet', model => setListType(model, 'UL'), {
+    editor.formatWithContentModel('toggleBullet', model => setListType(model, 'UL'), {
         preservePendingFormat: true,
     });
 }

--- a/packages/roosterjs-content-model/lib/publicApi/list/toggleNumbering.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/list/toggleNumbering.ts
@@ -1,4 +1,3 @@
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { setListType } from '../../modelApi/list/setListType';
 
@@ -9,7 +8,7 @@ import { setListType } from '../../modelApi/list/setListType';
  * @param editor The editor to operate on
  */
 export default function toggleNumbering(editor: IContentModelEditor) {
-    formatWithContentModel(editor, 'toggleNumbering', model => setListType(model, 'OL'), {
+    editor.formatWithContentModel('toggleNumbering', model => setListType(model, 'OL'), {
         preservePendingFormat: true,
     });
 }

--- a/packages/roosterjs-content-model/lib/publicApi/table/editTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/editTable.ts
@@ -4,7 +4,6 @@ import { applyTableFormat } from '../../modelApi/table/applyTableFormat';
 import { deleteTable } from '../../modelApi/table/deleteTable';
 import { deleteTableColumn } from '../../modelApi/table/deleteTableColumn';
 import { deleteTableRow } from '../../modelApi/table/deleteTableRow';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getFirstSelectedTable } from '../../modelApi/selection/collectSelections';
 import { hasMetadata } from '../../domUtils/metadata/updateMetadata';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
@@ -24,7 +23,7 @@ import { TableOperation } from 'roosterjs-editor-types';
  * @param operation The table operation to apply
  */
 export default function editTable(editor: IContentModelEditor, operation: TableOperation) {
-    formatWithContentModel(editor, 'editTable', model => {
+    editor.formatWithContentModel('editTable', model => {
         const tableModel = getFirstSelectedTable(model);
 
         if (tableModel) {

--- a/packages/roosterjs-content-model/lib/publicApi/table/formatTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/formatTable.ts
@@ -1,5 +1,4 @@
 import { applyTableFormat } from '../../modelApi/table/applyTableFormat';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getFirstSelectedTable } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { TableMetadataFormat } from '../../publicTypes/format/formatParts/TableMetadataFormat';
@@ -15,7 +14,7 @@ export default function formatTable(
     format: TableMetadataFormat,
     keepCellShade?: boolean
 ) {
-    formatWithContentModel(editor, 'formatTable', model => {
+    editor.formatWithContentModel('formatTable', model => {
         const tableModel = getFirstSelectedTable(model);
 
         if (tableModel) {

--- a/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
@@ -3,8 +3,6 @@ import { createContentModelDocument } from '../../modelApi/creators/createConten
 import { createSelectionMarker } from '../../modelApi/creators/createSelectionMarker';
 import { createTableStructure } from '../../modelApi/table/createTableStructure';
 import { deleteSelection } from '../../modelApi/edit/deleteSelection';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
-import { getOnDeleteEntityCallback } from '../../editor/utils/handleKeyboardEventCommon';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { mergeModel } from '../../modelApi/common/mergeModel';
@@ -27,8 +25,8 @@ export default function insertTable(
     rows: number,
     format?: TableMetadataFormat
 ) {
-    formatWithContentModel(editor, 'insertTable', model => {
-        const onDeleteEntity = getOnDeleteEntityCallback(editor);
+    editor.formatWithContentModel('insertTable', model => {
+        const onDeleteEntity = editor.getOnDeleteEntityCallback();
         const insertPosition = deleteSelection(model, onDeleteEntity).insertPoint;
 
         if (insertPosition) {

--- a/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/setTableCellShade.ts
@@ -1,5 +1,4 @@
 import hasSelectionInBlockGroup from '../selection/hasSelectionInBlockGroup';
-import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getFirstSelectedTable } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { normalizeTable } from '../../modelApi/table/normalizeTable';
@@ -11,7 +10,7 @@ import { setTableCellBackgroundColor } from '../../modelApi/table/setTableCellBa
  * @param color The color to set. Pass null to remove existing shade color
  */
 export default function setTableCellShade(editor: IContentModelEditor, color: string | null) {
-    formatWithContentModel(editor, 'setTableCellShade', model => {
+    editor.formatWithContentModel('setTableCellShade', model => {
         const table = getFirstSelectedTable(model);
 
         if (table) {

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatParagraphWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatParagraphWithContentModel.ts
@@ -1,5 +1,4 @@
 import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
-import { formatWithContentModel } from './formatWithContentModel';
 import { getSelectedParagraphs } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 
@@ -11,8 +10,7 @@ export function formatParagraphWithContentModel(
     apiName: string,
     setStyleCallback: (paragraph: ContentModelParagraph) => void
 ) {
-    formatWithContentModel(
-        editor,
+    editor.formatWithContentModel(
         apiName,
         model => {
             const paragraphs = getSelectedParagraphs(model);

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatSegmentWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatSegmentWithContentModel.ts
@@ -1,7 +1,6 @@
 import { adjustWordSelection } from '../../modelApi/selection/adjustWordSelection';
 import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
-import { formatWithContentModel } from './formatWithContentModel';
 import { getPendingFormat, setPendingFormat } from '../../modelApi/format/pendingFormat';
 import { getSelectedSegments } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
@@ -22,7 +21,7 @@ export function formatSegmentWithContentModel(
     ) => boolean,
     includingFormatHolder?: boolean
 ) {
-    formatWithContentModel(editor, apiName, model => {
+    editor.formatWithContentModel(apiName, model => {
         let segments = getSelectedSegments(model, !!includingFormatHolder);
         const pendingFormat = getPendingFormat(editor);
         let isCollapsedSelection =

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -1,9 +1,4 @@
-import { ChangeSource } from 'roosterjs-editor-types';
-import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
-import { DomToModelOption, IContentModelEditor } from '../../publicTypes/IContentModelEditor';
-import { getPendingFormat, setPendingFormat } from '../../modelApi/format/pendingFormat';
 import { OnNodeCreated } from '../../publicTypes/context/ModelToDomSettings';
-import { reducedModelChildProcessor } from '../../domToModel/processors/reducedModelChildProcessor';
 
 /**
  * @internal
@@ -40,70 +35,4 @@ export interface FormatWithContentModelOptions {
      * Optional callback to get an object used for change data in ContentChangedEvent
      */
     getChangeData?: () => any;
-}
-
-/**
- * @internal
- */
-export function formatWithContentModel(
-    editor: IContentModelEditor,
-    apiName: string,
-    callback: (model: ContentModelDocument) => boolean,
-    options?: FormatWithContentModelOptions
-) {
-    const {
-        useReducedModel,
-        onNodeCreated,
-        preservePendingFormat,
-        getChangeData,
-        skipUndoSnapshot,
-        changeSource,
-    } = options || {};
-    const domToModelOption: DomToModelOption | undefined = useReducedModel
-        ? {
-              processorOverride: {
-                  child: reducedModelChildProcessor,
-              },
-          }
-        : undefined;
-    const model = editor.createContentModel(domToModelOption);
-
-    if (callback(model)) {
-        const callback = () => {
-            editor.focus();
-            if (model) {
-                editor.setContentModel(model, { onNodeCreated });
-            }
-
-            if (preservePendingFormat) {
-                const pendingFormat = getPendingFormat(editor);
-                const pos = editor.getFocusedPosition();
-
-                if (pendingFormat && pos) {
-                    setPendingFormat(editor, pendingFormat, pos);
-                }
-            }
-
-            return getChangeData?.();
-        };
-
-        if (skipUndoSnapshot) {
-            callback();
-
-            if (changeSource) {
-                editor.triggerContentChangedEvent(changeSource, getChangeData?.());
-            }
-        } else {
-            editor.addUndoSnapshot(
-                callback,
-                changeSource || ChangeSource.Format,
-                false /*canUndoByBackspace*/,
-                {
-                    formatApiName: apiName,
-                }
-            );
-        }
-
-        editor.cacheContentModel?.(model);
-    }
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/ContentModelEditorCore.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/ContentModelEditorCore.ts
@@ -1,8 +1,16 @@
-import { ClipboardData, CoreApiMap, EditorCore, NodePosition } from 'roosterjs-editor-types';
 import { ContentModelDocument } from './group/ContentModelDocument';
 import { ContentModelSegmentFormat } from './format/ContentModelSegmentFormat';
 import { DomToModelOption, ModelToDomOption } from './IContentModelEditor';
 import { EditorContext } from './context/EditorContext';
+import { FormatWithContentModelOptions } from '../publicApi/utils/formatWithContentModel';
+import { OnDeleteEntity } from '../modelApi/edit/utils/DeleteSelectionStep';
+import {
+    ClipboardData,
+    CoreApiMap,
+    EditorCore,
+    EntityOperationEvent,
+    NodePosition,
+} from 'roosterjs-editor-types';
 
 /**
  * Create a EditorContext object used by ContentModel API
@@ -51,6 +59,13 @@ export type CreatePasteModel = (
     pasteAsImage: boolean
 ) => ContentModelDocument | null;
 
+export type FormatWithContentModel = (
+    core: ContentModelEditorCore,
+    apiName: string,
+    callback: (model: ContentModelDocument) => boolean,
+    options?: FormatWithContentModelOptions
+) => void;
+
 /**
  * The interface for the map of core API for Content Model editor.
  * Editor can call call API from this map under ContentModelEditorCore object
@@ -88,6 +103,8 @@ export interface ContentModelCoreApiMap extends CoreApiMap {
      * false to keep original format
      */
     createPasteModel: CreatePasteModel;
+
+    formatWithContentModel: FormatWithContentModel;
 }
 
 /**
@@ -133,4 +150,10 @@ export interface ContentModelEditorCore extends EditorCore {
      * Whether adding delimiter for entity is allowed
      */
     addDelimiterForEntity: boolean;
+
+    onDeleteEntityCallback: (
+        cmCore: ContentModelEditorCore,
+        rawEvent?: KeyboardEvent,
+        triggeredEntityEvents?: EntityOperationEvent[]
+    ) => OnDeleteEntity;
 }

--- a/packages/roosterjs-content-model/lib/publicTypes/IContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/IContentModelEditor.ts
@@ -1,6 +1,13 @@
 import { ContentModelDocument } from './group/ContentModelDocument';
 import { ContentModelSegmentFormat } from './format/ContentModelSegmentFormat';
-import { EditorOptions, IEditor, SelectionRangeEx } from 'roosterjs-editor-types';
+import {
+    EditorOptions,
+    EntityOperationEvent,
+    IEditor,
+    SelectionRangeEx,
+} from 'roosterjs-editor-types';
+import { FormatWithContentModelOptions } from '../publicApi/utils/formatWithContentModel';
+import { OnDeleteEntity } from '../modelApi/edit/utils/DeleteSelectionStep';
 import {
     ContentModelHandlerMap,
     DefaultImplicitFormatMap,
@@ -120,6 +127,17 @@ export interface IContentModelEditor extends IEditor {
      * @returns The default format
      */
     getContentModelDefaultFormat(): ContentModelSegmentFormat;
+
+    formatWithContentModel(
+        apiName: string,
+        callback: (model: ContentModelDocument) => boolean,
+        options?: FormatWithContentModelOptions
+    ): void;
+
+    getOnDeleteEntityCallback(
+        rawEvent?: KeyboardEvent | undefined,
+        triggeredEntityEvents?: EntityOperationEvent[] | undefined
+    ): OnDeleteEntity;
 }
 
 /**

--- a/packages/roosterjs-content-model/test/editor/plugins/ContentModelFormatPluginTest.ts
+++ b/packages/roosterjs-content-model/test/editor/plugins/ContentModelFormatPluginTest.ts
@@ -4,6 +4,7 @@ import { addSegment } from '../../../lib/modelApi/common/addSegment';
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
 import { createSelectionMarker } from '../../../lib/modelApi/creators/createSelectionMarker';
 import { createText } from '../../../lib/modelApi/creators/createText';
+import { formatWithContentModel } from '../../../lib/editor/coreApi/formatWithContentModel';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 import { PluginEventType } from 'roosterjs-editor-types';
 
@@ -42,6 +43,7 @@ describe('ContentModelFormatPlugin', () => {
             setContentModel,
             isInIME: () => false,
             cacheContentModel: () => {},
+            formatWithContentModel: () => {},
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
         const model = createContentModelDocument();
@@ -75,6 +77,7 @@ describe('ContentModelFormatPlugin', () => {
             createContentModel: () => model,
             setContentModel,
             cacheContentModel: () => {},
+            formatWithContentModel: () => {},
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 
@@ -106,6 +109,7 @@ describe('ContentModelFormatPlugin', () => {
             setContentModel,
             isInIME: () => false,
             cacheContentModel: () => {},
+            formatWithContentModel: () => {},
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 
@@ -145,6 +149,7 @@ describe('ContentModelFormatPlugin', () => {
                 callback();
             },
             cacheContentModel: () => {},
+            formatWithContentModel: () => {},
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 
@@ -212,6 +217,7 @@ describe('ContentModelFormatPlugin', () => {
                 callback();
             },
             cacheContentModel: () => {},
+            formatWithContentModel,
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 
@@ -270,6 +276,7 @@ describe('ContentModelFormatPlugin', () => {
             createContentModel: () => model,
             setContentModel,
             cacheContentModel: () => {},
+            formatWithContentModel,
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 
@@ -302,6 +309,7 @@ describe('ContentModelFormatPlugin', () => {
                 callback();
             },
             cacheContentModel: () => {},
+            formatWithContentModel,
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 
@@ -332,6 +340,7 @@ describe('ContentModelFormatPlugin', () => {
             createContentModel: () => model,
             setContentModel,
             cacheContentModel: () => {},
+            formatWithContentModel,
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 
@@ -362,6 +371,7 @@ describe('ContentModelFormatPlugin', () => {
             createContentModel: () => model,
             setContentModel,
             cacheContentModel: () => {},
+            formatWithContentModel,
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 

--- a/packages/roosterjs-content-model/test/publicApi/utils/formatWithContentModelTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/utils/formatWithContentModelTest.ts
@@ -43,7 +43,7 @@ describe('formatWithContentModel', () => {
     it('Callback return false', () => {
         const callback = jasmine.createSpy('callback').and.returnValue(false);
 
-        formatWithContentModel(editor, apiName, callback);
+        editor.formatWithContentModel(apiName, callback);
 
         expect(callback).toHaveBeenCalledWith(mockedModel);
         expect(createContentModel).toHaveBeenCalledTimes(1);
@@ -55,7 +55,7 @@ describe('formatWithContentModel', () => {
     it('Callback return true', () => {
         const callback = jasmine.createSpy('callback').and.returnValue(true);
 
-        formatWithContentModel(editor, apiName, callback);
+        editor.formatWithContentModel(apiName, callback);
 
         expect(callback).toHaveBeenCalledWith(mockedModel);
         expect(createContentModel).toHaveBeenCalledTimes(1);
@@ -77,7 +77,7 @@ describe('formatWithContentModel', () => {
         spyOn(pendingFormat, 'getPendingFormat').and.returnValue(mockedFormat);
         spyOn(pendingFormat, 'setPendingFormat');
 
-        formatWithContentModel(editor, apiName, callback, {
+        editor.formatWithContentModel(apiName, callback, {
             preservePendingFormat: true,
         });
 
@@ -104,7 +104,7 @@ describe('formatWithContentModel', () => {
         spyOn(pendingFormat, 'getPendingFormat').and.returnValue(mockedFormat);
         spyOn(pendingFormat, 'setPendingFormat');
 
-        formatWithContentModel(editor, apiName, callback, {
+        editor.formatWithContentModel(apiName, callback, {
             skipUndoSnapshot: true,
         });
 
@@ -116,7 +116,7 @@ describe('formatWithContentModel', () => {
     it('Customize change source', () => {
         const callback = jasmine.createSpy('callback').and.returnValue(true);
 
-        formatWithContentModel(editor, apiName, callback, { changeSource: 'TEST' });
+        editor.formatWithContentModel(apiName, callback, { changeSource: 'TEST' });
 
         expect(callback).toHaveBeenCalledWith(mockedModel);
         expect(createContentModel).toHaveBeenCalledTimes(1);
@@ -127,7 +127,7 @@ describe('formatWithContentModel', () => {
     it('Customize change source and skip undo snapshot', () => {
         const callback = jasmine.createSpy('callback').and.returnValue(true);
 
-        formatWithContentModel(editor, apiName, callback, {
+        editor.formatWithContentModel(apiName, callback, {
             changeSource: 'TEST',
             skipUndoSnapshot: true,
             getChangeData: () => 'DATA',
@@ -143,7 +143,7 @@ describe('formatWithContentModel', () => {
         const callback = jasmine.createSpy('callback').and.returnValue(true);
         const onNodeCreated = jasmine.createSpy('onNodeCreated');
 
-        formatWithContentModel(editor, apiName, callback, { onNodeCreated: onNodeCreated });
+        editor.formatWithContentModel(apiName, callback, { onNodeCreated: onNodeCreated });
 
         expect(callback).toHaveBeenCalledWith(mockedModel);
         expect(createContentModel).toHaveBeenCalledTimes(1);
@@ -156,7 +156,7 @@ describe('formatWithContentModel', () => {
         const mockedData = 'DATA' as any;
         const getChangeData = jasmine.createSpy('getChangeData').and.returnValue(mockedData);
 
-        formatWithContentModel(editor, apiName, callback, { getChangeData });
+        editor.formatWithContentModel(apiName, callback, { getChangeData });
 
         expect(callback).toHaveBeenCalledWith(mockedModel);
         expect(createContentModel).toHaveBeenCalledTimes(1);

--- a/packages/roosterjs-editor-core/lib/coreApi/coreApiMap.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/coreApiMap.ts
@@ -5,12 +5,15 @@ import { createPasteFragment } from './createPasteFragment';
 import { ensureTypeInContainer } from './ensureTypeInContainer';
 import { focus } from './focus';
 import { getContent } from './getContent';
+import { getCustomData } from './getCustomData';
+import { getFocusedPosition } from './getFocusedPosition';
 import { getPendableFormatState } from './getPendableFormatState';
 import { getSelectionRange } from './getSelectionRange';
 import { getSelectionRangeEx } from './getSelectionRangeEx';
 import { getStyleBasedFormatState } from './getStyleBasedFormatState';
 import { hasFocus } from './hasFocus';
 import { insertNode } from './insertNode';
+import { paste } from './paste';
 import { restoreUndoSnapshot } from './restoreUndoSnapshot';
 import { select } from './select';
 import { selectImage } from './selectImage';
@@ -46,4 +49,7 @@ export const coreApiMap: CoreApiMap = {
     triggerEvent,
     selectTable,
     selectImage,
+    paste,
+    getFocusedPosition,
+    getCustomData,
 };

--- a/packages/roosterjs-editor-core/lib/coreApi/getCustomData.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getCustomData.ts
@@ -1,0 +1,13 @@
+import { EditorCore, GetCustomData } from 'roosterjs-editor-types';
+
+export const getCustomData: GetCustomData = (
+    core: EditorCore,
+    key: string,
+    getter?: () => any,
+    disposer?: (value: any) => void
+) => {
+    return (core.lifecycle.customData[key] = core.lifecycle.customData[key] || {
+        value: getter ? getter() : undefined,
+        disposer,
+    }).value;
+};

--- a/packages/roosterjs-editor-core/lib/coreApi/getFocusedPosition.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getFocusedPosition.ts
@@ -1,0 +1,23 @@
+import { contains, Position } from 'roosterjs-editor-dom';
+import { EditorCore, GetFocusedPosition } from 'roosterjs-editor-types';
+
+/**
+ * @internal
+ * Focus to editor. If there is a cached selection range, use it as current selection
+ * @param core The EditorCore object
+ */
+export const getFocusedPosition: GetFocusedPosition = (core: EditorCore) => {
+    const contentDiv = core.contentDiv;
+    let sel = contentDiv.ownerDocument.defaultView?.getSelection();
+
+    if (sel?.focusNode && contains(contentDiv, sel.focusNode)) {
+        return new Position(sel.focusNode, sel.focusOffset);
+    }
+
+    let range = core.api.getSelectionRange(core, true /* tryGetFromCache */);
+    if (range) {
+        return Position.getStart(range);
+    }
+
+    return null;
+};

--- a/packages/roosterjs-editor-core/lib/coreApi/paste.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/paste.ts
@@ -1,0 +1,56 @@
+import { Position } from 'roosterjs-editor-dom';
+import {
+    EditorCore,
+    PasteApi,
+    ChangeSource,
+    ClipboardData,
+    GetContentMode,
+} from 'roosterjs-editor-types';
+
+export const paste: PasteApi = (
+    core: EditorCore,
+    clipboardData: ClipboardData,
+    pasteAsText: boolean,
+    applyCurrentFormat: boolean,
+    pasteAsImage: boolean
+) => {
+    if (!clipboardData) {
+        return;
+    }
+
+    if (clipboardData.snapshotBeforePaste) {
+        // Restore original content before paste a new one
+        core.api.setContent(
+            core,
+            clipboardData.snapshotBeforePaste,
+            true /* triggerContentChangedEvent */
+        );
+    } else {
+        clipboardData.snapshotBeforePaste = core.api.getContent(
+            core,
+            GetContentMode.RawHTMLWithSelection
+        );
+    }
+
+    const range = core.api.getSelectionRange(core, true /* tryGetFromCache */);
+    const pos = range && Position.getStart(range);
+    const fragment = core.api.createPasteFragment(
+        core,
+        clipboardData,
+        pos,
+        pasteAsText,
+        applyCurrentFormat,
+        pasteAsImage
+    );
+    if (fragment) {
+        core.api.addUndoSnapshot(
+            core,
+            () => {
+                core.api.insertNode(core, fragment, null /* InsertOption */);
+                return clipboardData;
+            },
+            ChangeSource.Paste,
+            false /* canUndoByBackspace */
+        );
+    }
+};

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -318,6 +318,23 @@ export type SelectImage = (
     image: HTMLImageElement | null
 ) => ImageSelectionRange | null;
 
+export type Paste = (
+    core: EditorCore,
+    clipboardData: ClipboardData,
+    pasteAsText: boolean,
+    applyCurrentFormat: boolean,
+    pasteAsImage: boolean
+) => void;
+
+export type GetFocusedPosition = (core: EditorCore) => NodePosition | null;
+
+export type GetCustomData = (
+    core: EditorCore,
+    key: string,
+    getter?: () => any,
+    disposer?: (value: any) => void
+) => any;
+
 /**
  * The interface for the map of core API.
  * Editor can call call API from this map under EditorCore object
@@ -505,4 +522,10 @@ export interface CoreApiMap {
      * @returns true if successful
      */
     selectImage: SelectImage;
+
+    paste: Paste;
+
+    getFocusedPosition: GetFocusedPosition;
+
+    getCustomData: GetCustomData;
 }

--- a/packages/roosterjs-editor-types/lib/interface/index.ts
+++ b/packages/roosterjs-editor-types/lib/interface/index.ts
@@ -92,6 +92,9 @@ export {
     TriggerEvent,
     SelectTable,
     SelectImage,
+    Paste as PasteApi,
+    GetCustomData,
+    GetFocusedPosition,
 } from './EditorCore';
 export { default as EditorOptions } from './EditorOptions';
 export {


### PR DESCRIPTION
This PR adds:

1. Add a new function to ContentModelEditor and ContentModelEditorCore for formatWithContentModel.
2. Add a new function to ContentModelEditor and ContentModelEditorCore for getOnDeleteEntityCallback.
3. Move paste from ContentModelEditor to EditorCore so we can change the api when promoting to ContentModelEditor, to accomplish this also moved getCustomData and getFocusedPosition to EditorCore.
4. Remove formatWithContentModel public api and update the places where it was used to use the new member in the ContentModelEditor.
5. Fix Test // TODO