### PR TITLE
Fix 215585

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/list/setListType.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/list/setListType.ts
@@ -1,4 +1,4 @@
-import { getOperationalBlocks, OperationalBlocks } from '../selection/collectSelections';
+import { getOperationalBlocks } from '../selection/collectSelections';
 import { isBlockGroupOfType } from '../common/isBlockGroupOfType';
 import {
     createListItem,
@@ -20,11 +20,10 @@ export function setListType(model: ContentModelDocument, listType: 'OL' | 'UL') 
         ['ListItem'],
         [] // Set stop types to be empty so we can find list items even cross the boundary of table, then we can always operation on the list item if any
     );
-    const alreadyInExpectedType = paragraphOrListItems.every(
-        ({ block }) =>
-            (isBlockGroupOfType<ContentModelListItem>(block, 'ListItem') &&
-                block.levels[block.levels.length - 1]?.listType == listType) ||
-            !shouldTurnOnList(paragraphOrListItems, block)
+    const alreadyInExpectedType = paragraphOrListItems.every(({ block }) =>
+        isBlockGroupOfType<ContentModelListItem>(block, 'ListItem')
+            ? block.levels[block.levels.length - 1]?.listType == listType
+            : shouldIgnoreBlock(block)
     );
     let existingListItems: ContentModelListItem[] = [];
     let hasIgnoredParagraphBefore = false;
@@ -43,7 +42,7 @@ export function setListType(model: ContentModelDocument, listType: 'OL' | 'UL') 
             const index = parent.blocks.indexOf(block);
 
             if (index >= 0) {
-                if (shouldTurnOnList(paragraphOrListItems, block)) {
+                if (paragraphOrListItems.length == 1 || !shouldIgnoreBlock(block)) {
                     const prevBlock = parent.blocks[index - 1];
                     const segmentFormat =
                         (block.blockType == 'Paragraph' && block.segments[0]?.format) || {};
@@ -96,14 +95,9 @@ export function setListType(model: ContentModelDocument, listType: 'OL' | 'UL') 
     return paragraphOrListItems.length > 0;
 }
 
-function shouldTurnOnList(
-    blocks: OperationalBlocks<ContentModelListItem>[],
-    block: ContentModelBlock
-): boolean {
+function shouldIgnoreBlock(block: ContentModelBlock) {
     return (
-        blocks.length == 1 ||
-        (block.blockType == 'Paragraph' &&
-            block.segments.length > 0 &&
-            block.segments.some(x => x.segmentType != 'Br' && x.segmentType != 'SelectionMarker'))
+        block.blockType != 'Paragraph' ||
+        block.segments.every(x => x.segmentType == 'Br' || x.segmentType == 'SelectionMarker')
     );
 }

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/list/setListTypeTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/list/setListTypeTest.ts
@@ -517,4 +517,34 @@ describe('indent', () => {
             ],
         });
     });
+
+    it('Change style type to existing list', () => {
+        const group = createContentModelDocument();
+        const list1 = createListItem([{ listType: 'OL' }]);
+        const para1 = createParagraph();
+        const br = createBr();
+
+        para1.segments.push(br);
+        list1.blocks.push(para1);
+        group.blocks.push(list1);
+
+        br.isSelected = true;
+
+        const result = setListType(group, 'UL');
+
+        expect(result).toBeTrue();
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [para1],
+                    levels: [{ listType: 'UL' }],
+                    formatHolder: { segmentType: 'SelectionMarker', isSelected: true, format: {} },
+                    format: {},
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
[Bug 215585](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/215585): [Format]Switching between bullets and numbering need to click the button twice

When switch list type, we check if all selected blocks are already in the expected list type, then turn the list off, otherwise we need to turn on list for those blocks that are not in expected type. However there is a code bug to check existing list type.
1. If a block is really in the expected list type, count it in
2. If a block is a non-empty paragraph, we should treat as not in that type
3. If a block is empty, but it is the only selected block, we should still treat it as not in that type, and will switch the list type on
4. If a block is empty and there are also other selected blocks, ignore this block.

After the fix, the logic of checking list type is:
1. If a block is a list, go to 2, otherwise go to 3
2. Check if the list type is expected
3. Check if it is paragraph and it is not empty