### PR TITLE
Demo site: Fix insert link button in Content Model ribbon

### DIFF
--- a/demo/scripts/controls/ribbonButtons/contentModel/insertLinkButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/insertLinkButton.ts
@@ -1,5 +1,5 @@
-import showInputDialog from 'roosterjs-react/lib/inputDialog/utils/showInputDialog';
 import { InsertLinkButtonStringKey, RibbonButton } from 'roosterjs-react';
+import { showInputDialog } from 'roosterjs-react/lib/inputDialog';
 import {
     adjustLinkSelection,
     insertLink,

--- a/packages-ui/roosterjs-react/lib/index.ts
+++ b/packages-ui/roosterjs-react/lib/index.ts
@@ -5,3 +5,4 @@ export * from './contextMenu/index';
 export * from './pasteOptions/index';
 export * from './colorPicker/index';
 export * from './emoji/index';
+export * from './inputDialog/index';

--- a/packages-ui/roosterjs-react/lib/inputDialog/index.ts
+++ b/packages-ui/roosterjs-react/lib/inputDialog/index.ts
@@ -1,0 +1,2 @@
+export { default as showInputDialog } from './utils/showInputDialog';
+export { default as DialogItem } from './type/DialogItem';

--- a/packages-ui/roosterjs-react/lib/inputDialog/type/DialogItem.ts
+++ b/packages-ui/roosterjs-react/lib/inputDialog/type/DialogItem.ts
@@ -1,9 +1,24 @@
 /**
- * @internal
+ * Item of input dialog
  */
 export default interface DialogItem<Strings extends string> {
+    /**
+     * Localized string key of the input item name
+     */
     labelKey: Strings | null;
+
+    /**
+     * Unlocalized string for the label text. This will be used when a valid localized string is not found using the given string key
+     */
     unlocalizedLabel: string | null;
+
+    /**
+     * Initial value of this item
+     */
     initValue: string;
+
+    /**
+     * Whether focus should be put into this item automatically
+     */
     autoFocus?: boolean;
 }

--- a/packages-ui/roosterjs-react/lib/inputDialog/utils/showInputDialog.tsx
+++ b/packages-ui/roosterjs-react/lib/inputDialog/utils/showInputDialog.tsx
@@ -10,7 +10,13 @@ import {
 } from '../../common/index';
 
 /**
- * @internal
+ * Show a dialog with input items
+ * @param uiUtilities UI utilities to help render the dialog
+ * @param dialogTitleKey Localized string key for title of this dialog
+ * @param unlocalizedTitle Unlocalized title string of this dialog. It will be used if a valid localized string is not found using dialogTitleKey
+ * @param items Input items in this dialog
+ * @param strings Localized strings
+ * @param onChange An optional callback that will be invoked when input item value is changed
  */
 export default function showInputDialog<Strings extends string, ItemNames extends string>(
     uiUtilities: UIUtilities,


### PR DESCRIPTION
I found that all dialogs from Content Model demo site are broken, because we split roosterjs-react code out of demo site code, and the input dialog function is not exported, so during runtime the input dialog function can't be found.

Fix: export input dialog function and related types from roosterjs-react.