### PR TITLE
Replace first cell content if input while on cell selection

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -93,6 +93,13 @@ export default class TableCellSelection implements EditorPlugin {
                         event.rawEvent.preventDefault();
                     }
                     break;
+                case PluginEventType.Input:
+                    if (!this.state.startedSelection) {
+                        this.handleInputEvent(this.editor);
+                    } else {
+                        event.rawEvent.preventDefault();
+                    }
+                    break;
                 case PluginEventType.Scroll:
                     if (this.state.startedSelection) {
                         handleScrollEvent(this.state, this.editor);
@@ -126,5 +133,19 @@ export default class TableCellSelection implements EditorPlugin {
             state.tableSelection = true;
             editor.select(selection.table, null);
         }
+    }
+
+    private handleInputEvent(editor: IEditor) {
+        // If typing on any cell selection, clear the first cell
+        const range = editor.getSelectionRangeEx();
+        if (range.type == SelectionRangeTypes.TableSelection) {
+            const row = range.ranges[0];
+            const firstCell = row.startContainer.childNodes[row.startOffset];
+            firstCell.childNodes.forEach(node => {
+                node.remove();
+            });
+        }
+        // Add undo snapshot after content deletion
+        editor.addUndoSnapshot();
     }
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -93,13 +93,6 @@ export default class TableCellSelection implements EditorPlugin {
                         event.rawEvent.preventDefault();
                     }
                     break;
-                case PluginEventType.Input:
-                    if (!this.state.startedSelection) {
-                        this.handleInputEvent(this.editor);
-                    } else {
-                        event.rawEvent.preventDefault();
-                    }
-                    break;
                 case PluginEventType.Scroll:
                     if (this.state.startedSelection) {
                         handleScrollEvent(this.state, this.editor);
@@ -133,19 +126,5 @@ export default class TableCellSelection implements EditorPlugin {
             state.tableSelection = true;
             editor.select(selection.table, null);
         }
-    }
-
-    private handleInputEvent(editor: IEditor) {
-        // If typing on any cell selection, clear the first cell
-        const range = editor.getSelectionRangeEx();
-        if (range.type == SelectionRangeTypes.TableSelection) {
-            const row = range.ranges[0];
-            const firstCell = row.startContainer.childNodes[row.startOffset];
-            firstCell.childNodes.forEach(node => {
-                node.remove();
-            });
-        }
-        // Add undo snapshot after content deletion
-        editor.addUndoSnapshot();
     }
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyDownEvent.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyDownEvent.ts
@@ -73,7 +73,13 @@ export function handleKeyDownEvent(
         editor.getSelectionRangeEx()?.type == SelectionRangeTypes.TableSelection &&
         (!isCtrlOrMetaPressed(event.rawEvent) || which == Keys.HOME || which == Keys.END)
     ) {
-        editor.select(null);
+        // Collapse selection to first selected cell
+        const range = editor.getSelectionRangeEx();
+        if (range.type == SelectionRangeTypes.TableSelection) {
+            const row = range.ranges[0];
+            const firstCell = row.startContainer.childNodes[row.startOffset];
+            editor.select(firstCell);
+        }
     }
 }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyDownEvent.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyDownEvent.ts
@@ -39,7 +39,6 @@ export function handleKeyDownEvent(
     }
 
     const range = editor.getSelectionRangeEx();
-
     if (shiftKey) {
         if (!state.firstTarget) {
             const pos = editor.getFocusedPosition();

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyDownEvent.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyDownEvent.ts
@@ -9,6 +9,7 @@ import { TableCellSelectionState } from '../TableCellSelectionState';
 import { updateSelection } from '../utils/updateSelection';
 import {
     contains,
+    createRange,
     isCtrlOrMetaPressed,
     Position,
     safeInstanceOf,
@@ -36,6 +37,8 @@ export function handleKeyDownEvent(
         state.preventKeyUp = defaultPrevented;
         return;
     }
+
+    const range = editor.getSelectionRangeEx();
 
     if (shiftKey) {
         if (!state.firstTarget) {
@@ -70,16 +73,15 @@ export function handleKeyDownEvent(
             }
         });
     } else if (
-        editor.getSelectionRangeEx()?.type == SelectionRangeTypes.TableSelection &&
+        range?.type == SelectionRangeTypes.TableSelection &&
         (!isCtrlOrMetaPressed(event.rawEvent) || which == Keys.HOME || which == Keys.END)
     ) {
-        // Collapse selection to first selected cell
-        const range = editor.getSelectionRangeEx();
-        if (range.type == SelectionRangeTypes.TableSelection) {
-            const row = range.ranges[0];
-            const firstCell = row.startContainer.childNodes[row.startOffset];
-            editor.select(firstCell);
-        }
+        // Select all content in the first cell
+        const row = range.ranges[0];
+        const firstCell = row.startContainer.childNodes[row.startOffset];
+        const children = firstCell.childNodes;
+        const contentRange = createRange(children[0], children[children.length - 1]);
+        editor.select(contentRange);
     }
 }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyUpEvent.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyUpEvent.ts
@@ -26,7 +26,7 @@ export function handleKeyUpEvent(
         !state.preventKeyUp &&
         IGNORE_KEY_UP_KEYS.indexOf(which) == -1
     ) {
-        clearState(state, editor);
+        editor.addUndoSnapshot(() => clearState(state, editor));
     }
     state.preventKeyUp = false;
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyUpEvent.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyUpEvent.ts
@@ -1,5 +1,6 @@
 import { clearState } from '../utils/clearState';
 import { IEditor, Keys, PluginKeyUpEvent } from 'roosterjs-editor-types';
+import { isCharacterValue } from 'roosterjs-editor-dom/lib';
 import { TableCellSelectionState } from '../TableCellSelectionState';
 
 const IGNORE_KEY_UP_KEYS = [
@@ -26,6 +27,9 @@ export function handleKeyUpEvent(
         !state.preventKeyUp &&
         IGNORE_KEY_UP_KEYS.indexOf(which) == -1
     ) {
+        if (isCharacterValue(event.rawEvent)) {
+            editor.addUndoSnapshot();
+        }
         clearState(state, editor);
     }
     state.preventKeyUp = false;

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyUpEvent.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyUpEvent.ts
@@ -26,7 +26,7 @@ export function handleKeyUpEvent(
         !state.preventKeyUp &&
         IGNORE_KEY_UP_KEYS.indexOf(which) == -1
     ) {
-        editor.addUndoSnapshot(() => clearState(state, editor));
+        clearState(state, editor);
     }
     state.preventKeyUp = false;
 }

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyUpEvent.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyUpEvent.ts
@@ -1,6 +1,6 @@
 import { clearState } from '../utils/clearState';
 import { IEditor, Keys, PluginKeyUpEvent } from 'roosterjs-editor-types';
-import { isCharacterValue } from 'roosterjs-editor-dom/lib';
+import { isCharacterValue } from 'roosterjs-editor-dom';
 import { TableCellSelectionState } from '../TableCellSelectionState';
 
 const IGNORE_KEY_UP_KEYS = [


### PR DESCRIPTION
### Description:

Fix of #2023 

Writing on a selected cell, or group of cells, does not replace the content of the first cell as expected.

### Fix

On the TableCellSelection plugin, the handle key down event used to end the cell selection when typing. Now it makes only the first cell selected and creates a new selection of all its children.

### Cases tested:

1. Create a table
2. Select one or more cells
3. Type something

**Before:** The place where the cursor was placed is where the typed text will be inserted.

**After:** The first cell in the selection, top left one, will be cleared and the typed text will be inserted.

### Warnings and implications

- Keys like the function keys and Caps Lock will end cell selections. This behaviour exits before this change. However for the case of typing, after pressing said keys the full contents of the cell will still be selected, so typing and replacing the content should not be affected.