### PR TITLE
Add font-size in image wrapper.

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/getFormatStateTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/getFormatStateTest.ts
@@ -1,7 +1,6 @@
 import * as getPendingFormat from '../../../lib/modelApi/format/pendingFormat';
 import * as retrieveModelFormatState from '../../../lib/modelApi/common/retrieveModelFormatState';
 import getFormatState from '../../../lib/publicApi/format/getFormatState';
-import { createRange } from 'roosterjs-editor-dom';
 import { FormatState, SelectionRangeTypes } from 'roosterjs-editor-types';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 import {

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -410,7 +410,7 @@ export default class ImageEdit implements EditorPlugin {
      * quit editing mode when editor lose focus
      */
     private onBlur = () => {
-        this.setEditingImage(null, false /* selectImage */);
+        this.setEditingImage(null, true /* selectImage */);
     };
     /**
      * Create editing wrapper for the image
@@ -480,6 +480,7 @@ export default class ImageEdit implements EditorPlugin {
             });
 
             this.shadowSpan.style.verticalAlign = 'bottom';
+            this.shadowSpan.style.fontSize = '24px';
 
             shadowRoot.appendChild(wrapper);
         }

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -410,7 +410,7 @@ export default class ImageEdit implements EditorPlugin {
      * quit editing mode when editor lose focus
      */
     private onBlur = () => {
-        this.setEditingImage(null, true /* selectImage */);
+        this.setEditingImage(null, false /* selectImage */);
     };
     /**
      * Create editing wrapper for the image

--- a/packages/roosterjs-editor-plugins/test/imageEdit/imageEditTest.ts
+++ b/packages/roosterjs-editor-plugins/test/imageEdit/imageEditTest.ts
@@ -220,7 +220,7 @@ describe('ImageEdit | rotate and flip', () => {
         editor.select(image);
         plugin.setEditingImage(image, ImageEditOperation.Resize);
         expect(editor.getContent()).toBe(
-            '<span style="vertical-align: bottom;"><img id="IMAGE_ID" src="test"></span>'
+            '<span style="vertical-align: bottom; font-size: 24px;"><img id="IMAGE_ID" src="test"></span>'
         );
     });
 });

--- a/packages/roosterjs-editor-plugins/test/paste/e2e/pasteFromWordTest.ts
+++ b/packages/roosterjs-editor-plugins/test/paste/e2e/pasteFromWordTest.ts
@@ -1,6 +1,5 @@
 import * as convertPastedContentFromWord from '../../../lib/plugins/Paste/wordConverter/convertPastedContentFromWord';
 import { Browser } from 'roosterjs-editor-dom';
-import { Browser } from 'roosterjs-editor-dom';
 import { ClipboardData, IEditor } from 'roosterjs-editor-types';
 import { initEditor } from '../../TestHelper';
 import { Paste } from '../../../lib/index';


### PR DESCRIPTION
Add font-size in image wrapper, so it do not inherit font-size. 

To test:
1. Apply a big font-size to a image
2. The image rotate handler icon will move out the rotate button 
![fontOnImageBug](https://github.com/microsoft/roosterjs/assets/87443959/c9a096d7-ce44-4be0-983f-a2aae4caed60)

After fix: 
![fontOnImage](https://github.com/microsoft/roosterjs/assets/87443959/b0665d29-ca41-4d99-b4dd-a3d2ae1fa64a)


