### PR TITLE
Content Model: Improve adjustWordSelection

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/modelApi/creators/createText.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelApi/creators/createText.ts
@@ -1,14 +1,37 @@
-import { ContentModelSegmentFormat, ContentModelText } from 'roosterjs-content-model-types';
+import { addCode, addLink } from '../common/addDecorators';
+import {
+    ContentModelCode,
+    ContentModelLink,
+    ContentModelSegmentFormat,
+    ContentModelText,
+} from 'roosterjs-content-model-types';
 
 /**
  * Create a ContentModelText model
  * @param text Text of this model
  * @param format @optional The format of this model
+ * @param link @optional The link decorator
+ * @param code @option The code decorator
  */
-export function createText(text: string, format?: ContentModelSegmentFormat): ContentModelText {
-    return {
+export function createText(
+    text: string,
+    format?: ContentModelSegmentFormat,
+    link?: ContentModelLink,
+    code?: ContentModelCode
+): ContentModelText {
+    const result: ContentModelText = {
         segmentType: 'Text',
         text: text,
         format: format ? { ...format } : {},
     };
+
+    if (link) {
+        addLink(result, link);
+    }
+
+    if (code) {
+        addCode(result, code);
+    }
+
+    return result;
 }

--- a/packages-content-model/roosterjs-content-model-dom/test/modelApi/creators/creatorsTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelApi/creators/creatorsTest.ts
@@ -15,6 +15,8 @@ import { createTable } from '../../../lib/modelApi/creators/createTable';
 import { createTableCell } from '../../../lib/modelApi/creators/createTableCell';
 import { createText } from '../../../lib/modelApi/creators/createText';
 import {
+    ContentModelCode,
+    ContentModelLink,
     ContentModelListLevel,
     ContentModelSegmentFormat,
     ContentModelTableCellFormat,
@@ -186,6 +188,47 @@ describe('Creators', () => {
         (<any>result.format).a = 2;
 
         expect(format).toEqual({ a: 1 });
+    });
+
+    it('createText with decorators', () => {
+        const format = { a: 1 } as any;
+        const text = 'test';
+        const link: ContentModelLink = {
+            dataset: {},
+            format: {
+                href: 'test',
+            },
+        };
+        const code: ContentModelCode = {
+            format: { fontFamily: 'test' },
+        };
+        const result = createText(text, format, link, code);
+
+        expect(result).toEqual({
+            segmentType: 'Text',
+            format: { a: 1 } as any,
+            text: text,
+            link,
+            code,
+        });
+        expect(result.link).not.toBe(link);
+        expect(result.code).not.toBe(code);
+
+        result.link!.dataset.a = 'b';
+        result.link!.format.href = 'test2';
+
+        expect(link).toEqual({
+            dataset: {},
+            format: {
+                href: 'test',
+            },
+        });
+
+        result.code!.format.fontFamily = 'test2';
+
+        expect(code).toEqual({
+            format: { fontFamily: 'test' },
+        });
     });
 
     it('createTable', () => {

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/selection/adjustWordSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/selection/adjustWordSelectionTest.ts
@@ -1,5 +1,11 @@
 import { adjustWordSelection } from '../../../lib/modelApi/selection/adjustWordSelection';
 import {
+    createContentModelDocument,
+    createParagraph,
+    createSelectionMarker,
+    createText,
+} from 'roosterjs-content-model-dom';
+import {
     ContentModelBlock,
     ContentModelDocument,
     ContentModelSegment,
@@ -884,5 +890,85 @@ describe('adjustWordSelection', () => {
                 }
             );
         });
+    });
+
+    it('Do not modify segments array if no word is selected: marker before text', () => {
+        const text = createText('Word1 Word2');
+        const marker = createSelectionMarker();
+        const paragraph = createParagraph();
+        const model = createContentModelDocument();
+
+        paragraph.segments.push(marker, text);
+        model.blocks.push(paragraph);
+
+        adjustWordSelection(model, marker);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [marker, text],
+                    format: {},
+                },
+            ],
+        });
+        expect(model.blocks[0]).toBe(paragraph);
+        expect(paragraph.segments[0]).toBe(marker);
+        expect(paragraph.segments[1]).toBe(text);
+    });
+
+    it('Do not modify segments array if no word is selected: marker after text', () => {
+        const text = createText('Word1 Word2');
+        const marker = createSelectionMarker();
+        const paragraph = createParagraph();
+        const model = createContentModelDocument();
+
+        paragraph.segments.push(text, marker);
+        model.blocks.push(paragraph);
+
+        adjustWordSelection(model, marker);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text, marker],
+                    format: {},
+                },
+            ],
+        });
+        expect(model.blocks[0]).toBe(paragraph);
+        expect(paragraph.segments[0]).toBe(text);
+        expect(paragraph.segments[1]).toBe(marker);
+    });
+
+    it('Do not modify segments array if no word is selected: marker between text', () => {
+        const text1 = createText('Word1 ');
+        const text2 = createText(' Word2');
+        const marker = createSelectionMarker();
+        const paragraph = createParagraph();
+        const model = createContentModelDocument();
+
+        paragraph.segments.push(text1, marker, text2);
+        model.blocks.push(paragraph);
+
+        adjustWordSelection(model, marker);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text1, marker, text2],
+                    format: {},
+                },
+            ],
+        });
+        expect(model.blocks[0]).toBe(paragraph);
+        expect(paragraph.segments[0]).toBe(text1);
+        expect(paragraph.segments[1]).toBe(marker);
+        expect(paragraph.segments[2]).toBe(text2);
     });
 });


### PR DESCRIPTION
The Content Model API `adjustWordSelection` can adjust the selection to a word around current cursor. However, if there is nothing to select, we should not modify the segments of paragraph.

In this change I let the function operation on some temp segments. And if finally we see word to select, update the temp segments to paragraph, otherwise just drop them.

Also improve `createText` to allow pass in decorators when create text model.