### PR TITLE
Graduate feature InlineEntityReadOnlyDelimiters

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/ContentModelEditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/ContentModelEditorOptionsPlugin.ts
@@ -28,10 +28,7 @@ const initialState: BuildInPluginState = {
     linkTitle: 'Ctrl+Click to follow the link:' + UrlPlaceholder,
     watermarkText: 'Type content here ...',
     forcePreserveRatio: false,
-    experimentalFeatures: [
-        ExperimentalFeatures.InlineEntityReadOnlyDelimiters,
-        ExperimentalFeatures.ContentModelPaste,
-    ],
+    experimentalFeatures: [ExperimentalFeatures.ContentModelPaste],
     isRtl: false,
     tableFeaturesContainerSelector: '#' + 'EditorContainer',
 };

--- a/demo/scripts/controls/sidePane/editorOptions/ContentModelExperimentalFeatures.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/ContentModelExperimentalFeatures.tsx
@@ -14,8 +14,6 @@ const FeatureNames: Partial<Record<ExperimentalFeatures, string>> = {
         "Reuse ancestor list elements even if they don't match the types from the list item.",
     [ExperimentalFeatures.DeleteTableWithBackspace]:
         'Delete a table selected with the table selector pressing Backspace key',
-    [ExperimentalFeatures.InlineEntityReadOnlyDelimiters]:
-        'Add read entities around read only entities to handle browser edge cases.',
     [ExperimentalFeatures.ContentModelPaste]: 'Paste with content model',
     [ExperimentalFeatures.DisableListChain]: 'Disable list chain functionality',
 };

--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -28,7 +28,7 @@ const initialState: BuildInPluginState = {
     linkTitle: 'Ctrl+Click to follow the link:' + UrlPlaceholder,
     watermarkText: 'Type content here ...',
     forcePreserveRatio: false,
-    experimentalFeatures: [ExperimentalFeatures.InlineEntityReadOnlyDelimiters],
+    experimentalFeatures: [],
     isRtl: false,
     tableFeaturesContainerSelector: '#' + 'EditorContainer',
 };

--- a/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -2,7 +2,6 @@ import BuildInPluginState, { BuildInPluginProps, UrlPlaceholder } from '../../Bu
 import getDefaultContentEditFeatureSettings from './getDefaultContentEditFeatureSettings';
 import OptionsPane from './OptionsPane';
 import SidePanePluginImpl from '../SidePanePluginImpl';
-import { ExperimentalFeatures } from 'roosterjs-editor-types';
 import { SidePaneElementProps } from '../SidePaneElement';
 
 const initialState: BuildInPluginState = {

--- a/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
+++ b/demo/scripts/controls/sidePane/editorOptions/ExperimentalFeatures.tsx
@@ -14,8 +14,6 @@ const FeatureNames: Partial<Record<ExperimentalFeatures, string>> = {
         "Reuse ancestor list elements even if they don't match the types from the list item.",
     [ExperimentalFeatures.DeleteTableWithBackspace]:
         'Delete a table selected with the table selector pressing Backspace key',
-    [ExperimentalFeatures.InlineEntityReadOnlyDelimiters]:
-        'Add read entities around read only entities to handle browser edge cases.',
     [ExperimentalFeatures.DisableListChain]: 'Disable list chain functionality',
 };
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/createEditorContext.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/createEditorContext.ts
@@ -6,13 +6,13 @@ import { EditorContext } from 'roosterjs-content-model-types';
  * Create a EditorContext object used by ContentModel API
  */
 export const createEditorContext: CreateEditorContext = core => {
-    const { lifecycle, defaultFormat, darkColorHandler, addDelimiterForEntity, contentDiv } = core;
+    const { lifecycle, defaultFormat, darkColorHandler, contentDiv } = core;
 
     const context: EditorContext = {
         isDarkMode: lifecycle.isDarkMode,
         defaultFormat: defaultFormat,
         darkColorHandler: darkColorHandler,
-        addDelimiterForEntity: addDelimiterForEntity,
+        addDelimiterForEntity: true,
         allowCacheElement: true,
     };
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/createContentModelEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/createContentModelEditorCore.ts
@@ -91,8 +91,6 @@ function promoteContentModelInfo(
     cmCore: ContentModelEditorCore,
     options: ContentModelEditorOptions
 ) {
-    const experimentalFeatures = cmCore.lifecycle.experimentalFeatures;
-
     cmCore.defaultDomToModelOptions = [
         {
             processorOverride: {
@@ -104,11 +102,6 @@ function promoteContentModelInfo(
     cmCore.defaultModelToDomOptions = [options.defaultModelToDomOptions];
     cmCore.defaultDomToModelConfig = createDomToModelConfig(cmCore.defaultDomToModelOptions);
     cmCore.defaultModelToDomConfig = createModelToDomConfig(cmCore.defaultModelToDomOptions);
-
-    cmCore.addDelimiterForEntity = isFeatureEnabled(
-        experimentalFeatures,
-        ExperimentalFeatures.InlineEntityReadOnlyDelimiters
-    );
 }
 
 function promoteCoreApi(cmCore: ContentModelEditorCore) {

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelEditorCore.ts
@@ -110,9 +110,4 @@ export interface ContentModelEditorCore extends EditorCore, ContentModelPluginSt
      * will be used for setting content model if there is no other customized options
      */
     defaultModelToDomConfig: ModelToDomSettings;
-
-    /**
-     * Whether adding delimiter for entity is allowed
-     */
-    addDelimiterForEntity: boolean;
 }

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/coreApi/createEditorContextTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/coreApi/createEditorContextTest.ts
@@ -6,7 +6,6 @@ describe('createEditorContext', () => {
         const isDarkMode = 'DARKMODE' as any;
         const defaultFormat = 'DEFAULTFORMAT' as any;
         const darkColorHandler = 'DARKHANDLER' as any;
-        const addDelimiterForEntity = 'ADDDELIMITER' as any;
         const getComputedStyleSpy = jasmine.createSpy('getComputedStyleSpy');
         const getBoundingClientRectSpy = jasmine.createSpy('getBoundingClientRect');
 
@@ -26,7 +25,6 @@ describe('createEditorContext', () => {
             },
             defaultFormat,
             darkColorHandler,
-            addDelimiterForEntity,
         } as any) as ContentModelEditorCore;
 
         const context = createEditorContext(core);
@@ -35,7 +33,7 @@ describe('createEditorContext', () => {
             isDarkMode,
             darkColorHandler,
             defaultFormat,
-            addDelimiterForEntity,
+            addDelimiterForEntity: true,
             allowCacheElement: true,
         });
     });
@@ -49,7 +47,6 @@ describe('createEditorContext - checkZoomScale', () => {
     const isDarkMode = 'DARKMODE' as any;
     const defaultFormat = 'DEFAULTFORMAT' as any;
     const darkColorHandler = 'DARKHANDLER' as any;
-    const addDelimiterForEntity = 'ADDDELIMITER' as any;
 
     beforeEach(() => {
         getComputedStyleSpy = jasmine.createSpy('getComputedStyleSpy');
@@ -70,7 +67,6 @@ describe('createEditorContext - checkZoomScale', () => {
             },
             defaultFormat,
             darkColorHandler,
-            addDelimiterForEntity,
         } as any) as ContentModelEditorCore;
     });
 
@@ -86,7 +82,7 @@ describe('createEditorContext - checkZoomScale', () => {
             isDarkMode,
             defaultFormat,
             darkColorHandler,
-            addDelimiterForEntity,
+            addDelimiterForEntity: true,
             zoomScale: 1,
             allowCacheElement: true,
         });
@@ -104,7 +100,7 @@ describe('createEditorContext - checkZoomScale', () => {
             isDarkMode,
             defaultFormat,
             darkColorHandler,
-            addDelimiterForEntity,
+            addDelimiterForEntity: true,
             zoomScale: 2,
             allowCacheElement: true,
         });
@@ -122,7 +118,7 @@ describe('createEditorContext - checkZoomScale', () => {
             isDarkMode,
             defaultFormat,
             darkColorHandler,
-            addDelimiterForEntity,
+            addDelimiterForEntity: true,
             zoomScale: 0.5,
             allowCacheElement: true,
         });
@@ -137,7 +133,6 @@ describe('createEditorContext - checkRootDir', () => {
     const isDarkMode = 'DARKMODE' as any;
     const defaultFormat = 'DEFAULTFORMAT' as any;
     const darkColorHandler = 'DARKHANDLER' as any;
-    const addDelimiterForEntity = 'ADDDELIMITER' as any;
 
     beforeEach(() => {
         getComputedStyleSpy = jasmine.createSpy('getComputedStyleSpy');
@@ -158,7 +153,6 @@ describe('createEditorContext - checkRootDir', () => {
             },
             defaultFormat,
             darkColorHandler,
-            addDelimiterForEntity,
         } as any) as ContentModelEditorCore;
     });
 
@@ -173,7 +167,7 @@ describe('createEditorContext - checkRootDir', () => {
             isDarkMode,
             defaultFormat,
             darkColorHandler,
-            addDelimiterForEntity,
+            addDelimiterForEntity: true,
             allowCacheElement: true,
         });
     });
@@ -189,7 +183,7 @@ describe('createEditorContext - checkRootDir', () => {
             isDarkMode,
             defaultFormat,
             darkColorHandler,
-            addDelimiterForEntity,
+            addDelimiterForEntity: true,
             isRootRtl: true,
             allowCacheElement: true,
         });

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/createContentModelEditorCoreTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/createContentModelEditorCoreTest.ts
@@ -4,12 +4,10 @@ import * as ContentModelFormatPlugin from '../../lib/editor/plugins/ContentModel
 import * as createDomToModelContext from 'roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext';
 import * as createEditorCore from 'roosterjs-editor-core/lib/editor/createEditorCore';
 import * as createModelToDomContext from 'roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext';
-import * as isFeatureEnabled from 'roosterjs-editor-core/lib/editor/isFeatureEnabled';
 import ContentModelTypeInContainerPlugin from '../../lib/editor/corePlugins/ContentModelTypeInContainerPlugin';
 import { createContentModel } from '../../lib/editor/coreApi/createContentModel';
 import { createContentModelEditorCore } from '../../lib/editor/createContentModelEditorCore';
 import { createEditorContext } from '../../lib/editor/coreApi/createEditorContext';
-import { ExperimentalFeatures } from 'roosterjs-editor-types';
 import { getSelectionRangeEx } from '../../lib/editor/coreApi/getSelectionRangeEx';
 import { setContentModel } from '../../lib/editor/coreApi/setContentModel';
 import { switchShadowEdit } from '../../lib/editor/coreApi/switchShadowEdit';
@@ -121,7 +119,6 @@ describe('createContentModelEditorCore', () => {
                 textColor: undefined,
                 backgroundColor: undefined,
             },
-            addDelimiterForEntity: false,
             contentDiv: {
                 style: {},
             },
@@ -187,7 +184,6 @@ describe('createContentModelEditorCore', () => {
                 textColor: undefined,
                 backgroundColor: undefined,
             },
-            addDelimiterForEntity: false,
             contentDiv: {
                 style: {},
             },
@@ -264,7 +260,6 @@ describe('createContentModelEditorCore', () => {
                 textColor: 'red',
                 backgroundColor: 'blue',
             },
-            addDelimiterForEntity: false,
             contentDiv: {
                 style: {},
             },
@@ -324,74 +319,6 @@ describe('createContentModelEditorCore', () => {
             defaultDomToModelConfig: mockedDomToModelConfig,
             defaultModelToDomConfig: mockedModelToDomConfig,
 
-            addDelimiterForEntity: false,
-            contentDiv: {
-                style: {},
-            },
-            cache: {},
-            copyPaste: { allowedCustomPasteType: [] },
-        } as any);
-    });
-
-    it('Allow entity delimiters', () => {
-        mockedCore.lifecycle.experimentalFeatures.push(
-            ExperimentalFeatures.InlineEntityReadOnlyDelimiters
-        );
-
-        const options = {
-            corePluginOverride: {
-                copyPaste: copyPastePlugin,
-            },
-        };
-
-        spyOn(isFeatureEnabled, 'isFeatureEnabled').and.callFake(
-            (features, feature) => feature == ExperimentalFeatures.InlineEntityReadOnlyDelimiters
-        );
-
-        const core = createContentModelEditorCore(contentDiv, options);
-
-        expect(createEditorCoreSpy).toHaveBeenCalledWith(contentDiv, {
-            plugins: [mockedCachePlugin, mockedFormatPlugin, mockedEditPlugin],
-            corePluginOverride: {
-                typeInContainer: new ContentModelTypeInContainerPlugin(),
-                copyPaste: copyPastePlugin,
-            },
-        });
-        expect(core).toEqual({
-            lifecycle: {
-                experimentalFeatures: [ExperimentalFeatures.InlineEntityReadOnlyDelimiters],
-                defaultFormat: {},
-            },
-            api: {
-                switchShadowEdit,
-                createEditorContext,
-                createContentModel,
-                setContentModel,
-                getSelectionRangeEx,
-            },
-            originalApi: {
-                a: 'b',
-                createEditorContext,
-                createContentModel,
-                setContentModel,
-            },
-            defaultDomToModelOptions: [
-                { processorOverride: { table: tablePreProcessor } },
-                undefined,
-            ],
-            defaultModelToDomOptions: [undefined],
-            defaultDomToModelConfig: mockedDomToModelConfig,
-            defaultModelToDomConfig: mockedModelToDomConfig,
-            defaultFormat: {
-                fontWeight: undefined,
-                italic: undefined,
-                underline: undefined,
-                fontFamily: undefined,
-                fontSize: undefined,
-                textColor: undefined,
-                backgroundColor: undefined,
-            },
-            addDelimiterForEntity: true,
             contentDiv: {
                 style: {},
             },

--- a/packages/roosterjs-editor-api/lib/format/insertEntity.ts
+++ b/packages/roosterjs-editor-api/lib/format/insertEntity.ts
@@ -14,7 +14,6 @@ import {
     ChangeSource,
     ContentPosition,
     Entity,
-    ExperimentalFeatures,
     IEditor,
     KnownCreateElementDataIndex,
     NodePosition,
@@ -149,10 +148,7 @@ export default function insertEntity(
                 editor.select(pos);
             }
         }
-    } else if (
-        isReadonly &&
-        editor.isFeatureEnabled(ExperimentalFeatures.InlineEntityReadOnlyDelimiters)
-    ) {
+    } else if (isReadonly) {
         addDelimiters(entity.wrapper);
         if (entity.wrapper.nextElementSibling) {
             editor.select(new Position(entity.wrapper.nextElementSibling, PositionType.After));

--- a/packages/roosterjs-editor-core/lib/corePlugins/EntityPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/EntityPlugin.ts
@@ -26,7 +26,6 @@ import {
     EntityOperationEvent,
     EntityPluginState,
     KnownEntityItem,
-    ExperimentalFeatures,
     HtmlSanitizerOptions,
     IEditor,
     Keys,
@@ -141,7 +140,7 @@ export default class EntityPlugin implements PluginWithState<EntityPluginState> 
                 break;
         }
 
-        if (this.editor?.isFeatureEnabled(ExperimentalFeatures.InlineEntityReadOnlyDelimiters)) {
+        if (this.editor) {
             inlineEntityOnPluginEvent(event, this.editor);
         }
     }
@@ -247,10 +246,7 @@ export default class EntityPlugin implements PluginWithState<EntityPluginState> 
             this.handleNewEntity(entity);
         });
 
-        if (
-            shouldNormalizeDelimiters &&
-            this.editor?.isFeatureEnabled(ExperimentalFeatures.InlineEntityReadOnlyDelimiters)
-        ) {
+        if (shouldNormalizeDelimiters && this.editor) {
             normalizeDelimitersInEditor(this.editor);
         }
     }

--- a/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/entityPluginTest.ts
@@ -1,5 +1,6 @@
 import * as commitEntity from 'roosterjs-editor-dom/lib/entity/commitEntity';
 import * as getEntityFromElement from 'roosterjs-editor-dom/lib/entity/getEntityFromElement';
+import * as inlineEntityOnPluginEvent from '../../lib/corePlugins/utils/inlineEntityOnPluginEvent';
 import EntityPlugin from '../../lib/corePlugins/EntityPlugin';
 import { createDefaultHtmlSanitizerOptions } from 'roosterjs-editor-dom';
 import {
@@ -23,6 +24,8 @@ describe('EntityPlugin', () => {
 
     beforeEach(() => {
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        spyOn(inlineEntityOnPluginEvent, 'inlineEntityOnPluginEvent');
+
         plugin = new EntityPlugin();
         state = plugin.getState();
         editor = <IEditor>(<any>{

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/entityFeatures.ts
@@ -23,7 +23,6 @@ import {
     DelimiterClasses,
     PluginEvent,
     NodeType,
-    ExperimentalFeatures,
     Entity,
     IContentTraverser,
     InlineElement,
@@ -215,17 +214,13 @@ function cacheGetNeighborEntityElement(
 }
 
 /**
- * @requires ExperimentalFeatures.InlineEntityReadOnlyDelimiters to be enabled
  * Content edit feature to move the cursor from Delimiters around Entities when using Right or Left Arrow Keys
  */
 const MoveBetweenDelimitersFeature: BuildInEditFeature<PluginKeyboardEvent> = {
     keys: [Keys.RIGHT, Keys.LEFT],
     allowFunctionKeys: true,
     shouldHandleEvent: (event: PluginKeyboardEvent, editor: IEditor) => {
-        if (
-            event.rawEvent.altKey ||
-            !editor.isFeatureEnabled(ExperimentalFeatures.InlineEntityReadOnlyDelimiters)
-        ) {
+        if (event.rawEvent.altKey) {
             return false;
         }
 
@@ -270,16 +265,11 @@ const MoveBetweenDelimitersFeature: BuildInEditFeature<PluginKeyboardEvent> = {
 };
 
 /**
- * @requires ExperimentalFeatures.InlineEntityReadOnlyDelimiters to be enabled
  * Content edit Feature to trigger a Delete Entity Operation when one of the Delimiter is about to be removed with DELETE or Backspace
  */
 const RemoveEntityBetweenDelimitersFeature: BuildInEditFeature<PluginKeyboardEvent> = {
     keys: [Keys.BACKSPACE, Keys.DELETE],
     shouldHandleEvent(event: PluginKeyboardEvent, editor: IEditor) {
-        if (!editor.isFeatureEnabled(ExperimentalFeatures.InlineEntityReadOnlyDelimiters)) {
-            return false;
-        }
-
         const range = editor.getSelectionRange();
         if (!range?.collapsed) {
             return false;
@@ -433,11 +423,7 @@ function triggerOperation(
         entity,
     });
 
-    if (
-        entity.isReadonly &&
-        !isBlockElement(entity.wrapper) &&
-        editor.isFeatureEnabled(ExperimentalFeatures.InlineEntityReadOnlyDelimiters)
-    ) {
+    if (entity.isReadonly && !isBlockElement(entity.wrapper)) {
         if (event.rawEvent.defaultPrevented) {
             editor.runAsync(() => {
                 if (!editor.contains(entity.wrapper)) {

--- a/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
+++ b/packages/roosterjs-editor-plugins/test/ContentEdit/features/inlineEntityFeatureTest.ts
@@ -9,14 +9,7 @@ import {
     Position,
     PositionContentSearcher,
 } from 'roosterjs-editor-dom';
-import {
-    Entity,
-    ExperimentalFeatures,
-    IEditor,
-    Keys,
-    PluginKeyDownEvent,
-    BlockElement,
-} from 'roosterjs-editor-types';
+import { Entity, IEditor, Keys, PluginKeyDownEvent, BlockElement } from 'roosterjs-editor-types';
 
 describe('Content Edit Features |', () => {
     const { moveBetweenDelimitersFeature, removeEntityBetweenDelimiters } = EntityFeatures;
@@ -68,8 +61,6 @@ describe('Content Edit Features |', () => {
                     collapsed: true,
                 },
             select,
-            isFeatureEnabled: (feature: ExperimentalFeatures) =>
-                feature === ExperimentalFeatures.InlineEntityReadOnlyDelimiters,
             getBodyTraverser: (startNode?: Node) =>
                 ContentTraverser.createBodyTraverser(testContainer, startNode),
             getBlockElementAtNode: (node: Node) => getBlockElementAtNode(document.body, node),

--- a/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
+++ b/packages/roosterjs-editor-types/lib/enum/ExperimentalFeatures.ts
@@ -142,6 +142,12 @@ export const enum ExperimentalFeatures {
      */
     AutoFormatList = 'AutoFormatList',
 
+    /**
+     * @deprecated This feature is always enabled
+     * Add entities around a Read Only  Inline entity to prevent cursor to be hidden when cursor is next of it.
+     */
+    InlineEntityReadOnlyDelimiters = 'InlineEntityReadOnlyDelimiters',
+
     //#endregion
 
     /**
@@ -161,11 +167,6 @@ export const enum ExperimentalFeatures {
      * Delete table with Backspace key with the whole was selected with table selector
      */
     DeleteTableWithBackspace = 'DeleteTableWithBackspace',
-
-    /**
-     * Add entities around a Read Only  Inline entity to prevent cursor to be hidden when cursor is next of it.
-     */
-    InlineEntityReadOnlyDelimiters = 'InlineEntityReadOnlyDelimiters',
 
     /**
      * Paste with Content model


### PR DESCRIPTION
Graduate feature InlineEntityReadOnlyDelimiters, and remove `addDelimiterForEntity` from `EditorContext`