### PR TITLE
Content Model: Allow set color without color handler

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/color.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/color.ts
@@ -38,7 +38,9 @@ export function setColor(
     darkColorHandler: DarkColorHandler | undefined | null,
     isDarkMode: boolean
 ) {
-    const effectiveColor = darkColorHandler?.registerColor(lightModeColor, isDarkMode) || '';
+    const effectiveColor = darkColorHandler
+        ? darkColorHandler.registerColor(lightModeColor, isDarkMode)
+        : lightModeColor;
 
     if (isBackground) {
         element.style.backgroundColor = effectiveColor;

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
@@ -137,6 +137,13 @@ describe('setColor with darkColorHandler', () => {
         expect(registerColor).toHaveBeenCalledWith('', true);
     });
 
+    it('setColor from a valid color, light mode, no darkColorHandler', () => {
+        const div = document.createElement('div');
+        setColor(div, 'green', false, undefined, false);
+
+        expect(div.outerHTML).toBe('<div style="color: green;"></div>');
+    });
+
     itChromeOnly('setColor from a color with existing color, dark mode', () => {
         const registerColor = jasmine.createSpy().and.returnValue('green');
         const darkColorHandler = ({ registerColor } as any) as DarkColorHandler;


### PR DESCRIPTION
When no DarkColorHandler is passed in, we should still allow write back color with the original color value.

This will be used by initial rewrite with Content Model.