### PR TITLE
Remove max-width

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/editInfoUtils/applyChange.ts
@@ -78,5 +78,6 @@ export default function applyChange(
         // Remove width/height style so that it won't affect the image size, since style width/height has higher priority
         image.style.removeProperty('width');
         image.style.removeProperty('height');
+        image.style.removeProperty('max-width');
     }
 }


### PR DESCRIPTION
After resizing an image, we set width and height values, then to preserve the aspect ratio of the resize image, the max-width of the image is removed. 

![removeMaxWidth](https://github.com/microsoft/roosterjs/assets/87443959/9ee14844-d4b9-448f-b2b4-05c18cb40047)
