### PR TITLE
Demo site minor improvement

### DIFF
--- a/demo/scripts/controls/sidePane/snapshot/SnapshotPane.tsx
+++ b/demo/scripts/controls/sidePane/snapshot/SnapshotPane.tsx
@@ -5,7 +5,7 @@ const styles = require('./SnapshotPane.scss');
 
 export interface SnapshotPaneProps {
     onTakeSnapshot: () => Snapshot;
-    onRestoreSnapshot: (snapshot: Snapshot) => void;
+    onRestoreSnapshot: (snapshot: Snapshot, triggerContentChangedEvent: boolean) => void;
     onMove: (moveStep: number) => void;
 }
 
@@ -40,11 +40,14 @@ export default class SnapshotPane extends React.Component<SnapshotPaneProps, Sna
                     <button onClick={this.takeSnapshot}>{'Take snapshot'}</button>{' '}
                     <button
                         onClick={() =>
-                            this.props.onRestoreSnapshot({
-                                html: this.textarea.value,
-                                metadata: null,
-                                knownColors: [],
-                            })
+                            this.props.onRestoreSnapshot(
+                                {
+                                    html: this.textarea.value,
+                                    metadata: null,
+                                    knownColors: [],
+                                },
+                                true
+                            )
                         }>
                         {'Restore snapshot'}
                     </button>

--- a/demo/scripts/controls/sidePane/snapshot/SnapshotPlugin.tsx
+++ b/demo/scripts/controls/sidePane/snapshot/SnapshotPlugin.tsx
@@ -85,12 +85,8 @@ export default class SnapshotPlugin implements SidePanePlugin {
         this.editorInstance.focus();
         this.editorInstance.setContent(
             this.component.snapshotToString(snapshot),
-            false /*triggerContentChangedEvent*/
+            triggerContentChangedEvent
         );
-
-        if (triggerContentChangedEvent) {
-            this.editorInstance.triggerContentChangedEvent(ChangeSource.SetContent);
-        }
     };
 
     private updateSnapshots = () => {

--- a/demo/scripts/controls/sidePane/snapshot/SnapshotPlugin.tsx
+++ b/demo/scripts/controls/sidePane/snapshot/SnapshotPlugin.tsx
@@ -78,16 +78,19 @@ export default class SnapshotPlugin implements SidePanePlugin {
 
     private onMove = (step: number) => {
         const snapshot = this.snapshotService.move(step);
-        this.onRestoreSnapshot(snapshot);
+        this.onRestoreSnapshot(snapshot, false);
     };
 
-    private onRestoreSnapshot = (snapshot: Snapshot) => {
+    private onRestoreSnapshot = (snapshot: Snapshot, triggerContentChangedEvent: boolean) => {
         this.editorInstance.focus();
         this.editorInstance.setContent(
             this.component.snapshotToString(snapshot),
             false /*triggerContentChangedEvent*/
         );
-        this.editorInstance.triggerContentChangedEvent(ChangeSource.SetContent);
+
+        if (triggerContentChangedEvent) {
+            this.editorInstance.triggerContentChangedEvent(ChangeSource.SetContent);
+        }
     };
 
     private updateSnapshots = () => {

--- a/demo/scripts/controls/sidePane/snapshot/SnapshotPlugin.tsx
+++ b/demo/scripts/controls/sidePane/snapshot/SnapshotPlugin.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import SidePanePlugin from '../../SidePanePlugin';
 import SnapshotPane from './SnapshotPane';
 import UndoSnapshots from './UndoSnapshots';
-import { ChangeSource, IEditor, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import { createSnapshots } from 'roosterjs-editor-dom';
+import { IEditor, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import { Snapshot } from 'roosterjs-editor-types';
 
 export default class SnapshotPlugin implements SidePanePlugin {


### PR DESCRIPTION
Previously in #1805, I added a change to demo site to always trigger ContentChangedEvent when restore an undo snapshot from site pane. This causes a side effect that all further undo snapshots are gone when double click a snapshot form Undo Snapshot pane.

To adjust it, I'm adding a parameter to `onRestoreSnapshot` callback of `SnapshotPlugin`, we now only trigger this event when we click "Restore snapshot" button. If double click from the existing snapshot list.