### PR TITLE
Fix blurry images

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/generateDataURL.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/generateDataURL.ts
@@ -26,12 +26,17 @@ export default function generateDataURL(image: HTMLImageElement, editInfo: Image
     } = editInfo;
     const imageWidth = naturalWidth * (1 - left - right);
     const imageHeight = naturalHeight * (1 - top - bottom);
+
+    // Adjust the canvas size and scaling for high display resolution
+    const devicePixelRatio = window.devicePixelRatio || 1;
     const canvas = document.createElement('canvas');
     const { targetWidth, targetHeight } = getGeneratedImageSize(editInfo);
-    canvas.width = targetWidth;
-    canvas.height = targetHeight;
+    canvas.width = targetWidth * devicePixelRatio;
+    canvas.height = targetHeight * devicePixelRatio;
+
     const context = canvas.getContext('2d');
     if (context) {
+        context.scale(devicePixelRatio, devicePixelRatio);
         context.translate(targetWidth / 2, targetHeight / 2);
         context.rotate(angle);
         context.scale(editInfo.flippedHorizontal ? -1 : 1, editInfo.flippedVertical ? -1 : 1);


### PR DESCRIPTION
When editing images with canvas, scale the image according to the device pixel ratio before doing the image operations to avoid quality loss. 
Reference: [Scaling for high resolution displays](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas#scaling_for_high_resolution_displays)

**Issue**: 
![Uploading blurryImageBug.gif…]()
**Fixed**:
![Uploading blurryImageFixed.gif…]()
