### PR TITLE
Content Model: Do color transform for entity when copy/paste

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -33,6 +33,7 @@ import {
     ClipboardData,
     SelectionRangeTypes,
     SelectionRangeEx,
+    ColorTransformDirection,
 } from 'roosterjs-editor-types';
 
 /**
@@ -94,7 +95,24 @@ export default class ContentModelCopyPastePlugin implements PluginWithState<Copy
         if (selection && !selection.areAllCollapsed) {
             const model = this.editor.createContentModel();
 
-            const pasteModel = cloneModel(model);
+            const pasteModel = cloneModel(model, {
+                includeCachedElement: this.editor.isDarkMode()
+                    ? (node, type) => {
+                          if (type == 'cache') {
+                              return undefined;
+                          } else {
+                              const result = node.cloneNode(true /*deep*/) as HTMLElement;
+
+                              this.editor?.transformToDarkColor(
+                                  result,
+                                  ColorTransformDirection.DarkToLight
+                              );
+
+                              return result;
+                          }
+                      }
+                    : false,
+            });
             if (selection.type === SelectionRangeTypes.TableSelection) {
                 iterateSelections([pasteModel], (path, tableContext) => {
                     if (tableContext?.table) {

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/cloneModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/cloneModel.ts
@@ -29,16 +29,25 @@ import type {
 
 /**
  * @internal
+ */
+export type CachedElementHandler = (
+    node: HTMLElement,
+    type: 'general' | 'entity' | 'cache'
+) => HTMLElement | undefined;
+
+/**
+ * @internal
  * Options for cloneModel API
  */
 export interface CloneModelOptions {
     /**
-     * When pass false or not passed, the cloned model will not have cached element even they exist in original model.
-     * For entity and general model, a cloned wrapper element will be added into cloned model. So that the cloned model will be fully disconnected from the original one
-     * When pass true, cloned model will have the same cached element and element wrapper with the original model
-     * @default true
+     * Specify how to deal with cached element, including cached block element, element in General Model, and wrapper element in Entity
+     * - True: Cloned model will have the same reference to the cached element
+     * - False/Not passed: For cached block element, cached element will be undefined. For General Model and Entity, the element will have deep clone and assign to the cloned model
+     * - A callback: invoke the callback with the source cached element and a string to specify model type, let the callback return the expected value of cached element.
+     * For General Model and Entity, the callback must return a valid element, otherwise there will be exception thrown.
      */
-    includeCachedElement?: boolean;
+    includeCachedElement?: boolean | CachedElementHandler;
 }
 
 /**
@@ -167,9 +176,7 @@ function cloneEntity(entity: ContentModelEntity, options: CloneModelOptions): Co
 
     return Object.assign(
         {
-            wrapper: options.includeCachedElement
-                ? wrapper
-                : (wrapper.cloneNode(true /*deep*/) as HTMLElement),
+            wrapper: handleCachedElement(wrapper, 'entity', options),
             isReadonly,
             type,
             id,
@@ -187,7 +194,7 @@ function cloneParagraph(
 
     const newParagraph: ContentModelParagraph = Object.assign(
         {
-            cachedElement: options.includeCachedElement ? cachedElement : undefined,
+            cachedElement: handleCachedElement(cachedElement, 'cache', options),
             isImplicit,
             segments: segments.map(segment => cloneSegment(segment, options)),
             segmentFormat: segmentFormat ? { ...segmentFormat } : undefined,
@@ -213,7 +220,7 @@ function cloneTable(table: ContentModelTable, options: CloneModelOptions): Conte
 
     return Object.assign(
         {
-            cachedElement: options.includeCachedElement ? cachedElement : undefined,
+            cachedElement: handleCachedElement(cachedElement, 'cache', options),
             widths: Array.from(widths),
             rows: rows.map(row => cloneTableRow(row, options)),
         },
@@ -231,7 +238,7 @@ function cloneTableRow(
     return Object.assign(
         {
             height,
-            cachedElement: options.includeCachedElement ? cachedElement : undefined,
+            cachedElement: handleCachedElement(cachedElement, 'cache', options),
             cells: cells.map(cell => cloneTableCell(cell, options)),
         },
         cloneModelWithFormat(row)
@@ -246,7 +253,7 @@ function cloneTableCell(
 
     return Object.assign(
         {
-            cachedElement: options.includeCachedElement ? cachedElement : undefined,
+            cachedElement: handleCachedElement(cachedElement, 'cache', options),
             isSelected,
             spanAbove,
             spanLeft,
@@ -264,7 +271,7 @@ function cloneFormatContainer(
 ): ContentModelFormatContainer {
     const { tagName, cachedElement } = container;
     const newContainer: ContentModelFormatContainer = Object.assign(
-        { tagName, cachedElement: options.includeCachedElement ? cachedElement : undefined },
+        { tagName, cachedElement: handleCachedElement(cachedElement, 'cache', options) },
         cloneBlockBase(container),
         cloneBlockGroupBase(container, options)
     );
@@ -307,7 +314,7 @@ function cloneDivider(
         {
             isSelected,
             tagName,
-            cachedElement: options.includeCachedElement ? cachedElement : undefined,
+            cachedElement: handleCachedElement(cachedElement, 'cache', options),
         },
         cloneBlockBase(divider)
     );
@@ -321,9 +328,7 @@ function cloneGeneralBlock(
 
     return Object.assign(
         {
-            element: options.includeCachedElement
-                ? element
-                : (element.cloneNode(true /*deep*/) as HTMLElement),
+            element: handleCachedElement(element, 'general', options),
         },
         cloneBlockBase(general),
         cloneBlockGroupBase(general, options)
@@ -354,4 +359,40 @@ function cloneGeneralSegment(
 function cloneText(textSegment: ContentModelText): ContentModelText {
     const { text } = textSegment;
     return Object.assign({ text }, cloneSegmentBase(textSegment));
+}
+
+function handleCachedElement<T extends HTMLElement>(
+    node: T,
+    type: 'general' | 'entity',
+    options: CloneModelOptions
+): T;
+
+function handleCachedElement<T extends HTMLElement>(
+    node: T | undefined,
+    type: 'cache',
+    options: CloneModelOptions
+): T | undefined;
+
+function handleCachedElement<T extends HTMLElement>(
+    node: T | undefined,
+    type: 'general' | 'entity' | 'cache',
+    options: CloneModelOptions
+): T | undefined {
+    const { includeCachedElement } = options;
+
+    if (!node) {
+        return undefined;
+    } else if (!includeCachedElement) {
+        return type == 'cache' ? undefined : (node.cloneNode(true /*deep*/) as T);
+    } else if (includeCachedElement === true) {
+        return node;
+    } else {
+        const result = includeCachedElement(node, type) as T | undefined;
+
+        if ((type == 'general' || type == 'entity') && !result) {
+            throw new Error('Entity and General Model must has wrapper element');
+        }
+
+        return result;
+    }
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/entity/insertEntity.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/entity/insertEntity.ts
@@ -85,6 +85,7 @@ export default function insertEntity(
             );
 
             context.skipUndoSnapshot = skipUndoSnapshot;
+            context.newEntities.push(entityModel);
 
             return true;
         },
@@ -92,10 +93,6 @@ export default function insertEntity(
             selectionOverride: typeof position === 'object' ? position : undefined,
         }
     );
-
-    if (editor.isDarkMode()) {
-        editor.transformToDarkColor(wrapper);
-    }
 
     const newEntity = getEntityFromElement(wrapper);
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/entity/insertEntity.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/entity/insertEntity.ts
@@ -1,6 +1,6 @@
 import { ChangeSource, Entity, SelectionRangeEx } from 'roosterjs-editor-types';
 import { commitEntity, getEntityFromElement } from 'roosterjs-editor-dom';
-import { createEntity } from 'roosterjs-content-model-dom';
+import { createEntity, normalizeContentModel } from 'roosterjs-content-model-dom';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { insertEntityModel } from '../../modelApi/entity/insertEntityModel';
@@ -83,6 +83,8 @@ export default function insertEntity(
                 focusAfterEntity,
                 context
             );
+
+            normalizeContentModel(model);
 
             context.skipUndoSnapshot = skipUndoSnapshot;
             context.newEntities.push(entityModel);

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
@@ -36,12 +36,14 @@ export function formatWithContentModel(
 
     const model = editor.createContentModel(undefined /*option*/, selectionOverride);
     const context: FormatWithContentModelContext = {
+        newEntities: [],
         deletedEntities: [],
         rawEvent,
     };
 
     if (formatter(model, context)) {
         const callback = () => {
+            handleNewEntities(editor, context);
             handleDeletedEntities(editor, context);
 
             if (model) {
@@ -78,6 +80,18 @@ export function formatWithContentModel(
         }
 
         editor.cacheContentModel?.(model);
+    }
+}
+
+function handleNewEntities(editor: IContentModelEditor, context: FormatWithContentModelContext) {
+    // TODO: Ideally we can trigger NewEntity event here. But to be compatible with original editor code, we don't do it here for now.
+    // Once Content Model Editor can be standalone, we can change this behavior to move triggering NewEntity event code
+    // from EntityPlugin to here
+
+    if (editor.isDarkMode()) {
+        context.newEntities.forEach(entity => {
+            editor.transformToDarkColor(entity.wrapper);
+        });
     }
 }
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
@@ -25,6 +25,11 @@ export interface DeletedEntity {
  */
 export interface FormatWithContentModelContext {
     /**
+     * New entities added during the format process
+     */
+    readonly newEntities: ContentModelEntity[];
+
+    /**
      * Entities got deleted during formatting. Need to be set by the formatter function
      */
     readonly deletedEntities: DeletedEntity[];

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelCopyPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelCopyPastePluginTest.ts
@@ -1,18 +1,20 @@
 import * as cloneModelFile from '../../../lib/modelApi/common/cloneModel';
 import * as contentModelToDomFile from 'roosterjs-content-model-dom/lib/modelToDom/contentModelToDom';
-import * as createRangeF from 'roosterjs-editor-dom/lib/selection/createRange';
 import * as deleteSelectionsFile from '../../../lib/modelApi/edit/deleteSelection';
 import * as extractClipboardItemsFile from 'roosterjs-editor-dom/lib/clipboard/extractClipboardItems';
 import * as iterateSelectionsFile from '../../../lib/modelApi/selection/iterateSelections';
 import * as normalizeContentModel from 'roosterjs-content-model-dom/lib/modelApi/common/normalizeContentModel';
 import * as PasteFile from '../../../lib/publicApi/utils/paste';
+import { commitEntity } from 'roosterjs-editor-dom';
 import { DeleteResult } from '../../../lib/modelApi/edit/utils/DeleteSelectionStep';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
+import createRange, * as createRangeF from 'roosterjs-editor-dom/lib/selection/createRange';
 import ContentModelCopyPastePlugin, {
     onNodeCreated,
 } from '../../../lib/editor/corePlugins/ContentModelCopyPastePlugin';
 import {
     ClipboardData,
+    ColorTransformDirection,
     DOMEventHandlerFunction,
     IEditor,
     SelectionRangeEx,
@@ -45,6 +47,8 @@ describe('ContentModelCopyPastePlugin |', () => {
 
     let isDisposed: jasmine.Spy;
     let pasteSpy: jasmine.Spy;
+    let cloneModelSpy: jasmine.Spy;
+    let transformToDarkColorSpy: jasmine.Spy;
 
     beforeEach(() => {
         div = document.createElement('div');
@@ -63,7 +67,10 @@ describe('ContentModelCopyPastePlugin |', () => {
         pasteSpy = jasmine.createSpy('paste_');
         isDisposed = jasmine.createSpy('isDisposed');
 
-        spyOn(cloneModelFile, 'cloneModel').and.callFake((model: any) => pasteModelValue);
+        cloneModelSpy = spyOn(cloneModelFile, 'cloneModel').and.callFake(
+            (model: any) => pasteModelValue
+        );
+        transformToDarkColorSpy = jasmine.createSpy('transformToDarkColor');
 
         plugin = new ContentModelCopyPastePlugin({
             allowedCustomPasteType,
@@ -119,6 +126,7 @@ describe('ContentModelCopyPastePlugin |', () => {
             paste: (ar1: any) => {
                 pasteSpy(ar1);
             },
+            transformToDarkColor: transformToDarkColorSpy,
             isDisposed,
         });
 
@@ -305,6 +313,82 @@ describe('ContentModelCopyPastePlugin |', () => {
                 undefined,
                 undefined
             );
+
+            // On Cut Spy
+            expect(undoSnapShotSpy).not.toHaveBeenCalled();
+            expect(setContentModelSpy).not.toHaveBeenCalledWith();
+            expect(iterateSelectionsFile.iterateSelections).toHaveBeenCalledTimes(0);
+        });
+
+        it('Selection not Collapsed and entity selection in Dark mode', () => {
+            // Arrange
+            const wrapper = document.createElement('span');
+
+            document.body.appendChild(wrapper);
+
+            commitEntity(wrapper, 'Entity', true, 'Entity');
+            selectionRangeExValue = <SelectionRangeEx>{
+                type: SelectionRangeTypes.Normal,
+                ranges: [createRange(wrapper)],
+                areAllCollapsed: false,
+            };
+
+            spyOn(deleteSelectionsFile, 'deleteSelection');
+            spyOn(contentModelToDomFile, 'contentModelToDom').and.callFake(() => {
+                div.appendChild(wrapper);
+                return selectionRangeExValue;
+            });
+            spyOn(iterateSelectionsFile, 'iterateSelections').and.returnValue(undefined);
+
+            triggerPluginEventSpy.and.callThrough();
+            focusSpy.and.callThrough();
+            selectSpy.and.callThrough();
+            setContentModelSpy.and.callThrough();
+
+            editor.isDarkMode = () => true;
+
+            cloneModelSpy.and.callFake((model, options) => {
+                expect(model).toEqual(modelValue);
+                expect(typeof options.includeCachedElement).toBe('function');
+
+                const cloneCache = options.includeCachedElement(wrapper, 'cache');
+                const cloneEntity = options.includeCachedElement(wrapper, 'entity');
+
+                expect(cloneCache).toBeUndefined();
+                expect(cloneEntity).toEqual(wrapper);
+                expect(cloneEntity).not.toBe(wrapper);
+                expect(transformToDarkColorSpy).toHaveBeenCalledTimes(1);
+                expect(transformToDarkColorSpy).toHaveBeenCalledWith(
+                    cloneEntity,
+                    ColorTransformDirection.DarkToLight
+                );
+
+                return pasteModelValue;
+            });
+
+            // Act
+            domEvents.copy?.(<Event>{});
+
+            // Assert
+            expect(getSelectionRangeEx).toHaveBeenCalled();
+            expect(deleteSelectionsFile.deleteSelection).not.toHaveBeenCalled();
+            expect(contentModelToDomFile.contentModelToDom).toHaveBeenCalledWith(
+                document,
+                div,
+                pasteModelValue,
+                undefined,
+                { onNodeCreated }
+            );
+            expect(createContentModelSpy).toHaveBeenCalled();
+            expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
+            expect(focusSpy).toHaveBeenCalled();
+            expect(selectSpy).toHaveBeenCalledWith(
+                selectionRangeExValue,
+                undefined,
+                undefined,
+                undefined
+            );
+            expect(cloneModelSpy).toHaveBeenCalledTimes(1);
 
             // On Cut Spy
             expect(undoSnapShotSpy).not.toHaveBeenCalled();

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelFormatPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelFormatPluginTest.ts
@@ -16,6 +16,7 @@ describe('ContentModelFormatPlugin', () => {
 
         const editor = ({
             cacheContentModel: () => {},
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 
@@ -149,6 +150,7 @@ describe('ContentModelFormatPlugin', () => {
                 callback();
             },
             cacheContentModel: () => {},
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 
@@ -211,6 +213,7 @@ describe('ContentModelFormatPlugin', () => {
                 callback();
             },
             cacheContentModel: () => {},
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
         const plugin = new ContentModelFormatPlugin();
 

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/utils/handleKeyboardEventCommonTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/utils/handleKeyboardEventCommonTest.ts
@@ -42,7 +42,7 @@ describe('handleKeyboardEventResult', () => {
         const mockedModel = 'MODEL' as any;
         const which = 'WHICH' as any;
         (<any>mockedEvent).which = which;
-        const context: FormatWithContentModelContext = { deletedEntities: [] };
+        const context: FormatWithContentModelContext = { newEntities: [], deletedEntities: [] };
         const result = handleKeyboardEventResult(
             mockedEditor,
             mockedModel,
@@ -64,7 +64,7 @@ describe('handleKeyboardEventResult', () => {
 
     it('DeleteResult.NotDeleted', () => {
         const mockedModel = 'MODEL' as any;
-        const context: FormatWithContentModelContext = { deletedEntities: [] };
+        const context: FormatWithContentModelContext = { newEntities: [], deletedEntities: [] };
         const result = handleKeyboardEventResult(
             mockedEditor,
             mockedModel,
@@ -84,7 +84,7 @@ describe('handleKeyboardEventResult', () => {
 
     it('DeleteResult.Range', () => {
         const mockedModel = 'MODEL' as any;
-        const context: FormatWithContentModelContext = { deletedEntities: [] };
+        const context: FormatWithContentModelContext = { newEntities: [], deletedEntities: [] };
         const result = handleKeyboardEventResult(
             mockedEditor,
             mockedModel,
@@ -106,7 +106,7 @@ describe('handleKeyboardEventResult', () => {
 
     it('DeleteResult.NothingToDelete', () => {
         const mockedModel = 'MODEL' as any;
-        const context: FormatWithContentModelContext = { deletedEntities: [] };
+        const context: FormatWithContentModelContext = { newEntities: [], deletedEntities: [] };
         const result = handleKeyboardEventResult(
             mockedEditor,
             mockedModel,

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
@@ -1,8 +1,11 @@
 import * as applyTableFormat from '../../../lib/modelApi/table/applyTableFormat';
 import * as normalizeTable from '../../../lib/modelApi/table/normalizeTable';
 import { ContentModelDocument } from 'roosterjs-content-model-types';
+import { EntityOperation } from 'roosterjs-editor-types';
+import { FormatWithContentModelContext } from '../../../lib/publicTypes/parameter/FormatWithContentModelContext';
 import { mergeModel } from '../../../lib/modelApi/common/mergeModel';
 import {
+    createBr,
     createContentModelDocument,
     createDivider,
     createEntity,
@@ -25,7 +28,7 @@ describe('mergeModel', () => {
         para.segments.push(marker);
         majorModel.blocks.push(para);
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -65,7 +68,7 @@ describe('mergeModel', () => {
         para2.segments.push(text1, text2);
         sourceModel.blocks.push(para2);
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -115,7 +118,7 @@ describe('mergeModel', () => {
         majorModel.blocks.push(para1);
         sourceModel.blocks.push(para2);
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -194,7 +197,7 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newPara1);
         sourceModel.blocks.push(newPara2);
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -289,7 +292,7 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newPara2);
         sourceModel.blocks.push(newPara3);
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -436,7 +439,7 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newList1);
         sourceModel.blocks.push(newList2);
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -602,7 +605,7 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newList1);
         sourceModel.blocks.push(newList2);
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -790,7 +793,7 @@ describe('mergeModel', () => {
 
         sourceModel.blocks.push(newTable1);
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -891,7 +894,7 @@ describe('mergeModel', () => {
         spyOn(applyTableFormat, 'applyTableFormat');
         spyOn(normalizeTable, 'normalizeTable');
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(normalizeTable.normalizeTable).not.toHaveBeenCalled();
         expect(majorModel).toEqual({
@@ -1011,7 +1014,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeTable: true,
             }
@@ -1153,7 +1156,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeTable: true,
             }
@@ -1284,7 +1287,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeTable: true,
             }
@@ -1398,7 +1401,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 insertPosition: {
                     marker: marker2,
@@ -1481,7 +1484,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeFormat: 'mergeAll',
             }
@@ -1543,7 +1546,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -1611,7 +1614,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -1706,7 +1709,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -1782,7 +1785,7 @@ describe('mergeModel', () => {
 
         sourceModel.blocks.push(divider);
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -1849,7 +1852,7 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newPara1);
         sourceModel.blocks.push(newPara2);
 
-        mergeModel(majorModel, sourceModel, { deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -1949,7 +1952,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -2030,7 +2033,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeFormat: 'mergeAll',
             }
@@ -2214,7 +2217,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeFormat: 'mergeAll',
             }
@@ -2752,9 +2755,13 @@ describe('mergeModel', () => {
             textColor: 'aliceblue',
             italic: true,
         });
+        const context: FormatWithContentModelContext = {
+            deletedEntities: [],
+            newEntities: [],
+        };
 
         sourceModel.blocks.push(newEntity);
-        mergeModel(majorModel, sourceModel);
+        mergeModel(majorModel, sourceModel, context);
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -2804,6 +2811,65 @@ describe('mergeModel', () => {
                         textColor: 'blue',
                         italic: false,
                     },
+                },
+            ],
+        });
+        expect(context).toEqual({
+            newEntities: [newEntity],
+            deletedEntities: [],
+        });
+    });
+
+    it('Merge and replace inline entities', () => {
+        const majorModel = createContentModelDocument();
+        const para1 = createParagraph();
+        const sourceEntity = createEntity('wrapper1' as any, true, 'E0');
+        const sourceBr = createBr();
+
+        sourceEntity.isSelected = true;
+        para1.segments.push(sourceEntity, sourceBr);
+        majorModel.blocks.push(para1);
+
+        const sourceModel: ContentModelDocument = createContentModelDocument();
+        const newPara = createParagraph();
+        const newEntity1 = createEntity('wrapper2' as any, true, 'E1');
+        const newEntity2 = createEntity('wrapper2' as any, true, 'E2');
+        const text = createText('test');
+
+        newPara.segments.push(newEntity1, text, newEntity2);
+        sourceModel.blocks.push(newPara);
+
+        const context: FormatWithContentModelContext = {
+            deletedEntities: [],
+            newEntities: [],
+        };
+        mergeModel(majorModel, sourceModel, context);
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        newEntity1,
+                        text,
+                        newEntity2,
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(context).toEqual({
+            newEntities: [newEntity1, newEntity2],
+            deletedEntities: [
+                {
+                    entity: sourceEntity,
+                    operation: EntityOperation.Overwrite,
                 },
             ],
         });

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/edit/deleteSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/edit/deleteSelectionTest.ts
@@ -1,4 +1,4 @@
-import { ContentModelSelectionMarker } from 'roosterjs-content-model-types';
+import { ContentModelEntity, ContentModelSelectionMarker } from 'roosterjs-content-model-types';
 import { DeletedEntity } from '../../../lib/publicTypes/parameter/FormatWithContentModelContext';
 import { DeleteResult } from '../../../lib/modelApi/edit/utils/DeleteSelectionStep';
 import { deleteSelection } from '../../../lib/modelApi/edit/deleteSelection';
@@ -527,7 +527,7 @@ describe('deleteSelection - selectionOnly', () => {
 
         entity.isSelected = true;
 
-        const result = deleteSelection(model, [], { deletedEntities });
+        const result = deleteSelection(model, [], { newEntities: [], deletedEntities });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
         expect(result.insertPoint).toEqual({
@@ -582,7 +582,7 @@ describe('deleteSelection - selectionOnly', () => {
         entity.isSelected = true;
 
         const deletedEntities: DeletedEntity[] = [];
-        const result = deleteSelection(model, [], { deletedEntities });
+        const result = deleteSelection(model, [], { newEntities: [], deletedEntities });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
         expect(result.insertPoint).toEqual({
@@ -1485,6 +1485,7 @@ describe('deleteSelection - forward', () => {
 
         const deletedEntities: DeletedEntity[] = [];
         const result = deleteSelection(model, [forwardDeleteCollapsedSelection], {
+            newEntities: [],
             deletedEntities,
         });
 
@@ -1531,6 +1532,7 @@ describe('deleteSelection - forward', () => {
 
         const deletedEntities: DeletedEntity[] = [];
         const result = deleteSelection(model, [forwardDeleteCollapsedSelection], {
+            newEntities: [],
             deletedEntities,
         });
 
@@ -3239,6 +3241,7 @@ describe('deleteSelection - backward', () => {
 
         const deletedEntities: DeletedEntity[] = [];
         const result = deleteSelection(model, [backwardDeleteCollapsedSelection], {
+            newEntities: [],
             deletedEntities,
         });
 
@@ -3284,7 +3287,9 @@ describe('deleteSelection - backward', () => {
         model.blocks.push(entity, para);
 
         const deletedEntities: DeletedEntity[] = [];
+        const newEntities: ContentModelEntity[] = [];
         const result = deleteSelection(model, [backwardDeleteCollapsedSelection], {
+            newEntities,
             deletedEntities,
         });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/block/paragraphTestCommon.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/block/paragraphTestCommon.ts
@@ -25,6 +25,7 @@ export function paragraphTestCommon(
         setContentModel,
         getCustomData: () => ({}),
         getFocusedPosition: () => ({}),
+        isDarkMode: () => false,
     } as any) as IContentModelEditor;
 
     executionCallback(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/block/setAlignmentTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/block/setAlignmentTest.ts
@@ -426,6 +426,7 @@ describe('setAlignment in table', () => {
             addUndoSnapshot: (callback: Function) => callback(),
             setContentModel,
             createContentModel,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });
 
@@ -817,6 +818,7 @@ describe('setAlignment in list', () => {
             addUndoSnapshot: (callback: Function) => callback(),
             setContentModel,
             createContentModel,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/editingTestCommon.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/editingTestCommon.ts
@@ -38,6 +38,7 @@ export function editingTestCommon(
         isDisposed: () => false,
         getFocusedPosition: () => null as NodePosition,
         triggerContentChangedEvent,
+        isDarkMode: () => false,
     } as any) as IContentModelEditor;
 
     executionCallback(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/handleKeyDownEventTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/handleKeyDownEventTest.ts
@@ -59,6 +59,7 @@ describe('handleKeyDownEvent', () => {
         );
 
         expect(deleteSelectionSpy).toHaveBeenCalledWith(input, expectedSteps, {
+            newEntities: [],
             deletedEntities: [],
             rawEvent: mockedEvent,
             skipUndoSnapshot: true,

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
@@ -31,6 +31,7 @@ describe('insertEntity', () => {
 
     beforeEach(() => {
         context = {
+            newEntities: [],
             deletedEntities: [],
         };
 
@@ -225,7 +226,17 @@ describe('insertEntity', () => {
             ChangeSource.InsertEntity,
             newEntity
         );
-        expect(transformToDarkColorSpy).toHaveBeenCalled();
+        expect(context.newEntities).toEqual([
+            {
+                segmentType: 'Entity',
+                blockType: 'Entity',
+                format: {},
+                id: undefined,
+                type: 'Entity',
+                isReadonly: true,
+                wrapper,
+            },
+        ]);
 
         expect(entity).toBe(newEntity);
     });

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
@@ -2,6 +2,7 @@ import * as commitEntity from 'roosterjs-editor-dom/lib/entity/commitEntity';
 import * as formatWithContentModel from '../../../lib/publicApi/utils/formatWithContentModel';
 import * as getEntityFromElement from 'roosterjs-editor-dom/lib/entity/getEntityFromElement';
 import * as insertEntityModel from '../../../lib/modelApi/entity/insertEntityModel';
+import * as normalizeContentModel from 'roosterjs-content-model-dom/lib/modelApi/common/normalizeContentModel';
 import insertEntity from '../../../lib/publicApi/entity/insertEntity';
 import { ChangeSource } from 'roosterjs-editor-types';
 import { FormatWithContentModelContext } from '../../../lib/publicTypes/parameter/FormatWithContentModelContext';
@@ -25,6 +26,7 @@ describe('insertEntity', () => {
     let insertEntityModelSpy: jasmine.Spy;
     let isDarkModeSpy: jasmine.Spy;
     let transformToDarkColorSpy: jasmine.Spy;
+    let normalizeContentModelSpy: jasmine.Spy;
 
     const type = 'Entity';
     const apiName = 'insertEntity';
@@ -61,6 +63,7 @@ describe('insertEntity', () => {
         getDocumentSpy = jasmine.createSpy('getDocumentSpy').and.returnValue({
             createElement: createElementSpy,
         });
+        normalizeContentModelSpy = spyOn(normalizeContentModel, 'normalizeContentModel');
 
         editor = {
             triggerContentChangedEvent: triggerContentChangedEventSpy,
@@ -104,6 +107,7 @@ describe('insertEntity', () => {
             newEntity
         );
         expect(transformToDarkColorSpy).not.toHaveBeenCalled();
+        expect(normalizeContentModelSpy).toHaveBeenCalled();
 
         expect(entity).toBe(newEntity);
     });
@@ -142,6 +146,7 @@ describe('insertEntity', () => {
             newEntity
         );
         expect(transformToDarkColorSpy).not.toHaveBeenCalled();
+        expect(normalizeContentModelSpy).toHaveBeenCalled();
 
         expect(entity).toBe(newEntity);
     });
@@ -187,6 +192,7 @@ describe('insertEntity', () => {
             newEntity
         );
         expect(transformToDarkColorSpy).not.toHaveBeenCalled();
+        expect(normalizeContentModelSpy).toHaveBeenCalled();
 
         expect(entity).toBe(newEntity);
     });
@@ -226,6 +232,8 @@ describe('insertEntity', () => {
             ChangeSource.InsertEntity,
             newEntity
         );
+        expect(normalizeContentModelSpy).toHaveBeenCalled();
+
         expect(context.newEntities).toEqual([
             {
                 segmentType: 'Entity',

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/applyPendingFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/applyPendingFormatTest.ts
@@ -48,6 +48,7 @@ describe('applyPendingFormat', () => {
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
                 callback(model, {
+                    newEntities: [],
                     deletedEntities: [],
                 });
             }
@@ -118,7 +119,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { deletedEntities: [] });
+                callback(model, { newEntities: [], deletedEntities: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
@@ -178,7 +179,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { deletedEntities: [] });
+                callback(model, { newEntities: [], deletedEntities: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
@@ -236,7 +237,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { deletedEntities: [] });
+                callback(model, { newEntities: [], deletedEntities: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
@@ -281,9 +282,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, {
-                    deletedEntities: [],
-                });
+                callback(model, { newEntities: [], deletedEntities: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/clearFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/clearFormatTest.ts
@@ -13,7 +13,7 @@ describe('clearFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('clearFormat');
-                callback(model, { deletedEntities: [] });
+                callback(model, { newEntities: [], deletedEntities: [] });
             }
         );
         spyOn(clearModelFormat, 'clearModelFormat');

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/changeImageTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/changeImageTest.ts
@@ -50,6 +50,7 @@ describe('changeImage', () => {
             getDocument: () => document,
             getSelectionRangeEx,
             triggerPluginEvent,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
 
         executionCallback(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/insertImageTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/insertImageTest.ts
@@ -37,6 +37,7 @@ describe('insertImage', () => {
             setContentModel,
             isDisposed: () => false,
             getDocument: () => document,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
 
         executionCallback(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/adjustLinkSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/adjustLinkSelectionTest.ts
@@ -25,6 +25,7 @@ describe('adjustLinkSelection', () => {
             addUndoSnapshot: (callback: Function) => callback(),
             setContentModel,
             createContentModel,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/insertLinkTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/insertLinkTest.ts
@@ -27,6 +27,7 @@ describe('insertLink', () => {
             createContentModel,
             getCustomData: () => ({}),
             getFocusedPosition: () => ({}),
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/removeLinkTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/removeLinkTest.ts
@@ -23,6 +23,7 @@ describe('removeLink', () => {
             addUndoSnapshot: (callback: Function) => callback(),
             setContentModel,
             createContentModel,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStartNumberTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStartNumberTest.ts
@@ -11,7 +11,7 @@ describe('setListStartNumber', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (editor, apiName, callback) => {
                 expect(apiName).toBe('setListStartNumber');
-                const result = callback(input, { deletedEntities: [] });
+                const result = callback(input, { newEntities: [], deletedEntities: [] });
 
                 expect(result).toBe(expectedResult);
             }

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStyleTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStyleTest.ts
@@ -12,7 +12,7 @@ describe('setListStyle', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (editor, apiName, callback) => {
                 expect(apiName).toBe('setListStyle');
-                const result = callback(input, { deletedEntities: [] });
+                const result = callback(input, { newEntities: [], deletedEntities: [] });
 
                 expect(result).toBe(expectedResult);
             }

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/toggleBulletTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/toggleBulletTest.ts
@@ -26,6 +26,7 @@ describe('toggleBullet', () => {
             setContentModel,
             getCustomData: () => ({}),
             getFocusedPosition: () => ({}),
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
 
         spyOn(setListType, 'setListType').and.returnValue(true);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/toggleNumberingTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/toggleNumberingTest.ts
@@ -26,6 +26,7 @@ describe('toggleNumbering', () => {
             setContentModel,
             getCustomData: () => ({}),
             getFocusedPosition: () => ({}),
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
 
         spyOn(setListType, 'setListType').and.returnValue(true);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/segment/changeFontSizeTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/segment/changeFontSizeTest.ts
@@ -351,6 +351,7 @@ describe('changeFontSize', () => {
             addUndoSnapshot,
             focus: jasmine.createSpy(),
             setContentModel,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
 
         changeFontSize(editor, 'increase');

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/segment/segmentTestCommon.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/segment/segmentTestCommon.ts
@@ -1,7 +1,7 @@
 import * as pendingFormat from '../../../lib/modelApi/format/pendingFormat';
+import { ContentModelDocument } from 'roosterjs-content-model-types';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 import { NodePosition } from 'roosterjs-editor-types';
-import { ContentModelDocument } from 'roosterjs-content-model-types';
 
 export function segmentTestCommon(
     apiName: string,
@@ -30,6 +30,7 @@ export function segmentTestCommon(
         setContentModel,
         isDisposed: () => false,
         getFocusedPosition: () => null as NodePosition,
+        isDarkMode: () => false,
     } as any) as IContentModelEditor;
 
     executionCallback(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/table/setTableCellShadeTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/table/setTableCellShadeTest.ts
@@ -20,6 +20,7 @@ describe('setTableCellShade', () => {
             addUndoSnapshot: (callback: Function) => callback(),
             setContentModel,
             createContentModel,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatImageWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatImageWithContentModelTest.ts
@@ -225,6 +225,7 @@ function segmentTestForPluginEvent(
         isDisposed: () => false,
         getFocusedPosition: () => null as NodePosition,
         triggerPluginEvent,
+        isDarkMode: () => false,
     } as any) as IContentModelEditor;
 
     executionCallback(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatParagraphWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatParagraphWithContentModelTest.ts
@@ -1,12 +1,12 @@
 import * as pendingFormat from '../../../lib/modelApi/format/pendingFormat';
 import { ContentModelDocument } from 'roosterjs-content-model-types';
+import { formatParagraphWithContentModel } from '../../../lib/publicApi/utils/formatParagraphWithContentModel';
+import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 import {
     createContentModelDocument,
     createParagraph,
     createText,
 } from 'roosterjs-content-model-dom';
-import { formatParagraphWithContentModel } from '../../../lib/publicApi/utils/formatParagraphWithContentModel';
-import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 
 describe('formatParagraphWithContentModel', () => {
     let editor: IContentModelEditor;
@@ -27,6 +27,7 @@ describe('formatParagraphWithContentModel', () => {
             addUndoSnapshot,
             createContentModel: () => model,
             setContentModel,
+            isDarkMode: () => false,
             getCustomData: () => ({}),
             getFocusedPosition: () => 'NewPosition',
         } as any) as IContentModelEditor;

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatSegmentWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatSegmentWithContentModelTest.ts
@@ -35,6 +35,7 @@ describe('formatSegmentWithContentModel', () => {
             createContentModel: () => model,
             setContentModel,
             getFocusedPosition: () => null as NodePosition,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
@@ -40,6 +40,7 @@ describe('formatWithContentModel', () => {
             getFocusedPosition,
             triggerContentChangedEvent,
             triggerPluginEvent,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });
 
@@ -49,6 +50,7 @@ describe('formatWithContentModel', () => {
         formatWithContentModel(editor, apiName, callback);
 
         expect(callback).toHaveBeenCalledWith(mockedModel, {
+            newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
         });
@@ -64,6 +66,7 @@ describe('formatWithContentModel', () => {
         formatWithContentModel(editor, apiName, callback);
 
         expect(callback).toHaveBeenCalledWith(mockedModel, {
+            newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
         });
@@ -91,6 +94,7 @@ describe('formatWithContentModel', () => {
         });
 
         expect(callback).toHaveBeenCalledWith(mockedModel, {
+            newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
         });
@@ -122,6 +126,7 @@ describe('formatWithContentModel', () => {
         formatWithContentModel(editor, apiName, callback);
 
         expect(callback).toHaveBeenCalledWith(mockedModel, {
+            newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
             skipUndoSnapshot: true,
@@ -136,6 +141,7 @@ describe('formatWithContentModel', () => {
         formatWithContentModel(editor, apiName, callback, { changeSource: 'TEST' });
 
         expect(callback).toHaveBeenCalledWith(mockedModel, {
+            newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
         });
@@ -155,6 +161,7 @@ describe('formatWithContentModel', () => {
         });
 
         expect(callback).toHaveBeenCalledWith(mockedModel, {
+            newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
             skipUndoSnapshot: true,
@@ -171,6 +178,7 @@ describe('formatWithContentModel', () => {
         formatWithContentModel(editor, apiName, callback, { onNodeCreated: onNodeCreated });
 
         expect(callback).toHaveBeenCalledWith(mockedModel, {
+            newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
         });
@@ -187,6 +195,7 @@ describe('formatWithContentModel', () => {
         formatWithContentModel(editor, apiName, callback, { getChangeData });
 
         expect(callback).toHaveBeenCalledWith(mockedModel, {
+            newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
         });
@@ -238,6 +247,35 @@ describe('formatWithContentModel', () => {
             operation: EntityOperation.RemoveFromEnd,
             rawEvent: rawEvent,
         });
+    });
+
+    it('Has new entity in dark mode', () => {
+        const wrapper1 = 'W1' as any;
+        const wrapper2 = 'W2' as any;
+        const entity1 = { id: 'E1', type: 'E', wrapper: wrapper1, isReadonly: true } as any;
+        const entity2 = { id: 'E2', type: 'E', wrapper: wrapper2, isReadonly: true } as any;
+        const rawEvent = 'RawEvent' as any;
+        const transformToDarkColorSpy = jasmine.createSpy('transformToDarkColor');
+
+        editor.isDarkMode = () => true;
+        editor.transformToDarkColor = transformToDarkColorSpy;
+
+        formatWithContentModel(
+            editor,
+            apiName,
+            (model, context) => {
+                context.newEntities.push(entity1, entity2);
+                return true;
+            },
+            {
+                rawEvent: rawEvent,
+            }
+        );
+
+        expect(triggerPluginEvent).not.toHaveBeenCalled();
+        expect(transformToDarkColorSpy).toHaveBeenCalledTimes(2);
+        expect(transformToDarkColorSpy).toHaveBeenCalledWith(wrapper1);
+        expect(transformToDarkColorSpy).toHaveBeenCalledWith(wrapper2);
     });
 
     it('With selectionOverride', () => {

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
@@ -109,6 +109,7 @@ describe('Paste ', () => {
             getDocument,
             getTrustedHTMLHandler,
             triggerPluginEvent,
+            isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });
 
@@ -429,7 +430,7 @@ describe('mergePasteContent', () => {
 
         pasteF.mergePasteContent(
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             pasteModel,
             false /* applyCurrentFormat */,
             undefined /* customizedMerge */
@@ -438,7 +439,7 @@ describe('mergePasteContent', () => {
         expect(mergeModelFile.mergeModel).toHaveBeenCalledWith(
             sourceModel,
             pasteModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeFormat: 'none',
                 mergeTable: true,
@@ -517,7 +518,7 @@ describe('mergePasteContent', () => {
 
         pasteF.mergePasteContent(
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             pasteModel,
             false /* applyCurrentFormat */,
             customizedMerge /* customizedMerge */
@@ -535,7 +536,7 @@ describe('mergePasteContent', () => {
 
         pasteF.mergePasteContent(
             sourceModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             pasteModel,
             true /* applyCurrentFormat */,
             undefined /* customizedMerge */
@@ -544,7 +545,7 @@ describe('mergePasteContent', () => {
         expect(mergeModelFile.mergeModel).toHaveBeenCalledWith(
             sourceModel,
             pasteModel,
-            { deletedEntities: [] },
+            { newEntities: [], deletedEntities: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
                 mergeTable: false,

--- a/packages/roosterjs-editor-core/lib/editor/EditorBase.ts
+++ b/packages/roosterjs-editor-core/lib/editor/EditorBase.ts
@@ -59,6 +59,7 @@ import {
 } from 'roosterjs-editor-dom';
 import type {
     CompatibleChangeSource,
+    CompatibleColorTransformDirection,
     CompatibleContentPosition,
     CompatibleExperimentalFeatures,
     CompatibleGetContentMode,
@@ -899,16 +900,16 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
     /**
      * Transform the given node and all its child nodes to dark mode color if editor is in dark mode
      * @param node The node to transform
+     * @param direction The transform direction. @default ColorTransformDirection.LightToDark
      */
-    public transformToDarkColor(node: Node) {
+    public transformToDarkColor(
+        node: Node,
+        direction:
+            | ColorTransformDirection
+            | CompatibleColorTransformDirection = ColorTransformDirection.LightToDark
+    ) {
         const core = this.getCore();
-        core.api.transformColor(
-            core,
-            node,
-            true /*includeSelf*/,
-            null /*callback*/,
-            ColorTransformDirection.LightToDark
-        );
+        core.api.transformColor(core, node, true /*includeSelf*/, null /*callback*/, direction);
     }
 
     /**

--- a/packages/roosterjs-editor-types/lib/interface/IEditor.ts
+++ b/packages/roosterjs-editor-types/lib/interface/IEditor.ts
@@ -11,6 +11,7 @@ import Region from './Region';
 import SelectionPath from './SelectionPath';
 import TableSelection from './TableSelection';
 import { ChangeSource } from '../enum/ChangeSource';
+import { ColorTransformDirection } from '../enum/ColorTransformDirection';
 import { ContentPosition } from '../enum/ContentPosition';
 import { DOMEventHandler } from '../type/domEventHandler';
 import { EditorUndoState, PendableFormatState, StyleBasedFormatState } from './FormatState';
@@ -34,6 +35,7 @@ import type { CompatibleExperimentalFeatures } from '../compatibleEnum/Experimen
 import type { CompatibleGetContentMode } from '../compatibleEnum/GetContentMode';
 import type { CompatibleQueryScope } from '../compatibleEnum/QueryScope';
 import type { CompatibleRegionType } from '../compatibleEnum/RegionType';
+import type { CompatibleColorTransformDirection } from '../compatibleEnum/ColorTransformDirection';
 
 /**
  * Interface of roosterjs editor object
@@ -594,8 +596,12 @@ export default interface IEditor {
     /**
      * Transform the given node and all its child nodes to dark mode color if editor is in dark mode
      * @param node The node to transform
+     * @param direction The transform direction. @default ColorTransformDirection.LightToDark
      */
-    transformToDarkColor(node: Node): void;
+    transformToDarkColor(
+        node: Node,
+        direction?: ColorTransformDirection | CompatibleColorTransformDirection
+    ): void;
 
     /**
      * Get a darkColorHandler object for this editor.


### PR DESCRIPTION
This change contains two parts:

1. When copy, we need to convert to light color for entities if editor is in dark mode
2. When paste, we need to convert to dark color for entities if editor is in dark mode

For copy, I modified `ContentModelCopyPastePlugin` to do color transformation on each cloned entity wrapper. To achieve this, I need to modify `cloneModel` API to allow passing in a callback.

For paste, I modified `mergeModel` and put all new entities onto a new `newEntities` array of `FormatWithContentModelContext`, hen `formatWithContentModel` API can handle this result and do color transformation if editor is in dark mode.

Also modified `insertEntity` API to leverage this new strategy, and call `normalizeContentModel` to make the model looks right after insert entity.