### PR TITLE
Remove disable controls to other webkit-based iOS/macOS clients

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/tableFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/tableFeatures.ts
@@ -172,7 +172,6 @@ const UpDownInTable: BuildInEditFeature<PluginKeyboardEvent> = {
             });
         }
     },
-    defaultDisabled: !Browser.isChrome && !Browser.isSafari,
 };
 
 /**

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/tableFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/tableFeatures.ts
@@ -15,7 +15,6 @@ import {
     ExperimentalFeatures,
 } from 'roosterjs-editor-types';
 import {
-    Browser,
     cacheGetEventData,
     contains,
     getTagOfNode,


### PR DESCRIPTION
`defaultDisabled: !Browser.isChrome && !Browser.isSafari` is added to exclude FireFox, but it also disable this feature for other webkit-based iOS/macOS clients