### PR TITLE
Content Model: Fix #1887

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/pProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/pProcessor.ts
@@ -11,16 +11,20 @@ import { stackFormat } from '../utils/stackFormat';
  * @internal
  */
 export const pProcessor: ElementProcessor<HTMLElement> = (group, element, context) => {
-    stackFormat(context, { blockDecorator: 'empty' }, () => {
-        context.blockDecorator = createParagraphDecorator(element.tagName);
+    stackFormat(
+        context,
+        { blockDecorator: 'empty', segment: 'shallowCloneForBlock', paragraph: 'shallowClone' },
+        () => {
+            context.blockDecorator = createParagraphDecorator(element.tagName);
 
-        const segmentFormat: ContentModelSegmentFormat = {};
+            const segmentFormat: ContentModelSegmentFormat = {};
 
-        parseFormat(element, context.formatParsers.segmentOnBlock, segmentFormat, context);
-        Object.assign(context.segmentFormat, segmentFormat);
+            parseFormat(element, context.formatParsers.segmentOnBlock, segmentFormat, context);
+            Object.assign(context.segmentFormat, segmentFormat);
 
-        blockProcessor(group, element, context, segmentFormat);
-    });
+            blockProcessor(group, element, context, segmentFormat);
+        }
+    );
 
     addBlock(group, createParagraph(true /*isImplicit*/, context.blockFormat));
 };

--- a/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
@@ -1599,4 +1599,54 @@ describe('End to end test for DOM => Model', () => {
             'aaa<b>bbb</b><div><b>ccc</b></div><b>ddd</b>eeee'
         );
     });
+
+    it('Multiple P tag with margin-left', () => {
+        runTest(
+            '<p style="margin-left: 40px">aaa</p><p style="margin-left: 40px">bbb</p>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {
+                            marginLeft: '40px',
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                format: {},
+                                text: 'aaa',
+                            },
+                        ],
+                        decorator: {
+                            format: {},
+                            tagName: 'p',
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        format: {
+                            marginLeft: '40px',
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                format: {},
+                                text: 'bbb',
+                            },
+                        ],
+                        decorator: {
+                            format: {},
+                            tagName: 'p',
+                        },
+                    },
+                ],
+            },
+            '<p style="margin-left: 40px;">aaa</p><p style="margin-left: 40px;">bbb</p>'
+        );
+    });
 });


### PR DESCRIPTION
Content Model Fidelity: margin-left in P is not correctly processed #1887

I forget to wrap the parser code of P tag with block format handling, that causes the block format bleeding outside so margin left (or right) will be accumulated.

To fixed, add block format handler property when call stackFormat().