### PR TITLE
Content Model Customization refactor 0

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/config/defaultContentModelFormatMap.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/config/defaultContentModelFormatMap.ts
@@ -1,0 +1,54 @@
+import { DefaultImplicitFormatMap } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ * A map from tag name to its default implicit formats
+ */
+export const defaultContentModelFormatMap: DefaultImplicitFormatMap = {
+    a: {
+        underline: true,
+    },
+    blockquote: {
+        marginTop: '1em',
+        marginBottom: '1em',
+        marginLeft: '40px',
+        marginRight: '40px',
+    },
+    code: {
+        fontFamily: 'monospace',
+    },
+    h1: {
+        fontWeight: 'bold',
+        fontSize: '2em',
+    },
+    h2: {
+        fontWeight: 'bold',
+        fontSize: '1.5em',
+    },
+    h3: {
+        fontWeight: 'bold',
+        fontSize: '1.17em',
+    },
+    h4: {
+        fontWeight: 'bold',
+        fontSize: '1em', // Set this default value here to overwrite existing font size when change heading level
+    },
+    h5: {
+        fontWeight: 'bold',
+        fontSize: '0.83em',
+    },
+    h6: {
+        fontWeight: 'bold',
+        fontSize: '0.67em',
+    },
+    p: {
+        marginTop: '1em',
+        marginBottom: '1em',
+    },
+    pre: {
+        fontFamily: 'monospace',
+        whiteSpace: 'pre',
+        marginTop: '1em',
+        marginBottom: '1em',
+    },
+};

--- a/packages-content-model/roosterjs-content-model-dom/lib/config/defaultHTMLStyleMap.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/config/defaultHTMLStyleMap.ts
@@ -1,4 +1,4 @@
-import { DefaultImplicitFormatMap, DefaultStyleMap } from 'roosterjs-content-model-types';
+import { DefaultStyleMap } from 'roosterjs-content-model-types';
 
 const blockElement: Partial<CSSStyleDeclaration> = {
     display: 'block',
@@ -7,7 +7,7 @@ const blockElement: Partial<CSSStyleDeclaration> = {
 /**
  * @internal
  */
-export const defaultStyleMap: DefaultStyleMap = {
+export const defaultHTMLStyleMap: DefaultStyleMap = {
     address: blockElement,
     article: blockElement,
     aside: blockElement,
@@ -122,70 +122,4 @@ export const defaultStyleMap: DefaultStyleMap = {
         textDecoration: 'underline',
     },
     ul: blockElement,
-};
-
-/**
- * @internal
- */
-export const enum PseudoTagNames {
-    childOfPre = 'pre *', // This value is not a CSS selector, it just to tell this will impact elements under PRE tag. Any unique value here can work actually
-}
-
-/**
- * A map from tag name to its default implicit formats
- */
-export const defaultImplicitFormatMap: DefaultImplicitFormatMap = {
-    a: {
-        underline: true,
-    },
-    blockquote: {
-        marginTop: '1em',
-        marginBottom: '1em',
-        marginLeft: '40px',
-        marginRight: '40px',
-    },
-    code: {
-        fontFamily: 'monospace',
-    },
-    h1: {
-        fontWeight: 'bold',
-        fontSize: '2em',
-    },
-    h2: {
-        fontWeight: 'bold',
-        fontSize: '1.5em',
-    },
-    h3: {
-        fontWeight: 'bold',
-        fontSize: '1.17em',
-    },
-    h4: {
-        fontWeight: 'bold',
-        fontSize: '1em', // Set this default value here to overwrite existing font size when change heading level
-    },
-    h5: {
-        fontWeight: 'bold',
-        fontSize: '0.83em',
-    },
-    h6: {
-        fontWeight: 'bold',
-        fontSize: '0.67em',
-    },
-    p: {
-        marginTop: '1em',
-        marginBottom: '1em',
-    },
-    pre: {
-        fontFamily: 'monospace',
-        whiteSpace: 'pre',
-        marginTop: '1em',
-        marginBottom: '1em',
-    },
-
-    // For PRE tag, the following styles will be included from the PRE tag.
-    // Adding this implicit style here so no need to generate these style for child elements
-    [PseudoTagNames.childOfPre]: {
-        fontFamily: 'monospace',
-        whiteSpace: 'pre',
-    },
 };

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext.ts
@@ -1,6 +1,5 @@
 import { defaultFormatParsers, getFormatParsers } from '../../formatHandlers/defaultFormatHandlers';
 import { defaultProcessorMap } from './defaultProcessors';
-import { defaultStyleMap } from '../../formatHandlers/utils/defaultStyles';
 import { DomToModelContext, DomToModelOption, EditorContext } from 'roosterjs-content-model-types';
 import { SelectionRangeEx } from 'roosterjs-editor-types';
 
@@ -41,11 +40,6 @@ export function createDomToModelContext(
         elementProcessors: {
             ...defaultProcessorMap,
             ...(options?.processorOverride || {}),
-        },
-
-        defaultStyles: {
-            ...defaultStyleMap,
-            ...(options?.defaultStyleOverride || {}),
         },
 
         formatParsers: getFormatParsers(

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/getDefaultStyle.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/getDefaultStyle.ts
@@ -1,3 +1,4 @@
+import { defaultHTMLStyleMap } from '../../config/defaultHTMLStyleMap';
 import { DefaultStyleMap, DomToModelContext } from 'roosterjs-content-model-types';
 
 /**
@@ -13,5 +14,5 @@ export function getDefaultStyle(
 ): Partial<CSSStyleDeclaration> {
     let tag = element.tagName.toLowerCase() as keyof DefaultStyleMap;
 
-    return context.defaultStyles[tag] || {};
+    return defaultHTMLStyleMap[tag] || {};
 }

--- a/packages-content-model/roosterjs-content-model-dom/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/index.ts
@@ -49,6 +49,6 @@ export { setParagraphNotImplicit } from './modelApi/block/setParagraphNotImplici
 export { parseValueWithUnit } from './formatHandlers/utils/parseValueWithUnit';
 export { BorderKeys } from './formatHandlers/common/borderFormatHandler';
 export { DeprecatedColors } from './formatHandlers/utils/color';
-export { defaultImplicitFormatMap } from './formatHandlers/utils/defaultStyles';
 
 export { createDomToModelContext } from './domToModel/context/createDomToModelContext';
+export { createModelToDomContext } from './modelToDom/context/createModelToDomContext';

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext.ts
@@ -1,5 +1,4 @@
 import { defaultContentModelHandlers } from './defaultContentModelHandlers';
-import { defaultImplicitFormatMap } from '../../formatHandlers/utils/defaultStyles';
 import { EditorContext, ModelToDomContext, ModelToDomOption } from 'roosterjs-content-model-types';
 import {
     defaultFormatAppliers,
@@ -38,10 +37,6 @@ export function createModelToDomContext(
         modelHandlers: {
             ...defaultContentModelHandlers,
             ...(options.modelHandlerOverride || {}),
-        },
-        defaultImplicitFormatMap: {
-            ...defaultImplicitFormatMap,
-            ...(options.defaultImplicitFormatOverride || {}),
         },
 
         defaultModelHandlers: defaultContentModelHandlers,

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext.ts
@@ -6,7 +6,6 @@ import {
 } from '../../formatHandlers/defaultFormatHandlers';
 
 /**
- * @internal
  * @param editorContext
  * @returns
  */

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleFormatContainer.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleFormatContainer.ts
@@ -1,13 +1,19 @@
 import { applyFormat } from '../utils/applyFormat';
 import { isBlockGroupEmpty } from '../../modelApi/common/isEmpty';
-import { PseudoTagNames } from '../../formatHandlers/utils/defaultStyles';
 import { reuseCachedElement } from '../utils/reuseCachedElement';
 import { stackFormat } from '../utils/stackFormat';
 import {
+    ContentModelBlockFormat,
     ContentModelBlockHandler,
     ContentModelFormatContainer,
+    ContentModelSegmentFormat,
     ModelToDomContext,
 } from 'roosterjs-content-model-types';
+
+const PreChildFormat: ContentModelSegmentFormat & ContentModelBlockFormat = {
+    fontFamily: 'monospace',
+    whiteSpace: 'pre',
+};
 
 /**
  * @internal
@@ -47,7 +53,7 @@ export const handleFormatContainer: ContentModelBlockHandler<ContentModelFormatC
         });
 
         if (container.tagName == 'pre') {
-            stackFormat(context, PseudoTagNames.childOfPre, () => {
+            stackFormat(context, PreChildFormat, () => {
                 context.modelHandlers.blockGroupChildren(doc, containerNode, container, context);
             });
         } else {

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/utils/stackFormat.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/utils/stackFormat.ts
@@ -1,3 +1,4 @@
+import { defaultContentModelFormatMap } from '../../config/defaultContentModelFormatMap';
 import {
     ContentModelBlockFormat,
     ContentModelSegmentFormat,
@@ -14,7 +15,7 @@ export function stackFormat(
 ) {
     const newFormat =
         typeof tagNameOrFormat === 'string'
-            ? context.defaultImplicitFormatMap[tagNameOrFormat]
+            ? defaultContentModelFormatMap[tagNameOrFormat]
             : tagNameOrFormat;
 
     if (newFormat) {

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/context/createDomToModelContextTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/context/createDomToModelContextTest.ts
@@ -125,7 +125,6 @@ describe('createDomToModelContext', () => {
 
     it('with override', () => {
         const mockedAProcessor = 'a' as any;
-        const mockedOlStyle = 'ol' as any;
         const mockedBoldParser = 'bold' as any;
         const mockedBlockParser = 'block' as any;
         const context = createDomToModelContext(undefined, {

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/context/createDomToModelContextTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/context/createDomToModelContextTest.ts
@@ -1,6 +1,5 @@
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
 import { defaultProcessorMap } from '../../../lib/domToModel/context/defaultProcessors';
-import { defaultStyleMap } from '../../../lib/formatHandlers/utils/defaultStyles';
 import { DomToModelListFormat, EditorContext } from 'roosterjs-content-model-types';
 import {
     defaultFormatParsers,
@@ -15,7 +14,6 @@ describe('createDomToModelContext', () => {
     };
     const contextOptions = {
         elementProcessors: defaultProcessorMap,
-        defaultStyles: defaultStyleMap,
         formatParsers: getFormatParsers(),
         defaultElementProcessors: defaultProcessorMap,
         defaultFormatParsers: defaultFormatParsers,
@@ -134,9 +132,6 @@ describe('createDomToModelContext', () => {
             processorOverride: {
                 a: mockedAProcessor,
             },
-            defaultStyleOverride: {
-                ol: mockedOlStyle,
-            },
             formatParserOverride: {
                 bold: mockedBoldParser,
             },
@@ -146,7 +141,6 @@ describe('createDomToModelContext', () => {
         });
 
         expect(context.elementProcessors.a).toBe(mockedAProcessor);
-        expect(context.defaultStyles.ol).toBe(mockedOlStyle);
         expect(context.formatParsers.segment.indexOf(mockedBoldParser)).toBeGreaterThanOrEqual(0);
         expect(context.formatParsers.block).toEqual([
             ...getFormatParsers().block,

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/utils/getDefaultStyleTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/utils/getDefaultStyleTest.ts
@@ -18,22 +18,6 @@ describe('getDefaultStyle', () => {
         });
     });
 
-    it('Get customized default style of DIV', () => {
-        context = createDomToModelContext(undefined, {
-            defaultStyleOverride: {
-                div: {
-                    color: 'red',
-                },
-            },
-        });
-        const div = document.createElement('div');
-        const style = getDefaultStyle(div, context);
-
-        expect(style).toEqual({
-            color: 'red',
-        });
-    });
-
     it('Get default style of customized element', () => {
         const test = document.createElement('test');
         const style = getDefaultStyle(test, context);

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/utils/isBlockElementTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/utils/isBlockElementTest.ts
@@ -67,52 +67,6 @@ describe('isBlockElement', () => {
         expect(result).toBeTrue();
     });
 
-    it('Override DIV default style', () => {
-        const div = document.createElement('div');
-
-        context = createDomToModelContext(undefined, {
-            defaultStyleOverride: {
-                div: {
-                    display: 'inline',
-                },
-            },
-        });
-
-        const result = isBlockElement(div, context);
-        expect(result).toBeFalse();
-    });
-
-    it('Override SPAN default style', () => {
-        const span = document.createElement('span');
-
-        context = createDomToModelContext(undefined, {
-            defaultStyleOverride: {
-                span: {
-                    display: 'block',
-                },
-            },
-        });
-
-        const result = isBlockElement(span, context);
-        expect(result).toBeTrue();
-    });
-
-    it('Double override SPAN', () => {
-        const span = document.createElement('span');
-        span.style.display = 'inline';
-
-        context = createDomToModelContext(undefined, {
-            defaultStyleOverride: {
-                span: {
-                    display: 'block',
-                },
-            },
-        });
-
-        const result = isBlockElement(span, context);
-        expect(result).toBeFalse();
-    });
-
     it('display = flex', () => {
         const div = document.createElement('div');
         div.style.display = 'flex';

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/segment/linkFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/segment/linkFormatHandlerTest.ts
@@ -1,5 +1,6 @@
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { defaultHTMLStyleMap } from '../../../lib/config/defaultHTMLStyleMap';
 import { DomToModelContext, LinkFormat, ModelToDomContext } from 'roosterjs-content-model-types';
 import { linkFormatHandler } from '../../../lib/formatHandlers/segment/linkFormatHandler';
 
@@ -17,7 +18,7 @@ describe('linkFormatHandler.parse', () => {
 
         div.setAttribute('href', '/test');
 
-        linkFormatHandler.parse(format, div, context, context.defaultStyles.a!);
+        linkFormatHandler.parse(format, div, context, defaultHTMLStyleMap.a!);
 
         expect(format).toEqual({});
     });
@@ -27,7 +28,7 @@ describe('linkFormatHandler.parse', () => {
 
         a.href = '/test';
 
-        linkFormatHandler.parse(format, a, context, context.defaultStyles.a!);
+        linkFormatHandler.parse(format, a, context, defaultHTMLStyleMap.a!);
 
         expect(format).toEqual({
             href: '/test',
@@ -45,7 +46,7 @@ describe('linkFormatHandler.parse', () => {
         a.target = 'target';
         a.name = 'name';
 
-        linkFormatHandler.parse(format, a, context, context.defaultStyles.a!);
+        linkFormatHandler.parse(format, a, context, defaultHTMLStyleMap.a!);
 
         expect(format).toEqual({
             anchorClass: 'class',

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/segment/textColorFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/segment/textColorFormatHandlerTest.ts
@@ -1,6 +1,7 @@
 import DarkColorHandlerImpl from 'roosterjs-editor-core/lib/editor/DarkColorHandlerImpl';
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { defaultHTMLStyleMap } from '../../../lib/config/defaultHTMLStyleMap';
 import { DeprecatedColors } from '../../../lib';
 import { expectHtml } from 'roosterjs-editor-dom/test/DomTestHelper';
 import { textColorFormatHandler } from '../../../lib/formatHandlers/segment/textColorFormatHandler';
@@ -74,7 +75,7 @@ describe('textColorFormatHandler.parse', () => {
     it('Color from hyperlink with override', () => {
         div.style.color = 'red';
 
-        textColorFormatHandler.parse(format, div, context, context.defaultStyles.a!);
+        textColorFormatHandler.parse(format, div, context, defaultHTMLStyleMap.a!);
 
         expect(format).toEqual({
             textColor: 'red',

--- a/packages-content-model/roosterjs-content-model-dom/test/modelToDom/context/createModelToDomContextTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelToDom/context/createModelToDomContextTest.ts
@@ -1,6 +1,5 @@
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { defaultContentModelHandlers } from '../../../lib/modelToDom/context/defaultContentModelHandlers';
-import { defaultImplicitFormatMap } from '../../../lib/formatHandlers/utils/defaultStyles';
 import { EditorContext, ModelToDomContext } from 'roosterjs-content-model-types';
 import {
     defaultFormatAppliers,
@@ -24,7 +23,6 @@ describe('createModelToDomContext', () => {
         implicitFormat: {},
         formatAppliers: getFormatAppliers(),
         modelHandlers: defaultContentModelHandlers,
-        defaultImplicitFormatMap: defaultImplicitFormatMap,
         defaultModelHandlers: defaultContentModelHandlers,
         defaultFormatAppliers: defaultFormatAppliers,
         onNodeCreated: undefined,
@@ -52,7 +50,6 @@ describe('createModelToDomContext', () => {
         const mockedBoldApplier = 'bold' as any;
         const mockedBlockApplier = 'block' as any;
         const mockedBrHandler = 'br' as any;
-        const mockedAStyle = 'a' as any;
         const onNodeCreated = 'OnNodeCreated' as any;
         const context = createModelToDomContext(undefined, {
             formatApplierOverride: {
@@ -63,9 +60,6 @@ describe('createModelToDomContext', () => {
             },
             modelHandlerOverride: {
                 br: mockedBrHandler,
-            },
-            defaultImplicitFormatOverride: {
-                a: mockedAStyle,
             },
             onNodeCreated,
         });
@@ -86,7 +80,6 @@ describe('createModelToDomContext', () => {
             mockedBlockApplier,
         ]);
         expect(context.modelHandlers.br).toBe(mockedBrHandler);
-        expect(context.defaultImplicitFormatMap.a).toEqual(mockedAStyle);
         expect(context.defaultModelHandlers).toEqual(defaultContentModelHandlers);
         expect(context.defaultFormatAppliers).toEqual(defaultFormatAppliers);
         expect(context.onNodeCreated).toBe(onNodeCreated);

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/block/setHeadingLevel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/block/setHeadingLevel.ts
@@ -1,12 +1,17 @@
-import { defaultImplicitFormatMap } from 'roosterjs-content-model-dom';
+import { ContentModelParagraphDecorator } from 'roosterjs-content-model-types';
 import { formatParagraphWithContentModel } from '../utils/formatParagraphWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
-import {
-    ContentModelParagraphDecorator,
-    ContentModelSegmentFormat,
-} from 'roosterjs-content-model-types';
 
 type HeadingLevelTags = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+const HeaderFontSizes: Record<HeadingLevelTags, string> = {
+    h1: '2em',
+    h2: '1.5em',
+    h3: '1.17em',
+    h4: '1em',
+    h5: '0.83em',
+    h6: '0.67em',
+};
 
 /**
  * Set heading level of selected paragraphs
@@ -22,13 +27,16 @@ export default function setHeadingLevel(
             headingLevel > 0
                 ? (('h' + headingLevel) as HeadingLevelTags | null)
                 : getExistingHeadingTag(para.decorator);
-        const headingStyle =
-            (tagName && (defaultImplicitFormatMap[tagName] as ContentModelSegmentFormat)) || {};
 
         if (headingLevel > 0) {
             para.decorator = {
                 tagName: tagName!,
-                format: { ...headingStyle },
+                format: tagName
+                    ? {
+                          fontWeight: 'bold',
+                          fontSize: HeaderFontSizes[tagName],
+                      }
+                    : {},
             };
 
             // Remove existing formats since tags have default font size and weight

--- a/packages-content-model/roosterjs-content-model-types/lib/context/DomToModelOption.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/context/DomToModelOption.ts
@@ -1,9 +1,4 @@
-import {
-    DefaultStyleMap,
-    ElementProcessorMap,
-    FormatParsers,
-    FormatParsersPerCategory,
-} from './DomToModelSettings';
+import { ElementProcessorMap, FormatParsers, FormatParsersPerCategory } from './DomToModelSettings';
 
 /**
  * Options for creating DomToModelContext
@@ -13,11 +8,6 @@ export interface DomToModelOption {
      * Overrides default element processors
      */
     processorOverride?: Partial<ElementProcessorMap>;
-
-    /**
-     * Overrides default element styles
-     */
-    defaultStyleOverride?: DefaultStyleMap;
 
     /**
      * Overrides default format handlers

--- a/packages-content-model/roosterjs-content-model-types/lib/context/DomToModelSettings.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/context/DomToModelSettings.ts
@@ -108,11 +108,6 @@ export interface DomToModelSettings {
     elementProcessors: ElementProcessorMap;
 
     /**
-     * Map of default styles
-     */
-    defaultStyles: DefaultStyleMap;
-
-    /**
      * Map of format parsers
      */
     formatParsers: FormatParsersPerCategory;

--- a/packages-content-model/roosterjs-content-model-types/lib/context/ModelToDomOption.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/context/ModelToDomOption.ts
@@ -1,6 +1,5 @@
 import {
     ContentModelHandlerMap,
-    DefaultImplicitFormatMap,
     FormatAppliers,
     FormatAppliersPerCategory,
     OnNodeCreated,
@@ -24,11 +23,6 @@ export interface ModelToDomOption {
      * Overrides default model handlers
      */
     modelHandlerOverride?: Partial<ContentModelHandlerMap>;
-
-    /**
-     * Overrides default element styles
-     */
-    defaultImplicitFormatOverride?: DefaultImplicitFormatMap;
 
     /**
      * An optional callback that will be called when a DOM node is created

--- a/packages-content-model/roosterjs-content-model-types/lib/context/ModelToDomSettings.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/context/ModelToDomSettings.ts
@@ -165,11 +165,6 @@ export interface ModelToDomSettings {
     formatAppliers: FormatAppliersPerCategory;
 
     /**
-     * Map of default implicit format for segment
-     */
-    defaultImplicitFormatMap: DefaultImplicitFormatMap;
-
-    /**
      * Default Content Model to DOM handlers before overriding.
      * This provides a way to call original handler from an overridden handler function
      */


### PR DESCRIPTION
Refactor existing Content Model Customization code

Step 0: Remove default styles from context since it is never really used.