### PR TITLE
Content Model: Add solid paragraph in new table cell

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/table/normalizeTable.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/table/normalizeTable.ts
@@ -1,4 +1,4 @@
-import { addSegment, createBr } from 'roosterjs-content-model-dom';
+import { addBlock, addSegment, createBr, createParagraph } from 'roosterjs-content-model-dom';
 import { arrayPush } from 'roosterjs-editor-dom';
 import {
     ContentModelSegment,
@@ -30,6 +30,14 @@ export function normalizeTable(
     table.rows.forEach((row, rowIndex) => {
         row.cells.forEach((cell, colIndex) => {
             if (cell.blocks.length == 0) {
+                addBlock(
+                    cell,
+                    createParagraph(
+                        undefined /*isImplicit*/,
+                        undefined /*blockFormat*/,
+                        defaultSegmentFormat
+                    )
+                );
                 addSegment(cell, createBr(defaultSegmentFormat));
             }
 

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/table/normalizeTableTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/table/normalizeTableTest.ts
@@ -78,7 +78,6 @@ describe('normalizeTable', () => {
                             blocks: [
                                 {
                                     blockType: 'Paragraph',
-                                    isImplicit: true,
                                     segments: [
                                         {
                                             segmentType: 'Br',
@@ -678,7 +677,6 @@ describe('normalizeTable', () => {
                             blocks: [
                                 {
                                     blockType: 'Paragraph',
-                                    isImplicit: true,
                                     segments: [
                                         {
                                             segmentType: 'Br',
@@ -688,6 +686,7 @@ describe('normalizeTable', () => {
                                         },
                                     ],
                                     format: {},
+                                    segmentFormat: { fontSize: '10px' },
                                 },
                             ],
                             dataset: {},
@@ -725,7 +724,6 @@ describe('normalizeTable', () => {
 
         const block: ContentModelParagraph = {
             blockType: 'Paragraph',
-            isImplicit: true,
             segments: [
                 {
                     segmentType: 'Br',


### PR DESCRIPTION
When insert new table, currently we are adding an implicit paragraph in each table cell, it will be represented as a BR tag. So if user keep typing and press ENTER, it will keep using BR as line splitter. This causes some problem such as applying bullet list causes only one list item is created.

To fix this, we add a solid (not implicit) paragraph in each table cell.