### PR TITLE
Content Model: Always return size in pt when getFormatState

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/retrieveModelFormatState.ts
@@ -121,6 +121,10 @@ export function retrieveModelFormatState(
             includeListFormatHolder: 'never',
         }
     );
+
+    if (formatState.fontSize) {
+        formatState.fontSize = px2Pt(formatState.fontSize);
+    }
 }
 
 function retrieveSegmentFormat(
@@ -230,4 +234,13 @@ function mergeValue<K extends keyof ContentModelFormatState>(
     } else if (newValue !== format[key]) {
         delete format[key];
     }
+}
+
+function px2Pt(px: string) {
+    if (px && px.indexOf('px') == px.length - 2) {
+        // Edge may not handle the floating computing well which causes the calculated value is a little less than actual value
+        // So add 0.05 to fix it
+        return Math.round(parseFloat(px) * 75 + 0.05) / 100 + 'pt';
+    }
+    return px;
 }

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/retrieveModelFormatStateTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/retrieveModelFormatStateTest.ts
@@ -35,7 +35,7 @@ describe('retrieveModelFormatState', () => {
     const baseFormatResult: ContentModelFormatState = {
         backgroundColor: 'red',
         fontName: 'Arial',
-        fontSize: '10px',
+        fontSize: '7.5pt',
         isBold: true,
         isItalic: true,
         isStrikeThrough: true,
@@ -329,7 +329,7 @@ describe('retrieveModelFormatState', () => {
             isStrikeThrough: true,
             fontName: 'Arial',
             isSuperscript: true,
-            fontSize: '10px',
+            fontSize: '7.5pt',
             backgroundColor: 'red',
             textColor: 'green',
         });
@@ -490,7 +490,7 @@ describe('retrieveModelFormatState', () => {
             isItalic: true,
             isUnderline: true,
             isStrikeThrough: true,
-            fontSize: '10px',
+            fontSize: '7.5pt',
         });
     });
 
@@ -701,7 +701,7 @@ describe('retrieveModelFormatState', () => {
             isSuperscript: false,
             isSubscript: false,
             fontName: 'Arial',
-            fontSize: '12px',
+            fontSize: '9pt',
             isCodeInline: false,
             canUnlink: false,
             canAddImageAltText: false,
@@ -734,7 +734,7 @@ describe('retrieveModelFormatState', () => {
             isBold: false,
             isSuperscript: false,
             isSubscript: false,
-            fontSize: '12px',
+            fontSize: '9pt',
             isCodeInline: false,
             canUnlink: false,
             canAddImageAltText: false,


### PR DESCRIPTION
Today when we call `getFormatState` from content model, it always returns whatever size we have in the code.

We'd better returns a consitent result in unit, e.g., always in pt.

So that UI layer can just directly parse the number and show current selected font size.