### PR TITLE
Merge Format when pasting.

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -1,5 +1,3 @@
-import paste from '../publicApi/utils/paste';
-import { ClipboardData, ExperimentalFeatures } from 'roosterjs-editor-types';
 import { ContentModelDocument } from '../publicTypes/group/ContentModelDocument';
 import { ContentModelEditorCore } from '../publicTypes/ContentModelEditorCore';
 import { ContentModelSegmentFormat } from '../publicTypes/format/ContentModelSegmentFormat';

--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -1,10 +1,10 @@
-import { ClipboardData, ExperimentalFeatures } from 'roosterjs-editor-types/lib';
+import paste from '../publicApi/utils/paste';
+import { ClipboardData, ExperimentalFeatures } from 'roosterjs-editor-types';
 import { ContentModelDocument } from '../publicTypes/group/ContentModelDocument';
 import { ContentModelEditorCore } from '../publicTypes/ContentModelEditorCore';
 import { ContentModelSegmentFormat } from '../publicTypes/format/ContentModelSegmentFormat';
 import { createContentModelEditorCore } from './createContentModelEditorCore';
 import { EditorBase } from 'roosterjs-editor-core';
-import { paste } from '../publicApi';
 import {
     ContentModelEditorOptions,
     DomToModelOption,
@@ -72,6 +72,13 @@ export default class ContentModelEditor
         return core.defaultFormat;
     }
 
+    /**
+     * Paste into editor using a clipboardData object
+     * @param clipboardData Clipboard data retrieved from clipboard
+     * @param pasteAsText Force pasting as plain text. Default value is false
+     * @param applyCurrentStyle True if apply format of current selection to the pasted content,
+     * false to keep original format.  Default value is false. When pasteAsText is true, this parameter is ignored
+     */
     public paste(
         clipboardData: ClipboardData,
         pasteAsText: boolean = false,

--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -1,8 +1,10 @@
+import { ClipboardData, ExperimentalFeatures } from 'roosterjs-editor-types/lib';
 import { ContentModelDocument } from '../publicTypes/group/ContentModelDocument';
 import { ContentModelEditorCore } from '../publicTypes/ContentModelEditorCore';
 import { ContentModelSegmentFormat } from '../publicTypes/format/ContentModelSegmentFormat';
 import { createContentModelEditorCore } from './createContentModelEditorCore';
 import { EditorBase } from 'roosterjs-editor-core';
+import { paste } from '../publicApi';
 import {
     ContentModelEditorOptions,
     DomToModelOption,
@@ -68,5 +70,18 @@ export default class ContentModelEditor
         const core = this.getCore();
 
         return core.defaultFormat;
+    }
+
+    public paste(
+        clipboardData: ClipboardData,
+        pasteAsText: boolean = false,
+        applyCurrentFormat: boolean = false,
+        pasteAsImage: boolean = false
+    ) {
+        if (this.isFeatureEnabled(ExperimentalFeatures.ContentModelPaste)) {
+            paste(this, clipboardData, pasteAsText, applyCurrentFormat, pasteAsImage);
+        } else {
+            super.paste(clipboardData, pasteAsText, applyCurrentFormat, pasteAsImage);
+        }
     }
 }

--- a/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
+++ b/packages/roosterjs-content-model/lib/editor/ContentModelEditor.ts
@@ -71,24 +71,4 @@ export default class ContentModelEditor
 
         return core.defaultFormat;
     }
-
-    /**
-     * Paste into editor using a clipboardData object
-     * @param clipboardData Clipboard data retrieved from clipboard
-     * @param pasteAsText Force pasting as plain text. Default value is false
-     * @param applyCurrentStyle True if apply format of current selection to the pasted content,
-     * false to keep original format.  Default value is false. When pasteAsText is true, this parameter is ignored
-     */
-    public paste(
-        clipboardData: ClipboardData,
-        pasteAsText: boolean = false,
-        applyCurrentFormat: boolean = false,
-        pasteAsImage: boolean = false
-    ) {
-        if (this.isFeatureEnabled(ExperimentalFeatures.ContentModelPaste)) {
-            paste(this, clipboardData, pasteAsText, applyCurrentFormat, pasteAsImage);
-        } else {
-            super.paste(clipboardData, pasteAsText, applyCurrentFormat, pasteAsImage);
-        }
-    }
 }

--- a/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
@@ -5,7 +5,7 @@ import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBloc
 import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
 import { ContentModelListItem } from '../../publicTypes/group/ContentModelListItem';
 import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
-import { ContentModelSegment } from 'roosterjs-content-model/lib/publicTypes';
+import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { createListItem } from '../creators/createListItem';

--- a/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
@@ -308,7 +308,7 @@ function getSemanticFormat(segment: ContentModelSegment): ContentModelSegmentFor
     const { fontWeight, italic, underline } = segment.format;
 
     if (fontWeight && fontWeight != 'normal') {
-        result.fontWeight = segment.format.fontWeight;
+        result.fontWeight = fontWeight;
     }
     if (italic) {
         result.italic = italic;

--- a/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
@@ -5,6 +5,7 @@ import { ContentModelBlockGroup } from '../../publicTypes/group/ContentModelBloc
 import { ContentModelDocument } from '../../publicTypes/group/ContentModelDocument';
 import { ContentModelListItem } from '../../publicTypes/group/ContentModelListItem';
 import { ContentModelParagraph } from '../../publicTypes/block/ContentModelParagraph';
+import { ContentModelSegment } from 'roosterjs-content-model/lib/publicTypes';
 import { ContentModelSegmentFormat } from '../../publicTypes/format/ContentModelSegmentFormat';
 import { ContentModelTable } from '../../publicTypes/block/ContentModelTable';
 import { createListItem } from '../creators/createListItem';
@@ -44,7 +45,9 @@ export interface MergeModelOption {
     mergeCurrentFormat?: boolean;
 
     /**
-     *
+     * When set to true, segment format of the insert position will be set into the content that is merged into current model.
+     * If the source model already has fontWeight, Italic or underline, it will not be overwritten.
+     * @default false
      */
     applyCurrentFormat?: boolean;
 }
@@ -71,7 +74,7 @@ export function mergeModel(
             applyDefaultFormat(
                 source,
                 newFormat,
-                options?.mergeCurrentFormat ? 'MergeCurrentFormat' : 'ApplyDefaultFormat'
+                options?.applyCurrentFormat ? 'ApplyDefaultFormat' : 'MergeCurrentFormat'
             );
         }
 
@@ -298,12 +301,28 @@ function applyDefaultFormat(
                             ? { ...format, ...segment.format }
                             : {
                                   ...format,
-                                  fontWeight: segment.format.fontWeight || format.fontWeight,
-                                  italic: segment.format.italic || format.italic,
-                                  underline: segment.format.underline || format.underline,
+                                  ...mergeSemanticFormat(segment, format),
                               };
                 });
                 break;
         }
     });
+}
+function mergeSemanticFormat(
+    segment: ContentModelSegment,
+    format: ContentModelSegmentFormat
+): ContentModelSegmentFormat {
+    const result: ContentModelSegmentFormat = {};
+
+    if (segment.format.fontWeight || format.fontWeight) {
+        result.fontWeight = segment.format.fontWeight || format.fontWeight;
+    }
+    if (segment.format.italic || format.italic) {
+        result.italic = segment.format.italic || format.italic;
+    }
+    if (segment.format.underline || format.underline) {
+        result.underline = segment.format.underline || format.underline;
+    }
+
+    return result;
 }

--- a/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
@@ -301,27 +301,25 @@ function applyDefaultFormat(
                             ? { ...format, ...segment.format }
                             : {
                                   ...format,
-                                  ...mergeSemanticFormat(segment, format),
+                                  ...getSemanticFormat(segment),
                               };
                 });
                 break;
         }
     });
 }
-function mergeSemanticFormat(
-    segment: ContentModelSegment,
-    format: ContentModelSegmentFormat
-): ContentModelSegmentFormat {
+
+function getSemanticFormat(segment: ContentModelSegment): ContentModelSegmentFormat {
     const result: ContentModelSegmentFormat = {};
 
-    if (segment.format.fontWeight || format.fontWeight) {
-        result.fontWeight = segment.format.fontWeight || format.fontWeight;
+    if (segment.format.fontWeight) {
+        result.fontWeight = segment.format.fontWeight;
     }
-    if (segment.format.italic || format.italic) {
-        result.italic = segment.format.italic || format.italic;
+    if (segment.format.italic) {
+        result.italic = segment.format.italic;
     }
-    if (segment.format.underline || format.underline) {
-        result.underline = segment.format.underline || format.underline;
+    if (segment.format.underline) {
+        result.underline = segment.format.underline;
     }
 
     return result;

--- a/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
+++ b/packages/roosterjs-content-model/lib/modelApi/common/mergeModel.ts
@@ -38,18 +38,14 @@ export interface MergeModelOption {
     insertPosition?: InsertPoint;
 
     /**
-     * When set to true, segment format of the insert position will be merged into the content that is merged into current model.
+     * Use this to decide whether to change the source model format when doing the merge.
+     * 'MergeCurrentFormat': segment format of the insert position will be merged into the content that is merged into current model.
      * If the source model already has some format, it will not be overwritten.
-     * @default false
-     */
-    mergeCurrentFormat?: boolean;
-
-    /**
-     * When set to true, segment format of the insert position will be set into the content that is merged into current model.
+     * 'ApplyCurrentFormat': format of the insert position will be set into the content that is merged into current model.
      * If the source model already has fontWeight, Italic or underline, it will not be overwritten.
-     * @default false
+     * @default undefined
      */
-    applyCurrentFormat?: boolean;
+    mergeFormatOption?: 'MergeCurrentFormat' | 'ApplyCurrentFormat';
 }
 
 /**
@@ -65,17 +61,13 @@ export function mergeModel(
         options?.insertPosition ?? deleteSelection(target, onDeleteEntity).insertPoint;
 
     if (insertPosition) {
-        if (options?.mergeCurrentFormat || options?.applyCurrentFormat) {
+        if (options?.mergeFormatOption) {
             const newFormat: ContentModelSegmentFormat = {
                 ...(target.format || {}),
                 ...insertPosition.marker.format,
             };
 
-            applyDefaultFormat(
-                source,
-                newFormat,
-                options?.applyCurrentFormat ? 'ApplyDefaultFormat' : 'MergeCurrentFormat'
-            );
+            applyDefaultFormat(source, newFormat, options.mergeFormatOption);
         }
 
         for (let i = 0; i < source.blocks.length; i++) {
@@ -274,7 +266,7 @@ function insertBlock(markerPosition: InsertPoint, block: ContentModelBlock) {
 function applyDefaultFormat(
     group: ContentModelBlockGroup,
     format: ContentModelSegmentFormat,
-    applyDefaultFormatOption: 'ApplyDefaultFormat' | 'MergeCurrentFormat'
+    applyDefaultFormatOption: 'MergeCurrentFormat' | 'ApplyCurrentFormat'
 ) {
     group.blocks.forEach(block => {
         switch (block.blockType) {

--- a/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
@@ -30,7 +30,9 @@ function insertImageWithSrc(editor: IContentModelEditor, src: string) {
         const doc = createContentModelDocument();
 
         addSegment(doc, image);
-        mergeModel(model, doc, getOnDeleteEntityCallback(editor), { mergeCurrentFormat: true });
+        mergeModel(model, doc, getOnDeleteEntityCallback(editor), {
+            mergeFormatOption: 'MergeCurrentFormat',
+        });
 
         return true;
     });

--- a/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/image/insertImage.ts
@@ -31,7 +31,7 @@ function insertImageWithSrc(editor: IContentModelEditor, src: string) {
 
         addSegment(doc, image);
         mergeModel(model, doc, getOnDeleteEntityCallback(editor), {
-            mergeFormatOption: 'MergeCurrentFormat',
+            mergeFormat: 'mergeAll',
         });
 
         return true;

--- a/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
@@ -94,7 +94,7 @@ export default function insertLink(
                     }
 
                     mergeModel(model, doc, getOnDeleteEntityCallback(editor), {
-                        mergeCurrentFormat: true,
+                        mergeFormatOption: 'MergeCurrentFormat',
                     });
                 }
 

--- a/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/link/insertLink.ts
@@ -94,7 +94,7 @@ export default function insertLink(
                     }
 
                     mergeModel(model, doc, getOnDeleteEntityCallback(editor), {
-                        mergeFormatOption: 'MergeCurrentFormat',
+                        mergeFormat: 'mergeAll',
                     });
                 }
 

--- a/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
@@ -39,7 +39,7 @@ export default function insertTable(
             applyTableFormat(table, format);
             mergeModel(model, doc, onDeleteEntity, {
                 insertPosition,
-                mergeFormatOption: 'MergeCurrentFormat',
+                mergeFormat: 'mergeAll',
             });
 
             const firstBlock = table.rows[0]?.cells[0]?.blocks[0];

--- a/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/table/insertTable.ts
@@ -39,7 +39,7 @@ export default function insertTable(
             applyTableFormat(table, format);
             mergeModel(model, doc, onDeleteEntity, {
                 insertPosition,
-                mergeCurrentFormat: true,
+                mergeFormatOption: 'MergeCurrentFormat',
             });
 
             const firstBlock = table.rows[0]?.cells[0]?.blocks[0];

--- a/packages/roosterjs-content-model/lib/publicApi/utils/paste.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/paste.ts
@@ -80,7 +80,7 @@ export default function paste(
             'Paste',
             model => {
                 mergeModel(model, pasteModel, getOnDeleteEntityCallback(editor), {
-                    mergeCurrentFormat: applyCurrentFormat,
+                    applyCurrentFormat,
                 });
                 return true;
             },

--- a/packages/roosterjs-content-model/lib/publicApi/utils/paste.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/paste.ts
@@ -80,7 +80,7 @@ export default function paste(
             'Paste',
             model => {
                 mergeModel(model, pasteModel, getOnDeleteEntityCallback(editor), {
-                    mergeFormatOption: applyCurrentFormat ? 'ApplyCurrentFormat' : undefined,
+                    mergeFormat: applyCurrentFormat ? 'keepSourceEmphasisFormat' : undefined,
                 });
                 return true;
             },

--- a/packages/roosterjs-content-model/lib/publicApi/utils/paste.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/utils/paste.ts
@@ -80,7 +80,7 @@ export default function paste(
             'Paste',
             model => {
                 mergeModel(model, pasteModel, getOnDeleteEntityCallback(editor), {
-                    applyCurrentFormat,
+                    mergeFormatOption: applyCurrentFormat ? 'ApplyCurrentFormat' : undefined,
                 });
                 return true;
             },

--- a/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
@@ -1403,7 +1403,9 @@ describe('mergeModel', () => {
         para1.segments.push(marker);
         majorModel.blocks.push(para1);
 
-        mergeModel(majorModel, sourceModel, onDeleteEntityMock, { mergeCurrentFormat: true });
+        mergeModel(majorModel, sourceModel, onDeleteEntityMock, {
+            mergeFormatOption: 'MergeCurrentFormat',
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -1458,7 +1460,9 @@ describe('mergeModel', () => {
         para1.segments.push(marker);
         majorModel.blocks.push(para1);
 
-        mergeModel(majorModel, sourceModel, onDeleteEntityMock, { applyCurrentFormat: true });
+        mergeModel(majorModel, sourceModel, onDeleteEntityMock, {
+            mergeFormatOption: 'ApplyCurrentFormat',
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -1519,7 +1523,9 @@ describe('mergeModel', () => {
         para1.segments.push(marker);
         majorModel.blocks.push(para1);
 
-        mergeModel(majorModel, sourceModel, onDeleteEntityMock, { applyCurrentFormat: true });
+        mergeModel(majorModel, sourceModel, onDeleteEntityMock, {
+            mergeFormatOption: 'ApplyCurrentFormat',
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',

--- a/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
@@ -1429,6 +1429,127 @@ describe('mergeModel', () => {
         });
     });
 
+    it('Merge with default format', () => {
+        const MockedFormat = {
+            formatName: 'mocked',
+        } as any;
+        const majorModel = createContentModelDocument(MockedFormat);
+        const sourceModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {
+                                formatName: 'ToBeRemoved',
+                            } as any,
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+        };
+        const para1 = createParagraph();
+        const marker = createSelectionMarker();
+
+        para1.segments.push(marker);
+        majorModel.blocks.push(para1);
+
+        mergeModel(majorModel, sourceModel, onDeleteEntityMock, { applyCurrentFormat: true });
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: MockedFormat,
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: MockedFormat,
+        });
+    });
+
+    it('Merge with default format, keep the source bold, italic and underline', () => {
+        const MockedFormat = {
+            formatName: 'mocked',
+            fontWeight: 'ToBeRemoved',
+            italic: 'ToBeRemoved',
+            underline: 'ToBeRemoved',
+        } as any;
+        const majorModel = createContentModelDocument(MockedFormat);
+        const sourceModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {
+                                formatName: 'ToBeRemoved',
+                                fontWeight: 'sourceFontWeight',
+                                italic: 'sourceItalic',
+                                underline: 'sourceUnderline',
+                            } as any,
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+        };
+        const para1 = createParagraph();
+        const marker = createSelectionMarker();
+
+        para1.segments.push(marker);
+        majorModel.blocks.push(para1);
+
+        mergeModel(majorModel, sourceModel, onDeleteEntityMock, { applyCurrentFormat: true });
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {
+                                formatName: 'mocked',
+                                fontWeight: 'sourceFontWeight',
+                                italic: 'sourceItalic',
+                                underline: 'sourceUnderline',
+                            } as any,
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: MockedFormat,
+        });
+    });
+
     it('Divider to single selected paragraph with inline format', () => {
         const majorModel = createContentModelDocument();
         const sourceModel = createContentModelDocument();

--- a/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
+++ b/packages/roosterjs-content-model/test/modelApi/common/mergeModelTest.ts
@@ -1404,7 +1404,7 @@ describe('mergeModel', () => {
         majorModel.blocks.push(para1);
 
         mergeModel(majorModel, sourceModel, onDeleteEntityMock, {
-            mergeFormatOption: 'MergeCurrentFormat',
+            mergeFormat: 'mergeAll',
         });
 
         expect(majorModel).toEqual({
@@ -1461,7 +1461,7 @@ describe('mergeModel', () => {
         majorModel.blocks.push(para1);
 
         mergeModel(majorModel, sourceModel, onDeleteEntityMock, {
-            mergeFormatOption: 'ApplyCurrentFormat',
+            mergeFormat: 'keepSourceEmphasisFormat',
         });
 
         expect(majorModel).toEqual({
@@ -1524,7 +1524,7 @@ describe('mergeModel', () => {
         majorModel.blocks.push(para1);
 
         mergeModel(majorModel, sourceModel, onDeleteEntityMock, {
-            mergeFormatOption: 'ApplyCurrentFormat',
+            mergeFormat: 'keepSourceEmphasisFormat',
         });
 
         expect(majorModel).toEqual({


### PR DESCRIPTION
When pasting and also using the Paste Option to merge the styles we need to apply the current format to the pasted content.
Following Word's behavior, if the pasted content contains text that is Bold/italic/Underline that format is going to be preserved.

![image](https://github.com/microsoft/roosterjs/assets/8291124/2af05dd8-9ad4-42af-9ba6-b6f331e028a9)

Source: https://support.microsoft.com/en-us/office/control-the-formatting-when-you-paste-text-20156a41-520e-48a6-8680-fb9ce15bf3d6?ui=en-us&rs=en-us&ad=us

With this change we add a new option to mergeModel so we can set the format to the pasted model.

Also, modified the current ContentModelEditor so we can use the 'Merge Format' Option from RoosterUI


![MergeFormatOnPaste1](https://github.com/microsoft/roosterjs/assets/8291124/c66f4461-94c9-467e-8ed8-718bc18e31a6)
