### PR TITLE
Fix table whole cell alignment

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/table/alignTableCell.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/table/alignTableCell.ts
@@ -59,6 +59,12 @@ export function alignTableCell(
                             return metadata;
                         });
                     }
+
+                    cell.blocks.forEach(block => {
+                        if (block.blockType === 'Paragraph') {
+                            delete block.format.textAlign;
+                        }
+                    });
                 }
             }
         }

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/table/alignTableCellTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/table/alignTableCellTest.ts
@@ -51,6 +51,9 @@ describe('alignTableCell', () => {
         expect(table.rows[1].cells[0].cachedElement).toEqual({} as any);
         expect(table.rows[1].cells[1].cachedElement).toBeUndefined();
         expect(table.rows[1].cells[2].cachedElement).toBeUndefined();
+        table.rows[0].cells[1].blocks.forEach(block => {
+            expect(block.format.textAlign).toEqual(undefined);
+        });
     }
 
     it('empty table', () => {


### PR DESCRIPTION
When align the cell for the whole text, remove the `textAligment` from the blocks inside the cell, so it do not override the cell alignment. 
![testAlignCell](https://github.com/microsoft/roosterjs/assets/87443959/cc6f2c07-26da-4eb2-b7f8-26b73ec027be)
