### PR TITLE
Content Model: Clear table selection fix

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/setSelection.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/setSelection.ts
@@ -102,14 +102,15 @@ function setSelectionToTable(
     start: Selectable | null,
     end: Selectable | null
 ): boolean {
+    const notFoundCo: Coordinates = { x: -1, y: -1 };
     const startCo = findCell(table, start);
-    const endCo = end ? findCell(table, end) : startCo;
+    const { x: firstX, y: firstY } = startCo ?? notFoundCo;
+    const { x: lastX, y: lastY } = (end ? findCell(table, end) : startCo) ?? notFoundCo;
 
-    if (!isInSelection && startCo && endCo) {
+    if (!isInSelection) {
         for (let row = 0; row < table.rows.length; row++) {
             for (let col = 0; col < table.rows[row].cells.length; col++) {
-                const isSelected =
-                    row >= startCo.y && row <= endCo.y && col >= startCo.x && col <= endCo.x;
+                const isSelected = row >= firstY && row <= lastY && col >= firstX && col <= lastX;
 
                 setIsSelected(table.rows[row].cells[col], isSelected);
             }

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/selection/setSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/selection/setSelectionTest.ts
@@ -725,4 +725,80 @@ describe('setSelection', () => {
             ],
         });
     });
+
+    it('Update table selection', () => {
+        const model = createContentModelDocument();
+        const table = createTable(3);
+
+        const cell_0_0 = createTableCell();
+        const cell_0_1 = createTableCell();
+        const cell_0_2 = createTableCell();
+        const cell_1_0 = createTableCell();
+        const cell_1_1 = createTableCell();
+        const cell_1_2 = createTableCell();
+        const cell_2_0 = createTableCell();
+        const cell_2_1 = createTableCell();
+        const cell_2_2 = createTableCell();
+
+        table.rows[0].cells.push(cell_0_0, cell_0_1, cell_0_2);
+        table.rows[1].cells.push(cell_1_0, cell_1_1, cell_1_2);
+        table.rows[2].cells.push(cell_2_0, cell_2_1, cell_2_2);
+
+        cell_0_0.isSelected = true;
+        cell_0_1.isSelected = true;
+        cell_1_0.isSelected = true;
+        cell_1_1.isSelected = true;
+
+        model.blocks.push(table);
+
+        setSelection(model, cell_1_1, cell_2_2);
+
+        expect(cell_0_0.isSelected).toBeFalsy();
+        expect(cell_0_1.isSelected).toBeFalsy();
+        expect(cell_0_2.isSelected).toBeFalsy();
+        expect(cell_1_0.isSelected).toBeFalsy();
+        expect(cell_1_1.isSelected).toBeTrue();
+        expect(cell_1_2.isSelected).toBeTrue();
+        expect(cell_2_0.isSelected).toBeFalsy();
+        expect(cell_2_1.isSelected).toBeTrue();
+        expect(cell_2_2.isSelected).toBeTrue();
+    });
+
+    it('Clear table selection', () => {
+        const model = createContentModelDocument();
+        const table = createTable(3);
+
+        const cell_0_0 = createTableCell();
+        const cell_0_1 = createTableCell();
+        const cell_0_2 = createTableCell();
+        const cell_1_0 = createTableCell();
+        const cell_1_1 = createTableCell();
+        const cell_1_2 = createTableCell();
+        const cell_2_0 = createTableCell();
+        const cell_2_1 = createTableCell();
+        const cell_2_2 = createTableCell();
+
+        table.rows[0].cells.push(cell_0_0, cell_0_1, cell_0_2);
+        table.rows[1].cells.push(cell_1_0, cell_1_1, cell_1_2);
+        table.rows[2].cells.push(cell_2_0, cell_2_1, cell_2_2);
+
+        cell_0_0.isSelected = true;
+        cell_0_1.isSelected = true;
+        cell_1_0.isSelected = true;
+        cell_1_1.isSelected = true;
+
+        model.blocks.push(table);
+
+        setSelection(model);
+
+        expect(cell_0_0.isSelected).toBeFalsy();
+        expect(cell_0_1.isSelected).toBeFalsy();
+        expect(cell_0_2.isSelected).toBeFalsy();
+        expect(cell_1_0.isSelected).toBeFalsy();
+        expect(cell_1_1.isSelected).toBeFalsy();
+        expect(cell_1_2.isSelected).toBeFalsy();
+        expect(cell_2_0.isSelected).toBeFalsy();
+        expect(cell_2_1.isSelected).toBeFalsy();
+        expect(cell_2_2.isSelected).toBeFalsy();
+    });
 });

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/selection/setSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/selection/setSelectionTest.ts
@@ -730,75 +730,75 @@ describe('setSelection', () => {
         const model = createContentModelDocument();
         const table = createTable(3);
 
-        const cell_0_0 = createTableCell();
-        const cell_0_1 = createTableCell();
-        const cell_0_2 = createTableCell();
-        const cell_1_0 = createTableCell();
-        const cell_1_1 = createTableCell();
-        const cell_1_2 = createTableCell();
-        const cell_2_0 = createTableCell();
-        const cell_2_1 = createTableCell();
-        const cell_2_2 = createTableCell();
+        const cell00 = createTableCell();
+        const cell01 = createTableCell();
+        const cell02 = createTableCell();
+        const cell10 = createTableCell();
+        const cell11 = createTableCell();
+        const cell12 = createTableCell();
+        const cell20 = createTableCell();
+        const cell21 = createTableCell();
+        const cell22 = createTableCell();
 
-        table.rows[0].cells.push(cell_0_0, cell_0_1, cell_0_2);
-        table.rows[1].cells.push(cell_1_0, cell_1_1, cell_1_2);
-        table.rows[2].cells.push(cell_2_0, cell_2_1, cell_2_2);
+        table.rows[0].cells.push(cell00, cell01, cell02);
+        table.rows[1].cells.push(cell10, cell11, cell12);
+        table.rows[2].cells.push(cell20, cell21, cell22);
 
-        cell_0_0.isSelected = true;
-        cell_0_1.isSelected = true;
-        cell_1_0.isSelected = true;
-        cell_1_1.isSelected = true;
+        cell00.isSelected = true;
+        cell01.isSelected = true;
+        cell10.isSelected = true;
+        cell11.isSelected = true;
 
         model.blocks.push(table);
 
-        setSelection(model, cell_1_1, cell_2_2);
+        setSelection(model, cell11, cell22);
 
-        expect(cell_0_0.isSelected).toBeFalsy();
-        expect(cell_0_1.isSelected).toBeFalsy();
-        expect(cell_0_2.isSelected).toBeFalsy();
-        expect(cell_1_0.isSelected).toBeFalsy();
-        expect(cell_1_1.isSelected).toBeTrue();
-        expect(cell_1_2.isSelected).toBeTrue();
-        expect(cell_2_0.isSelected).toBeFalsy();
-        expect(cell_2_1.isSelected).toBeTrue();
-        expect(cell_2_2.isSelected).toBeTrue();
+        expect(cell00.isSelected).toBeFalsy();
+        expect(cell01.isSelected).toBeFalsy();
+        expect(cell02.isSelected).toBeFalsy();
+        expect(cell10.isSelected).toBeFalsy();
+        expect(cell11.isSelected).toBeTrue();
+        expect(cell12.isSelected).toBeTrue();
+        expect(cell20.isSelected).toBeFalsy();
+        expect(cell21.isSelected).toBeTrue();
+        expect(cell22.isSelected).toBeTrue();
     });
 
     it('Clear table selection', () => {
         const model = createContentModelDocument();
         const table = createTable(3);
 
-        const cell_0_0 = createTableCell();
-        const cell_0_1 = createTableCell();
-        const cell_0_2 = createTableCell();
-        const cell_1_0 = createTableCell();
-        const cell_1_1 = createTableCell();
-        const cell_1_2 = createTableCell();
-        const cell_2_0 = createTableCell();
-        const cell_2_1 = createTableCell();
-        const cell_2_2 = createTableCell();
+        const cell00 = createTableCell();
+        const cell01 = createTableCell();
+        const cell02 = createTableCell();
+        const cell10 = createTableCell();
+        const cell11 = createTableCell();
+        const cell12 = createTableCell();
+        const cell20 = createTableCell();
+        const cell21 = createTableCell();
+        const cell22 = createTableCell();
 
-        table.rows[0].cells.push(cell_0_0, cell_0_1, cell_0_2);
-        table.rows[1].cells.push(cell_1_0, cell_1_1, cell_1_2);
-        table.rows[2].cells.push(cell_2_0, cell_2_1, cell_2_2);
+        table.rows[0].cells.push(cell00, cell01, cell02);
+        table.rows[1].cells.push(cell10, cell11, cell12);
+        table.rows[2].cells.push(cell20, cell21, cell22);
 
-        cell_0_0.isSelected = true;
-        cell_0_1.isSelected = true;
-        cell_1_0.isSelected = true;
-        cell_1_1.isSelected = true;
+        cell00.isSelected = true;
+        cell01.isSelected = true;
+        cell10.isSelected = true;
+        cell11.isSelected = true;
 
         model.blocks.push(table);
 
         setSelection(model);
 
-        expect(cell_0_0.isSelected).toBeFalsy();
-        expect(cell_0_1.isSelected).toBeFalsy();
-        expect(cell_0_2.isSelected).toBeFalsy();
-        expect(cell_1_0.isSelected).toBeFalsy();
-        expect(cell_1_1.isSelected).toBeFalsy();
-        expect(cell_1_2.isSelected).toBeFalsy();
-        expect(cell_2_0.isSelected).toBeFalsy();
-        expect(cell_2_1.isSelected).toBeFalsy();
-        expect(cell_2_2.isSelected).toBeFalsy();
+        expect(cell00.isSelected).toBeFalsy();
+        expect(cell01.isSelected).toBeFalsy();
+        expect(cell02.isSelected).toBeFalsy();
+        expect(cell10.isSelected).toBeFalsy();
+        expect(cell11.isSelected).toBeFalsy();
+        expect(cell12.isSelected).toBeFalsy();
+        expect(cell20.isSelected).toBeFalsy();
+        expect(cell21.isSelected).toBeFalsy();
+        expect(cell22.isSelected).toBeFalsy();
     });
 });


### PR DESCRIPTION
Content Model API `setSelection` handles selection udpate. If there is no selection parameter passed in, it should clear existing selection. There is a code bug when clear table selection. When nothing is selected, table selection should also be cleared.