### PR TITLE
Content Model: Fix selection of entity

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleEntity.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleEntity.ts
@@ -61,6 +61,8 @@ export const handleEntity: ContentModelBlockHandler<ContentModelEntity> = (
         const [after] = addDelimiters(wrapper);
 
         context.regularSelection.current.segment = after;
+    } else if (isInlineEntity) {
+        context.regularSelection.current.segment = wrapper;
     }
 
     context.onNodeCreated?.(entityModel, wrapper);

--- a/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleEntityTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleEntityTest.ts
@@ -174,6 +174,33 @@ describe('handleEntity', () => {
         expect(context.regularSelection.current.segment).toBe(span.nextSibling);
     });
 
+    it('Entity without delimiter', () => {
+        const span = document.createElement('span');
+        const entityModel: ContentModelEntity = {
+            blockType: 'Entity',
+            segmentType: 'Entity',
+            format: {},
+            id: 'entity_1',
+            type: 'entity',
+            isReadonly: true,
+            wrapper: span,
+        };
+
+        span.textContent = 'test';
+
+        const parent = document.createElement('div');
+        const result = handleEntity(document, parent, entityModel, context, null);
+
+        expect(parent.innerHTML).toBe(
+            '<span class="_Entity _EType_entity _EId_entity_1 _EReadonly_1" contenteditable="false">test</span>'
+        );
+        expect(span.outerHTML).toBe(
+            '<span class="_Entity _EType_entity _EId_entity_1 _EReadonly_1" contenteditable="false">test</span>'
+        );
+        expect(result).toBe(null);
+        expect(context.regularSelection.current.segment).toBe(span);
+    });
+
     it('With onNodeCreated', () => {
         const entityDiv = document.createElement('div');
         const entityModel: ContentModelEntity = {


### PR DESCRIPTION
Repro:
Use snapshot 
```html
<div>aaa<span class="entityDelimiterBefore">​</span><span style="display: inline-block;" class="_Entity _EType_bbb _EId_bbb_4 _EReadonly_1" contenteditable="false"><span><b>bbb</b></span></span><span class="entityDelimiterAfter">​</span></div><div><br></div><div><br></div><div><span style="letter-spacing: normal; font-family: &quot;Segoe UI&quot;, &quot;Segoe UI Web (West European)&quot;, &quot;Segoe UI&quot;, -apple-system, BlinkMacSystemFont, Roboto, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); font-weight: 400;">a</span><span class="entityDelimiterBefore">​</span><span style="font-family:&quot;Segoe UI&quot;, &quot;Segoe UI Web (West European)&quot;, &quot;Segoe UI&quot;, -apple-system, BlinkMacSystemFont, Roboto, &quot;Helvetica Neue&quot;, sans-serif;font-size:14px;font-style:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-indent:0px;text-transform:none;widows:2;word-spacing:0px;white-space:normal;display:inline-block" class="_Entity _EType_bbb _EId_bbb_5 _EReadonly_1" contenteditable="false"><span><b>bbb</b></span></span><span class="entityDelimiterAfter">​</span><br>1</div><!--{"type":0,"isDarkMode":false,"start":[0,0,2],"end":[0,3,0]}-->
```
copy,
paste.

The entity is not actually copied. This is because when write entity back without entity delimiter, we didn't correctly set current segment element, so that selection may not be correctly restored.

Fix:
Store entity segment element correctly.