### PR TITLE
Engineering improve: Use Yarn workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
         "url": "https://github.com/Microsoft/roosterjs"
     },
     "license": "MIT",
+    "private": true,
+    "workspaces": [
+        "packages/*",
+        "packages-ui/*",
+        "packages-content-model/*"
+    ],
     "scripts": {
         "clean": "node tools/build.js clean",
         "dts": "node tools/build.js clean normalize buildcommonjs dts",

--- a/packages-content-model/roosterjs-content-model-dom/package.json
+++ b/packages-content-model/roosterjs-content-model-dom/package.json
@@ -7,5 +7,6 @@
         "roosterjs-editor-dom": "",
         "roosterjs-content-model-types": ""
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages-content-model/roosterjs-content-model-editor/package.json
+++ b/packages-content-model/roosterjs-content-model-editor/package.json
@@ -9,5 +9,6 @@
         "roosterjs-content-model-dom": "",
         "roosterjs-content-model-types": ""
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages-content-model/roosterjs-content-model-types/package.json
+++ b/packages-content-model/roosterjs-content-model-types/package.json
@@ -4,5 +4,6 @@
     "dependencies": {
         "roosterjs-editor-types": ""
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages-content-model/roosterjs-content-model/package.json
+++ b/packages-content-model/roosterjs-content-model/package.json
@@ -11,5 +11,6 @@
         "roosterjs-content-model-editor": "",
         "roosterjs-color-utils": ""
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages-ui/roosterjs-react/package.json
+++ b/packages-ui/roosterjs-react/package.json
@@ -16,5 +16,6 @@
         "react-dom": ">=16.0.0",
         "@fluentui/react": ">=8.0.0"
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-api/package.json
+++ b/packages/roosterjs-editor-api/package.json
@@ -6,5 +6,6 @@
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": ""
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-core/package.json
+++ b/packages/roosterjs-editor-core/package.json
@@ -6,5 +6,6 @@
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": ""
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-dom/package.json
+++ b/packages/roosterjs-editor-dom/package.json
@@ -5,5 +5,6 @@
         "tslib": "^2.3.1",
         "roosterjs-editor-types": ""
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-plugins/package.json
+++ b/packages/roosterjs-editor-plugins/package.json
@@ -7,5 +7,6 @@
         "roosterjs-editor-dom": "",
         "roosterjs-editor-api": ""
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-types-compatible/package.json
+++ b/packages/roosterjs-editor-types-compatible/package.json
@@ -4,5 +4,6 @@
     "dependencies": {
         "roosterjs-editor-types": ""
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-editor-types/package.json
+++ b/packages/roosterjs-editor-types/package.json
@@ -2,5 +2,6 @@
     "name": "roosterjs-editor-types",
     "description": "Type definition for roosterjs",
     "dependencies": {},
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/packages/roosterjs/package.json
+++ b/packages/roosterjs/package.json
@@ -11,5 +11,6 @@
         "roosterjs-editor-plugins": "",
         "roosterjs-color-utils": ""
     },
+    "version": "0.0.0",
     "main": "./lib/index.ts"
 }

--- a/tools/buildTools/common.js
+++ b/tools/buildTools/common.js
@@ -31,10 +31,9 @@ const compatibleEnumPath = path.join(
 );
 
 function collectPackages(startPath) {
-    const packagePaths = glob.sync(
-        path.relative(rootPath, path.join(startPath, '**', 'package.json')),
-        { nocase: true }
-    );
+    const packagePaths = glob
+        .sync(path.relative(rootPath, path.join(startPath, '**', 'package.json')), { nocase: true })
+        .filter(x => x.indexOf('node_modules') < 0);
 
     const packageNames = packagePaths.map(path =>
         path.replace('packages/', '').replace('/package.json', '')
@@ -135,7 +134,7 @@ function getWebpackExternalCallback(externalLibraryPairs, internalLibraries) {
         ...externalLibraryPairs,
     ]);
 
-    return (_, request, callback) => {
+    return ({ request }, callback) => {
         for (const [key, value] of externalMap) {
             if (key instanceof RegExp && key.test(request)) {
                 return callback(null, request.replace(key, value));

--- a/tools/buildTools/dts.js
+++ b/tools/buildTools/dts.js
@@ -75,7 +75,7 @@ function parseExports(exports) {
     }
 }
 
-function defaultExternalHandler(_, __, callback) {
+function defaultExternalHandler(_, callback) {
     callback();
 }
 
@@ -86,7 +86,7 @@ function parseFrom(from, currentFileName, baseDir, projDir, externalHandler) {
         var currentPath = path.dirname(currentFileName);
         importFileName = path.resolve(currentPath, from + '.d.ts');
     } else {
-        (externalHandler || defaultExternalHandler)(null, from, (_, replacement) => {
+        (externalHandler || defaultExternalHandler)({ request: from }, (_, replacement) => {
             if (replacement) {
                 replacedName = replacement;
             } else if (AllowedCrossPackageImport[from]) {

--- a/tools/buildTools/normalize.js
+++ b/tools/buildTools/normalize.js
@@ -38,7 +38,7 @@ function normalize() {
             }
         });
 
-        if (packageJson.version) {
+        if (packageJson.version && packageJson.version != '0.0.0') {
             knownCustomizedPackages[packageName] = packageJson.version;
         } else {
             packageJson.version = version;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,7 +63,7 @@ module.exports = {
             },
         ],
     },
-    externals: function (context, request, callback) {
+    externals: function ({ request }, callback) {
         for (const [key, value] of externalMap) {
             if (key instanceof RegExp && key.test(request)) {
                 return callback(null, request.replace(key, value));
@@ -74,7 +74,6 @@ module.exports = {
 
         callback();
     },
-    watch: true,
     stats: 'minimal',
     devServer: {
         host: '0.0.0.0', // This makes the server public so that others can test by http://hostname ...

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,7 +1278,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.9.0, color-convert@^1.9.1, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -1310,6 +1310,14 @@ color-string@^1.5.4:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
 color@3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
@@ -1317,6 +1325,14 @@ color@3.1.3:
   dependencies:
     color-convert "^1.9.1"
     color-string "^1.5.4"
+
+color@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colors@1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Yarn workspaces: https://classic.yarnpkg.com/lang/en/docs/workspaces/

With this change, we can now easily navigate code between files, and imported types from other package won't show error in code editor:

Before change
<img width="559" alt="image" src="https://github.com/microsoft/roosterjs/assets/23065085/78be931e-aef5-42f6-9a5e-7adb41a137dc">

After change
<img width="600" alt="image" src="https://github.com/microsoft/roosterjs/assets/23065085/4aca18ac-17ab-4c32-b0c0-7088b9d8a6d9">


When navigate code across packages:
Before change, cannot navigate if build is not performed. And after a build, it will navigate to .d.ts file;
After change, navigate works before and after build, and navigate to correct .ts file
