### PR TITLE
Content Model: Fix #209891

### DIFF
--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -90,11 +90,14 @@ const defaultFormatHandlerMap: FormatHandlers = {
     wordBreak: wordBreakFormatHandler,
 };
 
-const sharedSegmentFormats: (keyof FormatHandlerTypeMap)[] = [
+const styleBasedSegmentFormats: (keyof FormatHandlerTypeMap)[] = [
     'letterSpacing',
-    'strike',
     'fontFamily',
     'fontSize',
+];
+
+const elementBasedSegmentFormats: (keyof FormatHandlerTypeMap)[] = [
+    'strike',
     'underline',
     'superOrSubScript',
     'italic',
@@ -129,9 +132,21 @@ const defaultFormatKeysPerCategory: {
         'padding',
         'listStylePosition',
     ],
-    segment: [...sharedSegmentFormats, 'textColor', 'backgroundColor', 'lineHeight'],
-    segmentOnBlock: [...sharedSegmentFormats, 'textColor'],
-    segmentOnTableCell: [...sharedSegmentFormats, 'textColorOnTableCell'],
+    styleBasedSegment: [...styleBasedSegmentFormats, 'textColor', 'backgroundColor', 'lineHeight'],
+    elementBasedSegment: elementBasedSegmentFormats,
+    segment: [
+        ...styleBasedSegmentFormats,
+        ...elementBasedSegmentFormats,
+        'textColor',
+        'backgroundColor',
+        'lineHeight',
+    ],
+    segmentOnBlock: [...styleBasedSegmentFormats, ...elementBasedSegmentFormats, 'textColor'],
+    segmentOnTableCell: [
+        ...styleBasedSegmentFormats,
+        ...elementBasedSegmentFormats,
+        'textColorOnTableCell',
+    ],
     tableCell: [
         'border',
         'backgroundColor',

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBr.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleBr.ts
@@ -1,6 +1,6 @@
-import { applyFormat } from '../utils/applyFormat';
 import { ContentModelBr } from '../../publicTypes/segment/ContentModelBr';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
+import { handleSegmentCommon } from '../utils/handleSegmentCommon';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
 
 /**
@@ -17,9 +17,5 @@ export const handleBr: ContentModelHandler<ContentModelBr> = (
     element.appendChild(br);
     parent.appendChild(element);
 
-    context.regularSelection.current.segment = br;
-    applyFormat(element, context.formatAppliers.segment, segment.format, context);
-
-    context.modelHandlers.segmentDecorator(doc, element, segment, context);
-    context.onNodeCreated?.(segment, br);
+    handleSegmentCommon(doc, br, element, segment, context);
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleGeneralModel.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleGeneralModel.ts
@@ -1,6 +1,6 @@
-import { applyFormat } from '../utils/applyFormat';
 import { ContentModelBlockHandler } from '../../publicTypes/context/ContentModelHandler';
 import { ContentModelGeneralBlock } from '../../publicTypes/group/ContentModelGeneralBlock';
+import { handleSegmentCommon } from '../utils/handleSegmentCommon';
 import { isGeneralSegment } from '../../modelApi/common/isGeneralSegment';
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
@@ -18,32 +18,26 @@ export const handleGeneralModel: ContentModelBlockHandler<ContentModelGeneralBlo
     context: ModelToDomContext,
     refNode: Node | null
 ) => {
-    let element: Node = group.element;
+    let node: Node = group.element;
 
-    if (refNode && element.parentNode == parent) {
-        refNode = reuseCachedElement(parent, element, refNode);
+    if (refNode && node.parentNode == parent) {
+        refNode = reuseCachedElement(parent, node, refNode);
     } else {
-        element = element.cloneNode();
-        group.element = element as HTMLElement;
+        node = node.cloneNode();
+        group.element = node as HTMLElement;
 
-        parent.insertBefore(element, refNode);
+        parent.insertBefore(node, refNode);
     }
 
-    if (isGeneralSegment(group) && isNodeOfType(element, NodeType.Element)) {
-        if (!group.element.firstChild) {
-            context.regularSelection.current.segment = element;
-        }
+    if (isGeneralSegment(group) && isNodeOfType(node, NodeType.Element)) {
+        const element = wrap(node, 'span');
 
-        const span = wrap(element, 'span');
-
-        applyFormat(span, context.formatAppliers.segment, group.format, context);
-
-        context.modelHandlers.segmentDecorator(doc, span, group, context);
+        handleSegmentCommon(doc, node, element, group, context);
+    } else {
+        context.onNodeCreated?.(group, node);
     }
 
-    context.modelHandlers.blockGroupChildren(doc, element, group, context);
-
-    context.onNodeCreated?.(group, element);
+    context.modelHandlers.blockGroupChildren(doc, node, group, context);
 
     return refNode;
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleImage.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleImage.ts
@@ -1,6 +1,7 @@
 import { applyFormat } from '../utils/applyFormat';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
 import { ContentModelImage } from '../../publicTypes/segment/ContentModelImage';
+import { handleSegmentCommon } from '../utils/handleSegmentCommon';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
 import { parseValueWithUnit } from '../../formatHandlers/utils/parseValueWithUnit';
 
@@ -32,8 +33,6 @@ export const handleImage: ContentModelHandler<ContentModelImage> = (
     applyFormat(img, context.formatAppliers.image, imageModel.format, context);
     applyFormat(img, context.formatAppliers.dataset, imageModel.dataset, context);
 
-    applyFormat(element, context.formatAppliers.segment, imageModel.format, context);
-
     const { width, height } = imageModel.format;
     const widthNum = width ? parseValueWithUnit(width) : 0;
     const heightNum = height ? parseValueWithUnit(height) : 0;
@@ -46,15 +45,11 @@ export const handleImage: ContentModelHandler<ContentModelImage> = (
         img.height = heightNum;
     }
 
-    context.modelHandlers.segmentDecorator(doc, element, imageModel, context);
-
-    context.regularSelection.current.segment = img;
-
     if (imageModel.isSelectedAsImageSelection) {
         context.imageSelection = {
             image: img,
         };
     }
 
-    context.onNodeCreated?.(imageModel, img);
+    handleSegmentCommon(doc, img, element, imageModel, context);
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/handlers/handleText.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/handlers/handleText.ts
@@ -1,6 +1,6 @@
-import { applyFormat } from '../utils/applyFormat';
 import { ContentModelHandler } from '../../publicTypes/context/ContentModelHandler';
 import { ContentModelText } from '../../publicTypes/segment/ContentModelText';
+import { handleSegmentCommon } from '../utils/handleSegmentCommon';
 import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
 
 /**
@@ -18,11 +18,5 @@ export const handleText: ContentModelHandler<ContentModelText> = (
     parent.appendChild(element);
     element.appendChild(txt);
 
-    context.regularSelection.current.segment = txt;
-
-    applyFormat(element, context.formatAppliers.segment, segment.format, context);
-
-    context.modelHandlers.segmentDecorator(doc, element, segment, context);
-
-    context.onNodeCreated?.(segment, txt);
+    handleSegmentCommon(doc, txt, element, segment, context);
 };

--- a/packages/roosterjs-content-model/lib/modelToDom/utils/handleSegmentCommon.ts
+++ b/packages/roosterjs-content-model/lib/modelToDom/utils/handleSegmentCommon.ts
@@ -1,0 +1,26 @@
+import { applyFormat } from './applyFormat';
+import { ContentModelSegment } from '../../publicTypes/segment/ContentModelSegment';
+import { ModelToDomContext } from '../../publicTypes/context/ModelToDomContext';
+
+/**
+ * @internal
+ */
+export function handleSegmentCommon(
+    doc: Document,
+    segmentNode: Node,
+    containerNode: HTMLElement,
+    segment: ContentModelSegment,
+    context: ModelToDomContext
+) {
+    if (!segmentNode.firstChild) {
+        context.regularSelection.current.segment = segmentNode;
+    }
+
+    applyFormat(containerNode, context.formatAppliers.styleBasedSegment, segment.format, context);
+
+    context.modelHandlers.segmentDecorator(doc, containerNode, segment, context);
+
+    applyFormat(containerNode, context.formatAppliers.elementBasedSegment, segment.format, context);
+
+    context.onNodeCreated?.(segment, segmentNode);
+}

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
@@ -21,6 +21,16 @@ export interface ContentModelFormatMap {
     block: ContentModelBlockFormat;
 
     /**
+     * Format type for style based segment format
+     */
+    styleBasedSegment: ContentModelSegmentFormat;
+
+    /**
+     * Format type for element based segment format
+     */
+    elementBasedSegment: ContentModelSegmentFormat;
+
+    /**
      * Format type for segment
      */
     segment: ContentModelSegmentFormat;

--- a/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
@@ -1528,4 +1528,31 @@ describe('End to end test for DOM => Model', () => {
             '<span style="color: red;"><a style="color: red; display: block;" href="#">test</a></span>'
         );
     });
+
+    it('Link inside superscript', () => {
+        runTest(
+            '<div><sup><a href="http://www.bing.com">www.bing.com</a></sup></div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'www.bing.com',
+                                format: { superOrSubScriptSequence: 'super' },
+                                link: {
+                                    format: { underline: true, href: 'http://www.bing.com' },
+                                    dataset: {},
+                                },
+                            },
+                        ],
+                        format: {},
+                    },
+                ],
+            },
+            '<div><sup><a href="http://www.bing.com">www.bing.com</a></sup></div>'
+        );
+    });
 });

--- a/packages/roosterjs-content-model/test/modelToDom/handlers/handleTextTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/handlers/handleTextTest.ts
@@ -5,7 +5,7 @@ import { createModelToDomContext } from '../../../lib/modelToDom/context/createM
 import { handleText } from '../../../lib/modelToDom/handlers/handleText';
 import { ModelToDomContext } from '../../../lib/publicTypes/context/ModelToDomContext';
 
-describe('handleSegment', () => {
+describe('handleText', () => {
     let parent: HTMLElement;
     let context: ModelToDomContext;
 

--- a/packages/roosterjs-content-model/test/modelToDom/utils/handleSegmentCommonTest.ts
+++ b/packages/roosterjs-content-model/test/modelToDom/utils/handleSegmentCommonTest.ts
@@ -1,0 +1,60 @@
+import DarkColorHandlerImpl from '../../../../roosterjs-editor-core/lib/editor/DarkColorHandlerImpl';
+import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { createText } from '../../../lib/modelApi/creators/createText';
+import { handleSegmentCommon } from '../../../lib/modelToDom/utils/handleSegmentCommon';
+
+describe('handleSegmentCommon', () => {
+    it('txt', () => {
+        const txt = document.createTextNode('test');
+        const container = document.createElement('span');
+        const segment = createText('test', {
+            textColor: 'red',
+            fontSize: '10pt',
+            lineHeight: '2',
+            fontWeight: 'bold',
+        });
+        const onNodeCreated = jasmine.createSpy('onNodeCreated');
+        const context = createModelToDomContext(undefined, {
+            onNodeCreated,
+        });
+        context.darkColorHandler = new DarkColorHandlerImpl(
+            document.createElement('div'),
+            s => 'darkMock: ' + s
+        );
+
+        segment.link = {
+            dataset: {},
+            format: {
+                href: 'href',
+            },
+        };
+
+        handleSegmentCommon(document, txt, container, segment, context);
+
+        expect(context.regularSelection.current.segment).toBe(txt);
+        expect(container.outerHTML).toBe(
+            '<span style="font-size: 10pt; color: red; line-height: 2;"><b><a href="href"></a></b></span>'
+        );
+        expect(onNodeCreated).toHaveBeenCalledWith(segment, txt);
+    });
+
+    it('element with child', () => {
+        const child = document.createTextNode('child');
+        const parent = document.createElement('span');
+
+        parent.appendChild(child);
+
+        const container = document.createElement('span');
+        const segment = createText('test', {});
+        const onNodeCreated = jasmine.createSpy('onNodeCreated');
+        const context = createModelToDomContext(undefined, {
+            onNodeCreated,
+        });
+
+        handleSegmentCommon(document, parent, container, segment, context);
+
+        expect(context.regularSelection.current.segment).toBe(null);
+        expect(container.outerHTML).toBe('<span></span>');
+        expect(onNodeCreated).toHaveBeenCalledWith(segment, parent);
+    });
+});


### PR DESCRIPTION
https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/209891/

Those element based styles needs to be applied before segment decorator (link, code) is applied, so that these elements can be created out of A tag.

Before fix:
![image](https://github.com/microsoft/roosterjs/assets/23065085/0dd61c18-6d2c-4ea4-85dc-5bc3cfa05f65)

```html
text <a href="http://www.bing.com" title="www.bing.com"><sup>link</sup></a>&nbsp;text
```

After fix:

![image](https://github.com/microsoft/roosterjs/assets/23065085/ea92afdd-a408-4cb9-a70e-3863354a559e)

```html
text <sup><a href="http://www.bing.com" title="www.bing.com">link</a></sup>&nbsp;text
```

To make this fix consistent to all segment types, extract the common code to a new API `handleSegmentCommon`.
