### PR TITLE
MergeModel, do not inherit the styles of table when splitting the param

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
@@ -287,7 +287,7 @@ function splitParagraph(markerPosition: InsertPoint, newParaFormat: ContentModel
 
 function insertBlock(markerPosition: InsertPoint, block: ContentModelBlock) {
     const { path } = markerPosition;
-    const newParaFormat = block.blockType === 'Table' ? {} : block.format;
+    const newParaFormat = block.blockType !== 'Paragraph' ? {} : block.format;
     const newPara = splitParagraph(markerPosition, newParaFormat);
     const blockIndex = path[0].blocks.indexOf(newPara);
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
@@ -287,7 +287,8 @@ function splitParagraph(markerPosition: InsertPoint, newParaFormat: ContentModel
 
 function insertBlock(markerPosition: InsertPoint, block: ContentModelBlock) {
     const { path } = markerPosition;
-    const newPara = splitParagraph(markerPosition, block.format);
+    const newParaFormat = block.blockType === 'Table' ? {} : block.format;
+    const newPara = splitParagraph(markerPosition, newParaFormat);
     const blockIndex = path[0].blocks.indexOf(newPara);
 
     if (blockIndex >= 0) {

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
@@ -5,6 +5,7 @@ import { mergeModel } from '../../../lib/modelApi/common/mergeModel';
 import {
     createContentModelDocument,
     createDivider,
+    createEntity,
     createListItem,
     createListLevel,
     createParagraph,
@@ -2517,6 +2518,273 @@ describe('mergeModel', () => {
                     },
                     widths: [],
                     dataset: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        { segmentType: 'Text', text: 'test2', format: {} },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Arial',
+                        fontSize: '15px',
+                        backgroundColor: 'red',
+                        textColor: 'blue',
+                        italic: false,
+                    },
+                },
+            ],
+        });
+    });
+
+    it('Merge Divider with styles into paragraph, paragraph after table should not inherit styles from table', () => {
+        const majorModel = createContentModelDocument();
+        const para1 = createParagraph(false, undefined, {
+            fontFamily: 'Arial',
+            fontSize: '15px',
+            backgroundColor: 'red',
+            textColor: 'blue',
+            italic: false,
+        });
+        const marker = createSelectionMarker();
+        const text1 = createText('test1');
+        const text2 = createText('test2');
+
+        para1.segments.push(text1, marker, text2);
+        majorModel.blocks.push(para1);
+
+        const sourceModel: ContentModelDocument = createContentModelDocument();
+        const newDiv = createDivider('div', {
+            textAlign: 'start',
+            whiteSpace: 'normal',
+            borderTop: '1px solid black',
+            borderRight: '1px solid black',
+            borderBottom: '1px solid black',
+            borderLeft: '1px solid black',
+            backgroundColor: 'rgb(255, 255, 255)',
+        });
+
+        sourceModel.blocks.push(newDiv);
+        mergeModel(majorModel, sourceModel);
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Text', text: 'test1', format: {} }],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Arial',
+                        fontSize: '15px',
+                        backgroundColor: 'red',
+                        textColor: 'blue',
+                        italic: false,
+                    },
+                },
+                {
+                    blockType: 'Divider',
+                    tagName: 'div',
+                    format: {
+                        textAlign: 'start',
+                        whiteSpace: 'normal',
+                        borderTop: '1px solid black',
+                        borderRight: '1px solid black',
+                        borderBottom: '1px solid black',
+                        borderLeft: '1px solid black',
+                        backgroundColor: 'rgb(255, 255, 255)',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        { segmentType: 'Text', text: 'test2', format: {} },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Arial',
+                        fontSize: '15px',
+                        backgroundColor: 'red',
+                        textColor: 'blue',
+                        italic: false,
+                    },
+                },
+            ],
+        });
+    });
+
+    it('Merge ListItem with styles into paragraph, paragraph after table should not inherit styles from table', () => {
+        const majorModel = createContentModelDocument();
+        const para1 = createParagraph(false, undefined, {
+            fontFamily: 'Arial',
+            fontSize: '15px',
+            backgroundColor: 'red',
+            textColor: 'blue',
+            italic: false,
+        });
+        const marker = createSelectionMarker();
+        const text1 = createText('test1');
+        const text2 = createText('test2');
+
+        para1.segments.push(text1, marker, text2);
+        majorModel.blocks.push(para1);
+
+        const sourceModel: ContentModelDocument = createContentModelDocument();
+        const newList = createListItem([
+            createListLevel('OL', {
+                marginBottom: '100px',
+            }),
+        ]);
+        const para2 = createParagraph(false, undefined, {
+            fontFamily: 'Arial',
+            fontSize: '15px',
+            backgroundColor: 'red',
+            textColor: 'blue',
+            italic: false,
+        });
+        const text3 = createText('test1');
+        newList.blocks.push(para2);
+        para2.segments.push(text3);
+
+        sourceModel.blocks.push(newList);
+        mergeModel(majorModel, sourceModel);
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Text', text: 'test1', format: {} }],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Arial',
+                        fontSize: '15px',
+                        backgroundColor: 'red',
+                        textColor: 'blue',
+                        italic: false,
+                    },
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [{ segmentType: 'Text', text: 'test1', format: {} }],
+                            format: {},
+                            segmentFormat: {
+                                fontFamily: 'Arial',
+                                fontSize: '15px',
+                                backgroundColor: 'red',
+                                textColor: 'blue',
+                                italic: false,
+                            },
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: { marginBottom: '100px' },
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        { segmentType: 'Text', text: 'test2', format: {} },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Arial',
+                        fontSize: '15px',
+                        backgroundColor: 'red',
+                        textColor: 'blue',
+                        italic: false,
+                    },
+                },
+            ],
+        });
+    });
+
+    it('Merge Entity with styles into paragraph, paragraph after table should not inherit styles from table', () => {
+        const majorModel = createContentModelDocument();
+        const para1 = createParagraph(false, undefined, {
+            fontFamily: 'Arial',
+            fontSize: '15px',
+            backgroundColor: 'red',
+            textColor: 'blue',
+            italic: false,
+        });
+        const marker = createSelectionMarker();
+        const text1 = createText('test1');
+        const text2 = createText('test2');
+
+        para1.segments.push(text1, marker, text2);
+        majorModel.blocks.push(para1);
+
+        const sourceModel: ContentModelDocument = createContentModelDocument();
+        const newEntity = createEntity(document.createElement('div'), false, {
+            fontFamily: 'Corbel',
+            fontSize: '20px',
+            backgroundColor: 'blue',
+            textColor: 'aliceblue',
+            italic: true,
+        });
+
+        sourceModel.blocks.push(newEntity);
+        mergeModel(majorModel, sourceModel);
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Text', text: 'test1', format: {} }],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Arial',
+                        fontSize: '15px',
+                        backgroundColor: 'red',
+                        textColor: 'blue',
+                        italic: false,
+                    },
+                },
+                {
+                    segmentType: 'Entity',
+                    blockType: 'Entity',
+                    format: {
+                        fontFamily: 'Corbel',
+                        fontSize: '20px',
+                        backgroundColor: 'blue',
+                        textColor: 'aliceblue',
+                        italic: true,
+                    },
+                    id: undefined,
+                    type: undefined,
+                    isReadonly: false,
+                    wrapper: newEntity.wrapper,
                 },
                 {
                     blockType: 'Paragraph',

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
@@ -2418,4 +2418,127 @@ describe('mergeModel', () => {
             ],
         });
     });
+
+    it('Merge Table with styles into paragraph, paragraph after table should not inherit styles from table', () => {
+        const majorModel = createContentModelDocument();
+        const para1 = createParagraph(false, undefined, {
+            fontFamily: 'Arial',
+            fontSize: '15px',
+            backgroundColor: 'red',
+            textColor: 'blue',
+            italic: false,
+        });
+        const marker = createSelectionMarker();
+        const text1 = createText('test1');
+        const text2 = createText('test2');
+
+        para1.segments.push(text1, marker, text2);
+        majorModel.blocks.push(para1);
+
+        const sourceModel: ContentModelDocument = createContentModelDocument();
+
+        const newPara1 = createParagraph();
+        const newText1 = createText('newText1');
+        const newCell1 = createTableCell(false, false);
+        const newTable1 = createTable(1, {
+            textAlign: 'start',
+            whiteSpace: 'normal',
+            borderTop: '1px solid black',
+            borderRight: '1px solid black',
+            borderBottom: '1px solid black',
+            borderLeft: '1px solid black',
+            backgroundColor: 'rgb(255, 255, 255)',
+            useBorderBox: true,
+            borderCollapse: true,
+        });
+
+        newPara1.segments.push(newText1);
+        newCell1.blocks.push(newPara1);
+        newTable1.rows[0].cells.push(newCell1);
+        sourceModel.blocks.push(newTable1);
+
+        mergeModel(majorModel, sourceModel);
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Text', text: 'test1', format: {} }],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Arial',
+                        fontSize: '15px',
+                        backgroundColor: 'red',
+                        textColor: 'blue',
+                        italic: false,
+                    },
+                },
+                {
+                    blockType: 'Table',
+                    rows: [
+                        {
+                            height: 0,
+                            format: {},
+                            cells: [
+                                {
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Text',
+                                                    text: 'newText1',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    spanLeft: false,
+                                    spanAbove: false,
+                                    isHeader: false,
+                                    dataset: {},
+                                },
+                            ],
+                        },
+                    ],
+                    format: {
+                        textAlign: 'start',
+                        whiteSpace: 'normal',
+                        borderTop: '1px solid black',
+                        borderRight: '1px solid black',
+                        borderBottom: '1px solid black',
+                        borderLeft: '1px solid black',
+                        backgroundColor: 'rgb(255, 255, 255)',
+                        useBorderBox: true,
+                        borderCollapse: true,
+                    },
+                    widths: [],
+                    dataset: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        { segmentType: 'Text', text: 'test2', format: {} },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Arial',
+                        fontSize: '15px',
+                        backgroundColor: 'red',
+                        textColor: 'blue',
+                        italic: false,
+                    },
+                },
+            ],
+        });
+    });
 });

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
@@ -2542,7 +2542,7 @@ describe('mergeModel', () => {
         });
     });
 
-    it('Merge Divider with styles into paragraph, paragraph after table should not inherit styles from table', () => {
+    it('Merge Divider with styles into paragraph, paragraph after table should not inherit styles from Divider', () => {
         const majorModel = createContentModelDocument();
         const para1 = createParagraph(false, undefined, {
             fontFamily: 'Arial',
@@ -2623,7 +2623,7 @@ describe('mergeModel', () => {
         });
     });
 
-    it('Merge ListItem with styles into paragraph, paragraph after table should not inherit styles from table', () => {
+    it('Merge ListItem with styles into paragraph, paragraph after table should not inherit styles from ListItem', () => {
         const majorModel = createContentModelDocument();
         const para1 = createParagraph(false, undefined, {
             fontFamily: 'Arial',
@@ -2728,7 +2728,7 @@ describe('mergeModel', () => {
         });
     });
 
-    it('Merge Entity with styles into paragraph, paragraph after table should not inherit styles from table', () => {
+    it('Merge Entity with styles into paragraph, paragraph after table should not inherit styles from Entity', () => {
         const majorModel = createContentModelDocument();
         const para1 = createParagraph(false, undefined, {
             fontFamily: 'Arial',


### PR DESCRIPTION
#2015
We should not add the table format when splitting the paragraph, as this can lead to border styles to be incorrectly applied to the splitted pagraph

Before
![image](https://github.com/microsoft/roosterjs/assets/8291124/ec88331e-8f5c-4aa4-8bf4-ed42ad2433a5)

After
![image](https://github.com/microsoft/roosterjs/assets/8291124/e1059eac-11bd-430f-916b-5acc253e7058)
