### PR TITLE
Fix Excel Border issue when pasting

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/Excel/processPastedContentFromExcel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/Excel/processPastedContentFromExcel.ts
@@ -1,5 +1,6 @@
 import addParser from '../utils/addParser';
 import { getTagOfNode, moveChildNodes } from 'roosterjs-editor-dom';
+import { setProcessor } from '../utils/setProcessor';
 import type ContentModelBeforePasteEvent from '../../../../publicTypes/event/ContentModelBeforePasteEvent';
 import type { TrustedHTMLHandler } from 'roosterjs-editor-types';
 
@@ -49,6 +50,20 @@ export function processPastedContentFromExcel(
             format.borderLeft = DEFAULT_BORDER_STYLE;
             format.borderRight = DEFAULT_BORDER_STYLE;
             format.borderTop = DEFAULT_BORDER_STYLE;
+        }
+    });
+
+    setProcessor(event.domToModelOption, 'child', (group, element, context) => {
+        const segmentFormat = { ...context.segmentFormat };
+        if (group.blockGroupType === 'TableCell' && group.format.textColor) {
+            context.segmentFormat.textColor = group.format.textColor;
+        }
+
+        context.defaultElementProcessors.child(group, element, context);
+
+        if (group.blockGroupType === 'TableCell' && group.format.textColor) {
+            context.segmentFormat = segmentFormat;
+            delete group.format.textColor;
         }
     });
 }

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelPastePluginTest.ts
@@ -108,7 +108,7 @@ describe('Content Model Paste Plugin Test', () => {
                 trustedHTMLHandler
             );
             expect(addParser.default).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 3);
-            expect(setProcessor.setProcessor).toHaveBeenCalledTimes(0);
+            expect(setProcessor.setProcessor).toHaveBeenCalledTimes(1);
             expect(chainSanitizerCallbackFile.default).toHaveBeenCalledTimes(1);
         });
 
@@ -141,7 +141,7 @@ describe('Content Model Paste Plugin Test', () => {
                 trustedHTMLHandler
             );
             expect(addParser.default).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 1);
-            expect(setProcessor.setProcessor).toHaveBeenCalledTimes(0);
+            expect(setProcessor.setProcessor).toHaveBeenCalledTimes(1);
             expect(chainSanitizerCallbackFile.default).toHaveBeenCalledTimes(1);
         });
 
@@ -157,7 +157,7 @@ describe('Content Model Paste Plugin Test', () => {
                 trustedHTMLHandler
             );
             expect(addParser.default).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 1);
-            expect(setProcessor.setProcessor).toHaveBeenCalledTimes(0);
+            expect(setProcessor.setProcessor).toHaveBeenCalledTimes(1);
             expect(chainSanitizerCallbackFile.default).toHaveBeenCalledTimes(1);
         });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelOnlineTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelOnlineTest.ts
@@ -3,6 +3,7 @@ import paste from '../../../../../lib/publicApi/utils/paste';
 import { ClipboardData } from 'roosterjs-editor-types';
 import { expectEqual, initEditor } from './testUtils';
 import { IContentModelEditor } from '../../../../../lib/publicTypes/IContentModelEditor';
+import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 
 const ID = 'CM_Paste_From_ExcelOnline_E2E';
@@ -44,7 +45,7 @@ describe(ID, () => {
         expect(processPastedContentFromExcel.processPastedContentFromExcel).toHaveBeenCalled();
     });
 
-    it('E2E Table with table cells with text color', () => {
+    itChromeOnly('E2E Table with table cells with text color', () => {
         const CD = <ClipboardData>(<any>{
             types: ['text/plain', 'text/html'],
             text:

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelOnlineTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelOnlineTest.ts
@@ -1,8 +1,8 @@
 import * as processPastedContentFromExcel from '../../../../../lib/editor/plugins/PastePlugin/Excel/processPastedContentFromExcel';
 import paste from '../../../../../lib/publicApi/utils/paste';
 import { ClipboardData } from 'roosterjs-editor-types';
+import { expectEqual, initEditor } from './testUtils';
 import { IContentModelEditor } from '../../../../../lib/publicTypes/IContentModelEditor';
-import { initEditor } from './testUtils';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 
 const ID = 'CM_Paste_From_ExcelOnline_E2E';
@@ -42,5 +42,1161 @@ describe(ID, () => {
         });
 
         expect(processPastedContentFromExcel.processPastedContentFromExcel).toHaveBeenCalled();
+    });
+
+    it('E2E Table with table cells with text color', () => {
+        const CD = <ClipboardData>(<any>{
+            types: ['text/plain', 'text/html'],
+            text:
+                'No.\tID\tWork Item Type\r\n1\tlink\tBug\r\n2\tlink\tBug\r\n3\tlink\tBug\r\n4\tlink\tBug\r\n5\tlink\tBug\r\n6\tlink\tBug\r\n7\tlink\tBug',
+            image: null,
+            files: [] as any,
+            rawHtml:
+                "<html>\r\n<body>\r\n<!--StartFragment--><div ccp_infra_version='3' ccp_infra_timestamp='1696347982050' ccp_infra_user_hash='1011877142' ccp_infra_copy_id='5ca49c09-d93e-4bbd-af7b-8a42769fd7bf' data-ccp-timestamp='1696347982050'><html><head><meta http-equiv=Content-Type content=\"text/html; charset=utf-8\"><meta name=ProgId content=Excel.Sheet><meta name=Generator content=\"Microsoft Excel 15\"><style>table\r\n\t{mso-displayed-decimal-separator:\"\\.\";\r\n\tmso-displayed-thousand-separator:\"\\,\";}\r\ntr\r\n\t{mso-height-source:auto;}\r\ncol\r\n\t{mso-width-source:auto;}\r\ntd\r\n\t{padding-top:1px;\r\n\tpadding-right:1px;\r\n\tpadding-left:1px;\r\n\tmso-ignore:padding;\r\n\tcolor:black;\r\n\tfont-size:11.0pt;\r\n\tfont-weight:400;\r\n\tfont-style:normal;\r\n\ttext-decoration:none;\r\n\tfont-family:Calibri, sans-serif;\r\n\tmso-font-charset:0;\r\n\ttext-align:general;\r\n\tvertical-align:bottom;\r\n\tborder:none;\r\n\twhite-space:nowrap;\r\n\tmso-rotate:0;}\r\n.xl30\r\n\t{color:#0563C1;\r\n\ttext-decoration:underline;\r\n\ttext-underline-style:single;\r\n\ttext-align:center;\r\n\tvertical-align:middle;\r\n\tborder:.5pt solid windowtext;\r\n\tbackground:white;\r\n\tmso-pattern:black none;}\r\n.xl31\r\n\t{color:black;\r\n\tfont-weight:700;\r\n\ttext-align:center;\r\n\tvertical-align:middle;\r\n\tborder:.5pt solid windowtext;\r\n\tbackground:white;\r\n\tmso-pattern:black none;\r\n\twhite-space:normal;}\r\n.xl32\r\n\t{color:black;\r\n\tfont-weight:700;\r\n\ttext-align:center;\r\n\tvertical-align:middle;\r\n\tborder:.5pt solid windowtext;\r\n\tbackground:white;\r\n\tmso-pattern:black none;}\r\n.xl33\r\n\t{color:black;\r\n\ttext-align:center;\r\n\tvertical-align:middle;\r\n\tborder:.5pt solid windowtext;\r\n\tbackground:white;\r\n\tmso-pattern:black none;}\r\n.xl34\r\n\t{color:#DBDBDB;\r\n\ttext-align:center;\r\n\tvertical-align:middle;\r\n\tborder:.5pt solid windowtext;\r\n\tbackground:white;\r\n\tmso-pattern:black none;}\r\n</style></head><body link=\"#0563C1\" vlink=\"#954F72\"><table width=209 style='border-collapse:collapse;width:157pt'><!--StartFragment--><col width=64 style='width:48pt'><col width=69 style='width:52pt'><col width=76 style='width:57pt'><tr height=38 style='height:28.5pt'><td width=64 height=38 class=xl32 style='width:48pt;height:28.5pt'>No.</td><td width=69 class=xl32 style='width:52pt'>ID</td><td width=76 class=xl31 style='width:57pt'>Work Item Type</td></tr><tr height=40 style='height:30.0pt'><td height=40 class=xl33 style='height:30.0pt'>1</td><td class=xl30><a href=\"http://www.microsoft.com/\">link</a></td><td class=xl34>Bug</td></tr><tr height=40 style='height:30.0pt'><td height=40 class=xl33 style='height:30.0pt'>2</td><td class=xl30><a href=\"http://www.microsoft.com/\">link</a></td><td class=xl34>Bug</td></tr><tr height=40 style='height:30.0pt'><td height=40 class=xl33 style='height:30.0pt'>3</td><td class=xl30><a href=\"http://www.microsoft.com/\">link</a></td><td class=xl34>Bug</td></tr><tr height=40 style='height:30.0pt'><td height=40 class=xl33 style='height:30.0pt'>4</td><td class=xl30><a href=\"http://www.microsoft.com/\">link</a></td><td class=xl34>Bug</td></tr><tr height=40 style='height:30.0pt'><td height=40 class=xl33 style='height:30.0pt'>5</td><td class=xl30><a href=\"http://www.microsoft.com/\">link</a></td><td class=xl34>Bug</td></tr><tr height=40 style='height:30.0pt'><td height=40 class=xl33 style='height:30.0pt'>6</td><td class=xl30><a href=\"http://www.microsoft.com/\">link</a></td><td class=xl34>Bug</td></tr><tr height=40 style='height:30.0pt'><td height=40 class=xl33 style='height:30.0pt'>7</td><td class=xl30><a href=\"http://www.microsoft.com/\">link</a></td><td class=xl34>Bug</td></tr><!--EndFragment--></table></body></html></div><!--EndFragment-->\r\n</body>\r\n</html>",
+            customValues: {},
+            pasteNativeEvent: true,
+            snapshotBeforePaste: '<div><br></div><!--{"start":[0,0],"end":[0,0]}-->',
+        });
+
+        paste(editor, CD);
+
+        const model = editor.createContentModel({
+            processorOverride: {
+                table: tableProcessor,
+            },
+        });
+
+        expectEqual(model, {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: jasmine.anything() as any,
+                    rows: [
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'No.',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '700',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        width: '48pt',
+                                        height: '28.5pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'ID',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '700',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        width: '52pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Work Item Type',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '700',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'normal',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'normal',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        width: '57pt',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '1',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '2',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '3',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '4',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '5',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '6',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '7',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    blockType: 'Table',
+                    format: {
+                        width: '157pt' as any,
+                        useBorderBox: true,
+                        borderCollapse: true,
+                    } as any,
+                    dataset: {},
+                },
+                {
+                    segments: [
+                        {
+                            isSelected: true,
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        });
     });
 });

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
@@ -2,8 +2,8 @@ import * as processPastedContentFromExcel from '../../../../../lib/editor/plugin
 import paste from '../../../../../lib/publicApi/utils/paste';
 import { Browser } from 'roosterjs-editor-dom';
 import { ClipboardData } from 'roosterjs-editor-types';
+import { expectEqual, initEditor } from './testUtils';
 import { IContentModelEditor } from '../../../../../lib/publicTypes/IContentModelEditor';
-import { initEditor } from './testUtils';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 
 const ID = 'CM_Paste_From_Excel_E2E';
@@ -90,5 +90,1125 @@ describe(ID, () => {
             },
         });
         expect(processPastedContentFromExcel.processPastedContentFromExcel).not.toHaveBeenCalled();
+    });
+
+    it('Copy Table with text color in cell', () => {
+        const CD = <ClipboardData>(<any>{
+            types: ['image/png', 'text/plain', 'text/html'],
+            text:
+                'No.\tID\tWork Item Type\r\n1\tlink\tBug\r\n2\tlink\tBug\r\n3\tlink\tBug\r\n4\tlink\tBug\r\n5\tlink\tBug\r\n6\tlink\tBug\r\n7\tlink\tBug\r\n',
+            image: {},
+            files: [],
+            rawHtml:
+                "<html xmlns:v=\"urn:schemas-microsoft-com:vml\"\r\nxmlns:o=\"urn:schemas-microsoft-com:office:office\"\r\nxmlns:x=\"urn:schemas-microsoft-com:office:excel\"\r\nxmlns=\"http://www.w3.org/TR/REC-html40\">\r\n\r\n<head>\r\n<meta http-equiv=Content-Type content=\"text/html; charset=utf-8\">\r\n<meta name=ProgId content=Excel.Sheet>\r\n<meta name=Generator content=\"Microsoft Excel 15\">\r\n<link id=Main-File rel=Main-File\r\nhref=\"file:///C:/Users/BVALVE~1/AppData/Local/Temp/msohtmlclip1/01/clip.htm\">\r\n<link rel=File-List\r\nhref=\"file:///C:/Users/BVALVE~1/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml\">\r\n<style>\r\n<!--table\r\n\t{mso-displayed-decimal-separator:\"\\.\";\r\n\tmso-displayed-thousand-separator:\"\\,\";}\r\n@page\r\n\t{margin:.75in .7in .75in .7in;\r\n\tmso-header-margin:.3in;\r\n\tmso-footer-margin:.3in;}\r\ntr\r\n\t{mso-height-source:auto;}\r\ncol\r\n\t{mso-width-source:auto;}\r\nbr\r\n\t{mso-data-placement:same-cell;}\r\ntd\r\n\t{padding-top:1px;\r\n\tpadding-right:1px;\r\n\tpadding-left:1px;\r\n\tmso-ignore:padding;\r\n\tcolor:black;\r\n\tfont-size:11.0pt;\r\n\tfont-weight:400;\r\n\tfont-style:normal;\r\n\ttext-decoration:none;\r\n\tfont-family:Calibri, sans-serif;\r\n\tmso-font-charset:0;\r\n\tmso-number-format:General;\r\n\ttext-align:general;\r\n\tvertical-align:bottom;\r\n\tborder:none;\r\n\tmso-background-source:auto;\r\n\tmso-pattern:auto;\r\n\tmso-protection:locked visible;\r\n\twhite-space:nowrap;\r\n\tmso-rotate:0;}\r\n.xl68\r\n\t{background:white;\r\n\tmso-pattern:black none;}\r\n.xl69\r\n\t{background:white;\r\n\tmso-pattern:black none;}\r\n.xl70\r\n\t{text-align:center;\r\n\tvertical-align:middle;\r\n\tbackground:white;\r\n\tmso-pattern:black none;}\r\n.xl71\r\n\t{text-align:center;\r\n\tvertical-align:middle;\r\n\tbackground:white;\r\n\tmso-pattern:black none;}\r\n.xl72\r\n\t{color:#0563C1;\r\n\ttext-decoration:underline;\r\n\ttext-underline-style:single;\r\n\ttext-align:center;\r\n\tvertical-align:middle;\r\n\tborder:.5pt solid windowtext;\r\n\tbackground:white;\r\n\tmso-pattern:black none;}\r\n.xl73\r\n\t{color:black;\r\n\tfont-weight:700;\r\n\ttext-align:center;\r\n\tvertical-align:middle;\r\n\tborder:.5pt solid windowtext;\r\n\tbackground:white;\r\n\tmso-pattern:black none;\r\n\twhite-space:normal;}\r\n.xl74\r\n\t{color:black;\r\n\tfont-weight:700;\r\n\ttext-align:center;\r\n\tvertical-align:middle;\r\n\tborder:.5pt solid windowtext;\r\n\tbackground:white;\r\n\tmso-pattern:black none;}\r\n.xl75\r\n\t{color:black;\r\n\ttext-align:center;\r\n\tvertical-align:middle;\r\n\tborder:.5pt solid windowtext;\r\n\tbackground:white;\r\n\tmso-pattern:black none;}\r\n.xl76\r\n\t{color:#DBDBDB;\r\n\ttext-align:center;\r\n\tvertical-align:middle;\r\n\tborder:.5pt solid windowtext;\r\n\tbackground:white;\r\n\tmso-pattern:black none;}\r\n-->\r\n</style>\r\n</head>\r\n\r\n<body link=\"#0563C1\" vlink=\"#954F72\">\r\n\r\n<table border=0 cellpadding=0 cellspacing=0 width=227 style='border-collapse:\r\n collapse;width:170pt'>\r\n<!--StartFragment-->\r\n <col width=70 style='width:52pt'>\r\n <col width=75 style='mso-width-source:userset;mso-width-alt:2519;width:56pt'>\r\n <col width=82 style='mso-width-source:userset;mso-width-alt:2775;width:62pt'>\r\n <tr height=38 style='mso-height-source:userset;height:28.5pt'>\r\n  <td height=38 class=xl74 width=70 style='height:28.5pt;width:52pt'>No.</td>\r\n  <td class=xl74 width=75 style='border-left:none;width:56pt'>ID</td>\r\n  <td class=xl73 width=82 style='border-left:none;width:62pt'>Work Item Type</td>\r\n </tr>\r\n <tr height=40 style='mso-height-source:userset;height:30.0pt'>\r\n  <td height=40 class=xl75 style='height:30.0pt;border-top:none'>1</td>\r\n  <td class=xl72 style='border-top:none;border-left:none'><a\r\n  href=\"http://www.microsoft.com/\">link</a></td>\r\n  <td class=xl76 style='border-top:none;border-left:none'>Bug</td>\r\n </tr>\r\n <tr height=40 style='mso-height-source:userset;height:30.0pt'>\r\n  <td height=40 class=xl75 style='height:30.0pt;border-top:none'>2</td>\r\n  <td class=xl72 style='border-top:none;border-left:none'><a\r\n  href=\"http://www.microsoft.com/\">link</a></td>\r\n  <td class=xl76 style='border-top:none;border-left:none'>Bug</td>\r\n </tr>\r\n <tr height=40 style='mso-height-source:userset;height:30.0pt'>\r\n  <td height=40 class=xl75 style='height:30.0pt;border-top:none'>3</td>\r\n  <td class=xl72 style='border-top:none;border-left:none'><a\r\n  href=\"http://www.microsoft.com/\">link</a></td>\r\n  <td class=xl76 style='border-top:none;border-left:none'>Bug</td>\r\n </tr>\r\n <tr height=40 style='mso-height-source:userset;height:30.0pt'>\r\n  <td height=40 class=xl75 style='height:30.0pt;border-top:none'>4</td>\r\n  <td class=xl72 style='border-top:none;border-left:none'><a\r\n  href=\"http://www.microsoft.com/\">link</a></td>\r\n  <td class=xl76 style='border-top:none;border-left:none'>Bug</td>\r\n </tr>\r\n <tr height=40 style='mso-height-source:userset;height:30.0pt'>\r\n  <td height=40 class=xl75 style='height:30.0pt;border-top:none'>5</td>\r\n  <td class=xl72 style='border-top:none;border-left:none'><a\r\n  href=\"http://www.microsoft.com/\">link</a></td>\r\n  <td class=xl76 style='border-top:none;border-left:none'>Bug</td>\r\n </tr>\r\n <tr height=40 style='mso-height-source:userset;height:30.0pt'>\r\n  <td height=40 class=xl75 style='height:30.0pt;border-top:none'>6</td>\r\n  <td class=xl72 style='border-top:none;border-left:none'><a\r\n  href=\"http://www.microsoft.com/\">link</a></td>\r\n  <td class=xl76 style='border-top:none;border-left:none'>Bug</td>\r\n </tr>\r\n <tr height=40 style='mso-height-source:userset;height:30.0pt'>\r\n  <td height=40 class=xl75 style='height:30.0pt;border-top:none'>7</td>\r\n  <td class=xl72 style='border-top:none;border-left:none'><a\r\n  href=\"http://www.microsoft.com/\">link</a></td>\r\n  <td class=xl76 style='border-top:none;border-left:none'>Bug</td>\r\n </tr>\r\n<!--EndFragment-->\r\n</table>\r\n\r\n</body>\r\n\r\n</html>\r\n",
+            customValues: {},
+            pasteNativeEvent: true,
+            imageDataUri: '',
+            snapshotBeforePaste: '<br><!--{"start":[0],"end":[0]}-->',
+        });
+
+        paste(editor, CD);
+
+        const model = editor.createContentModel({
+            processorOverride: {
+                table: tableProcessor,
+            },
+        });
+
+        expectEqual(model, {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: jasmine.anything() as any,
+                    rows: [
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'No.',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '700',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        width: '52pt',
+                                        height: '28.5pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'ID',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '700',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        width: '56pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Work Item Type',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '700',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'normal',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'normal',
+                                        borderTop: '0.5pt solid',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        width: '62pt',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '1',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '2',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '3',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '4',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '5',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '6',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                        {
+                            height: jasmine.anything() as any,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: '7',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'black',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        borderLeft: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                        height: '30pt',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'link',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(5, 99, 193)',
+                                                        underline: true,
+                                                    },
+                                                    link: {
+                                                        format: {
+                                                            underline: true,
+                                                            href: 'http://www.microsoft.com/',
+                                                        },
+                                                        dataset: {},
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'Bug',
+                                                    segmentType: 'Text',
+                                                    format: {
+                                                        fontFamily: 'Calibri, sans-serif',
+                                                        fontSize: '11pt',
+                                                        fontWeight: '400',
+                                                        textColor: 'rgb(219, 219, 219)',
+                                                    },
+                                                },
+                                            ],
+                                            blockType: 'Paragraph',
+                                            format: {
+                                                textAlign: 'center',
+                                                whiteSpace: 'nowrap',
+                                            },
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        whiteSpace: 'nowrap',
+                                        borderRight: '0.5pt solid',
+                                        borderBottom: '0.5pt solid',
+                                        backgroundColor: 'white',
+                                        paddingTop: '1px',
+                                        paddingRight: '1px',
+                                        paddingLeft: '1px',
+                                        verticalAlign: 'middle',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    blockType: 'Table',
+                    format: {
+                        width: jasmine.anything(),
+                        useBorderBox: true,
+                        borderCollapse: true,
+                    } as any,
+                    dataset: {},
+                },
+                {
+                    segments: [
+                        {
+                            isSelected: true,
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        });
     });
 });

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
@@ -4,6 +4,7 @@ import { Browser } from 'roosterjs-editor-dom';
 import { ClipboardData } from 'roosterjs-editor-types';
 import { expectEqual, initEditor } from './testUtils';
 import { IContentModelEditor } from '../../../../../lib/publicTypes/IContentModelEditor';
+import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 
 const ID = 'CM_Paste_From_Excel_E2E';
@@ -92,7 +93,7 @@ describe(ID, () => {
         expect(processPastedContentFromExcel.processPastedContentFromExcel).not.toHaveBeenCalled();
     });
 
-    it('Copy Table with text color in cell', () => {
+    itChromeOnly('Copy Table with text color in cell', () => {
         const CD = <ClipboardData>(<any>{
             types: ['image/png', 'text/plain', 'text/html'],
             text:

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/testUtils.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/testUtils.ts
@@ -22,14 +22,13 @@ export function initEditor(id: string) {
 }
 
 export function expectEqual(model1: ContentModelDocument, model2: ContentModelDocument) {
-    expect(
-        /// Remove Cached elements and undefined properties
-        JSON.parse(
-            JSON.stringify(
-                cloneModel(model1, {
-                    includeCachedElement: false,
-                })
-            )
+    /// Remove Cached elements and undefined properties
+    const newModel = JSON.parse(
+        JSON.stringify(
+            cloneModel(model1, {
+                includeCachedElement: false,
+            })
         )
-    ).toEqual(model2);
+    );
+    expect(newModel).toEqual(model2);
 }

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
@@ -220,7 +220,7 @@ describe('paste with content model & paste plugin', () => {
 
         pasteF.default(editor!, clipboardData);
 
-        expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
+        expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(1);
         expect(addParserF.default).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 1);
         expect(ExcelF.processPastedContentFromExcel).toHaveBeenCalledTimes(1);
     });
@@ -231,7 +231,7 @@ describe('paste with content model & paste plugin', () => {
 
         pasteF.default(editor!, clipboardData);
 
-        expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
+        expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(1);
         expect(addParserF.default).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 1);
         expect(ExcelF.processPastedContentFromExcel).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
When pasting a table from excel, if the text color of the cell was modified in Excel. The pasted cell will have the text color format property. This is fine, however, if the cell border color was deprecatedColor, we remove that format by default, leaving the border format property like `1px Solid`, since the color is not provided, the border color defaults to `initial` value and would use the Font color that is in the table cell.

To fix this, remove the font color in the cell, after applying it to the inner segments of the table cell.

Source:
![image](https://github.com/microsoft/roosterjs/assets/8291124/039f58c5-17ac-441a-8726-6f501a3714c7)

Before
![image](https://github.com/microsoft/roosterjs/assets/8291124/19872dc2-0cdd-4a52-98b7-afc0a699188e)

After
![image](https://github.com/microsoft/roosterjs/assets/8291124/48b6a9f3-97d2-45e0-9880-617509ff4d7a)
