### PR TITLE
Remove width and height after quit editing

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -405,6 +405,8 @@ export default class ImageEdit implements EditorPlugin {
             this.clonedImage = this.image.cloneNode(true) as HTMLImageElement;
             this.clonedImage.removeAttribute('id');
             this.clonedImage.style.removeProperty('max-width');
+            this.clonedImage.style.width = this.editInfo.widthPx + 'px';
+            this.clonedImage.style.height = this.editInfo.heightPx + 'px';
             this.wrapper = createElement(
                 KnownCreateElementDataIndex.ImageEditWrapper,
                 this.image.ownerDocument

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
@@ -74,7 +74,5 @@ export default function applyChange(
     if (wasResized || state == ImageEditInfoState.FullyChanged) {
         image.width = targetWidth;
         image.height = targetHeight;
-        image.style.width = targetWidth + 'px';
-        image.style.height = targetHeight + 'px';
     }
 }


### PR DESCRIPTION
Only set image width and height to the image in editing mode. After editing the image do set width and height style properties. This properties were removed, because it was causing an issue in Outlook after the image has been sent. 

**Bug:** 
![Screenshot 2023-06-16 at 14 37 18](https://github.com/microsoft/roosterjs/assets/87443959/898e9d2f-0af7-4da2-81f6-6ca7efcbc3d4)

**Expected:** 
![Screenshot 2023-06-16 at 14 37 00](https://github.com/microsoft/roosterjs/assets/87443959/5e39a4f7-dd79-40cb-9d72-985b7e804e03)
