### PR TITLE
Content Model: Improve insertEntity

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/entity/insertEntity.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/entity/insertEntity.ts
@@ -80,7 +80,7 @@ export default function insertEntity(
                 entityModel,
                 typeof position == 'string' ? position : 'focus',
                 isBlock,
-                isBlock ? focusAfterEntity : true,
+                focusAfterEntity,
                 context
             );
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
@@ -94,7 +94,7 @@ describe('insertEntity', () => {
             },
             'begin',
             false,
-            true,
+            undefined,
             context
         );
         expect(getEntityFromElementSpy).toHaveBeenCalledWith(wrapper);
@@ -217,7 +217,7 @@ describe('insertEntity', () => {
             },
             'begin',
             false,
-            true,
+            undefined,
             context
         );
         expect(getEntityFromElementSpy).toHaveBeenCalledWith(wrapper);


### PR DESCRIPTION
In the new `insertEntity` API, we should always respect `focusAfterEntity` setting, no matter it is inline or block entity