### PR TITLE
Select new row/column after insertion

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
@@ -1,7 +1,7 @@
 import Disposable from '../../../pluginUtils/Disposable';
 import TableEditFeature from './TableEditorFeature';
 import { createElement, getIntersectedRect, normalizeRect, VTable } from 'roosterjs-editor-dom';
-import { CreateElementData, IEditor, TableOperation } from 'roosterjs-editor-types';
+import { CreateElementData, IEditor, TableOperation, TableSelection } from 'roosterjs-editor-types';
 
 const INSERTER_COLOR = '#4A4A4A';
 const INSERTER_COLOR_DARK_MODE = 'white';
@@ -118,6 +118,21 @@ class TableInsertHandler implements Disposable {
         vtable.writeBack();
 
         this.onInsert(vtable.table);
+
+        // Select newly inserted row or column
+        if (vtable.row != undefined && vtable.col != undefined && vtable.cells) {
+            const inserted: TableSelection = this.isHorizontal
+                ? {
+                      firstCell: { x: 0, y: vtable.row + 1 },
+                      lastCell: { x: vtable.cells[vtable.row].length - 1, y: vtable.row + 1 },
+                  }
+                : {
+                      firstCell: { x: vtable.col + 1, y: 0 },
+                      lastCell: { x: vtable.col + 1, y: vtable.cells.length - 1 },
+                  };
+
+            this.editor.select(vtable.table, inserted);
+        }
     };
 }
 


### PR DESCRIPTION
### Description:

When using the table inserter, the focus gets moved to before the table.

### Fix

After a new insertion, the newly created row or column will be selected and the focus fill be on its first cell.

### Cases tested:

* Create a table
* Insert a new row or column using the table inserter
* Type any text

**Before:** Text will be typed before the whole table

**After:** Text will be typed on the first cell the cell selection.