### PR TITLE
Fix rotator and side resize handles visibility

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -85,11 +85,6 @@ const LIGHT_MODE_BGCOLOR = 'white';
 const DARK_MODE_BGCOLOR = '#333';
 
 /**
- * The biggest area of image with 4 handles
- */
-const MAX_SMALL_SIZE_IMAGE = 20000;
-
-/**
  * The smallest value of hight or width to make side handle and rotate handle visible
  */
 const MIN_HEIGHT_WIDTH = 100;
@@ -766,11 +761,7 @@ function isFixedNumberValue(value: string | number) {
 }
 
 function isASmallImage(widthPx: number, heightPx: number): boolean {
-    return widthPx &&
-        heightPx &&
-        (widthPx * widthPx < MAX_SMALL_SIZE_IMAGE ||
-            widthPx < MIN_HEIGHT_WIDTH ||
-            heightPx < MIN_HEIGHT_WIDTH)
+    return widthPx && heightPx && (widthPx < MIN_HEIGHT_WIDTH || heightPx < MIN_HEIGHT_WIDTH)
         ? true
         : false;
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -8,7 +8,7 @@ import ImageEditInfo from './types/ImageEditInfo';
 import ImageHtmlOptions from './types/ImageHtmlOptions';
 import { Cropper, getCropHTML } from './imageEditors/Cropper';
 import { deleteEditInfo, getEditInfoFromImage } from './editInfoUtils/editInfo';
-import { getRotateHTML, Rotator, updateRotateHandlePosition } from './imageEditors/Rotator';
+import { getRotateHTML, Rotator, updateRotateHandleState } from './imageEditors/Rotator';
 import { ImageEditElementClass } from './types/ImageEditElementClass';
 import { tryToConvertGifToPng } from './editInfoUtils/tryToConvertGifToPng';
 import {
@@ -87,7 +87,12 @@ const DARK_MODE_BGCOLOR = '#333';
 /**
  * The biggest area of image with 4 handles
  */
-const MAX_SMALL_SIZE_IMAGE = 10000;
+const MAX_SMALL_SIZE_IMAGE = 20000;
+
+/**
+ * The smallest value of hight or width to make side handle and rotate handle visible
+ */
+const MIN_HEIGHT_WIDTH = 100;
 
 /**
  * ImageEdit plugin provides the ability to edit an inline image in editor, including image resizing, rotation and cropping
@@ -451,7 +456,7 @@ export default class ImageEdit implements EditorPlugin {
                 rotateHandleBackColor: this.editor.isDarkMode()
                     ? DARK_MODE_BGCOLOR
                     : LIGHT_MODE_BGCOLOR,
-                isSmallImage: isASmallImage(this.editInfo!),
+                isSmallImage: isASmallImage(this.editInfo.widthPx, this.editInfo.heightPx),
             };
             const htmlData: CreateElementData[] = [getResizeBordersHTML(options)];
 
@@ -598,9 +603,12 @@ export default class ImageEdit implements EditorPlugin {
                 }
 
                 const viewport = this.editor?.getVisibleViewport();
+                const isSmall = isASmallImage(targetWidth, targetHeight);
                 if (rotateHandle && rotateCenter && viewport) {
-                    updateRotateHandlePosition(viewport, rotateCenter, rotateHandle);
+                    updateRotateHandleState(viewport, rotateCenter, rotateHandle, isSmall);
                 }
+
+                updateSideHandlesVisibility(resizeHandles, isSmall);
 
                 updateHandleCursor(resizeHandles, angleRad);
             }
@@ -714,10 +722,19 @@ function rotateHandles(angleRad: number, y: string = '', x: string = ''): string
  * @param angleRad The angle that the image was rotated.
  */
 function updateHandleCursor(handles: HTMLElement[], angleRad: number) {
-    handles.map(handle => {
-        const y = handle.dataset.y;
-        const x = handle.dataset.x;
+    handles.forEach(handle => {
+        const { y, x } = handle.dataset;
         handle.style.cursor = `${rotateHandles(angleRad, y, x)}-resize`;
+    });
+}
+
+function updateSideHandlesVisibility(handles: HTMLElement[], isSmall: boolean) {
+    handles.forEach(handle => {
+        const { y, x } = handle.dataset;
+        const coordinate = (y ?? '') + (x ?? '');
+        const directions = ['n', 's', 'e', 'w'];
+        const isSideHandle = directions.indexOf(coordinate) > -1;
+        handle.style.display = isSideHandle && isSmall ? 'none' : '';
     });
 }
 
@@ -748,9 +765,14 @@ function isFixedNumberValue(value: string | number) {
     return !isNaN(numberValue);
 }
 
-function isASmallImage(editInfo: ImageEditInfo): boolean {
-    const { widthPx, heightPx } = editInfo;
-    return widthPx && heightPx && widthPx * widthPx < MAX_SMALL_SIZE_IMAGE ? true : false;
+function isASmallImage(widthPx: number, heightPx: number): boolean {
+    return widthPx &&
+        heightPx &&
+        (widthPx * widthPx < MAX_SMALL_SIZE_IMAGE ||
+            widthPx < MIN_HEIGHT_WIDTH ||
+            heightPx < MIN_HEIGHT_WIDTH)
+        ? true
+        : false;
 }
 
 function getColorString(color: string | ModeIndependentColor, isDarkMode: boolean): string {

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -406,7 +406,7 @@ export default class ImageEdit implements EditorPlugin {
      * quit editing mode when editor lose focus
      */
     private onBlur = () => {
-        // this.setEditingImage(null, false /* selectImage */);
+        this.setEditingImage(null, false /* selectImage */);
     };
     /**
      * Create editing wrapper for the image

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -406,7 +406,7 @@ export default class ImageEdit implements EditorPlugin {
      * quit editing mode when editor lose focus
      */
     private onBlur = () => {
-        this.setEditingImage(null, false /* selectImage */);
+        // this.setEditingImage(null, false /* selectImage */);
     };
     /**
      * Create editing wrapper for the image

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -10,6 +10,7 @@ import { Cropper, getCropHTML } from './imageEditors/Cropper';
 import { deleteEditInfo, getEditInfoFromImage } from './editInfoUtils/editInfo';
 import { getRotateHTML, Rotator, updateRotateHandleState } from './imageEditors/Rotator';
 import { ImageEditElementClass } from './types/ImageEditElementClass';
+import { MIN_HEIGHT_WIDTH } from './constants/constants';
 import { tryToConvertGifToPng } from './editInfoUtils/tryToConvertGifToPng';
 import {
     arrayPush,
@@ -83,11 +84,6 @@ const ImageEditHTMLMap = {
  */
 const LIGHT_MODE_BGCOLOR = 'white';
 const DARK_MODE_BGCOLOR = '#333';
-
-/**
- * The smallest value of hight or width to make side handle and rotate handle visible
- */
-const MIN_HEIGHT_WIDTH = 100;
 
 /**
  * ImageEdit plugin provides the ability to edit an inline image in editor, including image resizing, rotation and cropping

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/constants/constants.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/constants/constants.ts
@@ -1,23 +1,24 @@
 import { DNDDirectionX, DnDDirectionY } from '../types/DragAndDropContext';
 
 export const RESIZE_HANDLE_SIZE = 10;
-export const RESIZE_HANDLE_MARGIN = 3;
+export const RESIZE_HANDLE_MARGIN = 6;
 
 export const ROTATE_SIZE = 32;
 export const ROTATE_GAP = 15;
 export const DEG_PER_RAD = 180 / Math.PI;
 export const DEFAULT_ROTATE_HANDLE_HEIGHT = ROTATE_SIZE / 2 + ROTATE_GAP;
 export const ROTATE_ICON_MARGIN = 8;
-
-export const CROP_HANDLE_SIZE = 22;
-export const CROP_HANDLE_WIDTH = 7;
-export const Xs: DNDDirectionX[] = ['w', 'e'];
-export const Ys: DnDDirectionY[] = ['s', 'n'];
 export const ROTATION: Record<string, number> = {
     sw: 0,
     nw: 90,
     ne: 180,
     se: 270,
 };
+export const ROTATE_WIDTH = 1;
+export const ROTATE_HANDLE_TOP = ROTATE_GAP + RESIZE_HANDLE_MARGIN;
+export const CROP_HANDLE_SIZE = 22;
+export const CROP_HANDLE_WIDTH = 7;
+export const Xs: DNDDirectionX[] = ['w', '', 'e'];
+export const Ys: DnDDirectionY[] = ['s', '', 'n'];
 
 export const MIN_HEIGHT_WIDTH = 3 * RESIZE_HANDLE_SIZE + 2 * RESIZE_HANDLE_MARGIN;

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/constants/constants.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/constants/constants.ts
@@ -1,0 +1,23 @@
+import { DNDDirectionX, DnDDirectionY } from '../types/DragAndDropContext';
+
+export const RESIZE_HANDLE_SIZE = 10;
+export const RESIZE_HANDLE_MARGIN = 3;
+
+export const ROTATE_SIZE = 32;
+export const ROTATE_GAP = 15;
+export const DEG_PER_RAD = 180 / Math.PI;
+export const DEFAULT_ROTATE_HANDLE_HEIGHT = ROTATE_SIZE / 2 + ROTATE_GAP;
+export const ROTATE_ICON_MARGIN = 8;
+
+export const CROP_HANDLE_SIZE = 22;
+export const CROP_HANDLE_WIDTH = 7;
+export const Xs: DNDDirectionX[] = ['w', 'e'];
+export const Ys: DnDDirectionY[] = ['s', 'n'];
+export const ROTATION: Record<string, number> = {
+    sw: 0,
+    nw: 90,
+    ne: 180,
+    se: 270,
+};
+
+export const MIN_HEIGHT_WIDTH = 3 * RESIZE_HANDLE_SIZE + 2 * RESIZE_HANDLE_MARGIN;

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Cropper.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Cropper.ts
@@ -1,20 +1,10 @@
 import DragAndDropContext, { DNDDirectionX, DnDDirectionY } from '../types/DragAndDropContext';
 import DragAndDropHandler from '../../../pluginUtils/DragAndDropHandler';
 import { CreateElementData } from 'roosterjs-editor-types';
+import { CROP_HANDLE_SIZE, CROP_HANDLE_WIDTH, ROTATION, Xs, Ys } from '../constants/constants';
 import { CropInfo } from '../types/ImageEditInfo';
 import { ImageEditElementClass } from '../types/ImageEditElementClass';
 import { rotateCoordinate } from './Resizer';
-
-const CROP_HANDLE_SIZE = 22;
-const CROP_HANDLE_WIDTH = 7;
-const Xs: DNDDirectionX[] = ['w', 'e'];
-const Ys: DnDDirectionY[] = ['s', 'n'];
-const ROTATION: Record<string, number> = {
-    sw: 0,
-    nw: 90,
-    ne: 180,
-    se: 270,
-};
 
 /**
  * @internal

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
@@ -4,6 +4,7 @@ import ImageEditInfo, { ResizeInfo } from '../types/ImageEditInfo';
 import ImageHtmlOptions from '../types/ImageHtmlOptions';
 import { CreateElementData } from 'roosterjs-editor-types';
 import { ImageEditElementClass } from '../types/ImageEditElementClass';
+import { RESIZE_HANDLE_MARGIN, RESIZE_HANDLE_SIZE, Xs, Ys } from '../constants/constants';
 
 /**
  * An optional callback to allow customize resize handle element of image resizing.
@@ -18,10 +19,6 @@ const enum HandleTypes {
     SquareHandles,
     CircularHandlesCorner,
 }
-const RESIZE_HANDLE_SIZE = 10;
-const RESIZE_HANDLE_MARGIN = 3;
-const Xs: DNDDirectionX[] = ['w', '', 'e'];
-const Ys: DnDDirectionY[] = ['s', '', 'n'];
 
 /**
  * @internal

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
@@ -160,7 +160,7 @@ export function getCornerResizeHTML(
 export function getSideResizeHTML(
     { borderColor: resizeBorderColor }: ImageHtmlOptions,
     onShowResizeHandle?: OnShowResizeHandle
-): CreateElementData[] | null {
+): CreateElementData[] {
     const result: CreateElementData[] = [];
     Xs.forEach(x =>
         Ys.forEach(y => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
@@ -161,12 +161,9 @@ export function getCornerResizeHTML(
  * Get HTML for resize handles on the sides
  */
 export function getSideResizeHTML(
-    { borderColor: resizeBorderColor, isSmallImage: isSmallImage }: ImageHtmlOptions,
+    { borderColor: resizeBorderColor }: ImageHtmlOptions,
     onShowResizeHandle?: OnShowResizeHandle
 ): CreateElementData[] | null {
-    if (isSmallImage) {
-        return null;
-    }
     const result: CreateElementData[] = [];
     Xs.forEach(x =>
         Ys.forEach(y => {

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
@@ -4,12 +4,13 @@ import ImageHtmlOptions from '../types/ImageHtmlOptions';
 import { CreateElementData, Rect } from 'roosterjs-editor-types';
 import { ImageEditElementClass } from '../types/ImageEditElementClass';
 import { RotateInfo } from '../types/ImageEditInfo';
-
-const ROTATE_SIZE = 32;
-const ROTATE_GAP = 15;
-const DEG_PER_RAD = 180 / Math.PI;
-const DEFAULT_ROTATE_HANDLE_HEIGHT = ROTATE_SIZE / 2 + ROTATE_GAP;
-const ROTATE_ICON_MARGIN = 8;
+import {
+    DEFAULT_ROTATE_HANDLE_HEIGHT,
+    DEG_PER_RAD,
+    ROTATE_GAP,
+    ROTATE_ICON_MARGIN,
+    ROTATE_SIZE,
+} from '../constants/constants';
 
 /**
  * @internal

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
@@ -44,34 +44,43 @@ export const Rotator: DragAndDropHandler<DragAndDropContext, RotateInfo> = {
  * Move rotate handle. When image is very close to the border of editor, rotate handle may not be visible.
  * Fix it by reduce the distance from image to rotate handle
  */
-export function updateRotateHandlePosition(
+export function updateRotateHandleState(
     editorRect: Rect,
     rotateCenter: HTMLElement,
-    rotateHandle: HTMLElement
+    rotateHandle: HTMLElement,
+    isSmallImage: boolean
 ) {
-    const rotateHandleRect = rotateHandle.getBoundingClientRect();
+    if (isSmallImage) {
+        rotateCenter.style.display = 'none';
+        rotateHandle.style.display = 'none';
+        return;
+    } else {
+        rotateCenter.style.display = '';
+        rotateHandle.style.display = '';
+        const rotateHandleRect = rotateHandle.getBoundingClientRect();
 
-    if (rotateHandleRect) {
-        const top = rotateHandleRect.top - editorRect.top;
-        const left = rotateHandleRect.left - editorRect.left;
-        const right = rotateHandleRect.right - editorRect.right;
-        const bottom = rotateHandleRect.bottom - editorRect.bottom;
-        let adjustedDistance = Number.MAX_SAFE_INTEGER;
-        if (top <= 0) {
-            adjustedDistance = top;
-        } else if (left <= 0) {
-            adjustedDistance = left;
-        } else if (right >= 0) {
-            adjustedDistance = right;
-        } else if (bottom >= 0) {
-            adjustedDistance = bottom;
+        if (rotateHandleRect) {
+            const top = rotateHandleRect.top - editorRect.top;
+            const left = rotateHandleRect.left - editorRect.left;
+            const right = rotateHandleRect.right - editorRect.right;
+            const bottom = rotateHandleRect.bottom - editorRect.bottom;
+            let adjustedDistance = Number.MAX_SAFE_INTEGER;
+            if (top <= 0) {
+                adjustedDistance = top;
+            } else if (left <= 0) {
+                adjustedDistance = left;
+            } else if (right >= 0) {
+                adjustedDistance = right;
+            } else if (bottom >= 0) {
+                adjustedDistance = bottom;
+            }
+
+            const rotateGap = Math.max(Math.min(ROTATE_GAP, adjustedDistance), 0);
+            const rotateTop = Math.max(Math.min(ROTATE_SIZE, adjustedDistance - rotateGap), 0);
+            rotateCenter.style.top = -rotateGap + 'px';
+            rotateCenter.style.height = rotateGap + 'px';
+            rotateHandle.style.top = -rotateTop + 'px';
         }
-
-        const rotateGap = Math.max(Math.min(ROTATE_GAP, adjustedDistance), 0);
-        const rotateTop = Math.max(Math.min(ROTATE_SIZE, adjustedDistance - rotateGap), 0);
-        rotateCenter.style.top = -rotateGap + 'px';
-        rotateCenter.style.height = rotateGap + 'px';
-        rotateHandle.style.top = -rotateTop + 'px';
     }
 }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
@@ -7,9 +7,12 @@ import { RotateInfo } from '../types/ImageEditInfo';
 import {
     DEFAULT_ROTATE_HANDLE_HEIGHT,
     DEG_PER_RAD,
+    RESIZE_HANDLE_MARGIN,
     ROTATE_GAP,
+    ROTATE_HANDLE_TOP,
     ROTATE_ICON_MARGIN,
     ROTATE_SIZE,
+    ROTATE_WIDTH,
 } from '../constants/constants';
 
 /**
@@ -78,7 +81,7 @@ export function updateRotateHandleState(
 
             const rotateGap = Math.max(Math.min(ROTATE_GAP, adjustedDistance), 0);
             const rotateTop = Math.max(Math.min(ROTATE_SIZE, adjustedDistance - rotateGap), 0);
-            rotateCenter.style.top = -rotateGap + 'px';
+            rotateCenter.style.top = -rotateGap - RESIZE_HANDLE_MARGIN + 'px';
             rotateCenter.style.height = rotateGap + 'px';
             rotateHandle.style.top = -rotateTop + 'px';
         }
@@ -98,12 +101,14 @@ export function getRotateHTML({
         {
             tag: 'div',
             className: ImageEditElementClass.RotateCenter,
-            style: `position:absolute;left:50%;width:1px;background-color:${borderColor};top:${-ROTATE_GAP}px;height:${ROTATE_GAP}px;`,
+            style: `position:absolute;left:50%;width:1px;background-color:${borderColor};top:${-ROTATE_HANDLE_TOP}px;height:${ROTATE_GAP}px;margin-left:${-ROTATE_WIDTH}px;`,
             children: [
                 {
                     tag: 'div',
                     className: ImageEditElementClass.RotateHandle,
-                    style: `position:absolute;background-color:${rotateHandleBackColor};border:solid 1px ${borderColor};border-radius:50%;width:${ROTATE_SIZE}px;height:${ROTATE_SIZE}px;left:-${handleLeft}px;cursor:move;top:${-ROTATE_SIZE}px;`,
+                    style: `position:absolute;background-color:${rotateHandleBackColor};border:solid 1px ${borderColor};border-radius:50%;width:${ROTATE_SIZE}px;height:${ROTATE_SIZE}px;left:-${
+                        handleLeft + ROTATE_WIDTH
+                    }px;cursor:move;top:${-ROTATE_SIZE}px;`,
                     children: [getRotateIconHTML(borderColor)],
                 },
             ],

--- a/packages/roosterjs-editor-plugins/test/imageEdit/rotatorTest.ts
+++ b/packages/roosterjs-editor-plugins/test/imageEdit/rotatorTest.ts
@@ -11,7 +11,7 @@ import DragAndDropContext, {
 import {
     getRotateHTML,
     Rotator,
-    updateRotateHandlePosition,
+    updateRotateHandleState,
 } from '../../lib/plugins/ImageEdit/imageEditors/Rotator';
 
 const ROTATE_SIZE = 32;
@@ -140,7 +140,7 @@ describe('updateRotateHandlePosition', () => {
         };
         editorGetVisibleViewport.and.returnValue(viewport);
 
-        updateRotateHandlePosition(viewport, rotateCenter, rotateHandle);
+        updateRotateHandleState(viewport, rotateCenter, rotateHandle, false);
 
         expect(rotateCenter.style.top).toBe(rotateCenterTop);
         expect(rotateCenter.style.height).toBe(rotateCenterHeight);

--- a/packages/roosterjs-editor-plugins/test/imageEdit/rotatorTest.ts
+++ b/packages/roosterjs-editor-plugins/test/imageEdit/rotatorTest.ts
@@ -150,7 +150,7 @@ describe('updateRotateHandlePosition', () => {
     it('adjust rotate handle - ROTATOR HIDDEN ON TOP', () => {
         runTest(
             {
-                top: 1,
+                top: 0,
                 bottom: 3,
                 left: 3,
                 right: 5,
@@ -160,7 +160,7 @@ describe('updateRotateHandlePosition', () => {
                 y: 3,
                 toJSON: () => {},
             },
-            '0px',
+            '-6px',
             '0px',
             '0px'
         );
@@ -179,7 +179,7 @@ describe('updateRotateHandlePosition', () => {
                 y: 3,
                 toJSON: () => {},
             },
-            '-15px',
+            '-21px',
             '15px',
             '-32px'
         );
@@ -190,7 +190,7 @@ describe('updateRotateHandlePosition', () => {
             {
                 top: 2,
                 bottom: 3,
-                left: 1,
+                left: 0,
                 right: 5,
                 height: 2,
                 width: 2,
@@ -198,7 +198,7 @@ describe('updateRotateHandlePosition', () => {
                 y: 3,
                 toJSON: () => {},
             },
-            '0px',
+            '-6px',
             '0px',
             '0px'
         );
@@ -208,7 +208,7 @@ describe('updateRotateHandlePosition', () => {
         runTest(
             {
                 top: 2,
-                bottom: 201,
+                bottom: 200,
                 left: 1,
                 right: 5,
                 height: 2,
@@ -217,7 +217,7 @@ describe('updateRotateHandlePosition', () => {
                 y: 3,
                 toJSON: () => {},
             },
-            '0px',
+            '-6px',
             '0px',
             '0px'
         );
@@ -229,14 +229,14 @@ describe('updateRotateHandlePosition', () => {
                 top: 2,
                 bottom: 3,
                 left: 1,
-                right: 201,
+                right: 200,
                 height: 2,
                 width: 2,
                 x: 1,
                 y: 3,
                 toJSON: () => {},
             },
-            '0px',
+            '-6px',
             '0px',
             '0px'
         );


### PR DESCRIPTION
Update visibility rotate handle and side resize handles according to image size. 
If image has width/height less than the sum of 3 resize handles diameters plus 2 resize margins, hide side resize handles and rotator handle. 

![dynamic_resizer_delight](https://github.com/microsoft/roosterjs/assets/87443959/5f9ebbf4-4850-46f0-bb85-aba68e7458f3)


