### PR TITLE
Always set new size dimensions when crop an image

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -293,7 +293,7 @@ export default class ImageEdit implements EditorPlugin {
                 this.image,
                 this.editInfo,
                 this.lastSrc,
-                this.wasResized,
+                this.wasResized || this.isCropping,
                 this.clonedImage
             );
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
@@ -12,6 +12,7 @@ import { IEditor, PluginEventType } from 'roosterjs-editor-types';
  * @param image The image to apply the change
  * @param editInfo Edit info that contains the changed information of the image
  * @param previousSrc Last src value of the image before the change was made
+ * @param wasResizedOrCropped if the image was resized or cropped apply the new image dimensions
  * @param editingImage (optional) Image in editing state
  */
 export default function applyChange(
@@ -19,7 +20,7 @@ export default function applyChange(
     image: HTMLImageElement,
     editInfo: ImageEditInfo,
     previousSrc: string,
-    wasResized: boolean,
+    wasResizedOrCropped: boolean,
     editingImage?: HTMLImageElement
 ) {
     let newSrc = '';
@@ -71,10 +72,8 @@ export default function applyChange(
     const { targetWidth, targetHeight } = getGeneratedImageSize(editInfo);
     image.src = newSrc;
 
-    if (wasResized || state == ImageEditInfoState.FullyChanged) {
+    if (wasResizedOrCropped || state == ImageEditInfoState.FullyChanged) {
         image.width = targetWidth;
         image.height = targetHeight;
-        image.style.width = targetWidth + 'px';
-        image.style.height = targetHeight + 'px';
     }
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
@@ -75,5 +75,7 @@ export default function applyChange(
     if (wasResizedOrCropped || state == ImageEditInfoState.FullyChanged) {
         image.width = targetWidth;
         image.height = targetHeight;
+        image.style.width = targetWidth + 'px';
+        image.style.height = targetHeight + 'px';
     }
 }


### PR DESCRIPTION
When we crop a resized image and then restore it to the full image (no cropping),  the image edit info object of the edited image will be the same  as original, except for the image size dimensions, then when apply changes happens, it cannot detect the image was cropped and the it will not restore the size before crop.  Therefore, to fix this issue, we changed the parameter `wasResized` to `wasResizedOrCropped`, then when `wasResizedOrCropped` is true, the image size dimensions are adjusted. 

**Bug:**
![resizeCropBug](https://github.com/microsoft/roosterjs/assets/87443959/b2ab9534-c513-46f7-b165-2ca377d256fe)

**Expected:** 
![resizeCropFix](https://github.com/microsoft/roosterjs/assets/87443959/7f4fbdd9-e0af-4fa8-951f-e20308c32c73)


