### PR TITLE
Do not add link to trailing spaces

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/insertLinkTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/insertLinkTest.ts
@@ -340,4 +340,40 @@ describe('insertLink', () => {
 
         document.body.removeChild(div);
     });
+
+    it('Valid url on existing text with trailing space', () => {
+        const doc = createContentModelDocument();
+        const text = createText('test   ');
+
+        text.isSelected = true;
+        addSegment(doc, text);
+
+        runTest(doc, 'http://test.com', {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    isImplicit: true,
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test',
+                            link: {
+                                dataset: {},
+                                format: {
+                                    href: 'http://test.com',
+                                    anchorTitle: undefined,
+                                    target: undefined,
+                                    underline: true,
+                                },
+                            },
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
When insert link to not insert it in trailing spaces segments. Split the trailing spaces in the selected segments and only apply link to non trailing spaces segments
Before: 
![Screenshot 2023-09-26 at 14 03 34](https://github.com/microsoft/roosterjs/assets/87443959/45795754-487e-4690-a93c-63320c28c1fc)

After: 
![Screenshot 2023-09-26 at 14 02 53](https://github.com/microsoft/roosterjs/assets/87443959/522bb2ee-4700-4eba-87d9-79d5c8b3eb2a)
