### PR TITLE
Allow picture shadows to set a custom margin around image

### DIFF
--- a/demo/scripts/controls/ribbonButtons/contentModel/imageBoxShadowButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/imageBoxShadowButton.ts
@@ -43,7 +43,7 @@ export const imageBoxShadowButton: RibbonButton<'buttonNameImageBoxSHadow'> = {
     },
     onClick: (editor, size) => {
         if (isContentModelEditor(editor)) {
-            setImageBoxShadow(editor, STYLES[size]);
+            setImageBoxShadow(editor, STYLES[size], STYLES[size].length ? '4px' : null);
         }
         return true;
     },

--- a/packages/roosterjs-content-model/lib/publicApi/image/setImageBoxShadow.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/setImageBoxShadow.ts
@@ -5,10 +5,26 @@ import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 /**
  * Set image box shadow for all selected images at selection.
  * @param editor The editor instance
- * @param boxShadow The image box shadow
+ * @param boxShadow The image box boxShadow
+ * @param margin The image margin for all sides (eg. "4px"), null to remove margin
  */
-export default function setImageBoxShadow(editor: IContentModelEditor, boxShadow: string) {
+export default function setImageBoxShadow(
+    editor: IContentModelEditor,
+    boxShadow: string,
+    margin?: string | null
+) {
     formatImageWithContentModel(editor, 'setImageBoxShadow', (image: ContentModelImage) => {
         image.format.boxShadow = boxShadow;
+        if (margin) {
+            image.format.marginBottom = margin;
+            image.format.marginLeft = margin;
+            image.format.marginRight = margin;
+            image.format.marginTop = margin;
+        } else if (margin === null) {
+            delete image.format.marginBottom;
+            delete image.format.marginLeft;
+            delete image.format.marginRight;
+            delete image.format.marginTop;
+        }
     });
 }

--- a/packages/roosterjs-content-model/test/publicApi/image/setImageBoxShadowTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/image/setImageBoxShadowTest.ts
@@ -8,14 +8,16 @@ import { segmentTestCommon } from '../segment/segmentTestCommon';
 
 describe('setImageBoxShadow', () => {
     const style = '0px 0px 3px 3px #aaaaaa';
+    const margin = '1px';
     function runTest(
         model: ContentModelDocument,
         result: ContentModelDocument,
-        calledTimes: number
+        calledTimes: number,
+        nullMargin: boolean = false
     ) {
         segmentTestCommon(
             'setImageBoxShadow',
-            editor => setImageBoxShadow(editor, style),
+            editor => setImageBoxShadow(editor, style, nullMargin ? null : margin),
             model,
             result,
             calledTimes
@@ -120,6 +122,10 @@ describe('setImageBoxShadow', () => {
                                 dataset: {},
                                 format: {
                                     boxShadow: '0px 0px 3px 3px #aaaaaa',
+                                    marginBottom: margin,
+                                    marginLeft: margin,
+                                    marginRight: margin,
+                                    marginTop: margin,
                                 },
                             },
                         ],
@@ -127,6 +133,47 @@ describe('setImageBoxShadow', () => {
                 ],
             },
             1
+        );
+    });
+
+    it('Doc with selection and image with margin, removing margin', () => {
+        const doc = createContentModelDocument();
+        const img = createImage('test', {
+            marginBottom: margin,
+            marginLeft: margin,
+            marginRight: margin,
+            marginTop: margin,
+        });
+
+        img.isSelected = true;
+
+        addSegment(doc, img);
+
+        runTest(
+            doc,
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {},
+                        isImplicit: true,
+                        segments: [
+                            {
+                                segmentType: 'Image',
+                                src: 'test',
+                                isSelected: true,
+                                dataset: {},
+                                format: {
+                                    boxShadow: '0px 0px 3px 3px #aaaaaa',
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+            1,
+            true /* nullMargin */
         );
     });
 });


### PR DESCRIPTION
![image](https://github.com/microsoft/roosterjs/assets/44042957/4c161374-c7c3-48c9-b9c0-bc3949f1ea6d)

Allows the addition of margins to image shadows in order for them to be shown as shadows are not taken into account for box container.