### PR TITLE
Simplify the domToModel call in `paste.ts`

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/ContentModelPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/ContentModelPastePlugin.ts
@@ -1,5 +1,7 @@
 import addParser from './utils/addParser';
 import ContentModelBeforePasteEvent from '../../../publicTypes/event/ContentModelBeforePasteEvent';
+import { ContentModelBlockFormat } from 'roosterjs-content-model-types/lib/format/ContentModelBlockFormat';
+import { FormatParser } from 'roosterjs-content-model-types/lib/context/DomToModelSettings';
 import { getPasteSource } from 'roosterjs-editor-dom';
 import { IContentModelEditor } from '../../../publicTypes/IContentModelEditor';
 import { parseDeprecatedColor } from './utils/deprecatedColorParser';
@@ -8,6 +10,7 @@ import { processPastedContentFromExcel } from './Excel/processPastedContentFromE
 import { processPastedContentFromPowerPoint } from './PowerPoint/processPastedContentFromPowerPoint';
 import { processPastedContentFromWordDesktop } from './WordDesktop/processPastedContentFromWordDesktop';
 import { processPastedContentWacComponents } from './WacComponents/processPastedContentWacComponents';
+import { setProcessor } from './utils/setProcessor';
 import {
     EditorPlugin,
     IEditor,
@@ -107,6 +110,23 @@ export default class ContentModelPastePlugin implements EditorPlugin {
         addParser(ev.domToModelOption, 'link', parseLink);
         parseDeprecatedColor(ev.sanitizingOption);
 
+        if (event.pasteType === PasteType.MergeFormat) {
+            addParser(ev.domToModelOption, 'block', blockElementParser);
+            addParser(ev.domToModelOption, 'listItem', blockElementParser);
+        }
+
         event.sanitizingOption.unknownTagReplacement = this.unknownTagReplacement;
     }
 }
+
+/**
+ * For block elements that have background color style, remove the background color when user selects the merge current format
+ * paste option
+ */
+const blockElementParser: FormatParser<ContentModelBlockFormat> = (
+    format: ContentModelBlockFormat
+) => {
+    if (format.backgroundColor) {
+        delete format.backgroundColor;
+    }
+};

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/ContentModelPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/ContentModelPastePlugin.ts
@@ -1,7 +1,6 @@
 import addParser from './utils/addParser';
 import ContentModelBeforePasteEvent from '../../../publicTypes/event/ContentModelBeforePasteEvent';
-import { ContentModelBlockFormat } from 'roosterjs-content-model-types/lib/format/ContentModelBlockFormat';
-import { FormatParser } from 'roosterjs-content-model-types/lib/context/DomToModelSettings';
+import { ContentModelBlockFormat, FormatParser } from 'roosterjs-content-model-types';
 import { getPasteSource } from 'roosterjs-editor-dom';
 import { IContentModelEditor } from '../../../publicTypes/IContentModelEditor';
 import { parseDeprecatedColor } from './utils/deprecatedColorParser';
@@ -10,7 +9,6 @@ import { processPastedContentFromExcel } from './Excel/processPastedContentFromE
 import { processPastedContentFromPowerPoint } from './PowerPoint/processPastedContentFromPowerPoint';
 import { processPastedContentFromWordDesktop } from './WordDesktop/processPastedContentFromWordDesktop';
 import { processPastedContentWacComponents } from './WacComponents/processPastedContentWacComponents';
-import { setProcessor } from './utils/setProcessor';
 import {
     EditorPlugin,
     IEditor,
@@ -112,7 +110,7 @@ export default class ContentModelPastePlugin implements EditorPlugin {
 
         if (event.pasteType === PasteType.MergeFormat) {
             addParser(ev.domToModelOption, 'block', blockElementParser);
-            addParser(ev.domToModelOption, 'listItem', blockElementParser);
+            addParser(ev.domToModelOption, 'listLevel', blockElementParser);
         }
 
         event.sanitizingOption.unknownTagReplacement = this.unknownTagReplacement;
@@ -124,9 +122,10 @@ export default class ContentModelPastePlugin implements EditorPlugin {
  * paste option
  */
 const blockElementParser: FormatParser<ContentModelBlockFormat> = (
-    format: ContentModelBlockFormat
+    format: ContentModelBlockFormat,
+    element: HTMLElement
 ) => {
-    if (format.backgroundColor) {
+    if (element.style.backgroundColor) {
         delete format.backgroundColor;
     }
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/paste.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/paste.ts
@@ -70,20 +70,7 @@ export default function paste(
         eventData
     );
 
-    const pasteModel = domToContentModel(fragment, {
-        ...domToModelOption,
-        additionalFormatParsers: {
-            ...domToModelOption.additionalFormatParsers,
-            block: [
-                ...(domToModelOption.additionalFormatParsers?.block || []),
-                ...(applyCurrentFormat ? [blockElementParser] : []),
-            ],
-            listLevel: [
-                ...(domToModelOption.additionalFormatParsers?.listLevel || []),
-                ...(applyCurrentFormat ? [blockElementParser] : []),
-            ],
-        },
-    });
+    const pasteModel = domToContentModel(fragment, domToModelOption);
 
     if (pasteModel) {
         formatWithContentModel(
@@ -214,17 +201,3 @@ function triggerPluginEventAndCreatePasteFragment(
 
     return pluginEvent || eventData;
 }
-
-/**
- * For block elements that have background color style, remove the background color when user selects the merge current format
- * paste option
- */
-const blockElementParser: FormatParser<ContentModelBlockFormat> = (
-    format: ContentModelBlockFormat,
-    element: HTMLElement
-) => {
-    if (element.style.backgroundColor) {
-        element.style.backgroundColor = '';
-        delete format.backgroundColor;
-    }
-};

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/paste.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/paste.ts
@@ -4,11 +4,7 @@ import { FormatWithContentModelContext } from '../../publicTypes/parameter/Forma
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { mergeModel } from '../../modelApi/common/mergeModel';
 import { NodePosition } from 'roosterjs-editor-types';
-import {
-    ContentModelBlockFormat,
-    ContentModelDocument,
-    FormatParser,
-} from 'roosterjs-content-model-types';
+import { ContentModelDocument } from 'roosterjs-content-model-types';
 import ContentModelBeforePasteEvent, {
     ContentModelBeforePasteEventData,
 } from '../../publicTypes/event/ContentModelBeforePasteEvent';

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelPastePluginTest.ts
@@ -106,7 +106,7 @@ describe('Paste', () => {
                 event,
                 trustedHTMLHandler
             );
-            expect(addParser.default).toHaveBeenCalledTimes(2);
+            expect(addParser.default).toHaveBeenCalledTimes(4);
             expect(setProcessor.setProcessor).toHaveBeenCalledTimes(0);
             expect(chainSanitizerCallbackFile.default).toHaveBeenCalledTimes(3);
         });


### PR DESCRIPTION
Instead of adding the additional parsers when we need to merge the current format in paste.ts do it in ContentModelPastePlugin. 