### PR TITLE
Content Model: Fix #1888

### DIFF
--- a/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/processors/knownElementProcessor.ts
@@ -67,11 +67,28 @@ export const knownElementProcessor: ElementProcessor<HTMLElement> = (group, elem
             );
         }
     } else {
-        stackFormat(context, { segment: 'shallowClone', paragraph: 'shallowClone' }, () => {
-            parseFormat(element, context.formatParsers.segment, context.segmentFormat, context);
+        stackFormat(
+            context,
+            {
+                segment: 'shallowClone',
+                paragraph: 'shallowClone',
+                link: 'cloneFormat',
+            },
+            () => {
+                parseFormat(element, context.formatParsers.segment, context.segmentFormat, context);
 
-            context.elementProcessors.child(group, element, context);
-        });
+                if (context.link.format.href && element.tagName != 'A') {
+                    parseFormat(
+                        element,
+                        context.formatParsers.segmentUnderLink,
+                        context.link.format,
+                        context
+                    );
+                }
+
+                context.elementProcessors.child(group, element, context);
+            }
+        );
     }
 };
 

--- a/packages/roosterjs-content-model/lib/domToModel/utils/stackFormat.ts
+++ b/packages/roosterjs-content-model/lib/domToModel/utils/stackFormat.ts
@@ -14,7 +14,7 @@ export interface StackFormatOptions {
     segment?: 'shallowClone' | 'shallowCloneForBlock' | 'empty';
     paragraph?: 'shallowClone' | 'shallowCloneForGroup' | 'empty';
     blockDecorator?: 'empty';
-    link?: 'linkDefault' | 'empty';
+    link?: 'linkDefault' | 'cloneFormat' | 'empty';
     code?: 'codeDefault' | 'empty';
 }
 
@@ -67,7 +67,10 @@ export function stackFormat(
     }
 }
 
-function stackLinkInternal(linkFormat: ContentModelLink, link?: 'linkDefault' | 'empty') {
+function stackLinkInternal(
+    linkFormat: ContentModelLink,
+    link?: 'linkDefault' | 'cloneFormat' | 'empty'
+) {
     switch (link) {
         case 'linkDefault':
             return {
@@ -83,8 +86,12 @@ function stackLinkInternal(linkFormat: ContentModelLink, link?: 'linkDefault' | 
                 dataset: {},
             };
 
+        case 'cloneFormat':
         default:
-            return linkFormat;
+            return {
+                dataset: linkFormat.dataset,
+                format: { ...linkFormat.format },
+            };
     }
 }
 

--- a/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model/lib/formatHandlers/defaultFormatHandlers.ts
@@ -174,6 +174,7 @@ const defaultFormatKeysPerCategory: {
         'size',
         'textAlign',
     ],
+    segmentUnderLink: ['textColor'],
     code: ['fontFamily', 'display'],
     dataset: ['dataset'],
     divider: [...sharedBlockFormats, ...sharedContainerFormats, 'display', 'size', 'htmlAlign'],

--- a/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
+++ b/packages/roosterjs-content-model/lib/publicTypes/format/ContentModelFormatMap.ts
@@ -101,6 +101,11 @@ export interface ContentModelFormatMap {
     link: ContentModelHyperLinkFormat;
 
     /**
+     * Format type for segment inside link
+     */
+    segmentUnderLink: ContentModelHyperLinkFormat;
+
+    /**
      * Format type for code
      */
     code: FontFamilyFormat;

--- a/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/endToEndTest.ts
@@ -1626,4 +1626,50 @@ describe('End to end test for DOM => Model', () => {
             '<div><sup><a href="http://www.bing.com">www.bing.com</a></sup></div>'
         );
     });
+
+    it('SPAN inside link with color', () => {
+        runTest(
+            '<a href="#">before<span style="color:red">test</span>after</a>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'before',
+                                format: {},
+                                link: {
+                                    format: { underline: true, href: '#' },
+                                    dataset: {},
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: { textColor: 'red' },
+                                link: {
+                                    format: { underline: true, href: '#', textColor: 'red' },
+                                    dataset: {},
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: 'after',
+                                format: {},
+                                link: {
+                                    format: { underline: true, href: '#' },
+                                    dataset: {},
+                                },
+                            },
+                        ],
+                        format: {},
+                        isImplicit: true,
+                    },
+                ],
+            },
+            '<a href="#">before</a><span style="color: red;"><a href="#" style="color: red;">test</a></span><a href="#">after</a>'
+        );
+    });
 });

--- a/packages/roosterjs-content-model/test/domToModel/utils/stackFormatTest.ts
+++ b/packages/roosterjs-content-model/test/domToModel/utils/stackFormatTest.ts
@@ -70,6 +70,35 @@ describe('stackFormat', () => {
         });
     });
 
+    it('Clone format for link', () => {
+        const context = createDomToModelContext();
+
+        context.link.format.textColor = 'red';
+        context.link.format.underline = true;
+        context.link.dataset = { a: 'b' };
+
+        stackFormat(context, { link: 'cloneFormat' }, () => {
+            expect(context.link).toEqual({
+                format: {
+                    underline: true,
+                    textColor: 'red',
+                },
+                dataset: { a: 'b' },
+            });
+
+            context.link.format.textColor = 'green';
+            context.link.dataset.a = 'c';
+        });
+
+        expect(context.link).toEqual({
+            format: {
+                textColor: 'red',
+                underline: true,
+            },
+            dataset: { a: 'c' },
+        });
+    });
+
     it('use default style for code', () => {
         const context = createDomToModelContext();
 


### PR DESCRIPTION
Content Model Fidelity: SPAN style under A #1888

Today Content Model code does not distinguish the following two cases:

Case 1:
```html
<a href="#"><span style="color:red">test</span></a>
```
<img width="45" alt="image" src="https://github.com/microsoft/roosterjs/assets/23065085/fff61d3d-0584-4bab-b331-d99948024938">


Case 2:
```html
<span style="color:red"><a href="#">test</a></span>
```
<img width="41" alt="image" src="https://github.com/microsoft/roosterjs/assets/23065085/fdd80a6a-7fdb-4f45-8c51-a8475dd59ec6">


But actually the rendering results are different. Because text color won't go across `<A>` tag, in the second case the text will not render in red. However, our code treat both of them to be case 2.

To fix this, we need to apply the text color into format object of link decorator as well so that when we write back, the text color can be applied to `<A>` tag, so the text will be rendered in specified color.

Before rerender: 

<img width="45" alt="image" src="https://github.com/microsoft/roosterjs/assets/23065085/78494d7e-ee57-4902-b904-4cfc9039e5af">

After rerender, before fix:
<img width="40" alt="image" src="https://github.com/microsoft/roosterjs/assets/23065085/3b43c359-c754-48af-a27e-4a73f35b21ce">


After rerender, after fix:
<img width="38" alt="image" src="https://github.com/microsoft/roosterjs/assets/23065085/9dec8197-e1d2-4fc8-a4e0-8856129db202">

Now the only problem is the underline color is changed, but I think that is acceptable given this case itself is not very common, and showing a different color of underline actually makes it feels bad.
