### PR TITLE
Content Model Fix 144958

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/ContentModelEditor.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/ContentModelEditor.ts
@@ -1,13 +1,13 @@
+import { ContentModelEditorCore } from '../publicTypes/ContentModelEditorCore';
+import { ContentModelEditorOptions, IContentModelEditor } from '../publicTypes/IContentModelEditor';
+import { createContentModelEditorCore } from './createContentModelEditorCore';
+import { EditorBase } from 'roosterjs-editor-core';
 import {
     ContentModelDocument,
     ContentModelSegmentFormat,
     DomToModelOption,
     ModelToDomOption,
 } from 'roosterjs-content-model-types';
-import { ContentModelEditorCore } from '../publicTypes/ContentModelEditorCore';
-import { ContentModelEditorOptions, IContentModelEditor } from '../publicTypes/IContentModelEditor';
-import { createContentModelEditorCore } from './createContentModelEditorCore';
-import { EditorBase } from 'roosterjs-editor-core';
 
 /**
  * Editor for Content Model.
@@ -55,6 +55,7 @@ export default class ContentModelEditor
 
         if (core.reuseModel && !core.lifecycle.shadowEditFragment) {
             core.cachedModel = model || undefined;
+            core.cachedRangeEx = undefined;
         }
     }
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/getSelectionRangeEx.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/getSelectionRangeEx.ts
@@ -1,0 +1,11 @@
+import { ContentModelEditorCore } from '../../publicTypes/ContentModelEditorCore';
+import { GetSelectionRangeEx } from 'roosterjs-editor-types';
+
+/**
+ * @internal
+ */
+export const getSelectionRangeEx: GetSelectionRangeEx = core => {
+    const contentModelCore = core as ContentModelEditorCore;
+
+    return contentModelCore.cachedRangeEx ?? core.originalApi.getSelectionRangeEx(core);
+};

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/setContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/setContentModel.ts
@@ -21,5 +21,8 @@ export const setContentModel: SetContentModel = (core, model, option) => {
 
     if (!core.lifecycle.shadowEditFragment) {
         core.api.select(core, range);
+        core.cachedRangeEx = range || undefined;
     }
+
+    return range;
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/switchShadowEdit.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/switchShadowEdit.ts
@@ -24,12 +24,12 @@ export const switchShadowEdit: SwitchShadowEdit = (editorCore, isOn): void => {
                 range && getSelectionPath(core.contentDiv, range);
             core.lifecycle.shadowEditFragment = core.contentDiv.ownerDocument.createDocumentFragment();
         } else {
+            core.lifecycle.shadowEditFragment = null;
+            core.lifecycle.shadowEditSelectionPath = null;
+
             if (core.cachedModel) {
                 core.api.setContentModel(core, core.cachedModel);
             }
-
-            core.lifecycle.shadowEditFragment = null;
-            core.lifecycle.shadowEditSelectionPath = null;
         }
     }
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/createContentModelEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/createContentModelEditorCore.ts
@@ -9,6 +9,7 @@ import { CoreCreator, EditorCore, ExperimentalFeatures } from 'roosterjs-editor-
 import { createContentModel } from './coreApi/createContentModel';
 import { createEditorContext } from './coreApi/createEditorContext';
 import { createEditorCore, isFeatureEnabled } from 'roosterjs-editor-core';
+import { getSelectionRangeEx } from './coreApi/getSelectionRangeEx';
 import { setContentModel } from './coreApi/setContentModel';
 import { switchShadowEdit } from './coreApi/switchShadowEdit';
 
@@ -95,6 +96,7 @@ function promoteCoreApi(cmCore: ContentModelEditorCore) {
     cmCore.api.createEditorContext = createEditorContext;
     cmCore.api.createContentModel = createContentModel;
     cmCore.api.setContentModel = setContentModel;
+    cmCore.api.getSelectionRangeEx = getSelectionRangeEx;
 
     if (
         isFeatureEnabled(

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/segment/setBackgroundColor.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/segment/setBackgroundColor.ts
@@ -1,5 +1,8 @@
+import { ContentModelParagraph } from 'roosterjs-content-model-types';
+import { createSelectionMarker } from 'roosterjs-content-model-dom';
 import { formatSegmentWithContentModel } from '../utils/formatSegmentWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
+import { setSelection } from '../../modelApi/selection/setSelection';
 
 /**
  * Set background color
@@ -10,15 +13,35 @@ export default function setBackgroundColor(
     editor: IContentModelEditor,
     backgroundColor: string | null
 ) {
+    let lastParagraph: ContentModelParagraph | null = null;
+    let lastSegmentIndex: number = -1;
+
     formatSegmentWithContentModel(
         editor,
         'setBackgroundColor',
-        backgroundColor === null
-            ? format => {
-                  delete format.backgroundColor;
-              }
-            : format => {
-                  format.backgroundColor = backgroundColor;
-              }
+        (format, _, segment, paragraph) => {
+            if (backgroundColor === null) {
+                delete format.backgroundColor;
+            } else {
+                format.backgroundColor = backgroundColor;
+            }
+
+            if (segment && paragraph && segment.segmentType != 'SelectionMarker') {
+                lastParagraph = paragraph;
+                lastSegmentIndex = lastParagraph.segments.indexOf(segment);
+            }
+        },
+        undefined /*segmentHasStyleCallback*/,
+        undefined /*includingFormatHolder*/,
+        model => {
+            if (lastParagraph && lastSegmentIndex >= 0) {
+                const marker = createSelectionMarker(
+                    lastParagraph.segments[lastSegmentIndex]?.format
+                );
+
+                lastParagraph.segments.splice(lastSegmentIndex + 1, 0, marker);
+                setSelection(model, marker, marker);
+            }
+        }
     );
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatSegmentWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatSegmentWithContentModel.ts
@@ -4,6 +4,7 @@ import { getPendingFormat, setPendingFormat } from '../../modelApi/format/pendin
 import { getSelectedSegmentsAndParagraphs } from '../../modelApi/selection/collectSelections';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import {
+    ContentModelDocument,
     ContentModelParagraph,
     ContentModelSegment,
     ContentModelSegmentFormat,
@@ -17,14 +18,16 @@ export function formatSegmentWithContentModel(
     toggleStyleCallback: (
         format: ContentModelSegmentFormat,
         isTuringOn: boolean,
-        segment: ContentModelSegment | null
+        segment: ContentModelSegment | null,
+        paragraph: ContentModelParagraph | null
     ) => void,
     segmentHasStyleCallback?: (
         format: ContentModelSegmentFormat,
         segment: ContentModelSegment | null,
         paragraph: ContentModelParagraph | null
     ) => boolean,
-    includingFormatHolder?: boolean
+    includingFormatHolder?: boolean,
+    afterFormatCallback?: (model: ContentModelDocument) => void
 ) {
     formatWithContentModel(editor, apiName, model => {
         let segmentAndParagraphs = getSelectedSegmentsAndParagraphs(model, !!includingFormatHolder);
@@ -60,9 +63,11 @@ export function formatSegmentWithContentModel(
               )
             : false;
 
-        formatsAndSegments.forEach(([format, segment]) =>
-            toggleStyleCallback(format, !isTurningOff, segment)
+        formatsAndSegments.forEach(([format, segment, paragraph]) =>
+            toggleStyleCallback(format, !isTurningOff, segment, paragraph)
         );
+
+        afterFormatCallback?.(model);
 
         if (!pendingFormat && isCollapsedSelection) {
             const pos = editor.getFocusedPosition();

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelEditorCore.ts
@@ -1,4 +1,4 @@
-import { CoreApiMap, EditorCore } from 'roosterjs-editor-types';
+import { CoreApiMap, EditorCore, SelectionRangeEx } from 'roosterjs-editor-types';
 import {
     ContentModelDocument,
     ContentModelSegmentFormat,
@@ -80,6 +80,11 @@ export interface ContentModelEditorCore extends EditorCore {
      * When reuse Content Model is allowed, we cache the Content Model object here after created
      */
     cachedModel?: ContentModelDocument;
+
+    /**
+     * Cached selection range ex. This range only exist when cached model exists and it has selection
+     */
+    cachedRangeEx?: SelectionRangeEx;
 
     /**
      * Default format used by Content Model. This is calculated from lifecycle.defaultFormat

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/createContentModelEditorCoreTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/createContentModelEditorCoreTest.ts
@@ -7,6 +7,7 @@ import { createContentModel } from '../../lib/editor/coreApi/createContentModel'
 import { createContentModelEditorCore } from '../../lib/editor/createContentModelEditorCore';
 import { createEditorContext } from '../../lib/editor/coreApi/createEditorContext';
 import { ExperimentalFeatures } from 'roosterjs-editor-types';
+import { getSelectionRangeEx } from '../../lib/editor/coreApi/getSelectionRangeEx';
 import { setContentModel } from '../../lib/editor/coreApi/setContentModel';
 import { switchShadowEdit } from '../../lib/editor/coreApi/switchShadowEdit';
 
@@ -67,6 +68,7 @@ describe('createContentModelEditorCore', () => {
                 createEditorContext,
                 createContentModel,
                 setContentModel,
+                getSelectionRangeEx,
             },
             originalApi: {
                 a: 'b',
@@ -128,6 +130,7 @@ describe('createContentModelEditorCore', () => {
                 createEditorContext,
                 createContentModel,
                 setContentModel,
+                getSelectionRangeEx,
             },
             originalApi: {
                 a: 'b',
@@ -202,6 +205,7 @@ describe('createContentModelEditorCore', () => {
                 createEditorContext,
                 createContentModel,
                 setContentModel,
+                getSelectionRangeEx,
             },
             originalApi: {
                 a: 'b',
@@ -262,6 +266,7 @@ describe('createContentModelEditorCore', () => {
                 createEditorContext,
                 createContentModel,
                 setContentModel,
+                getSelectionRangeEx,
             },
             originalApi: {
                 a: 'b',
@@ -324,6 +329,7 @@ describe('createContentModelEditorCore', () => {
                 createEditorContext,
                 createContentModel,
                 setContentModel,
+                getSelectionRangeEx,
             },
             originalApi: {
                 a: 'b',

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/segment/setBackgroundColorTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/segment/setBackgroundColorTest.ts
@@ -150,6 +150,12 @@ describe('setBackgroundColor', () => {
                                 format: {
                                     backgroundColor: 'red',
                                 },
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
+                                format: {
+                                    backgroundColor: 'red',
+                                },
                                 isSelected: true,
                             },
                         ],
@@ -189,6 +195,12 @@ describe('setBackgroundColor', () => {
                             {
                                 segmentType: 'Text',
                                 text: 'test',
+                                format: {
+                                    backgroundColor: 'red',
+                                },
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
                                 format: {
                                     backgroundColor: 'red',
                                 },
@@ -240,11 +252,16 @@ describe('setBackgroundColor', () => {
                                 format: {
                                     backgroundColor: 'red',
                                 },
-                                isSelected: true,
                             },
                             {
                                 segmentType: 'Text',
                                 text: 'test',
+                                format: {
+                                    backgroundColor: 'red',
+                                },
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
                                 format: {
                                     backgroundColor: 'red',
                                 },
@@ -299,7 +316,6 @@ describe('setBackgroundColor', () => {
                                 segmentType: 'Text',
                                 text: 'test',
                                 format: { backgroundColor: 'red' },
-                                isSelected: true,
                             },
                             {
                                 segmentType: 'Text',
@@ -309,6 +325,10 @@ describe('setBackgroundColor', () => {
                             {
                                 segmentType: 'Text',
                                 text: 'test',
+                                format: { backgroundColor: 'red' },
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
                                 format: { backgroundColor: 'red' },
                                 isSelected: true,
                             },
@@ -349,6 +369,10 @@ describe('setBackgroundColor', () => {
                             {
                                 segmentType: 'Text',
                                 text: 'test',
+                                format: {},
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
                                 format: {},
                                 isSelected: true,
                             },

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatSegmentWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatSegmentWithContentModelTest.ts
@@ -132,7 +132,7 @@ describe('formatSegmentWithContentModel', () => {
         expect(segmentHasStyleCallback).toHaveBeenCalledTimes(1);
         expect(segmentHasStyleCallback).toHaveBeenCalledWith(text.format, text, para);
         expect(toggleStyleCallback).toHaveBeenCalledTimes(1);
-        expect(toggleStyleCallback).toHaveBeenCalledWith(text.format, false, text);
+        expect(toggleStyleCallback).toHaveBeenCalledWith(text.format, false, text, para);
         expect(getPendingFormat).toHaveBeenCalledTimes(1);
         expect(setPendingFormat).toHaveBeenCalledTimes(0);
     });
@@ -203,8 +203,8 @@ describe('formatSegmentWithContentModel', () => {
         expect(segmentHasStyleCallback).toHaveBeenCalledWith(text1.format, text1, para);
         expect(segmentHasStyleCallback).toHaveBeenCalledWith(text3.format, text3, para);
         expect(toggleStyleCallback).toHaveBeenCalledTimes(2);
-        expect(toggleStyleCallback).toHaveBeenCalledWith(text1.format, true, text1);
-        expect(toggleStyleCallback).toHaveBeenCalledWith(text3.format, true, text3);
+        expect(toggleStyleCallback).toHaveBeenCalledWith(text1.format, true, text1, para);
+        expect(toggleStyleCallback).toHaveBeenCalledWith(text3.format, true, text3, para);
         expect(getPendingFormat).toHaveBeenCalledTimes(1);
         expect(setPendingFormat).toHaveBeenCalledTimes(0);
     });


### PR DESCRIPTION
[Bug 144958](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/144958): Highlighting text should remove selection

Add a callback to function `formatSegmentWithContentModel` to allow do some additional work after format, so that we can change the selection to be after the last selected segment.

In order to be able to restore selection before applying format, I added a new cachedRangeEx in `ContentModelEditorCore` to store selection range after model is restored, and if this cached range exists, `getSelectionRangeEx` will return this range directly. This solves the issue that after restore a content model we got incorrect range issue.

Before:
![bgcolor1](https://github.com/microsoft/roosterjs/assets/23065085/a31a20f5-1218-4836-a3ee-d4641ce3a63b)

After:
![bgcolor2](https://github.com/microsoft/roosterjs/assets/23065085/1c953279-63b5-4d0a-a84a-71e9718b91a5)

