### PR TITLE
Fix #1953 Content Model: Delete the only character loses format under implicit paragraph

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/deleteSteps/deleteCollapsedSelection.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/deleteSteps/deleteCollapsedSelection.ts
@@ -4,7 +4,7 @@ import { createInsertPoint } from '../utils/createInsertPoint';
 import { deleteBlock } from '../utils/deleteBlock';
 import { DeleteResult, DeleteSelectionStep } from '../utils/DeleteSelectionStep';
 import { deleteSegment } from '../utils/deleteSegment';
-import { setParagraphNotImplicit } from 'roosterjs-content-model-dom/lib';
+import { setParagraphNotImplicit } from 'roosterjs-content-model-dom';
 
 function getDeleteCollapsedSelection(direction: 'forward' | 'backward'): DeleteSelectionStep {
     return (context, onDeleteEntity) => {

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/deleteSteps/deleteCollapsedSelection.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/deleteSteps/deleteCollapsedSelection.ts
@@ -4,6 +4,7 @@ import { createInsertPoint } from '../utils/createInsertPoint';
 import { deleteBlock } from '../utils/deleteBlock';
 import { DeleteResult, DeleteSelectionStep } from '../utils/DeleteSelectionStep';
 import { deleteSegment } from '../utils/deleteSegment';
+import { setParagraphNotImplicit } from 'roosterjs-content-model-dom/lib';
 
 function getDeleteCollapsedSelection(direction: 'forward' | 'backward'): DeleteSelectionStep {
     return (context, onDeleteEntity) => {
@@ -20,6 +21,10 @@ function getDeleteCollapsedSelection(direction: 'forward' | 'backward'): DeleteS
         if (segmentToDelete) {
             if (deleteSegment(paragraph, segmentToDelete, onDeleteEntity, direction)) {
                 context.deleteResult = DeleteResult.SingleChar;
+
+                // It is possible that we have deleted everything from this paragraph, so we need to mark it as not implicit
+                // to avoid losing its format. See https://github.com/microsoft/roosterjs/issues/1953
+                setParagraphNotImplicit(paragraph);
             }
         } else if ((blockToDelete = getLeafSiblingBlock(path, paragraph, isForward))) {
             const { block, path, siblingSegment } = blockToDelete;

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/edit/deleteSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/edit/deleteSelectionTest.ts
@@ -4650,4 +4650,46 @@ describe('deleteSelection - backward', () => {
             ],
         });
     });
+
+    it('Delete under an implicit paragraph', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        const text1 = createText('t');
+
+        para.isImplicit = true;
+        para.segments.push(text1, marker);
+        model.blocks.push(para);
+
+        const result = deleteSelection(model, onDeleteEntityMock, [
+            backwardDeleteCollapsedSelection,
+        ]);
+
+        expect(result.deleteResult).toBe(DeleteResult.SingleChar);
+
+        expect(result.insertPoint).toEqual({
+            marker: marker,
+            paragraph: para,
+            path: [model],
+            tableContext: undefined,
+        });
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    isImplicit: false,
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
When delete, we need to make sure we are under a non-implicit paragraph, so that after delete, we can call normalizeContentModel() which will make sure current paragraph has at least one segment to hold the segment format.