### PR TITLE
Content Model: Fix a regression of shadow edit

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/switchShadowEdit.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/switchShadowEdit.ts
@@ -14,10 +14,7 @@ export const switchShadowEdit: SwitchShadowEdit = (editorCore, isOn): void => {
 
     if (isOn != !!core.lifecycle.shadowEditFragment) {
         if (isOn) {
-            if (!core.cachedModel) {
-                core.cachedModel = core.api.createContentModel(core);
-            }
-
+            const model = !core.cachedModel ? core.api.createContentModel(core) : null;
             const range = core.api.getSelectionRange(core, true /*tryGetFromCache*/);
 
             // Fake object, not used in Content Model Editor, just to satisfy original editor code
@@ -34,6 +31,12 @@ export const switchShadowEdit: SwitchShadowEdit = (editorCore, isOn): void => {
                 },
                 false /*broadcast*/
             );
+
+            // This need to be done after EnteredShadowEdit event is triggered since EnteredShadowEdit event will cause a SelectionChanged event
+            // if current selection is table selection or image selection
+            if (!core.cachedModel && model) {
+                core.cachedModel = model;
+            }
 
             core.lifecycle.shadowEditSelectionPath = selectionPath;
             core.lifecycle.shadowEditFragment = fragment;

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/coreApi/switchShadowEditTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/coreApi/switchShadowEditTest.ts
@@ -32,6 +32,7 @@ describe('switchShadowEdit', () => {
 
     describe('was off', () => {
         it('no cache, isOn', () => {
+            core.cachedModel = undefined;
             switchShadowEdit(core, true);
 
             expect(createContentModel).toHaveBeenCalledWith(core);


### PR DESCRIPTION
From change https://github.com/microsoft/roosterjs/pull/2053, a EnteredShadowEdit event will be triggered when start shadow edit. However, table selection and image selection plugin will reselect current selection when receive this event, that causes cached content model to be cleared. So shadow edit format won't work since it can't get cached content model.

To fix it, we need to first get content model, then trigger event, and set cached model at last.