### PR TITLE
Fix table inserter for merged vertical cells

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -13,10 +13,10 @@ import {
 } from 'roosterjs-editor-types';
 
 const INSERTER_HOVER_OFFSET = 6;
-const TOP_OR_SIDE = {
-    top: 0,
-    side: 1,
-};
+const enum TOP_OR_SIDE {
+    top = 0,
+    side = 1,
+}
 /**
  * @internal
  *

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -151,8 +151,6 @@ export default class TableEditor {
                     const isOnLeftOrRight = this.isRTL
                         ? tdRect.right <= tableRect.right && tdRect.right >= tableRect.right - 1
                         : tdRect.left >= tableRect.left && tdRect.left <= tableRect.left + 1;
-
-                    // Top inserter
                     if (i === 0 && topOrSide == TOP_OR_SIDE.top) {
                         const center = (tdRect.left + tdRect.right) / 2;
                         const isOnRightHalf = this.isRTL ? x < center : x > center;
@@ -160,9 +158,7 @@ export default class TableEditor {
                             isOnRightHalf ? td : tr.cells[j - 1],
                             false /*isHorizontal*/
                         );
-                    }
-                    // Side inserter
-                    else if (j === 0 && topOrSide == TOP_OR_SIDE.side && isOnLeftOrRight) {
+                    } else if (j === 0 && topOrSide == TOP_OR_SIDE.side && isOnLeftOrRight) {
                         const tdAbove = this.table.rows[i - 1]?.cells[0];
                         const tdAboveRect = tdAbove
                             ? normalizeRect(tdAbove.getBoundingClientRect())

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -12,8 +12,11 @@ import {
     CreateElementData,
 } from 'roosterjs-editor-types';
 
-const INSERTER_HOVER_OFFSET = 5;
-
+const INSERTER_HOVER_OFFSET = 6;
+const TOP_OR_SIDE = {
+    top: 0,
+    side: 1,
+};
 /**
  * @internal
  *
@@ -106,6 +109,23 @@ export default class TableEditor {
     }
 
     onMouseMove(x: number, y: number) {
+        //Get Cell [0,0]
+        const firstCell = this.table.rows[0].cells[0];
+        const firstCellRect = normalizeRect(firstCell.getBoundingClientRect());
+
+        //Determine if cursor is on top or side
+        const topOrSide =
+            y <= firstCellRect.top + INSERTER_HOVER_OFFSET
+                ? TOP_OR_SIDE.top
+                : this.isRTL
+                ? x >= firstCellRect.right - INSERTER_HOVER_OFFSET
+                    ? TOP_OR_SIDE.side
+                    : undefined
+                : x <= firstCellRect.left + INSERTER_HOVER_OFFSET
+                ? TOP_OR_SIDE.side
+                : undefined;
+
+        // i is row index, j is column index
         for (let i = 0; i < this.table.rows.length; i++) {
             const tr = this.table.rows[i];
             let j = 0;
@@ -118,27 +138,31 @@ export default class TableEditor {
                     continue;
                 }
 
+                // Determine the cell the cursor is in range of
                 const lessThanBottom = y <= tdRect.bottom;
-                const lessThanRight = this.isRTL ? x >= tdRect.right : x <= tdRect.right;
+                const lessThanRight = this.isRTL
+                    ? x <= tdRect.right + INSERTER_HOVER_OFFSET
+                    : x <= tdRect.right;
+                const moreThanLeft = this.isRTL
+                    ? x >= tdRect.left
+                    : x >= tdRect.left - INSERTER_HOVER_OFFSET;
 
-                if (lessThanRight && lessThanBottom) {
+                if (lessThanBottom && lessThanRight && moreThanLeft) {
                     const isOnLeftOrRight = this.isRTL
                         ? tdRect.right <= tableRect.right && tdRect.right >= tableRect.right - 1
                         : tdRect.left >= tableRect.left && tdRect.left <= tableRect.left + 1;
-                    if (i === 0 && y <= tdRect.top + INSERTER_HOVER_OFFSET) {
+
+                    // Top inserter
+                    if (i === 0 && topOrSide == TOP_OR_SIDE.top) {
                         const center = (tdRect.left + tdRect.right) / 2;
                         const isOnRightHalf = this.isRTL ? x < center : x > center;
                         this.setInserterTd(
                             isOnRightHalf ? td : tr.cells[j - 1],
                             false /*isHorizontal*/
                         );
-                    } else if (
-                        j == 0 &&
-                        (this.isRTL
-                            ? x >= tdRect.right - INSERTER_HOVER_OFFSET
-                            : x <= tdRect.left + INSERTER_HOVER_OFFSET) &&
-                        isOnLeftOrRight
-                    ) {
+                    }
+                    // Side inserter
+                    else if (j === 0 && topOrSide == TOP_OR_SIDE.side && isOnLeftOrRight) {
                         const tdAbove = this.table.rows[i - 1]?.cells[0];
                         const tdAboveRect = tdAbove
                             ? normalizeRect(tdAbove.getBoundingClientRect())

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
@@ -42,17 +42,19 @@ export default function createTableInserter(
         const div = createElement(createElementData, document) as HTMLDivElement;
 
         if (isHorizontal) {
+            // tableRect.left/right is used because the Inserter is always intended to be on the side
             div.style.left = `${
                 isRTL
-                    ? tdRect.right
-                    : tdRect.left - (INSERTER_SIDE_LENGTH - 1 + 2 * INSERTER_BORDER_SIZE)
+                    ? tableRect.right
+                    : tableRect.left - (INSERTER_SIDE_LENGTH - 1 + 2 * INSERTER_BORDER_SIZE)
             }px`;
             div.style.top = `${tdRect.bottom - 8}px`;
             (div.firstChild as HTMLElement).style.width = `${tableRect.right - tableRect.left}px`;
         } else {
             div.style.left = `${isRTL ? tdRect.left - 8 : tdRect.right - 8}px`;
+            // tableRect.top is used because the Inserter is always intended to be on top
             div.style.top = `${
-                tdRect.top - (INSERTER_SIDE_LENGTH - 1 + 2 * INSERTER_BORDER_SIZE)
+                tableRect.top - (INSERTER_SIDE_LENGTH - 1 + 2 * INSERTER_BORDER_SIZE)
             }px`;
             (div.firstChild as HTMLElement).style.height = `${tableRect.bottom - tableRect.top}px`;
         }


### PR DESCRIPTION
### Description:

If some cells are merged vertically, the row inserter will not be accessible for any intersecting row except the first one. The issue is not present for horizontally merged cells and the column inserter.

Example table:
<div><table ><tbody><tr><td><br/></td><td><br/></td><td rowspan="3"><br/></td></tr><tr><td><br/></td><td><br/></td></tr><tr><td><br/></td><td><br/></td></tr></tbody></table>

### Fix

A new condition was added to check if the cursor's position is more than the left margin of the cell, plus other minor optimisations. This was done because the previous two conditions (less than right and less than bottom) were being met by any vertically merged cell in the wrong row, so the inserter would not appear for the intersecting rows of that cell, except the first one.

### Cases tested:

Using the above table as example, Insert a new row after the second one using the table inserter.

**Before:** The inserter is not showing, so the only way to insert the row is though a menu.

**After:** The row inserter is accessible

### Warnings and implications

- It could be considered to separate the behaviour of the Table Inserter and Table Resizer.
- The Table Resizer is not usable for left edges of a vertically merged cell, except the first one.