### PR TITLE
Content Model: Fix focus issue again

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/coreApi/setContentModel.ts
+++ b/packages/roosterjs-content-model/lib/editor/coreApi/setContentModel.ts
@@ -21,19 +21,5 @@ export const setContentModel: SetContentModel = (core, model, option) => {
 
     if (!core.lifecycle.shadowEditFragment) {
         core.api.select(core, range);
-
-        // We realize a behavior when current paragraph is empty (only has a BR), the focus
-        // will not be correctly set, and the final result. When this happens, focus will be directly
-        // put under editor content DIV.
-        // To workaround it, we can set focus again after a rerender, so we can call requestAnimationFrame
-        // and set focus again
-        if (
-            core.api.getSelectionRange(core, false /*tryGetFromCache*/)?.startContainer ==
-            core.contentDiv
-        ) {
-            core.contentDiv.ownerDocument.defaultView?.requestAnimationFrame(() => {
-                core.api.select(core, range);
-            });
-        }
     }
 };

--- a/packages/roosterjs-content-model/lib/editor/coreApi/switchShadowEdit.ts
+++ b/packages/roosterjs-content-model/lib/editor/coreApi/switchShadowEdit.ts
@@ -11,13 +11,15 @@ export const switchShadowEdit: SwitchShadowEdit = (editorCore, isOn): void => {
     // TODO: Use strong-typed editor core object
     const core = editorCore as ContentModelEditorCore;
 
-    if (isOn && !core.cachedModel) {
-        core.cachedModel = core.api.createContentModel(core);
-    }
+    if (isOn != !!core.lifecycle.shadowEditFragment) {
+        if (isOn && !core.cachedModel) {
+            core.cachedModel = core.api.createContentModel(core);
+        }
 
-    core.originalApi.switchShadowEdit(editorCore, isOn);
+        core.originalApi.switchShadowEdit(editorCore, isOn);
 
-    if (!isOn && core.cachedModel) {
-        core.api.setContentModel(core, core.cachedModel);
+        if (!isOn && core.cachedModel) {
+            core.api.setContentModel(core, core.cachedModel);
+        }
     }
 };

--- a/packages/roosterjs-content-model/test/editor/coreApi/switchShadowEditTest.ts
+++ b/packages/roosterjs-content-model/test/editor/coreApi/switchShadowEditTest.ts
@@ -23,46 +23,95 @@ describe('switchShadowEdit', () => {
             originalApi: {
                 switchShadowEdit: originalSwitchShadowEdit,
             },
+            lifecycle: {},
         } as any) as ContentModelEditorCore;
     });
 
-    it('no cache, isOn', () => {
-        switchShadowEdit(core, true);
+    describe('was off', () => {
+        it('no cache, isOn', () => {
+            switchShadowEdit(core, true);
 
-        expect(createContentModel).toHaveBeenCalledWith(core);
-        expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, true);
-        expect(setContentModel).not.toHaveBeenCalled();
-        expect(core.cachedModel).toBe(mockedModel);
+            expect(createContentModel).toHaveBeenCalledWith(core);
+            expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, true);
+            expect(setContentModel).not.toHaveBeenCalled();
+            expect(core.cachedModel).toBe(mockedModel);
+        });
+
+        it('with cache, isOn', () => {
+            core.cachedModel = mockedCachedModel;
+
+            switchShadowEdit(core, true);
+
+            expect(createContentModel).not.toHaveBeenCalled();
+            expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, true);
+            expect(setContentModel).not.toHaveBeenCalled();
+            expect(core.cachedModel).toBe(mockedCachedModel);
+        });
+
+        it('no cache, isOff', () => {
+            switchShadowEdit(core, false);
+
+            expect(createContentModel).not.toHaveBeenCalled();
+            expect(originalSwitchShadowEdit).not.toHaveBeenCalled();
+            expect(setContentModel).not.toHaveBeenCalled();
+            expect(core.cachedModel).toBe(undefined);
+        });
+
+        it('with cache, isOff', () => {
+            core.cachedModel = mockedCachedModel;
+
+            switchShadowEdit(core, false);
+
+            expect(createContentModel).not.toHaveBeenCalled();
+            expect(originalSwitchShadowEdit).not.toHaveBeenCalled();
+            expect(setContentModel).not.toHaveBeenCalled();
+            expect(core.cachedModel).toBe(mockedCachedModel);
+        });
     });
 
-    it('with cache, isOn', () => {
-        core.cachedModel = mockedCachedModel;
+    describe('was on', () => {
+        beforeEach(() => {
+            core.lifecycle.shadowEditFragment = {} as any;
+        });
 
-        switchShadowEdit(core, true);
+        it('no cache, isOn', () => {
+            switchShadowEdit(core, true);
 
-        expect(createContentModel).not.toHaveBeenCalled();
-        expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, true);
-        expect(setContentModel).not.toHaveBeenCalled();
-        expect(core.cachedModel).toBe(mockedCachedModel);
-    });
+            expect(createContentModel).not.toHaveBeenCalled();
+            expect(originalSwitchShadowEdit).not.toHaveBeenCalled();
+            expect(setContentModel).not.toHaveBeenCalled();
+            expect(core.cachedModel).toBe(undefined);
+        });
 
-    it('no cache, isOff', () => {
-        switchShadowEdit(core, false);
+        it('with cache, isOn', () => {
+            core.cachedModel = mockedCachedModel;
 
-        expect(createContentModel).not.toHaveBeenCalled();
-        expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, false);
-        expect(setContentModel).not.toHaveBeenCalled();
-        expect(core.cachedModel).toBe(undefined);
-    });
+            switchShadowEdit(core, true);
 
-    it('with cache, isOff', () => {
-        core.cachedModel = mockedCachedModel;
+            expect(createContentModel).not.toHaveBeenCalled();
+            expect(originalSwitchShadowEdit).not.toHaveBeenCalled();
+            expect(setContentModel).not.toHaveBeenCalled();
+            expect(core.cachedModel).toBe(mockedCachedModel);
+        });
 
-        switchShadowEdit(core, false);
+        it('no cache, isOff', () => {
+            switchShadowEdit(core, false);
 
-        expect(createContentModel).not.toHaveBeenCalled();
-        expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, false);
-        expect(setContentModel).toHaveBeenCalledWith(core, mockedCachedModel);
-        expect(core.cachedModel).toBe(mockedCachedModel);
+            expect(createContentModel).not.toHaveBeenCalled();
+            expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, false);
+            expect(setContentModel).not.toHaveBeenCalled();
+            expect(core.cachedModel).toBe(undefined);
+        });
+
+        it('with cache, isOff', () => {
+            core.cachedModel = mockedCachedModel;
+
+            switchShadowEdit(core, false);
+
+            expect(createContentModel).not.toHaveBeenCalled();
+            expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, false);
+            expect(setContentModel).toHaveBeenCalledWith(core, mockedCachedModel);
+            expect(core.cachedModel).toBe(mockedCachedModel);
+        });
     });
 });


### PR DESCRIPTION
In #1814, I added an async call to set focus again if thte focus was not correctly set. 

Now I found that the original issue was actually caused by incorrectly switching shadow edit. If editor is not in shadow edit state, no need to turn it off again. So fix the shadow edit code and partially revert the original change