### PR TITLE
Fix type on image selection

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -1,5 +1,5 @@
 import { PluginEventType, PositionType, SelectionRangeTypes } from 'roosterjs-editor-types';
-import { safeInstanceOf } from 'roosterjs-editor-dom';
+import { Position, safeInstanceOf } from 'roosterjs-editor-dom';
 import type { EditorPlugin, IEditor, PluginEvent } from 'roosterjs-editor-types';
 
 const Escape = 'Escape';
@@ -59,7 +59,7 @@ export default class ImageSelection implements EditorPlugin {
                         this.editor.select(null);
                     }
                     break;
-                case PluginEventType.KeyUp:
+                case PluginEventType.KeyDown:
                     const key = event.rawEvent.key;
                     const keyDownSelection = this.editor.getSelectionRangeEx();
                     if (keyDownSelection.type === SelectionRangeTypes.ImageSelection) {
@@ -71,7 +71,12 @@ export default class ImageSelection implements EditorPlugin {
                             this.editor.deleteNode(keyDownSelection.image);
                             event.rawEvent.preventDefault();
                         } else {
-                            this.editor.select(keyDownSelection.ranges[0]);
+                            const position = new Position(
+                                keyDownSelection.image,
+                                PositionType.Begin
+                            );
+
+                            this.editor.select(position);
                         }
                     }
                     break;

--- a/packages/roosterjs-editor-core/test/corePlugins/imageSelectionTest.ts
+++ b/packages/roosterjs-editor-core/test/corePlugins/imageSelectionTest.ts
@@ -107,7 +107,7 @@ describe('ImageSelectionPlugin |', () => {
         imageSelection.onPluginEvent(keyUp(Space));
         const selection = editor.getSelectionRangeEx();
         expect(selection.type).toBe(SelectionRangeTypes.Normal);
-        expect(selection.areAllCollapsed).toBe(false);
+        expect(selection.areAllCollapsed).toBe(true);
     });
 
     it('should handle contextMenu', () => {


### PR DESCRIPTION
When type on image selection, use the key down event trigger to insert the cursor before the image. 

Before: 
1. Select image
2. Type a
3. Type b 
4. The result is image + ba 

After: 
1. Select image
2. Type a
3. Type b 
4. The result is ab + image 