### PR TITLE
Remove image alternative text when change picture

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/image/changeImage.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/image/changeImage.ts
@@ -25,6 +25,7 @@ export default function changeImage(editor: IContentModelEditor, file: File) {
                     image.dataset = {};
                     image.format.width = '';
                     image.format.height = '';
+                    image.alt = '';
                 },
                 {
                     image: selection.image,

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/changeImageTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/changeImageTest.ts
@@ -172,6 +172,7 @@ describe('changeImage', () => {
                                 src: testUrl,
                                 isSelected: true,
                                 dataset: {},
+                                alt: '',
                                 format: {
                                     boxShadow: '0px 0px 3px 3px #aaaaaa',
                                     width: '',


### PR DESCRIPTION
Remove alternative image text of image when change image of an image element. 
![changeImageAlt](https://github.com/microsoft/roosterjs/assets/87443959/25204050-82c0-4b18-9b8e-a98cbe971f45)
