### PR TITLE
Demo site improvement: Rename FormatPainterPlugin

### DIFF
--- a/demo/scripts/controls/ContentModelEditorMainPane.tsx
+++ b/demo/scripts/controls/ContentModelEditorMainPane.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import ApiPlaygroundPlugin from './sidePane/apiPlayground/ApiPlaygroundPlugin';
 import ContentModelEditorOptionsPlugin from './sidePane/editorOptions/ContentModelEditorOptionsPlugin';
+import ContentModelFormatPainterPlugin from './contentModel/plugins/ContentModelFormatPainterPlugin';
 import ContentModelFormatStatePlugin from './sidePane/formatState/ContentModelFormatStatePlugin';
 import ContentModelPanePlugin from './sidePane/contentModel/ContentModelPanePlugin';
 import ContentModelRibbon from './ribbonButtons/contentModel/ContentModelRibbon';
 import EventViewPlugin from './sidePane/eventViewer/EventViewPlugin';
-import FormatPainterPlugin from './contentModel/plugins/FormatPainterPlugin';
 import getToggleablePlugins from './getToggleablePlugins';
 import MainPaneBase from './MainPaneBase';
 import SampleEntityPlugin from './sampleEntity/SampleEntityPlugin';
@@ -92,7 +92,7 @@ class ContentModelEditorMainPane extends MainPaneBase {
     private pasteOptionPlugin: EditorPlugin;
     private emojiPlugin: EditorPlugin;
     private toggleablePlugins: EditorPlugin[] | null = null;
-    private formatPainterPlugin: FormatPainterPlugin;
+    private formatPainterPlugin: ContentModelFormatPainterPlugin;
     private sampleEntityPlugin: SampleEntityPlugin;
 
     constructor(props: {}) {
@@ -108,7 +108,7 @@ class ContentModelEditorMainPane extends MainPaneBase {
         this.contentModelRibbonPlugin = new ContentModelRibbonPlugin();
         this.pasteOptionPlugin = createPasteOptionPlugin();
         this.emojiPlugin = createEmojiPlugin();
-        this.formatPainterPlugin = new FormatPainterPlugin();
+        this.formatPainterPlugin = new ContentModelFormatPainterPlugin();
         this.sampleEntityPlugin = new SampleEntityPlugin();
         this.state = {
             showSidePane: window.location.hash != '',

--- a/demo/scripts/controls/MainPane.tsx
+++ b/demo/scripts/controls/MainPane.tsx
@@ -3,7 +3,6 @@ import * as ReactDOM from 'react-dom';
 import ApiPlaygroundPlugin from './sidePane/apiPlayground/ApiPlaygroundPlugin';
 import EditorOptionsPlugin from './sidePane/editorOptions/EditorOptionsPlugin';
 import EventViewPlugin from './sidePane/eventViewer/EventViewPlugin';
-import FormatPainterPlugin from './contentModel/plugins/FormatPainterPlugin';
 import FormatStatePlugin from './sidePane/formatState/FormatStatePlugin';
 import getToggleablePlugins from './getToggleablePlugins';
 import MainPaneBase from './MainPaneBase';
@@ -102,7 +101,6 @@ class MainPane extends MainPaneBase {
     private pasteOptionPlugin: EditorPlugin;
     private emojiPlugin: EditorPlugin;
     private toggleablePlugins: EditorPlugin[] | null = null;
-    private formatPainterPlugin: FormatPainterPlugin;
     private sampleEntityPlugin: SampleEntityPlugin;
     private mainWindowButtons: RibbonButton<RibbonStringKeys>[];
     private popoutWindowButtons: RibbonButton<RibbonStringKeys>[];
@@ -118,7 +116,6 @@ class MainPane extends MainPaneBase {
         this.ribbonPlugin = createRibbonPlugin();
         this.pasteOptionPlugin = createPasteOptionPlugin();
         this.emojiPlugin = createEmojiPlugin();
-        this.formatPainterPlugin = new FormatPainterPlugin();
         this.sampleEntityPlugin = new SampleEntityPlugin();
 
         this.mainWindowButtons = getButtons([
@@ -183,7 +180,6 @@ class MainPane extends MainPaneBase {
             this.ribbonPlugin,
             this.pasteOptionPlugin,
             this.emojiPlugin,
-            this.formatPainterPlugin,
             this.sampleEntityPlugin,
         ];
 

--- a/demo/scripts/controls/contentModel/plugins/ContentModelFormatPainterPlugin.ts
+++ b/demo/scripts/controls/contentModel/plugins/ContentModelFormatPainterPlugin.ts
@@ -14,7 +14,7 @@ interface FormatPainterFormatHolder {
     format: ContentModelSegmentFormat | null;
 }
 
-export default class FormatPainterPlugin implements EditorPlugin {
+export default class ContentModelFormatPainterPlugin implements EditorPlugin {
     private editor: IContentModelEditor | null = null;
 
     getName() {

--- a/demo/scripts/controls/ribbonButtons/contentModel/formatPainterButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/formatPainterButton.ts
@@ -1,4 +1,4 @@
-import FormatPainterPlugin from '../../contentModel/plugins/FormatPainterPlugin';
+import ContentModelFormatPainterPlugin from '../../contentModel/plugins/ContentModelFormatPainterPlugin';
 import { isContentModelEditor } from 'roosterjs-content-model-editor';
 import { RibbonButton } from 'roosterjs-react';
 
@@ -12,7 +12,7 @@ export const formatPainterButton: RibbonButton<'formatPainter'> = {
     iconName: 'Brush',
     onClick: editor => {
         if (isContentModelEditor(editor)) {
-            FormatPainterPlugin.startFormatPainter(editor);
+            ContentModelFormatPainterPlugin.startFormatPainter(editor);
         }
         return true;
     },


### PR DESCRIPTION
In demo site:
1. Rename `FormatPainterPlugin` to `ContentModelFormatPainterPlugin` since it is only used by Content Model editor
2. Remove `FormatPainterPlugin` from original MainPane since it is not used.