### PR TITLE
Content Model: Fix 219312

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/tableProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/tableProcessor.ts
@@ -3,6 +3,7 @@ import { createTable } from '../../modelApi/creators/createTable';
 import { createTableCell } from '../../modelApi/creators/createTableCell';
 import { getBoundingClientRect } from '../utils/getBoundingClientRect';
 import { parseFormat } from '../utils/parseFormat';
+import { safeInstanceOf } from 'roosterjs-editor-dom';
 import { SelectionRangeTypes } from 'roosterjs-editor-types';
 import { stackFormat } from '../utils/stackFormat';
 import {
@@ -74,7 +75,11 @@ export const tableProcessor: ElementProcessor<HTMLTableElement> = (
                 const tr = tableElement.rows[row];
                 const tableRow = table.rows[row];
 
-                if (context.allowCacheElement) {
+                const tbody = tr.parentNode;
+
+                if (safeInstanceOf(tbody, 'HTMLTableSectionElement')) {
+                    parseFormat(tbody, context.formatParsers.tableRow, tableRow.format, context);
+                } else if (context.allowCacheElement) {
                     tableRow.cachedElement = tr;
                 }
 

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/tableProcessorTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/tableProcessorTest.ts
@@ -1239,4 +1239,58 @@ describe('tableProcessor', () => {
             ],
         });
     });
+
+    it('Respect background on tbody', () => {
+        const group = createContentModelDocument();
+        const table = document.createElement('table');
+        const tbody = document.createElement('tbody');
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+
+        tbody.style.backgroundColor = 'red';
+
+        table.appendChild(tbody);
+        tbody.appendChild(tr);
+        tr.appendChild(td);
+
+        childProcessor.and.callFake(() => {
+            expect(context.blockFormat).toEqual({});
+            expect(context.segmentFormat).toEqual({});
+        });
+
+        tableProcessor(group, table, context);
+
+        expect(childProcessor).toHaveBeenCalledTimes(1);
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Table',
+                    widths: [100],
+                    dataset: {},
+
+                    rows: [
+                        {
+                            format: {
+                                backgroundColor: 'red',
+                            },
+                            height: 200,
+                            cells: [
+                                {
+                                    blockGroupType: 'TableCell',
+                                    blocks: [],
+                                    format: {},
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    dataset: {},
+                                },
+                            ],
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
[Bug 219312](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/219312):  When deleting a column in a table, header of the table is also get deleted.

This is actually a content fidelity issue. Mini repro:
```html
<table style="box-sizing: border-box; width: 28.75px; height: 24.6667px;"><tbody style="background-color:red"><tr><td style="box-sizing: border-box; width: 24.75px; height: 20.6667px;">test</td></tr></tbody></table><!--{"type":0,"isDarkMode":false,"start":[0,0,0,0,0,2],"end":[0,0,0,0,0,2]}-->
```
When rewrite with content model, the background color is gone.

Fix: Parse and respect the background color from THEAD/TBODY/TFOOT if any.

Related test case aded