### PR TITLE
Fix 216972

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableEditor.ts
@@ -331,7 +331,7 @@ export default class TableEditor {
             this.editor.select(this.start, this.end);
         }
 
-        this.editor.addUndoSnapshot(undefined /*callback*/, ChangeSource.Format);
+        this.editor.addUndoSnapshot(() => {}, ChangeSource.Format); // Pass in an empty callback to make sure ContentChangedEvent is triggered
         this.onChanged();
         this.isCurrentlyEditing = false;
 


### PR DESCRIPTION
Fix [Bug 216972](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/216972): [Table] Inserted row/column disappear after make changes for the table

We need to trigger a ContentChangedEvent after each time editing a table. Currently the API `addUndoSnapshot` won't trigger the event if the first parameter is null/undefined. This could be a bug, but to reduce the risk, I just pass in a valid function to make it work.