### PR TITLE
Fix image rotator handle height

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Rotator.ts
@@ -63,35 +63,35 @@ export function updateRotateHandleState(
     } else {
         rotateCenter.style.display = '';
         rotateHandle.style.display = '';
-        const rotateHandleRect = rotateHandle.getBoundingClientRect();
+        const rotateCenterRect = rotateCenter.getBoundingClientRect();
         const wrapperRect = wrapper.getBoundingClientRect();
-
-        if (rotateHandleRect && wrapperRect) {
+        const ROTATOR_HEIGHT = ROTATE_SIZE + ROTATE_GAP + RESIZE_HANDLE_MARGIN;
+        if (rotateCenterRect && wrapperRect) {
             let adjustedDistance = Number.MAX_SAFE_INTEGER;
             const angle = angleRad * DEG_PER_RAD;
 
-            if (angle < 45 && angle > -45 && wrapperRect.top - editorRect.top < ROTATE_GAP) {
-                const top = rotateHandleRect.top - editorRect.top;
+            if (angle < 45 && angle > -45 && wrapperRect.top - editorRect.top < ROTATOR_HEIGHT) {
+                const top = rotateCenterRect.top - editorRect.top;
                 adjustedDistance = top;
             } else if (
                 angle <= -80 &&
                 angle >= -100 &&
-                wrapperRect.left - editorRect.left < ROTATE_GAP
+                wrapperRect.left - editorRect.left < ROTATOR_HEIGHT
             ) {
-                const left = rotateHandleRect.left - editorRect.left;
+                const left = rotateCenterRect.left - editorRect.left;
                 adjustedDistance = left;
             } else if (
                 angle >= 80 &&
                 angle <= 100 &&
-                editorRect.right - wrapperRect.right < ROTATE_GAP
+                editorRect.right - wrapperRect.right < ROTATOR_HEIGHT
             ) {
-                const right = rotateHandleRect.right - editorRect.right;
+                const right = rotateCenterRect.right - editorRect.right;
                 adjustedDistance = Math.min(editorRect.right - wrapperRect.right, right);
             } else if (
                 (angle <= -160 || angle >= 160) &&
-                editorRect.bottom - wrapperRect.bottom < ROTATE_GAP
+                editorRect.bottom - wrapperRect.bottom < ROTATOR_HEIGHT
             ) {
-                const bottom = rotateHandleRect.bottom - editorRect.bottom;
+                const bottom = rotateCenterRect.bottom - editorRect.bottom;
                 adjustedDistance = Math.min(editorRect.bottom - wrapperRect.bottom, bottom);
             }
 

--- a/packages/roosterjs-editor-plugins/test/imageEdit/rotatorTest.ts
+++ b/packages/roosterjs-editor-plugins/test/imageEdit/rotatorTest.ts
@@ -229,8 +229,8 @@ describe('updateRotateHandlePosition', () => {
                 y: 3,
                 toJSON: () => {},
             },
-            '-7px',
-            '1px',
+            '-6px',
+            '0px',
             '0px',
             {
                 top: 2,


### PR DESCRIPTION
Consider the rotator handle center when calculate the rotator handle height. 
**Before:**
![WrongHeight](https://github.com/microsoft/roosterjs/assets/87443959/2f4957df-0fb3-4fb3-9931-39b7534e650e)

**After:**
![CorrectHeight](https://github.com/microsoft/roosterjs/assets/87443959/25f905f9-fc81-4ee0-981e-7f4be6fb09eb)
