### PR TITLE
Content Model: Fix #209223

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/coreApi/switchShadowEdit.ts
+++ b/packages/roosterjs-content-model/lib/editor/coreApi/switchShadowEdit.ts
@@ -23,10 +23,7 @@ export const switchShadowEdit: SwitchShadowEdit = (editorCore, isOn): void => {
             core.lifecycle.shadowEditSelectionPath =
                 range && getSelectionPath(core.contentDiv, range);
             core.lifecycle.shadowEditFragment = core.contentDiv.ownerDocument.createDocumentFragment();
-        }
-
-        // core.originalApi.switchShadowEdit(editorCore, isOn);
-        else {
+        } else {
             if (core.cachedModel) {
                 core.api.setContentModel(core, core.cachedModel);
             }

--- a/packages/roosterjs-content-model/lib/editor/coreApi/switchShadowEdit.ts
+++ b/packages/roosterjs-content-model/lib/editor/coreApi/switchShadowEdit.ts
@@ -1,4 +1,5 @@
 import { ContentModelEditorCore } from '../../publicTypes/ContentModelEditorCore';
+import { getSelectionPath } from 'roosterjs-editor-dom';
 import { SwitchShadowEdit } from 'roosterjs-editor-types';
 
 /**
@@ -12,14 +13,26 @@ export const switchShadowEdit: SwitchShadowEdit = (editorCore, isOn): void => {
     const core = editorCore as ContentModelEditorCore;
 
     if (isOn != !!core.lifecycle.shadowEditFragment) {
-        if (isOn && !core.cachedModel) {
-            core.cachedModel = core.api.createContentModel(core);
+        if (isOn) {
+            if (!core.cachedModel) {
+                core.cachedModel = core.api.createContentModel(core);
+            }
+
+            const range = core.api.getSelectionRange(core, true /*tryGetFromCache*/);
+
+            core.lifecycle.shadowEditSelectionPath =
+                range && getSelectionPath(core.contentDiv, range);
+            core.lifecycle.shadowEditFragment = core.contentDiv.ownerDocument.createDocumentFragment();
         }
 
-        core.originalApi.switchShadowEdit(editorCore, isOn);
+        // core.originalApi.switchShadowEdit(editorCore, isOn);
+        else {
+            if (core.cachedModel) {
+                core.api.setContentModel(core, core.cachedModel);
+            }
 
-        if (!isOn && core.cachedModel) {
-            core.api.setContentModel(core, core.cachedModel);
+            core.lifecycle.shadowEditFragment = null;
+            core.lifecycle.shadowEditSelectionPath = null;
         }
     }
 };

--- a/packages/roosterjs-content-model/test/editor/coreApi/switchShadowEditTest.ts
+++ b/packages/roosterjs-content-model/test/editor/coreApi/switchShadowEditTest.ts
@@ -8,22 +8,21 @@ describe('switchShadowEdit', () => {
     let core: ContentModelEditorCore;
     let createContentModel: jasmine.Spy;
     let setContentModel: jasmine.Spy;
-    let originalSwitchShadowEdit: jasmine.Spy;
+    let getSelectionRange: jasmine.Spy;
 
     beforeEach(() => {
         createContentModel = jasmine.createSpy('createContentModel').and.returnValue(mockedModel);
         setContentModel = jasmine.createSpy('setContentModel');
-        originalSwitchShadowEdit = jasmine.createSpy('originalSwitchShadowEdit');
+        getSelectionRange = jasmine.createSpy('getSelectionRange');
 
         core = ({
             api: {
                 createContentModel,
                 setContentModel,
-            },
-            originalApi: {
-                switchShadowEdit: originalSwitchShadowEdit,
+                getSelectionRange,
             },
             lifecycle: {},
+            contentDiv: document.createElement('div'),
         } as any) as ContentModelEditorCore;
     });
 
@@ -32,7 +31,6 @@ describe('switchShadowEdit', () => {
             switchShadowEdit(core, true);
 
             expect(createContentModel).toHaveBeenCalledWith(core);
-            expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, true);
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(mockedModel);
         });
@@ -43,7 +41,6 @@ describe('switchShadowEdit', () => {
             switchShadowEdit(core, true);
 
             expect(createContentModel).not.toHaveBeenCalled();
-            expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, true);
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(mockedCachedModel);
         });
@@ -52,7 +49,6 @@ describe('switchShadowEdit', () => {
             switchShadowEdit(core, false);
 
             expect(createContentModel).not.toHaveBeenCalled();
-            expect(originalSwitchShadowEdit).not.toHaveBeenCalled();
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(undefined);
         });
@@ -63,7 +59,6 @@ describe('switchShadowEdit', () => {
             switchShadowEdit(core, false);
 
             expect(createContentModel).not.toHaveBeenCalled();
-            expect(originalSwitchShadowEdit).not.toHaveBeenCalled();
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(mockedCachedModel);
         });
@@ -78,7 +73,6 @@ describe('switchShadowEdit', () => {
             switchShadowEdit(core, true);
 
             expect(createContentModel).not.toHaveBeenCalled();
-            expect(originalSwitchShadowEdit).not.toHaveBeenCalled();
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(undefined);
         });
@@ -89,7 +83,6 @@ describe('switchShadowEdit', () => {
             switchShadowEdit(core, true);
 
             expect(createContentModel).not.toHaveBeenCalled();
-            expect(originalSwitchShadowEdit).not.toHaveBeenCalled();
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(mockedCachedModel);
         });
@@ -98,7 +91,6 @@ describe('switchShadowEdit', () => {
             switchShadowEdit(core, false);
 
             expect(createContentModel).not.toHaveBeenCalled();
-            expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, false);
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(undefined);
         });
@@ -109,7 +101,6 @@ describe('switchShadowEdit', () => {
             switchShadowEdit(core, false);
 
             expect(createContentModel).not.toHaveBeenCalled();
-            expect(originalSwitchShadowEdit).toHaveBeenCalledWith(core, false);
             expect(setContentModel).toHaveBeenCalledWith(core, mockedCachedModel);
             expect(core.cachedModel).toBe(mockedCachedModel);
         });


### PR DESCRIPTION
Fix https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/209223/?triage=true

This is caused by a conflict between original and content model switchShadowEdit() API. In original API, each time we apply a format during shadow edit, we will rebuild the content from the cloned fragment, then content model API will write the content again, which makes content be rewritten twice.

After this change, for ContentModelEditor we will only reformat once everytime and use the cached model so no need to reformat the whole doc.

The side effect of this change is that old format API won't work with ContentModelEditor now.