### PR TITLE
Fix 216431

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/ContentModelEditPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/ContentModelEditPlugin.ts
@@ -96,6 +96,7 @@ export default class ContentModelEditPlugin implements EditorPlugin {
 
                 case PluginEventType.ContentChanged:
                 case PluginEventType.MouseUp:
+                case PluginEventType.SelectionChanged:
                     this.editor.cacheContentModel(null);
                     break;
             }

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelEditPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelEditPluginTest.ts
@@ -186,6 +186,18 @@ describe('ContentModelEditPlugin', () => {
             );
             expect(cacheContentModel).not.toHaveBeenCalled();
         });
+
+        it('SelectionChanged event should clear cached model', () => {
+            const plugin = new ContentModelEditPlugin();
+
+            plugin.initialize(editor);
+            plugin.onPluginEvent({
+                eventType: PluginEventType.SelectionChanged,
+                selectionRangeEx: null!,
+            });
+
+            expect(cacheContentModel).toHaveBeenCalledWith(null);
+        });
     });
 
     describe('onPluginEvent, no need to go through Content Model', () => {


### PR DESCRIPTION
Fix [Bug 216431](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/216431): [Table] Aligning whole table not working correctly

When do table selection, we need to handle SelectionChangedEvent so that content model knows we need to update the cached model.