### PR TITLE
Content Model Fix 214383

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/delimiterProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/delimiterProcessor.ts
@@ -8,12 +8,14 @@ import { handleRegularSelection } from './childProcessor';
  * @param element
  * @param context
  */
-export const delimiterProcessor: ElementProcessor<HTMLSpanElement> = (group, element, context) => {
+export const delimiterProcessor: ElementProcessor<Node> = (group, element, context) => {
     let index = 0;
     const [nodeStartOffset, nodeEndOffset] = getRegularSelectionOffsets(context, element);
 
     for (let child = element.firstChild; child; child = child.nextSibling) {
         handleRegularSelection(index, context, group, nodeStartOffset, nodeEndOffset);
+
+        delimiterProcessor(group, child, context);
         index++;
     }
 

--- a/packages-content-model/roosterjs-content-model-types/lib/context/DomToModelSettings.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/context/DomToModelSettings.ts
@@ -95,7 +95,7 @@ export type ElementProcessorMap = {
         /**
          * Processor for Inline Readonly Delimiters
          */
-        delimiter?: ElementProcessor<HTMLSpanElement>;
+        delimiter?: ElementProcessor<Node>;
     };
 
 /**


### PR DESCRIPTION
[Bug 214383](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/214383): [Mail]Cannot delete multiple beautiful links at once

The root cause is selection is not correctly generated in content model when start position is inside a entity delimiter. Because we didn't go into the delimiter SPAN to check selection. To fix it, we just need to recursively loop all child nodes of an entity delimiter to find selection position. Then all entities will be correctly selected.