### PR TITLE
use Import Helpers to reduce pack size

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "sass-loader": "8.0.2",
         "toposort": "2.0.2",
         "ts-loader": "7.0.2",
+        "tslib": "^2.3.1",
         "tslint": "6.1.2",
         "tslint-eslint-rules": "5.4.0",
         "tslint-microsoft-contrib": "6.2.0",

--- a/packages-ui/roosterjs-react/package.json
+++ b/packages-ui/roosterjs-react/package.json
@@ -2,6 +2,7 @@
     "name": "roosterjs-react",
     "description": "React wrapper of roosterjs",
     "dependencies": {
+        "tslib": "^2.3.1",
         "roosterjs-editor-types": "",
         "roosterjs-editor-types-compatible": "",
         "roosterjs-editor-dom": "",

--- a/packages/roosterjs-color-utils/package.json
+++ b/packages/roosterjs-color-utils/package.json
@@ -2,6 +2,7 @@
     "name": "roosterjs-color-utils",
     "description": "Color utilities for roosterjs",
     "dependencies": {
+        "tslib": "^2.3.1",
         "color": "^3.0.0"
     },
     "main": "./lib/index.ts",

--- a/packages/roosterjs-content-model/package.json
+++ b/packages/roosterjs-content-model/package.json
@@ -2,6 +2,7 @@
     "name": "roosterjs-content-model",
     "description": "Content Model for roosterjs (Under development)",
     "dependencies": {
+        "tslib": "^2.3.1",
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": "",
         "roosterjs-editor-core": ""

--- a/packages/roosterjs-editor-api/package.json
+++ b/packages/roosterjs-editor-api/package.json
@@ -2,6 +2,7 @@
     "name": "roosterjs-editor-api",
     "description": "Programming API for roosterjs",
     "dependencies": {
+        "tslib": "^2.3.1",
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": ""
     },

--- a/packages/roosterjs-editor-core/package.json
+++ b/packages/roosterjs-editor-core/package.json
@@ -2,6 +2,7 @@
     "name": "roosterjs-editor-core",
     "description": "Editor core for roosterjs",
     "dependencies": {
+        "tslib": "^2.3.1",
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": ""
     },

--- a/packages/roosterjs-editor-dom/package.json
+++ b/packages/roosterjs-editor-dom/package.json
@@ -2,6 +2,7 @@
     "name": "roosterjs-editor-dom",
     "description": "Object Model for roosterjs",
     "dependencies": {
+        "tslib": "^2.3.1",
         "roosterjs-editor-types": ""
     },
     "main": "./lib/index.ts"

--- a/packages/roosterjs-editor-plugins/package.json
+++ b/packages/roosterjs-editor-plugins/package.json
@@ -2,6 +2,7 @@
     "name": "roosterjs-editor-plugins",
     "description": "Plugins for roosterjs",
     "dependencies": {
+        "tslib": "^2.3.1",
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": "",
         "roosterjs-editor-api": ""

--- a/packages/roosterjs/package.json
+++ b/packages/roosterjs/package.json
@@ -2,6 +2,7 @@
     "name": "roosterjs",
     "description": "A simple facade for all roosterjs code",
     "dependencies": {
+        "tslib": "^2.3.1",
         "roosterjs-editor-types": "",
         "roosterjs-editor-types-compatible": "",
         "roosterjs-editor-dom": "",

--- a/packages/tsconfig.build.json
+++ b/packages/tsconfig.build.json
@@ -10,6 +10,7 @@
         "preserveConstEnums": false,
         "noUnusedLocals": true,
         "downlevelIteration": true,
+        "importHelpers": true,
         "baseUrl": ".",
         "paths": {
             "*": ["*"]

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -11,6 +11,7 @@
         "preserveConstEnums": true,
         "noUnusedLocals": true,
         "downlevelIteration": true,
+        "importHelpers": true,
         "baseUrl": ".",
         "paths": {
             "*": ["*"]

--- a/tools/buildTools/buildDemo.js
+++ b/tools/buildTools/buildDemo.js
@@ -37,6 +37,7 @@ async function buildDemoSite() {
                     options: {
                         compilerOptions: {
                             downlevelIteration: true,
+                            importHelpers: true,
                         },
                     },
                 },

--- a/tools/buildTools/pack.js
+++ b/tools/buildTools/pack.js
@@ -40,6 +40,7 @@ async function pack(isProduction, isAmd, isUi, filename) {
                             strict: false,
                             declaration: false,
                             downlevelIteration: true,
+                            importHelpers: true,
                         },
                     },
                 },

--- a/tools/tsconfig.doc.json
+++ b/tools/tsconfig.doc.json
@@ -10,6 +10,7 @@
         },
         "rootDir": "..",
         "downlevelIteration": true,
+        "importHelpers": true,
         "lib": ["es6", "dom"]
     },
     "include": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
                 options: {
                     compilerOptions: {
                         downlevelIteration: true,
+                        importHelpers: true,
                     },
                 },
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5242,6 +5242,11 @@ tslib@^2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
+tslib@^2.3.1:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
+  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
+
 tslint-eslint-rules@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz#e488cc9181bf193fe5cd7bfca213a7695f1737b5"


### PR DESCRIPTION
Use typescript compile option `importHelpers` to avoid generating duplicated functions such as __assign.

This need to take tslib as dependency so that those common functions can be found by `require` when compile.