### PR TITLE
Content Model Fix 139624

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/image/insertImage.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/image/insertImage.ts
@@ -24,7 +24,7 @@ export default function insertImage(editor: IContentModelEditor, imageFileOrSrc:
 
 function insertImageWithSrc(editor: IContentModelEditor, src: string) {
     formatWithContentModel(editor, 'insertImage', model => {
-        const image = createImage(src);
+        const image = createImage(src, { backgroundColor: '' });
         const doc = createContentModelDocument();
 
         addSegment(doc, image);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/insertImageTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/insertImageTest.ts
@@ -94,7 +94,9 @@ describe('insertImage', () => {
                             {
                                 segmentType: 'Image',
                                 src: testUrl,
-                                format: {},
+                                format: {
+                                    backgroundColor: '',
+                                },
                                 dataset: {},
                             },
                             {
@@ -133,7 +135,9 @@ describe('insertImage', () => {
                             {
                                 segmentType: 'Image',
                                 src: testUrl,
-                                format: {},
+                                format: {
+                                    backgroundColor: '',
+                                },
                                 dataset: {},
                             },
                             {
@@ -179,6 +183,7 @@ describe('insertImage', () => {
                                 format: {
                                     fontFamily: 'Test',
                                     fontSize: '20px',
+                                    backgroundColor: '',
                                 },
                                 dataset: {},
                             },


### PR DESCRIPTION
[Bug 139624](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/139624): [Mail] The inline picture will be also highlighted if text is highlighted

Fix by setting an empty background color for new image so after merge the existing background color will be removed