### PR TITLE
Fix flipped image

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -432,11 +432,6 @@ export default class ImageEdit implements EditorPlugin {
             // Set image src to original src to help show editing UI, also it will be used when regenerate image dataURL after editing
             if (this.clonedImage) {
                 this.clonedImage.src = this.pngSource ?? this.editInfo.src;
-                setFlipped(
-                    this.clonedImage,
-                    this.editInfo.flippedHorizontal,
-                    this.editInfo.flippedVertical
-                );
                 this.clonedImage.style.position = 'absolute';
             }
 
@@ -525,6 +520,8 @@ export default class ImageEdit implements EditorPlugin {
                 leftPercent,
                 rightPercent,
                 topPercent,
+                flippedHorizontal,
+                flippedVertical,
             } = this.editInfo;
 
             // Width/height of the image
@@ -556,6 +553,9 @@ export default class ImageEdit implements EditorPlugin {
             // Update size of the image
             this.clonedImage.style.width = getPx(originalWidth);
             this.clonedImage.style.height = getPx(originalHeight);
+
+            //Update flip direction
+            setFlipped(this.clonedImage.parentElement, flippedHorizontal, flippedVertical);
 
             if (this.isCropping) {
                 // For crop, we also need to set position of the overlays
@@ -777,11 +777,13 @@ function getColorString(color: string | ModeIndependentColor, isDarkMode: boolea
 }
 
 function setFlipped(
-    element: HTMLImageElement,
+    element: HTMLElement | null,
     flippedHorizontally?: boolean,
     flippedVertically?: boolean
 ) {
-    element.style.transform = `scale(${flippedHorizontally ? '-1' : '1'}, ${
-        flippedVertically ? '-1' : '1'
-    })`;
+    if (element) {
+        element.style.transform = `scale(${flippedHorizontally ? -1 : 1}, ${
+            flippedVertically ? -1 : 1
+        })`;
+    }
 }


### PR DESCRIPTION
When flip a cropped picture, the cloned image was not being cropped in the right position. Therefore, the wrapper should resized before flip the parent of cloned image cloned image, so the visible part of image match the part that was cropped. 

**Before:** 
![bugFlip](https://github.com/microsoft/roosterjs/assets/87443959/1a2d0daf-64cd-4f44-ba68-b684e017f75d)


**After:** 
![fixFlip](https://github.com/microsoft/roosterjs/assets/87443959/5fe36bb5-f75e-4ca9-859d-21627ced1144)
