### PR TITLE
Fix Table Inserter Color in Dark Mode

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
@@ -126,7 +126,7 @@ function getInsertElementData(
     backgroundColor: string
 ): CreateElementData {
     const inserterColor = isDark ? INSERTER_COLOR_DARK_MODE : INSERTER_COLOR;
-    const outerDivStyle = `position: fixed; width: ${INSERTER_SIDE_LENGTH}px; height: ${INSERTER_SIDE_LENGTH}px; font-size: 16px; color: ${inserterColor}; line-height: 8px; vertical-align: middle; text-align: center; cursor: pointer; border: solid ${INSERTER_BORDER_SIZE}px ${inserterColor}; border-radius: 50%; background-color: ${backgroundColor}`;
+    const outerDivStyle = `position: fixed; width: ${INSERTER_SIDE_LENGTH}px; height: ${INSERTER_SIDE_LENGTH}px; font-size: 16px; color: black; line-height: 8px; vertical-align: middle; text-align: center; cursor: pointer; border: solid ${INSERTER_BORDER_SIZE}px ${inserterColor}; border-radius: 50%; background-color: ${backgroundColor}`;
     const leftOrRight = isRTL ? 'right' : 'left';
     const childBaseStyles = `position: absolute; box-sizing: border-box; background-color: ${backgroundColor};`;
     const childInfo: CreateElementData = {


### PR DESCRIPTION
In dark mode the table inserter `+` sign is not visible, so fixing that in this PR:

before
![image](https://github.com/microsoft/roosterjs/assets/8291124/2f75df7a-6604-4338-8fa7-57724fd6ad66)

after
![image](https://github.com/microsoft/roosterjs/assets/8291124/e25b8f20-7f6d-4739-a12a-148bac676b11)
