### PR TITLE
Fix 218869: Do not allow dragging on readonly content

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
@@ -84,7 +84,8 @@ export default class DOMEventPlugin implements PluginWithState<DOMEventPluginSta
                 });
             },
 
-            // 4. Drop event
+            // 4. Drag and Drop event
+            dragstart: this.onDragStart,
             drop: this.onDrop,
 
             // 5. Focus management
@@ -146,6 +147,14 @@ export default class DOMEventPlugin implements PluginWithState<DOMEventPluginSta
         return this.state;
     }
 
+    private onDragStart = (e: Event) => {
+        const dragEvent = e as DragEvent;
+        const element = this.editor?.getElementAtCursor('*', dragEvent.target as Node);
+
+        if (element && !element.isContentEditable) {
+            dragEvent.preventDefault();
+        }
+    };
     private onDrop = () => {
         this.editor?.runAsync(editor => {
             editor.addUndoSnapshot(() => {}, ChangeSource.Drop);

--- a/packages/roosterjs-editor-core/lib/corePlugins/EntityPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/EntityPlugin.ts
@@ -64,7 +64,6 @@ const REMOVE_ENTITY_OPERATIONS: (EntityOperation | CompatibleEntityOperation)[] 
 export default class EntityPlugin implements PluginWithState<EntityPluginState> {
     private editor: IEditor | null = null;
     private state: EntityPluginState;
-    private disposer: (() => void) | null = null;
 
     /**
      * Construct a new instance of EntityPlugin
@@ -88,15 +87,12 @@ export default class EntityPlugin implements PluginWithState<EntityPluginState> 
      */
     initialize(editor: IEditor) {
         this.editor = editor;
-        this.disposer = this.editor.addDomEventHandler('dragstart', this.onDragStart);
     }
 
     /**
      * Dispose this plugin
      */
     dispose() {
-        this.disposer?.();
-        this.disposer = null;
         this.editor = null;
         this.state.entityMap = {};
     }
@@ -276,18 +272,6 @@ export default class EntityPlugin implements PluginWithState<EntityPluginState> 
             this.triggerEvent(element as HTMLElement, EntityOperation.ReplaceTemporaryContent);
         });
     }
-
-    private onDragStart = (e: Event) => {
-        const dragEvent = e as DragEvent;
-        const entityWrapper = this.editor?.getElementAtCursor(
-            getEntitySelector(),
-            dragEvent.target as Node
-        );
-
-        if (entityWrapper && getEntityFromElement(entityWrapper)?.isReadonly) {
-            dragEvent.preventDefault();
-        }
-    };
 
     private checkRemoveEntityForRange(event: Event) {
         const editableEntityElements: HTMLElement[] = [];

--- a/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
@@ -20,25 +20,17 @@ describe('EntityPlugin', () => {
     let triggerPluginEvent: jasmine.Spy;
     let state: EntityPluginState;
     let editor: IEditor;
-    let addDomEventHandler: jasmine.Spy;
-    let onDragStartFunc: (e: any) => void;
 
     beforeEach(() => {
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
         plugin = new EntityPlugin();
         state = plugin.getState();
-        addDomEventHandler = jasmine
-            .createSpy('addDomEventHandler')
-            .and.callFake((eventName, onDragStart) => {
-                onDragStartFunc = onDragStart;
-            });
         editor = <IEditor>(<any>{
             getDocument: () => document,
             getElementAtCursor: (selector: string, node: Node) => node,
             addContentEditFeature: () => {},
             triggerPluginEvent,
             isFeatureEnabled: () => false,
-            addDomEventHandler,
         });
         plugin.initialize(editor);
     });
@@ -661,37 +653,5 @@ describe('EntityPlugin', () => {
                 },
             });
         });
-    });
-
-    it('Do Not allow dragging readonly entity', () => {
-        const wrapper = document.createElement('div');
-        const preventDefault = jasmine.createSpy('preventDefault');
-
-        commitEntity.default(wrapper, 'TestEntity', true);
-
-        expect(addDomEventHandler).toHaveBeenCalledTimes(1);
-        expect(addDomEventHandler.calls.argsFor(0)[0]).toBe('dragstart');
-
-        onDragStartFunc({
-            target: wrapper,
-            preventDefault,
-        });
-
-        expect(preventDefault).toHaveBeenCalledTimes(1);
-    });
-
-    it('Still allow dragging when click normal node', () => {
-        const wrapper = document.createElement('div');
-        const preventDefault = jasmine.createSpy('preventDefault');
-
-        expect(addDomEventHandler).toHaveBeenCalledTimes(1);
-        expect(addDomEventHandler.calls.argsFor(0)[0]).toBe('dragstart');
-
-        onDragStartFunc({
-            target: wrapper,
-            preventDefault,
-        });
-
-        expect(preventDefault).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
[Bug 218869](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/218869): [Beautiful link]Dragging beautiful link will duplicate it

In my change #1898 I disabled dragging an entity.

But actually there are other cases that readonly content can exist without an entity. So we should disable dragging readonly element instead.