### PR TITLE
Image selection on shadow edit

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -38,14 +38,6 @@ export default class ImageSelection implements EditorPlugin {
     onPluginEvent(event: PluginEvent) {
         if (this.editor) {
             switch (event.eventType) {
-                case PluginEventType.EnteredShadowEdit:
-                case PluginEventType.LeavingShadowEdit:
-                    const selection = this.editor.getSelectionRangeEx();
-                    if (selection.type == SelectionRangeTypes.ImageSelection) {
-                        this.editor.select(selection.image);
-                    }
-                    break;
-
                 case PluginEventType.MouseUp:
                     const target = event.rawEvent.target;
                     if (

--- a/packages/roosterjs-editor-core/test/corePlugins/imageSelectionTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/imageSelectionTest.ts
@@ -67,26 +67,6 @@ describe('ImageSelectionPlugin |', () => {
         expect(selection.areAllCollapsed).toBe(false);
     });
 
-    it('should be triggered in shadow Edit', () => {
-        editor.setContent(`<img id=${imageId}></img>`);
-        const target = document.getElementById(imageId);
-        editorIsFeatureEnabled.and.returnValue(true);
-        editor.focus();
-        editor.select(target);
-
-        editor.startShadowEdit();
-
-        let selection = editor.getSelectionRangeEx();
-        expect(selection.type).toBe(SelectionRangeTypes.ImageSelection);
-        expect(selection.areAllCollapsed).toBe(false);
-
-        editor.stopShadowEdit();
-
-        selection = editor.getSelectionRangeEx();
-        expect(selection.type).toBe(SelectionRangeTypes.ImageSelection);
-        expect(selection.areAllCollapsed).toBe(false);
-    });
-
     it('should handle a ESCAPE KEY in a image', () => {
         editor.setContent(`<img id=${imageId}></img>`);
         const target = document.getElementById(imageId);


### PR DESCRIPTION
Since shadow edit it is not changing the selection, remove the code related to reselect the image when leave and enter shadow edit. 
![ShadowEditImage](https://github.com/microsoft/roosterjs/assets/87443959/1b4f1f77-20fb-4398-94aa-6833d0372b5f)
