### PR TITLE
Fix config for test:coverage

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -32,7 +32,10 @@ module.exports = function (config) {
         ? [
               {
                   test: /lib(\\|\/).*\.ts$/,
-                  loader: ['@jsdevtools/coverage-istanbul-loader', 'ts-loader'],
+                  use: [
+                      { loader: '@jsdevtools/coverage-istanbul-loader' },
+                      { loader: 'ts-loader' },
+                  ],
               },
               {
                   test: /test(\\|\/).*\.ts$/,


### PR DESCRIPTION
With the previous fix for nodejs 17+, I see the official build fails at running code coverage with the error:
![image](https://github.com/microsoft/roosterjs/assets/23065085/700c5542-9cf5-42ac-ad57-820b637892b7)

This need a fix to the webpack config of karma test, so fix it here.