### PR TITLE
Add data to the ContentChange event when pasting

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/createContentModelEditorCore.ts
+++ b/packages/roosterjs-content-model/lib/editor/createContentModelEditorCore.ts
@@ -33,7 +33,12 @@ export const createContentModelEditorCore: CoreCreator<
             )
                 ? new ContentModelTypeInContainerPlugin()
                 : undefined,
-            copyPaste: new ContentModelCopyPastePlugin(options),
+            copyPaste: isFeatureEnabled(
+                options.experimentalFeatures,
+                ExperimentalFeatures.ContentModelPaste
+            )
+                ? new ContentModelCopyPastePlugin(options)
+                : undefined,
             ...(options.corePluginOverride || {}),
         },
     };

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -48,7 +48,7 @@ export interface FormatWithContentModelOptions {
 export function formatWithContentModel(
     editor: IContentModelEditor,
     apiName: string,
-    callback: (model: ContentModelDocument) => any,
+    callback: (model: ContentModelDocument) => boolean,
     options?: FormatWithContentModelOptions
 ) {
     const {

--- a/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/formatWithContentModel.ts
@@ -48,7 +48,7 @@ export interface FormatWithContentModelOptions {
 export function formatWithContentModel(
     editor: IContentModelEditor,
     apiName: string,
-    callback: (model: ContentModelDocument) => boolean,
+    callback: (model: ContentModelDocument) => any,
     options?: FormatWithContentModelOptions
 ) {
     const {

--- a/packages/roosterjs-content-model/lib/publicApi/utils/paste.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/paste.ts
@@ -82,7 +82,7 @@ export default function paste(
                 mergeModel(model, pasteModel, getOnDeleteEntityCallback(editor), {
                     mergeCurrentFormat: applyCurrentFormat,
                 });
-                return true;
+                return clipboardData;
             },
             {
                 changeSource: ChangeSource.Paste,

--- a/packages/roosterjs-content-model/lib/publicApi/utils/paste.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/paste.ts
@@ -82,10 +82,11 @@ export default function paste(
                 mergeModel(model, pasteModel, getOnDeleteEntityCallback(editor), {
                     mergeCurrentFormat: applyCurrentFormat,
                 });
-                return clipboardData;
+                return true;
             },
             {
                 changeSource: ChangeSource.Paste,
+                getChangeData: () => clipboardData,
             }
         );
     }

--- a/packages/roosterjs-content-model/test/publicApi/utils/pasteTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/utils/pasteTest.ts
@@ -23,6 +23,7 @@ describe('Paste ', () => {
     let isDarkMode: jasmine.Spy;
     let getDarkColorHandler: jasmine.Spy;
     let getDefaultFormat: jasmine.Spy;
+    let undoSnapshotResult: any;
 
     const mockedPos = 'POS' as any;
 
@@ -47,7 +48,9 @@ describe('Paste ', () => {
         mockedModel = ({} as any) as ContentModelDocument;
         mockedMergeModel = ({} as any) as ContentModelDocument;
 
-        addUndoSnapshot = jasmine.createSpy('addUndoSnapshot').and.callFake(callback => callback());
+        addUndoSnapshot = jasmine
+            .createSpy('addUndoSnapshot')
+            .and.callFake(callback => (undoSnapshotResult = callback()));
         createContentModel = jasmine.createSpy('createContentModel').and.returnValue(mockedModel);
         setContentModel = jasmine.createSpy('setContentModel');
         focus = jasmine.createSpy('focus');
@@ -102,5 +105,6 @@ describe('Paste ', () => {
         expect(getDocument).toHaveBeenCalled();
         expect(getTrustedHTMLHandler).toHaveBeenCalled();
         expect(mockedModel).toEqual(mockedMergeModel);
+        expect(clipboardData).toEqual(undoSnapshotResult);
     });
 });


### PR DESCRIPTION
When using paste we need to return the clipboardData when invoking addUndoSnapshot. That way when other plugins handle the ContentChangeEvent. They can also use the data property. 
This is used for example in the PasteOption Plugin.

This PR adds this functionality to the new paste public API

+ Minor fix in promoteContentModelEditorCore since we were always adding the ContentModelCopyPastePlugin