### PR TITLE
Content Model Fix 189344

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/collectSelections.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/collectSelections.ts
@@ -123,19 +123,28 @@ export function getOperationalBlocks<T extends ContentModelBlockGroup>(
 /**
  * @internal
  */
-export function getFirstSelectedTable(model: ContentModelDocument): ContentModelTable | undefined {
+export function getFirstSelectedTable(
+    model: ContentModelDocument
+): [ContentModelTable | undefined, ContentModelBlockGroup | undefined] {
     const selections = collectSelections(model, { includeListFormatHolder: 'never' });
     let table: ContentModelTable | undefined;
+    let parent: ContentModelBlockGroup | undefined;
 
     removeUnmeaningfulSelections(selections);
 
-    selections.forEach(({ block, tableContext }) => {
+    selections.forEach(({ block, tableContext, path }) => {
         if (!table) {
-            table = block?.blockType == 'Table' ? block : tableContext?.table;
+            if (block?.blockType == 'Table') {
+                table = block;
+                parent = path[0];
+            } else if (tableContext?.table) {
+                table = tableContext.table;
+                parent = path.filter(group => group.blocks.indexOf(tableContext.table) >= 0)[0];
+            }
         }
     });
 
-    return table;
+    return [table, parent];
 }
 
 /**

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/editTable.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/editTable.ts
@@ -14,7 +14,7 @@ import { mergeTableCells } from '../../modelApi/table/mergeTableCells';
 import { mergeTableColumn } from '../../modelApi/table/mergeTableColumn';
 import { mergeTableRow } from '../../modelApi/table/mergeTableRow';
 import { normalizeTable } from '../../modelApi/table/normalizeTable';
-import { setSelection } from 'roosterjs-content-model-editor/lib/modelApi/selection/setSelection';
+import { setSelection } from '../../modelApi/selection/setSelection';
 import { splitTableCellHorizontally } from '../../modelApi/table/splitTableCellHorizontally';
 import { splitTableCellVertically } from '../../modelApi/table/splitTableCellVertically';
 import { TableOperation } from 'roosterjs-editor-types';

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/formatTable.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/formatTable.ts
@@ -16,7 +16,7 @@ export default function formatTable(
     keepCellShade?: boolean
 ) {
     formatWithContentModel(editor, 'formatTable', model => {
-        const tableModel = getFirstSelectedTable(model);
+        const [tableModel] = getFirstSelectedTable(model);
 
         if (tableModel) {
             applyTableFormat(tableModel, format, keepCellShade);

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/setTableCellShade.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/setTableCellShade.ts
@@ -12,7 +12,7 @@ import { setTableCellBackgroundColor } from '../../modelApi/table/setTableCellBa
  */
 export default function setTableCellShade(editor: IContentModelEditor, color: string | null) {
     formatWithContentModel(editor, 'setTableCellShade', model => {
-        const table = getFirstSelectedTable(model);
+        const [table] = getFirstSelectedTable(model);
 
         if (table) {
             normalizeTable(table);


### PR DESCRIPTION
[Bug 189344](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/189344): [Table]The cursor goes to the end after delete table

After edit a table, we need to check if the table still has focus. If not, set a focus, or replace the table with an empty paragraph if table is already empty