### PR TITLE
Update ContentModelCopyPaste Core Plugin state initialization.

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages/roosterjs-content-model/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -25,7 +25,6 @@ import {
 import {
     ChangeSource,
     CopyPastePluginState,
-    EditorOptions,
     IEditor,
     PluginEventType,
     PluginWithState,
@@ -48,10 +47,8 @@ export default class ContentModelCopyPastePlugin implements PluginWithState<Copy
      * Construct a new instance of CopyPastePlugin
      * @param options The editor options
      */
-    constructor(options: EditorOptions) {
-        this.state = {
-            allowedCustomPasteType: options.allowedCustomPasteType || [],
-        };
+    constructor(state: CopyPastePluginState) {
+        this.state = state;
     }
 
     /**
@@ -83,6 +80,7 @@ export default class ContentModelCopyPastePlugin implements PluginWithState<Copy
         }
         this.disposer = null;
         this.editor = null;
+        this.state = null!;
     }
 
     /**

--- a/packages/roosterjs-content-model/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages/roosterjs-content-model/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -41,15 +41,12 @@ import {
 export default class ContentModelCopyPastePlugin implements PluginWithState<CopyPastePluginState> {
     private editor: IContentModelEditor | null = null;
     private disposer: (() => void) | null = null;
-    private state: CopyPastePluginState;
 
     /**
      * Construct a new instance of CopyPastePlugin
      * @param options The editor options
      */
-    constructor(state: CopyPastePluginState) {
-        this.state = state;
-    }
+    constructor(private state: CopyPastePluginState) {}
 
     /**
      * Get a friendly name of  this plugin

--- a/packages/roosterjs-content-model/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages/roosterjs-content-model/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -77,7 +77,6 @@ export default class ContentModelCopyPastePlugin implements PluginWithState<Copy
         }
         this.disposer = null;
         this.editor = null;
-        this.state = null!;
     }
 
     /**

--- a/packages/roosterjs-content-model/lib/editor/createContentModelEditorCore.ts
+++ b/packages/roosterjs-content-model/lib/editor/createContentModelEditorCore.ts
@@ -33,7 +33,9 @@ export const createContentModelEditorCore: CoreCreator<
             )
                 ? new ContentModelTypeInContainerPlugin()
                 : undefined,
-            copyPaste: new ContentModelCopyPastePlugin(options),
+            copyPaste: new ContentModelCopyPastePlugin({
+                allowedCustomPasteType: options.allowedCustomPasteType || [],
+            }),
             ...(options.corePluginOverride || {}),
         },
     };


### PR DESCRIPTION
Update ContentModelCopyPaste Core Plugin state initialization, so we receive the state object instead of creating it inside of the plugin.