### PR TITLE
Demo site: Fix #2096

### DIFF
--- a/demo/scripts/controls/ContentModelEditorMainPane.scss
+++ b/demo/scripts/controls/ContentModelEditorMainPane.scss
@@ -45,6 +45,7 @@
     top: 0;
     right: 0;
     bottom: 0;
+    white-space: break-spaces;
 }
 
 .resizer {

--- a/demo/scripts/controls/MainPane.scss
+++ b/demo/scripts/controls/MainPane.scss
@@ -45,6 +45,7 @@
     top: 0;
     right: 0;
     bottom: 0;
+    white-space: break-spaces;
 }
 
 .resizer {


### PR DESCRIPTION
#2096 

Add CSS style "white-space: break-spaces" into demo site to make sure spaces can be correctly display in iOS.