### PR TITLE
Fix #2084

### DIFF
--- a/packages-ui/roosterjs-react/lib/emoji/components/EmojiPane.tsx
+++ b/packages-ui/roosterjs-react/lib/emoji/components/EmojiPane.tsx
@@ -225,7 +225,10 @@ const EmojiPane = React.forwardRef(function EmojiPaneFunc(
         [mode, currentFamily, currentEmojiList]
     );
 
-    const getEmojiIconId = React.useCallback((emoji: Emoji) => `${listId}-${emoji.key}`, [listId]);
+    const getEmojiIconId = React.useCallback(
+        (emoji: Emoji) => (emoji ? `${listId}-${emoji.key}` : ''),
+        [listId]
+    );
 
     React.useImperativeHandle(
         ref,


### PR DESCRIPTION
#2084 

When change image selection, we need to do a null check since if the selection is "...", there is no related emoji.