### PR TITLE
Remove deprecated colors for all elements on paste

### DIFF
--- a/packages/roosterjs-content-model/lib/editor/plugins/PastePlugin/ContentModelPastePlugin.ts
+++ b/packages/roosterjs-content-model/lib/editor/plugins/PastePlugin/ContentModelPastePlugin.ts
@@ -1,6 +1,6 @@
 import addParser from './utils/addParser';
 import ContentModelBeforePasteEvent from '../../../publicTypes/event/ContentModelBeforePasteEvent';
-import deprecatedColorParser from './utils/deprecatedColorParser';
+import sanitizeHtmlColorsFromPastedContent from './utils/deprecatedColorParser';
 import sanitizeLinks from './utils/linkParser';
 import { getPasteSource } from 'roosterjs-editor-dom';
 import { IContentModelEditor } from '../../../publicTypes/IContentModelEditor';
@@ -103,9 +103,8 @@ export default class ContentModelFormatPlugin implements EditorPlugin {
                 break;
         }
 
-        addParser(ev.domToModelOption, 'segment', deprecatedColorParser);
-        addParser(ev.domToModelOption, 'segmentOnBlock', deprecatedColorParser);
         addParser(ev.domToModelOption, 'link', sanitizeLinks);
+        sanitizeHtmlColorsFromPastedContent(ev.sanitizingOption);
 
         event.sanitizingOption.unknownTagReplacement = this.unknownTagReplacement;
     }

--- a/packages/roosterjs-content-model/lib/editor/plugins/PastePlugin/utils/deprecatedColorParser.ts
+++ b/packages/roosterjs-content-model/lib/editor/plugins/PastePlugin/utils/deprecatedColorParser.ts
@@ -1,7 +1,5 @@
-import { ContentModelHyperLinkFormat } from '../../../../publicTypes/format/ContentModelHyperLinkFormat';
-import { ContentModelSegmentFormat } from '../../../../publicTypes/format/ContentModelSegmentFormat';
-import { DomToModelContext } from '../../../../publicTypes/context/DomToModelContext';
-import { FormatParser } from '../../../../publicTypes/context/DomToModelSettings';
+import { chainSanitizerCallback } from 'roosterjs-editor-dom';
+import { HtmlSanitizerOptions } from 'roosterjs-editor-types';
 
 const DeprecatedColorList: string[] = [
     'activeborder',
@@ -32,20 +30,14 @@ const DeprecatedColorList: string[] = [
 /**
  * @internal
  */
-const deprecatedColorParser: FormatParser<ContentModelHyperLinkFormat> = (
-    format: ContentModelSegmentFormat,
-    element: HTMLElement,
-    context: DomToModelContext,
-    defaultStyles: Readonly<Partial<CSSStyleDeclaration>>
-): void => {
-    if (DeprecatedColorList.indexOf(element.style.backgroundColor) > -1) {
-        format.backgroundColor = defaultStyles.backgroundColor;
-        element.style.backgroundColor = defaultStyles.backgroundColor ?? '';
-    }
-    if (DeprecatedColorList.indexOf(element.style.color) > -1) {
-        format.textColor = defaultStyles.color;
-        element.style.color = defaultStyles.color ?? '';
-    }
-};
+function sanitizeHtmlColorsFromPastedContent(sanitizingOption: Required<HtmlSanitizerOptions>) {
+    ['color', 'background-color'].forEach(property => {
+        chainSanitizerCallback(
+            sanitizingOption.cssStyleCallbacks,
+            property,
+            (value: string) => DeprecatedColorList.indexOf(value) < 0
+        );
+    });
+}
 
-export default deprecatedColorParser;
+export default sanitizeHtmlColorsFromPastedContent;

--- a/packages/roosterjs-content-model/test/editor/plugins/ContentModelPastePluginTest.ts
+++ b/packages/roosterjs-content-model/test/editor/plugins/ContentModelPastePluginTest.ts
@@ -3,7 +3,6 @@ import * as getPasteSource from 'roosterjs-editor-dom/lib/pasteSourceValidations
 import * as WordDesktopFile from '../../../lib/editor/plugins/PastePlugin/WordDesktop/processPastedContentFromWordDesktop';
 import ContentModelBeforePasteEvent from '../../../lib/publicTypes/event/ContentModelBeforePasteEvent';
 import ContentModelPastePlugin from '../../../lib/editor/plugins/PastePlugin/ContentModelPastePlugin';
-import deprecatedColorParser from '../../../lib/editor/plugins/PastePlugin/utils/deprecatedColorParser';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 import { KnownPasteSourceType, PluginEventType } from 'roosterjs-editor-types';
 
@@ -72,12 +71,6 @@ describe('Paste', () => {
             expect(event.domToModelOption.processorOverride?.element).toBe(
                 WordDesktopFile.wordDesktopElementProcessor
             );
-            expect(event.domToModelOption.additionalFormatParsers?.segment).toContain(
-                deprecatedColorParser
-            );
-            expect(event.domToModelOption.additionalFormatParsers?.segmentOnBlock).toContain(
-                deprecatedColorParser
-            );
         });
 
         it('Default', () => {
@@ -90,12 +83,6 @@ describe('Paste', () => {
 
             expect(WordDesktopFile.processPastedContentFromWordDesktop).not.toHaveBeenCalled();
             expect(event.domToModelOption.processorOverride?.element).toBeUndefined();
-            expect(event.domToModelOption.additionalFormatParsers?.segment).toContain(
-                deprecatedColorParser
-            );
-            expect(event.domToModelOption.additionalFormatParsers?.segmentOnBlock).toContain(
-                deprecatedColorParser
-            );
         });
     });
 });


### PR DESCRIPTION
Remove the parsers that removed the deprecated colors and instead use a chainSanitizerCallback to remove all these styles. Since not only format for segments can have these color values.