### PR TITLE
Uncaught TypeError: Cannot read properties of undefined (reading 'cells')

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts
@@ -130,7 +130,7 @@ export default class TableResize implements EditorPlugin {
             this.disposeTableEditor();
         }
 
-        if (!this.tableEditor && table && this.editor) {
+        if (!this.tableEditor && table && this.editor && table.rows.length > 0) {
             this.tableEditor = new TableEditor(
                 this.editor,
                 table,

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -114,7 +114,7 @@ export default class TableEditor {
 
     onMouseMove(x: number, y: number) {
         //Get Cell [0,0]
-        const firstCell = this.table?.rows[0]?.cells[0];
+        const firstCell = this.table.rows[0].cells[0];
 
         if (!firstCell) {
             return;

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -114,7 +114,12 @@ export default class TableEditor {
 
     onMouseMove(x: number, y: number) {
         //Get Cell [0,0]
-        const firstCell = this.table.rows[0].cells[0];
+        const firstCell = this.table?.rows[0]?.cells[0];
+
+        if (!firstCell) {
+            return;
+        }
+
         const firstCellRect = normalizeRect(firstCell.getBoundingClientRect());
 
         if (!firstCellRect) {

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -114,7 +114,7 @@ export default class TableEditor {
 
     onMouseMove(x: number, y: number) {
         //Get Cell [0,0]
-        const firstCell = this.table.rows[0].cells[0];
+        const firstCell = this.table.rows[0]?.cells[0];
 
         if (!firstCell) {
             return;


### PR DESCRIPTION
Fix Uncaught TypeError: Cannot read properties of undefined (reading 'cells')

Callstack
webpack://.../roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts cells 117
webpack://.../roosterjs-editor-plugins/lib/plugins/TableResize/TableResize.ts onMouseMove 125
webpack://.../roosterjs-editor-core/lib/coreApi/attachDomEvent.ts beforeDispatch 27

Do not create the TableEditor if the table do not have rows. to prevent the issue. Also add a null check on the line that cause the regression