### PR TITLE
Fix #2078

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
@@ -109,6 +109,7 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
                 }
             } else {
                 unwrap(container);
+                container = undefined;
             }
         });
     }

--- a/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleParagraphTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleParagraphTest.ts
@@ -465,6 +465,30 @@ describe('handleParagraph', () => {
         expect(onNodeCreated.calls.argsFor(0)[1]).toBe(parent.querySelector('div'));
     });
 
+    it('With onNodeCreated on implicit paragraph', () => {
+        const parent = document.createElement('div');
+        const segment: ContentModelSegment = {
+            segmentType: 'Text',
+            text: 'test',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+            isImplicit: true,
+        };
+
+        const onNodeCreated = jasmine.createSpy('onNodeCreated');
+
+        context.onNodeCreated = onNodeCreated;
+
+        handleParagraph(document, parent, paragraph, context, null);
+
+        expect(parent.innerHTML).toBe('');
+        expect(onNodeCreated).not.toHaveBeenCalled();
+    });
+
     it('Paragraph with only selection marker and BR', () => {
         const paragraph: ContentModelParagraph = {
             blockType: 'Paragraph',

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -11,13 +11,7 @@ import {
     isNodeOfType,
     normalizeContentModel,
 } from 'roosterjs-content-model-dom';
-import type {
-    ContentModelBlock,
-    ContentModelBlockGroup,
-    ContentModelDecorator,
-    ContentModelSegment,
-    ContentModelTableRow,
-} from 'roosterjs-content-model-types';
+import type { OnNodeCreated } from 'roosterjs-content-model-types';
 import {
     addRangeToSelection,
     createElement,
@@ -280,15 +274,7 @@ function selectionExToRange(
  * @internal
  * Exported only for unit testing
  */
-export const onNodeCreated = (
-    _:
-        | ContentModelBlock
-        | ContentModelBlockGroup
-        | ContentModelSegment
-        | ContentModelDecorator
-        | ContentModelTableRow,
-    node: Node
-): void => {
+export const onNodeCreated: OnNodeCreated = (_, node): void => {
     if (safeInstanceOf(node, 'HTMLTableElement')) {
         wrap(node, 'div');
     }

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -8,6 +8,7 @@ import { iterateSelections } from '../../modelApi/selection/iterateSelections';
 import {
     contentModelToDom,
     createModelToDomContext,
+    isNodeOfType,
     normalizeContentModel,
 } from 'roosterjs-content-model-dom';
 import type {
@@ -38,6 +39,7 @@ import {
     SelectionRangeTypes,
     SelectionRangeEx,
     ColorTransformDirection,
+    NodeType,
 } from 'roosterjs-editor-types';
 
 /**
@@ -181,6 +183,8 @@ export default class ContentModelCopyPastePlugin implements PluginWithState<Copy
                         );
                     }
                 });
+            } else {
+                cleanUpAndRestoreSelection(tempDiv);
             }
         }
     }
@@ -287,5 +291,8 @@ export const onNodeCreated = (
 ): void => {
     if (safeInstanceOf(node, 'HTMLTableElement')) {
         wrap(node, 'div');
+    }
+    if (isNodeOfType(node, NodeType.Element) && !node.isContentEditable) {
+        node.removeAttribute('contenteditable');
     }
 };

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelCopyPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelCopyPastePluginTest.ts
@@ -670,4 +670,28 @@ describe('ContentModelCopyPastePlugin |', () => {
             expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
         });
     });
+
+    it('onNodeCreated with table', () => {
+        const div = document.createElement('div');
+        const table = document.createElement('table');
+
+        div.appendChild(table);
+
+        onNodeCreated(null!, table);
+
+        expect(div.innerHTML).toEqual('<div><table></table></div>');
+    });
+
+    it('onNodeCreated with readonly element', () => {
+        const div = document.createElement('div');
+        div.contentEditable = 'true';
+
+        const span = document.createElement('span');
+        div.appendChild(span);
+        span.contentEditable = 'false';
+
+        onNodeCreated(null!, span);
+
+        expect(div.innerHTML).toBe('<span></span>');
+    });
 });

--- a/packages-ui/roosterjs-react/lib/emoji/components/EmojiPane.tsx
+++ b/packages-ui/roosterjs-react/lib/emoji/components/EmojiPane.tsx
@@ -225,7 +225,10 @@ const EmojiPane = React.forwardRef(function EmojiPaneFunc(
         [mode, currentFamily, currentEmojiList]
     );
 
-    const getEmojiIconId = React.useCallback((emoji: Emoji) => `${listId}-${emoji.key}`, [listId]);
+    const getEmojiIconId = React.useCallback(
+        (emoji: Emoji) => (emoji ? `${listId}-${emoji.key}` : ''),
+        [listId]
+    );
 
     React.useImperativeHandle(
         ref,


### PR DESCRIPTION
#2078 

When copy only an entity, Chrome has some weird behavior:
1. Since all the selected content is readonly, browser didn't copy the "A" tag, but only content inside it
2. Chrome will add BR before and after the copied content

To solve this, we need to remove "contenteditable=false" attribute. For a readonly entity, we will add it back when paste. But if the only copied content is an entity, the entity SPAN will be ignored when copy. If we see any issue caused by this behavior, we need to handle BeforeCutCopy event to dehydrate the entity beforer cut/copy.