### PR TITLE
Content Model: Fix 212656

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleTable.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleTable.ts
@@ -110,11 +110,11 @@ export const handleTable: ContentModelBlockHandler<ContentModelTable> = (
                 }
 
                 if (!cell.cachedElement || (cell.format.useBorderBox && hasMetadata(table))) {
-                    if (width > 0) {
+                    if (width > 0 && !td.style.width) {
                         td.style.width = width + 'px';
                     }
 
-                    if (height > 0) {
+                    if (height > 0 && !td.style.height) {
                         td.style.height = height + 'px';
                     }
                 }

--- a/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
@@ -546,4 +546,27 @@ describe('handleTable', () => {
 
         expect(parent.innerHTML).toBe('<table><tbody><tr id="tr1"><td></td></tr></tbody></table>');
     });
+
+    it('TD already has width and height', () => {
+        const parent = document.createElement('div');
+        const table = createTable(1, {});
+        const cell = createTableCell();
+
+        table.rows[0].cells.push(cell);
+
+        const td = document.createElement('td');
+        cell.cachedElement = td;
+
+        td.style.width = '20px';
+        td.style.height = '40px';
+
+        table.widths = [100];
+        table.rows[0].height = 200;
+
+        handleTable(document, parent, table, context, null);
+
+        expect(parent.innerHTML).toBe(
+            '<table><tbody><tr><td style="width: 20px; height: 40px;"></td></tr></tbody></table>'
+        );
+    });
 });


### PR DESCRIPTION
[Bug 212656](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/212656): Table row height isn't adjusted correctly after entering multi-line text and deleting it

The fix here is to check if there is already width/height on TD, no need to rewrite it.

This will be conflict with table resize. For now table resize is still using VTable. So when we port table resize plugin to use Content Model, we can fix it by remove the cached TD element.