### PR TITLE
Content Model: Fix header level issue

### DIFF
--- a/packages/roosterjs-content-model/lib/publicApi/block/setHeaderLevel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setHeaderLevel.ts
@@ -28,10 +28,6 @@ export default function setHeaderLevel(
                 tagName: tagName!,
                 format: { ...headerStyle },
             };
-
-            para.segments.forEach(segment => {
-                Object.assign(segment.format, headerStyle);
-            });
         } else if (tagName) {
             delete para.decorator;
         }

--- a/packages/roosterjs-content-model/lib/publicApi/block/setHeaderLevel.ts
+++ b/packages/roosterjs-content-model/lib/publicApi/block/setHeaderLevel.ts
@@ -28,6 +28,12 @@ export default function setHeaderLevel(
                 tagName: tagName!,
                 format: { ...headerStyle },
             };
+
+            // Remove existing formats since tags have default font size and weight
+            para.segments.forEach(segment => {
+                delete segment.format.fontSize;
+                delete segment.format.fontWeight;
+            });
         } else if (tagName) {
             delete para.decorator;
         }

--- a/packages/roosterjs-content-model/test/publicApi/block/setHeaderLevelTest.ts
+++ b/packages/roosterjs-content-model/test/publicApi/block/setHeaderLevelTest.ts
@@ -102,11 +102,11 @@ describe('setHeaderLevel to 1', () => {
                             {
                                 segmentType: 'Text',
                                 text: 'test',
-                                format: { fontSize: '2em', fontWeight: 'bold' },
+                                format: {},
                             },
                             {
                                 segmentType: 'SelectionMarker',
-                                format: { fontSize: '2em', fontWeight: 'bold' },
+                                format: {},
                                 isSelected: true,
                             },
                         ],
@@ -153,10 +153,7 @@ describe('setHeaderLevel to 1', () => {
                             {
                                 segmentType: 'Text',
                                 text: 'test',
-                                format: {
-                                    fontSize: '2em',
-                                    fontWeight: 'bold',
-                                },
+                                format: {},
                                 isSelected: true,
                             },
                         ],
@@ -213,10 +210,7 @@ describe('setHeaderLevel to 1', () => {
                             {
                                 segmentType: 'Text',
                                 text: 'test',
-                                format: {
-                                    fontSize: '2em',
-                                    fontWeight: 'bold',
-                                },
+                                format: {},
                                 isSelected: true,
                             },
                         ],


### PR DESCRIPTION
Problem: Turn on Content Model toolbar, select some text, turn on header, then turn off. The text should return to the format before turn on header, but it keeps the header's format.

Root cause: In a previous change we changed the code of how paragraph decorator works. Now the segment does not need to copy the format of decorator. 

Fix: Remove the code to copy format to segment, and delete exiting font size and weight style from segment if any in order to match header's style.