### PR TITLE
Content Model: Clear cache when input in expanded selection

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCachePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCachePlugin.ts
@@ -1,5 +1,5 @@
 import { areSameRangeEx } from '../../modelApi/selection/areSameRangeEx';
-import { isCharacterValue } from 'roosterjs-editor-dom/lib';
+import { isCharacterValue } from 'roosterjs-editor-dom';
 import { Keys, PluginEventType } from 'roosterjs-editor-types';
 import type ContentModelContentChangedEvent from '../../publicTypes/event/ContentModelContentChangedEvent';
 import type { ContentModelCachePluginState } from '../../publicTypes/pluginState/ContentModelCachePluginState';

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelCachePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelCachePluginTest.ts
@@ -74,7 +74,24 @@ describe('ContentModelCachePlugin', () => {
             });
         });
 
-        it('Other key', () => {
+        it('Other key without selection', () => {
+            plugin.onPluginEvent({
+                eventType: PluginEventType.KeyDown,
+                rawEvent: {
+                    which: Keys.B,
+                    key: 'B',
+                } as any,
+            });
+
+            expect(state).toEqual({ cachedModel: undefined, cachedSelection: undefined });
+        });
+
+        it('Other key with collapsed selection', () => {
+            state.cachedSelection = {
+                type: 'range',
+                range: { collapsed: true } as any,
+            };
+
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
                 rawEvent: {
@@ -82,7 +99,80 @@ describe('ContentModelCachePlugin', () => {
                 } as any,
             });
 
-            expect(state).toEqual({});
+            expect(state).toEqual({
+                cachedSelection: { type: 'range', range: { collapsed: true } as any },
+            });
+        });
+
+        it('Expanded selection with text input', () => {
+            state.cachedSelection = {
+                type: 'range',
+                range: { collapsed: false } as any,
+            };
+
+            plugin.onPluginEvent({
+                eventType: PluginEventType.KeyDown,
+                rawEvent: {
+                    which: Keys.B,
+                    key: 'B',
+                } as any,
+            });
+
+            expect(state).toEqual({ cachedModel: undefined, cachedSelection: undefined });
+        });
+
+        it('Expanded selection with arrow input', () => {
+            state.cachedSelection = {
+                type: 'range',
+                range: { collapsed: false } as any,
+            };
+
+            plugin.onPluginEvent({
+                eventType: PluginEventType.KeyDown,
+                rawEvent: {
+                    which: Keys.UP,
+                    key: 'Up',
+                } as any,
+            });
+
+            expect(state).toEqual({
+                cachedSelection: {
+                    type: 'range',
+                    range: { collapsed: false } as any,
+                },
+            });
+        });
+
+        it('Table selection', () => {
+            state.cachedSelection = {
+                type: 'table',
+            } as any;
+
+            plugin.onPluginEvent({
+                eventType: PluginEventType.KeyDown,
+                rawEvent: {
+                    which: Keys.B,
+                    key: 'B',
+                } as any,
+            });
+
+            expect(state).toEqual({ cachedModel: undefined, cachedSelection: undefined });
+        });
+
+        it('Image selection', () => {
+            state.cachedSelection = {
+                type: 'image',
+            } as any;
+
+            plugin.onPluginEvent({
+                eventType: PluginEventType.KeyDown,
+                rawEvent: {
+                    which: Keys.B,
+                    key: 'B',
+                } as any,
+            });
+
+            expect(state).toEqual({ cachedModel: undefined, cachedSelection: undefined });
         });
 
         it('Do not clear cache when in shadow edit', () => {


### PR DESCRIPTION
To repro, use the following snapshot in Content Model editor:

```html
<div>aaaaa</div><div>bbbbb</div><!--{"type":0,"isDarkMode":false,"start":[0,0,2],"end":[1,0,3]}-->
```

Then type "1", and the press "B" button on ribbon.

Expect:
![image](https://github.com/microsoft/roosterjs/assets/23065085/867c5d6e-682e-4372-813a-3ec86adbdd91)


Actual:
![image](https://github.com/microsoft/roosterjs/assets/23065085/9e42d9b2-01af-4a66-8a2e-0d6140f2b6e4)

This is because when there is an expanded selection that across paragraphs and we input to overwrite, the two paragraphs will be merged into one, but Content Model is not updated accordingly. For now we didn't handle this case in our cache update code, so the easiest fix is just clear the cache so that we can regenerate Content Model.
