### PR TITLE
Do not inherit styles in Sanitizer, and instead let Content Model Handle the style merge

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/paste.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/paste.ts
@@ -12,7 +12,6 @@ import {
     handleImagePaste,
     handleTextPaste,
     moveChildNodes,
-    Position,
     retrieveMetadataFromClipboard,
     sanitizePasteContent,
 } from 'roosterjs-editor-dom';
@@ -46,8 +45,6 @@ export default function paste(
         clipboardData.snapshotBeforePaste = editor.getContent(GetContentMode.RawHTMLWithSelection);
     }
 
-    const range = editor.getSelectionRange();
-    const position = range && Position.getStart(range);
     const event = createBeforePasteEvent(
         editor,
         clipboardData,
@@ -57,7 +54,7 @@ export default function paste(
     const fragment = createFragmentFromClipboardData(
         editor,
         clipboardData,
-        position,
+        null /* position */,
         pasteAsText,
         pasteAsImage,
         event

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
@@ -54,7 +54,6 @@ describe('Paste ', () => {
         getFocusedPosition = jasmine.createSpy('getFocusedPosition').and.returnValue(mockedPos);
         getContent = jasmine.createSpy('getContent');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
-        getSelectionRange = jasmine.createSpy('getSelectionRange');
         getDocument = jasmine.createSpy('getDocument').and.returnValue(document);
         getTrustedHTMLHandler = jasmine
             .createSpy('getTrustedHTMLHandler')
@@ -89,7 +88,6 @@ describe('Paste ', () => {
         expect(getFocusedPosition).not.toHaveBeenCalled();
         expect(getContent).toHaveBeenCalled();
         expect(triggerPluginEvent).toHaveBeenCalled();
-        expect(getSelectionRange).toHaveBeenCalled();
         expect(getDocument).toHaveBeenCalled();
         expect(getTrustedHTMLHandler).toHaveBeenCalled();
         expect(mockedModel).toEqual(mockedMergeModel);


### PR DESCRIPTION
If we set the position when sanitizing the pasted content, some styles are removed in the HTMLSanitizer.
We do not need to continue using the HTMLSanitizer implementation to inherit the styles as Content model does the job of inheriting and merging the styles

Before
![copfix2](https://github.com/microsoft/roosterjs/assets/8291124/22e7aed0-6b3d-4b53-98a0-e4544c06822c)

After
![copfix1](https://github.com/microsoft/roosterjs/assets/8291124/81f9ef6b-bf6e-45a7-b4ae-69103cae2711)

