### PR TITLE
Remove style width/height

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -476,7 +476,7 @@ export default class ImageEdit implements EditorPlugin {
         if (this.image) {
             this.shadowSpan = wrap(this.image, 'span');
             if (this.shadowSpan) {
-                const shadowRoot = this.shadowSpan?.attachShadow({
+                const shadowRoot = this.shadowSpan.attachShadow({
                     mode: 'open',
                 });
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -475,14 +475,16 @@ export default class ImageEdit implements EditorPlugin {
     private insertImageWrapper(wrapper: HTMLSpanElement) {
         if (this.image) {
             this.shadowSpan = wrap(this.image, 'span');
-            const shadowRoot = this.shadowSpan.attachShadow({
-                mode: 'open',
-            });
+            if (this.shadowSpan) {
+                const shadowRoot = this.shadowSpan?.attachShadow({
+                    mode: 'open',
+                });
 
-            this.shadowSpan.style.verticalAlign = 'bottom';
-            this.shadowSpan.style.fontSize = '24px';
+                this.shadowSpan.style.verticalAlign = 'bottom';
+                this.shadowSpan.style.fontSize = '24px';
 
-            shadowRoot.appendChild(wrapper);
+                shadowRoot.appendChild(wrapper);
+            }
         }
     }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
@@ -75,5 +75,8 @@ export default function applyChange(
     if (wasResizedOrCropped || state == ImageEditInfoState.FullyChanged) {
         image.width = targetWidth;
         image.height = targetHeight;
+        // Remove width/height style so that it won't affect the image size, since style width/height has higher priority
+        image.style.removeProperty('width');
+        image.style.removeProperty('height');
     }
 }

--- a/packages/roosterjs-editor-plugins/test/imageEdit/imageEditTest.ts
+++ b/packages/roosterjs-editor-plugins/test/imageEdit/imageEditTest.ts
@@ -343,4 +343,18 @@ describe('ImageEdit | wrapper', () => {
         const imageShadow = shadowRoot?.querySelector('img');
         expect(imageShadow?.style.maxWidth).toBe('');
     });
+
+    it('image selection, cloned image should use style width/height attributes', () => {
+        const IMG_ID = 'IMAGE_ID';
+        const content = `<img id="${IMG_ID}" style="width: 300px; height: 300px" src='test'/>`;
+        editor.setContent(content);
+        const image = document.getElementById(IMG_ID) as HTMLImageElement;
+        editor.focus();
+        editor.select(image);
+        const imageParent = image.parentElement;
+        const shadowRoot = imageParent?.shadowRoot;
+        const imageShadow = shadowRoot?.querySelector('img');
+        expect(imageShadow?.style.height).toBe('300px');
+        expect(imageShadow?.style.width).toBe('300px');
+    });
 });

--- a/packages/roosterjs-editor-plugins/test/imageEdit/resizeByPercentageTest.ts
+++ b/packages/roosterjs-editor-plugins/test/imageEdit/resizeByPercentageTest.ts
@@ -107,5 +107,5 @@ describe('resizeByPercentage', () => {
 });
 
 function createImage() {
-    return `<img id="${IMG_ID}" src="${IMG_SRC}"/>`;
+    return `<img id="${IMG_ID}" style="width: 30px; height: 30px;" src="${IMG_SRC}"/>`;
 }


### PR DESCRIPTION
When an image is resized, the width/height width attributes are changed to set the new size. If the image already has width/height style properties, those properties must be removed, because they have high priority and it will prevent the image from resize.  