### PR TITLE
Content Model: trigger ShadowEdit events

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/switchShadowEdit.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/switchShadowEdit.ts
@@ -20,19 +20,23 @@ export const switchShadowEdit: SwitchShadowEdit = (editorCore, isOn): void => {
 
             const range = core.api.getSelectionRange(core, true /*tryGetFromCache*/);
 
-            core.lifecycle.shadowEditSelectionPath =
-                range && getSelectionPath(core.contentDiv, range);
-            core.lifecycle.shadowEditFragment = core.contentDiv.ownerDocument.createDocumentFragment();
+            // Fake object, not used in Content Model Editor, just to satisfy original editor code
+            // TODO: we can remove them once we have standalone Content Model Editor
+            const fragment = core.contentDiv.ownerDocument.createDocumentFragment();
+            const selectionPath = range && getSelectionPath(core.contentDiv, range);
 
             core.api.triggerEvent(
                 core,
                 {
                     eventType: PluginEventType.EnteredShadowEdit,
-                    fragment: core.lifecycle.shadowEditFragment,
-                    selectionPath: core.lifecycle.shadowEditSelectionPath,
+                    fragment,
+                    selectionPath,
                 },
                 false /*broadcast*/
             );
+
+            core.lifecycle.shadowEditSelectionPath = selectionPath;
+            core.lifecycle.shadowEditFragment = fragment;
         } else {
             core.lifecycle.shadowEditFragment = null;
             core.lifecycle.shadowEditSelectionPath = null;

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/switchShadowEdit.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/switchShadowEdit.ts
@@ -1,6 +1,6 @@
 import { ContentModelEditorCore } from '../../publicTypes/ContentModelEditorCore';
 import { getSelectionPath } from 'roosterjs-editor-dom';
-import { SwitchShadowEdit } from 'roosterjs-editor-types';
+import { PluginEventType, SwitchShadowEdit } from 'roosterjs-editor-types';
 
 /**
  * @internal
@@ -23,9 +23,27 @@ export const switchShadowEdit: SwitchShadowEdit = (editorCore, isOn): void => {
             core.lifecycle.shadowEditSelectionPath =
                 range && getSelectionPath(core.contentDiv, range);
             core.lifecycle.shadowEditFragment = core.contentDiv.ownerDocument.createDocumentFragment();
+
+            core.api.triggerEvent(
+                core,
+                {
+                    eventType: PluginEventType.EnteredShadowEdit,
+                    fragment: core.lifecycle.shadowEditFragment,
+                    selectionPath: core.lifecycle.shadowEditSelectionPath,
+                },
+                false /*broadcast*/
+            );
         } else {
             core.lifecycle.shadowEditFragment = null;
             core.lifecycle.shadowEditSelectionPath = null;
+
+            core.api.triggerEvent(
+                core,
+                {
+                    eventType: PluginEventType.LeavingShadowEdit,
+                },
+                false /*broadcast*/
+            );
 
             if (core.cachedModel) {
                 core.api.setContentModel(core, core.cachedModel);

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/coreApi/switchShadowEditTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/coreApi/switchShadowEditTest.ts
@@ -1,4 +1,5 @@
 import { ContentModelEditorCore } from '../../../lib/publicTypes/ContentModelEditorCore';
+import { PluginEventType } from 'roosterjs-editor-types';
 import { switchShadowEdit } from '../../../lib/editor/coreApi/switchShadowEdit';
 
 const mockedModel = 'MODEL' as any;
@@ -9,17 +10,20 @@ describe('switchShadowEdit', () => {
     let createContentModel: jasmine.Spy;
     let setContentModel: jasmine.Spy;
     let getSelectionRange: jasmine.Spy;
+    let triggerEvent: jasmine.Spy;
 
     beforeEach(() => {
         createContentModel = jasmine.createSpy('createContentModel').and.returnValue(mockedModel);
         setContentModel = jasmine.createSpy('setContentModel');
         getSelectionRange = jasmine.createSpy('getSelectionRange');
+        triggerEvent = jasmine.createSpy('triggerEvent');
 
         core = ({
             api: {
                 createContentModel,
                 setContentModel,
                 getSelectionRange,
+                triggerEvent,
             },
             lifecycle: {},
             contentDiv: document.createElement('div'),
@@ -33,6 +37,16 @@ describe('switchShadowEdit', () => {
             expect(createContentModel).toHaveBeenCalledWith(core);
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(mockedModel);
+            expect(triggerEvent).toHaveBeenCalledTimes(1);
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: PluginEventType.EnteredShadowEdit,
+                    fragment: document.createDocumentFragment(),
+                    selectionPath: undefined,
+                },
+                false
+            );
         });
 
         it('with cache, isOn', () => {
@@ -43,6 +57,17 @@ describe('switchShadowEdit', () => {
             expect(createContentModel).not.toHaveBeenCalled();
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(mockedCachedModel);
+
+            expect(triggerEvent).toHaveBeenCalledTimes(1);
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: PluginEventType.EnteredShadowEdit,
+                    fragment: document.createDocumentFragment(),
+                    selectionPath: undefined,
+                },
+                false
+            );
         });
 
         it('no cache, isOff', () => {
@@ -51,6 +76,8 @@ describe('switchShadowEdit', () => {
             expect(createContentModel).not.toHaveBeenCalled();
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(undefined);
+
+            expect(triggerEvent).not.toHaveBeenCalled();
         });
 
         it('with cache, isOff', () => {
@@ -61,6 +88,8 @@ describe('switchShadowEdit', () => {
             expect(createContentModel).not.toHaveBeenCalled();
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(mockedCachedModel);
+
+            expect(triggerEvent).not.toHaveBeenCalled();
         });
     });
 
@@ -75,6 +104,8 @@ describe('switchShadowEdit', () => {
             expect(createContentModel).not.toHaveBeenCalled();
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(undefined);
+
+            expect(triggerEvent).not.toHaveBeenCalled();
         });
 
         it('with cache, isOn', () => {
@@ -85,6 +116,8 @@ describe('switchShadowEdit', () => {
             expect(createContentModel).not.toHaveBeenCalled();
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(mockedCachedModel);
+
+            expect(triggerEvent).not.toHaveBeenCalled();
         });
 
         it('no cache, isOff', () => {
@@ -93,6 +126,15 @@ describe('switchShadowEdit', () => {
             expect(createContentModel).not.toHaveBeenCalled();
             expect(setContentModel).not.toHaveBeenCalled();
             expect(core.cachedModel).toBe(undefined);
+
+            expect(triggerEvent).toHaveBeenCalledTimes(1);
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: PluginEventType.LeavingShadowEdit,
+                },
+                false
+            );
         });
 
         it('with cache, isOff', () => {
@@ -103,6 +145,15 @@ describe('switchShadowEdit', () => {
             expect(createContentModel).not.toHaveBeenCalled();
             expect(setContentModel).toHaveBeenCalledWith(core, mockedCachedModel);
             expect(core.cachedModel).toBe(mockedCachedModel);
+
+            expect(triggerEvent).toHaveBeenCalledTimes(1);
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: PluginEventType.LeavingShadowEdit,
+                },
+                false
+            );
         });
     });
 });


### PR DESCRIPTION
In new `switchShadowEdit` API for Content Model, we missed the call to trigger ShadowEdit related event. So add them back.