### PR TITLE
Standalone editor: remove NodeType from Content Model

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/childProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/childProcessor.ts
@@ -1,7 +1,7 @@
 import { addSelectionMarker } from '../utils/addSelectionMarker';
 import { getRegularSelectionOffsets } from '../utils/getRegularSelectionOffsets';
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
-import { NodeType, SelectionRangeTypes } from 'roosterjs-editor-types';
+import { SelectionRangeTypes } from 'roosterjs-editor-types';
 import {
     ContentModelBlockGroup,
     DomToModelContext,
@@ -45,9 +45,9 @@ export function processChildNode(
     child: Node,
     context: DomToModelContext
 ) {
-    if (isNodeOfType(child, NodeType.Element) && child.style.display != 'none') {
+    if (isNodeOfType(child, 'ELEMENT_NODE') && child.style.display != 'none') {
         context.elementProcessors.element(group, child, context);
-    } else if (isNodeOfType(child, NodeType.Text)) {
+    } else if (isNodeOfType(child, 'TEXT_NODE')) {
         context.elementProcessors['#text'](group, child, context);
     }
 }

--- a/packages-content-model/roosterjs-content-model-dom/lib/domUtils/isNodeOfType.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domUtils/isNodeOfType.ts
@@ -1,5 +1,3 @@
-import { NodeType } from 'roosterjs-editor-types';
-
 /**
  * A type map from node type number to its type declaration. This is used by utility function isNodeOfType()
  */
@@ -7,41 +5,42 @@ export interface NodeTypeMap {
     /**
      * Attribute node
      */
-    [NodeType.Attribute]: Attr;
+    ATTRIBUTE_NODE: Attr;
 
     /**
      * Comment node
      */
-    [NodeType.Comment]: Comment;
+    COMMENT_NODE: Comment;
 
     /**
      * DocumentFragment node
      */
-    [NodeType.DocumentFragment]: DocumentFragment;
+    DOCUMENT_FRAGMENT_NODE: DocumentFragment;
 
     /**
      * Document node
      */
-    [NodeType.Document]: Document;
+    DOCUMENT_NODE: Document;
 
     /**
      * DocumentType node
      */
-    [NodeType.DocumentType]: DocumentType;
+    DOCUMENT_TYPE_NODE: DocumentType;
 
     /**
      * HTMLElement node
      */
-    [NodeType.Element]: HTMLElement;
+    ELEMENT_NODE: HTMLElement;
+
     /**
      * ProcessingInstruction node
      */
-    [NodeType.ProcessingInstruction]: ProcessingInstruction;
+    PROCESSING_INSTRUCTION_NODE: ProcessingInstruction;
 
     /**
      * Text node
      */
-    [NodeType.Text]: Text;
+    TEXT_NODE: Text;
 }
 
 /**
@@ -49,9 +48,9 @@ export interface NodeTypeMap {
  * @param node The node to check
  * @param expectedType The type to check
  */
-export function isNodeOfType<T extends NodeType>(
+export function isNodeOfType<T extends keyof NodeTypeMap>(
     node: Node | null | undefined,
     expectedType: T
 ): node is NodeTypeMap[T] {
-    return !!node && node.nodeType == expectedType;
+    return !!node && node.nodeType == Node[expectedType];
 }

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listItemMetadataFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listItemMetadataFormatHandler.ts
@@ -2,7 +2,6 @@ import { FormatHandler } from '../FormatHandler';
 import { getObjectKeys, getTagOfNode } from 'roosterjs-editor-dom';
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import { ListMetadataFormat } from 'roosterjs-content-model-types';
-import { NodeType } from 'roosterjs-editor-types';
 import { OrderedMap, UnorderedMap } from './listLevelMetadataFormatHandler';
 
 const OrderedMapPlaceholderRegex = /\$\{(\w+)\}/;
@@ -36,7 +35,7 @@ export const listItemMetadataFormatHandler: FormatHandler<ListMetadataFormat> = 
         const parent = element.parentNode;
         const depth = context.listFormat.nodeStack.length - 2; // Minus two for the parent element and convert length to index
 
-        if (depth >= 0 && isNodeOfType(parent, NodeType.Element) && !parent.style.listStyleType) {
+        if (depth >= 0 && isNodeOfType(parent, 'ELEMENT_NODE') && !parent.style.listStyleType) {
             const parentTag = getTagOfNode(parent);
             const style =
                 parentTag == 'OL'

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/contentModelToDom.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/contentModelToDom.ts
@@ -1,17 +1,12 @@
 import { createRange, Position, toArray } from 'roosterjs-editor-dom';
 import { isNodeOfType } from '../domUtils/isNodeOfType';
+import { NodePosition, SelectionRangeEx, SelectionRangeTypes } from 'roosterjs-editor-types';
 import {
     ContentModelDocument,
     ModelToDomBlockAndSegmentNode,
     ModelToDomContext,
     OnNodeCreated,
 } from 'roosterjs-content-model-types';
-import {
-    NodePosition,
-    NodeType,
-    SelectionRangeEx,
-    SelectionRangeTypes,
-} from 'roosterjs-editor-types';
 
 /**
  * Create DOM tree fragment from Content Model document
@@ -92,7 +87,7 @@ function calcPosition(pos: ModelToDomBlockAndSegmentNode): NodePosition | undefi
     if (pos.block) {
         if (!pos.segment) {
             result = new Position(pos.block, 0);
-        } else if (isNodeOfType(pos.segment, NodeType.Text)) {
+        } else if (isNodeOfType(pos.segment, 'TEXT_NODE')) {
             result = new Position(pos.segment, pos.segment.nodeValue?.length || 0);
         } else {
             result = new Position(
@@ -104,7 +99,7 @@ function calcPosition(pos: ModelToDomBlockAndSegmentNode): NodePosition | undefi
         }
     }
 
-    if (isNodeOfType(result?.node, NodeType.DocumentFragment)) {
+    if (isNodeOfType(result?.node, 'DOCUMENT_FRAGMENT_NODE')) {
         result = result?.normalize();
     }
 

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleGeneralModel.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleGeneralModel.ts
@@ -1,6 +1,5 @@
 import { handleSegmentCommon } from '../utils/handleSegmentCommon';
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
-import { NodeType } from 'roosterjs-editor-types';
 import { reuseCachedElement } from '../utils/reuseCachedElement';
 import { wrap } from 'roosterjs-editor-dom';
 import {
@@ -51,7 +50,7 @@ export const handleGeneralSegment: ContentModelSegmentHandler<ContentModelGenera
     group.element = node;
     parent.appendChild(node);
 
-    if (isNodeOfType(node, NodeType.Element)) {
+    if (isNodeOfType(node, 'ELEMENT_NODE')) {
         const element = wrap(node, 'span');
 
         handleSegmentCommon(doc, node, element, group, context, segmentNodes);

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/optimizers/mergeNode.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/optimizers/mergeNode.ts
@@ -1,5 +1,4 @@
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
-import { NodeType } from 'roosterjs-editor-types';
 
 const OptimizeTags = ['SPAN', 'B', 'EM', 'I', 'U', 'SUB', 'SUP', 'STRIKE', 'S', 'A', 'CODE'];
 
@@ -12,8 +11,8 @@ export function mergeNode(root: Node) {
 
         if (
             next &&
-            isNodeOfType(child, NodeType.Element) &&
-            isNodeOfType(next, NodeType.Element) &&
+            isNodeOfType(child, 'ELEMENT_NODE') &&
+            isNodeOfType(next, 'ELEMENT_NODE') &&
             child.tagName == next.tagName &&
             OptimizeTags.indexOf(child.tagName) >= 0 &&
             hasSameAttributes(child, next)

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/optimizers/optimize.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/optimizers/optimize.ts
@@ -1,4 +1,4 @@
-import { EntityClasses, NodeType } from 'roosterjs-editor-types';
+import { EntityClasses } from 'roosterjs-editor-types';
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import { mergeNode } from './mergeNode';
 import { removeUnnecessarySpan } from './removeUnnecessarySpan';
@@ -11,7 +11,7 @@ export function optimize(root: Node) {
      * Do no do any optimization to entity
      */
     if (
-        isNodeOfType(root, NodeType.Element) &&
+        isNodeOfType(root, 'ELEMENT_NODE') &&
         root.classList.contains(EntityClasses.ENTITY_INFO_NAME)
     ) {
         return;

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/optimizers/removeUnnecessarySpan.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/optimizers/removeUnnecessarySpan.ts
@@ -1,5 +1,4 @@
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
-import { NodeType } from 'roosterjs-editor-types';
 
 /**
  * @internal
@@ -7,7 +6,7 @@ import { NodeType } from 'roosterjs-editor-types';
 export function removeUnnecessarySpan(root: Node) {
     for (let child = root.firstChild; child; ) {
         if (
-            isNodeOfType(child, NodeType.Element) &&
+            isNodeOfType(child, 'ELEMENT_NODE') &&
             child.tagName == 'SPAN' &&
             child.attributes.length == 0
         ) {

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/utils/reuseCachedElement.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/utils/reuseCachedElement.ts
@@ -1,6 +1,5 @@
 import { getEntityFromElement } from 'roosterjs-editor-dom';
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
-import { NodeType } from 'roosterjs-editor-types';
 
 /**
  * @internal
@@ -40,5 +39,5 @@ export function removeNode(node: Node): Node | null {
 }
 
 function isEntity(node: Node) {
-    return isNodeOfType(node, NodeType.Element) && !!getEntityFromElement(node);
+    return isNodeOfType(node, 'ELEMENT_NODE') && !!getEntityFromElement(node);
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -33,7 +33,6 @@ import {
     SelectionRangeTypes,
     SelectionRangeEx,
     ColorTransformDirection,
-    NodeType,
 } from 'roosterjs-editor-types';
 
 /**
@@ -278,7 +277,7 @@ export const onNodeCreated: OnNodeCreated = (_, node): void => {
     if (safeInstanceOf(node, 'HTMLTableElement')) {
         wrap(node, 'div');
     }
-    if (isNodeOfType(node, NodeType.Element) && !node.isContentEditable) {
+    if (isNodeOfType(node, 'ELEMENT_NODE') && !node.isContentEditable) {
         node.removeAttribute('contenteditable');
     }
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/WordDesktop/processWordLists.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/WordDesktop/processWordLists.ts
@@ -1,9 +1,9 @@
 import { getStyles } from 'roosterjs-editor-dom';
-import { NodeType } from 'roosterjs-editor-types';
 import {
     addBlock,
     createListItem,
     createListLevel,
+    isNodeOfType,
     parseFormat,
 } from 'roosterjs-content-model-dom';
 import {
@@ -184,7 +184,7 @@ function getFakeBulletText(node: Node, levels?: number): string {
             if (result.length == 0) {
                 result = 'o';
             }
-        } else if (child.nodeType == NodeType.Element && levels > 1) {
+        } else if (isNodeOfType(child, 'ELEMENT_NODE') && levels > 1) {
             // If this is an element and we are not in the last level, try to get the fake bullet
             // out of the child
             result = getFakeBulletText(child, levels - 1);
@@ -201,7 +201,7 @@ function getFakeBulletText(node: Node, levels?: number): string {
  * HTML lists
  */
 function isIgnoreNode(node: Node): boolean {
-    if (node.nodeType == NodeType.Element) {
+    if (isNodeOfType(node, 'ELEMENT_NODE')) {
         let listAttribute = getStyles(node as HTMLElement)[MSO_LIST];
         if (
             listAttribute &&

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/utils/contentModelDomIndexer.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/utils/contentModelDomIndexer.ts
@@ -1,11 +1,6 @@
 import { createSelectionMarker, createText, isNodeOfType } from 'roosterjs-content-model-dom';
 import { setSelection } from '../../modelApi/selection/setSelection';
-import {
-    NodeType,
-    SelectionRangeEx,
-    SelectionRangeTypes,
-    TableSelection,
-} from 'roosterjs-editor-types';
+import { SelectionRangeEx, SelectionRangeTypes, TableSelection } from 'roosterjs-editor-types';
 import {
     ContentModelDocument,
     ContentModelDomIndexer,
@@ -79,7 +74,7 @@ function onParagraph(paragraphElement: HTMLElement) {
     let previousText: Text | null = null;
 
     for (let child = paragraphElement.firstChild; child; child = child.nextSibling) {
-        if (isNodeOfType(child, NodeType.Text)) {
+        if (isNodeOfType(child, 'TEXT_NODE')) {
             if (!previousText) {
                 previousText = child;
             } else {
@@ -92,7 +87,7 @@ function onParagraph(paragraphElement: HTMLElement) {
                     child.__roosterjsContentModel.segments = [];
                 }
             }
-        } else if (isNodeOfType(child, NodeType.Element)) {
+        } else if (isNodeOfType(child, 'ELEMENT_NODE')) {
             previousText = null;
 
             onParagraph(child);
@@ -118,7 +113,7 @@ function reconcileSelection(
         if (
             oldRangeEx?.type == SelectionRangeTypes.Normal &&
             range?.collapsed &&
-            isNodeOfType(range.startContainer, NodeType.Text)
+            isNodeOfType(oldRangeEx.ranges[0].startContainer, 'TEXT_NODE')
         ) {
             if (isIndexedSegment(range.startContainer)) {
                 reconcileTextSelection(range.startContainer);
@@ -176,7 +171,7 @@ function reconcileSelection(
                     return !!reconcileNodeSelection(startContainer, startOffset);
                 } else if (
                     startContainer == endContainer &&
-                    isNodeOfType(startContainer, NodeType.Text)
+                    isNodeOfType(startContainer, 'TEXT_NODE')
                 ) {
                     return (
                         isIndexedSegment(startContainer) &&
@@ -202,7 +197,7 @@ function reconcileSelection(
 }
 
 function reconcileNodeSelection(node: Node, offset: number): Selectable | undefined {
-    if (isNodeOfType(node, NodeType.Text)) {
+    if (isNodeOfType(node, 'TEXT_NODE')) {
         return isIndexedSegment(node) ? reconcileTextSelection(node, offset) : undefined;
     } else if (offset >= node.childNodes.length) {
         return insertMarker(node.lastChild, true /*isAfter*/);

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/editing/keyboardDelete.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/editing/keyboardDelete.ts
@@ -1,10 +1,11 @@
 import { Browser, isModifierKey } from 'roosterjs-editor-dom';
-import { ChangeSource, Keys, NodeType, SelectionRangeTypes } from 'roosterjs-editor-types';
+import { ChangeSource, Keys, SelectionRangeTypes } from 'roosterjs-editor-types';
 import { deleteAllSegmentBefore } from '../../modelApi/edit/deleteSteps/deleteAllSegmentBefore';
 import { DeleteResult, DeleteSelectionStep } from '../../modelApi/edit/utils/DeleteSelectionStep';
 import { deleteSelection } from '../../modelApi/edit/deleteSelection';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
+import { isNodeOfType } from 'roosterjs-content-model-dom';
 import {
     handleKeyboardEventResult,
     shouldDeleteAllSegmentsBefore,
@@ -77,7 +78,7 @@ function getDeleteSteps(rawEvent: KeyboardEvent): (DeleteSelectionStep | null)[]
 function shouldDeleteWithContentModel(range: Range | null, rawEvent: KeyboardEvent) {
     return !(
         range?.collapsed &&
-        range.startContainer.nodeType == NodeType.Text &&
+        isNodeOfType(range.startContainer, 'TEXT_NODE') &&
         !isModifierKey(rawEvent) &&
         (canDeleteBefore(rawEvent, range) || canDeleteAfter(rawEvent, range))
     );

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/format/applyDefaultFormat.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/format/applyDefaultFormat.ts
@@ -6,7 +6,7 @@ import { getPendingFormat, setPendingFormat } from '../../modelApi/format/pendin
 import { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import { isBlockElement, Position } from 'roosterjs-editor-dom';
 import { isNodeOfType, normalizeContentModel } from 'roosterjs-content-model-dom';
-import { NodePosition, NodeType, SelectionRangeTypes } from 'roosterjs-editor-types';
+import { NodePosition, SelectionRangeTypes } from 'roosterjs-editor-types';
 
 /**
  * @internal
@@ -20,7 +20,7 @@ export default function applyDefaultFormat(editor: IContentModelEditor) {
     let node: Node | null = startPos?.node ?? null;
 
     while (node && editor.contains(node)) {
-        if (isNodeOfType(node, NodeType.Element) && node.getAttribute?.('style')) {
+        if (isNodeOfType(node, 'ELEMENT_NODE') && node.getAttribute?.('style')) {
             return;
         } else if (isBlockElement(node)) {
             break;


### PR DESCRIPTION
In order to build a standalone editor, I'm removing dependency from Content Model to old packages.

In this change I'm removing `NodeType` from Content Model, and use a string literal type instead.

`NodeType` is only used in utility function `isNodeOfType`. Now I can use the built-in Node properties (TEXT_NODE, ...) as string literal type instead, so `NodeType` is not needed any more.
