### PR TITLE
Standalone editor: decouple utilities

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext.ts
@@ -1,5 +1,5 @@
 import { defaultProcessorMap } from './defaultProcessors';
-import { getObjectKeys } from 'roosterjs-editor-dom';
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
 import {
     defaultFormatKeysPerCategory,
     defaultFormatParsers,

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/headingProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/headingProcessor.ts
@@ -2,7 +2,7 @@ import { addBlock } from '../../modelApi/common/addBlock';
 import { blockProcessor } from './blockProcessor';
 import { createParagraph } from '../../modelApi/creators/createParagraph';
 import { createParagraphDecorator } from '../../modelApi/creators/createParagraphDecorator';
-import { getObjectKeys } from 'roosterjs-editor-dom';
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
 import { parseFormat } from '../utils/parseFormat';
 import { stackFormat } from '../utils/stackFormat';
 import type { ContentModelSegmentFormat, ElementProcessor } from 'roosterjs-content-model-types';

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/tableProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/tableProcessor.ts
@@ -2,8 +2,9 @@ import { addBlock } from '../../modelApi/common/addBlock';
 import { createTable } from '../../modelApi/creators/createTable';
 import { createTableCell } from '../../modelApi/creators/createTableCell';
 import { getBoundingClientRect } from '../utils/getBoundingClientRect';
+import { isElementOfType } from '../../domUtils/isElementOfType';
+import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import { parseFormat } from '../utils/parseFormat';
-import { safeInstanceOf } from 'roosterjs-editor-dom';
 import { stackFormat } from '../utils/stackFormat';
 import type {
     ContentModelTableCellFormat,
@@ -71,7 +72,12 @@ export const tableProcessor: ElementProcessor<HTMLTableElement> = (
 
                 const tbody = tr.parentNode;
 
-                if (safeInstanceOf(tbody, 'HTMLTableSectionElement')) {
+                if (
+                    isNodeOfType(tbody, 'ELEMENT_NODE') &&
+                    (isElementOfType(tbody, 'tbody') ||
+                        isElementOfType(tbody, 'thead') ||
+                        isElementOfType(tbody, 'tfoot'))
+                ) {
                     parseFormat(tbody, context.formatParsers.tableRow, tableRow.format, context);
                 } else if (context.allowCacheElement) {
                     tableRow.cachedElement = tr;

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/areSameFormats.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/areSameFormats.ts
@@ -1,4 +1,4 @@
-import { getObjectKeys } from 'roosterjs-editor-dom';
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
 import type { ContentModelFormatBase } from 'roosterjs-content-model-types';
 
 /**

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/stackFormat.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/stackFormat.ts
@@ -1,4 +1,4 @@
-import { getObjectKeys } from 'roosterjs-editor-dom';
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
 import type {
     ContentModelBlockFormat,
     ContentModelCode,

--- a/packages-content-model/roosterjs-content-model-dom/lib/domUtils/getObjectKeys.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domUtils/getObjectKeys.ts
@@ -1,0 +1,10 @@
+/**
+ * Provide a strong-typed version of Object.keys()
+ * @param obj The source object
+ * @returns Array of keys
+ */
+export function getObjectKeys<T extends string | number | symbol>(
+    obj: Record<T, any> | Partial<Record<T, any>>
+): T[] {
+    return Object.keys(obj) as T[];
+}

--- a/packages-content-model/roosterjs-content-model-dom/lib/domUtils/isElementOfType.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domUtils/isElementOfType.ts
@@ -1,0 +1,12 @@
+/**
+ * Check if the given element is of the type that we are checking according to its tag name
+ * @param element The element to check
+ * @param tag The HTML tag name to check
+ * @returns True if the element has the given tag, otherwise false
+ */
+export function isElementOfType<Tag extends keyof HTMLElementTagNameMap>(
+    element: HTMLElement,
+    tag: Tag
+): element is HTMLElementTagNameMap[Tag] {
+    return element?.tagName?.toLocaleLowerCase() == tag;
+}

--- a/packages-content-model/roosterjs-content-model-dom/lib/domUtils/toArray.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domUtils/toArray.ts
@@ -1,0 +1,35 @@
+/**
+ * Convert a named node map to an array
+ * @param collection The map to convert
+ */
+export default function toArray(collection: NamedNodeMap): Attr[];
+
+/**
+ * Convert a named node map to an array
+ * @param collection The map to convert
+ */
+export default function toArray(collection: DataTransferItemList): DataTransferItem[];
+
+/**
+ * Convert a collection to an array
+ * @param collection The collection to convert
+ */
+export default function toArray<T extends Node>(collection: NodeListOf<T>): T[];
+
+/**
+ * Convert a collection to an array
+ * @param collection The collection to convert
+ */
+export default function toArray<T extends Element>(collection: HTMLCollectionOf<T>): T[];
+
+/**
+ * Convert an array to an array.
+ * This is to satisfy typescript compiler. For some cases the object can be a collection at runtime,
+ * but the declaration is an array. e.g. ClipboardData.types
+ * @param array The array to convert
+ */
+export default function toArray<T>(array: readonly T[]): T[];
+
+export default function toArray(collection: any): any[] {
+    return [].slice.call(collection);
+}

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/common/datasetFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/common/datasetFormatHandler.ts
@@ -1,4 +1,4 @@
-import { getObjectKeys } from 'roosterjs-editor-dom';
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
 import type { DatasetFormat } from 'roosterjs-content-model-types';
 import type { FormatHandler } from '../FormatHandler';
 

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
@@ -10,7 +10,7 @@ import { entityFormatHandler } from './entity/entityFormatHandler';
 import { floatFormatHandler } from './common/floatFormatHandler';
 import { fontFamilyFormatHandler } from './segment/fontFamilyFormatHandler';
 import { fontSizeFormatHandler } from './segment/fontSizeFormatHandler';
-import { getObjectKeys } from 'roosterjs-editor-dom';
+import { getObjectKeys } from '../domUtils/getObjectKeys';
 import { htmlAlignFormatHandler } from './block/htmlAlignFormatHandler';
 import { idFormatHandler } from './common/idFormatHandler';
 import { italicFormatHandler } from './segment/italicFormatHandler';

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listItemMetadataFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listItemMetadataFormatHandler.ts
@@ -1,4 +1,4 @@
-import { getObjectKeys, getTagOfNode } from 'roosterjs-editor-dom';
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import { OrderedMap, UnorderedMap } from './listLevelMetadataFormatHandler';
 import type { FormatHandler } from '../FormatHandler';
@@ -36,7 +36,7 @@ export const listItemMetadataFormatHandler: FormatHandler<ListMetadataFormat> = 
         const depth = context.listFormat.nodeStack.length - 2; // Minus two for the parent element and convert length to index
 
         if (depth >= 0 && isNodeOfType(parent, 'ELEMENT_NODE') && !parent.style.listStyleType) {
-            const parentTag = getTagOfNode(parent);
+            const parentTag = parent.tagName;
             const style =
                 parentTag == 'OL'
                     ? getOrderedListStyleValue(

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listItemThreadFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listItemThreadFormatHandler.ts
@@ -1,4 +1,5 @@
-import { safeInstanceOf } from 'roosterjs-editor-dom';
+import { isElementOfType } from '../../domUtils/isElementOfType';
+import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import type { FormatHandler } from '../FormatHandler';
 import type { ListThreadFormat } from 'roosterjs-content-model-types';
 
@@ -41,7 +42,8 @@ export const listItemThreadFormatHandler: FormatHandler<ListThreadFormat> = {
 
 function isLiUnderOl(element: HTMLElement) {
     return (
-        safeInstanceOf(element, 'HTMLLIElement') &&
-        safeInstanceOf(element.parentNode, 'HTMLOListElement')
+        isElementOfType(element, 'li') &&
+        isNodeOfType(element.parentNode, 'ELEMENT_NODE') &&
+        isElementOfType(element.parentNode, 'ol')
     );
 }

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listLevelMetadataFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listLevelMetadataFormatHandler.ts
@@ -1,5 +1,6 @@
 import { BulletListType, NumberingListType } from 'roosterjs-editor-types';
-import { getObjectKeys, getTagOfNode, safeInstanceOf } from 'roosterjs-editor-dom';
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
+import { isElementOfType } from '../../domUtils/isElementOfType';
 import type { FormatHandler } from '../FormatHandler';
 import type { ListMetadataFormat } from 'roosterjs-content-model-types';
 
@@ -59,8 +60,8 @@ export const listLevelMetadataFormatHandler: FormatHandler<ListMetadataFormat> =
     parse: (format, element) => {
         const listStyle =
             element.style.listStyleType ||
-            (safeInstanceOf(element, 'HTMLOListElement') && OLTypeToStyleMap[element.type]);
-        const tag = getTagOfNode(element);
+            (isElementOfType(element, 'ol') && OLTypeToStyleMap[element.type]);
+        const tag = element.tagName;
 
         if (listStyle) {
             if (tag == 'OL' && format.orderedStyleType === undefined) {
@@ -75,7 +76,7 @@ export const listLevelMetadataFormatHandler: FormatHandler<ListMetadataFormat> =
         }
     },
     apply: (format, element) => {
-        const tag = getTagOfNode(element);
+        const tag = element.tagName;
         const listType =
             tag == 'OL'
                 ? OrderedMap[format.orderedStyleType!]

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listLevelThreadFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listLevelThreadFormatHandler.ts
@@ -1,4 +1,4 @@
-import { safeInstanceOf } from 'roosterjs-editor-dom';
+import { isElementOfType } from '../../domUtils/isElementOfType';
 import type { FormatHandler } from '../FormatHandler';
 import type { ListThreadFormat } from 'roosterjs-content-model-types';
 
@@ -7,7 +7,7 @@ import type { ListThreadFormat } from 'roosterjs-content-model-types';
  */
 export const listLevelThreadFormatHandler: FormatHandler<ListThreadFormat> = {
     parse: (format, element, context) => {
-        if (safeInstanceOf(element, 'HTMLOListElement')) {
+        if (isElementOfType(element, 'ol')) {
             const { listFormat } = context;
             const { threadItemCounts, levels } = listFormat;
             const depth = levels.length;
@@ -28,7 +28,7 @@ export const listLevelThreadFormatHandler: FormatHandler<ListThreadFormat> = {
         } = context;
         const depth = nodeStack.length - 1; // The first one is always the parent of list
 
-        if (depth >= 0 && safeInstanceOf(element, 'HTMLOListElement')) {
+        if (depth >= 0 && isElementOfType(element, 'ol')) {
             const startNumber = format.startNumberOverride;
 
             if (typeof startNumber === 'number') {

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/segment/linkFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/segment/linkFormatHandler.ts
@@ -1,4 +1,4 @@
-import { safeInstanceOf } from 'roosterjs-editor-dom';
+import { isElementOfType } from '../../domUtils/isElementOfType';
 import type { FormatHandler } from '../FormatHandler';
 import type { LinkFormat } from 'roosterjs-content-model-types';
 
@@ -7,7 +7,7 @@ import type { LinkFormat } from 'roosterjs-content-model-types';
  */
 export const linkFormatHandler: FormatHandler<LinkFormat> = {
     parse: (format, element) => {
-        if (safeInstanceOf(element, 'HTMLAnchorElement')) {
+        if (isElementOfType(element, 'a')) {
             const name = element.name;
             const href = element.getAttribute('href'); // Use getAttribute to get original HREF but not the resolved absolute url
             const target = element.target;
@@ -46,7 +46,7 @@ export const linkFormatHandler: FormatHandler<LinkFormat> = {
         }
     },
     apply: (format, element) => {
-        if (safeInstanceOf(element, 'HTMLAnchorElement') && format.href) {
+        if (isElementOfType(element, 'a') && format.href) {
             element.href = format.href;
 
             if (format.name) {

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/color.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/color.ts
@@ -1,4 +1,3 @@
-import { getTagOfNode } from 'roosterjs-editor-dom';
 import type { DarkColorHandler } from 'roosterjs-editor-types';
 
 /**
@@ -97,7 +96,7 @@ function tryGetFontColor(
 ) {
     let darkColor: string | null;
 
-    return getTagOfNode(element) == 'FONT' &&
+    return element.tagName == 'FONT' &&
         !element.style.getPropertyValue(isBackground ? 'background-color' : 'color') &&
         isDarkMode &&
         (darkColor = element.getAttribute(isBackground ? 'bgcolor' : 'color'))

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/parseValueWithUnit.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/parseValueWithUnit.ts
@@ -1,5 +1,3 @@
-import { getComputedStyle } from 'roosterjs-editor-dom';
-
 const MarginValueRegex = /(-?\d+(\.\d+)?)([a-z]+|%)/;
 
 /**
@@ -55,7 +53,9 @@ function getFontSize(currentSizeOrElement?: number | HTMLElement): number {
     } else if (typeof currentSizeOrElement === 'number') {
         return currentSizeOrElement;
     } else {
-        const styleInPt = getComputedStyle(currentSizeOrElement, 'font-size');
+        const styleInPt =
+            currentSizeOrElement.ownerDocument.defaultView?.getComputedStyle(currentSizeOrElement)
+                .fontSize ?? '';
         const floatInPt = parseFloat(styleInPt);
         const floatInPx = ptToPx(floatInPt);
 

--- a/packages-content-model/roosterjs-content-model-dom/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/index.ts
@@ -15,6 +15,9 @@ export { areSameFormats } from './domToModel/utils/areSameFormats';
 export { updateMetadata, hasMetadata } from './domUtils/metadata/updateMetadata';
 export { updateListMetadata } from './domUtils/metadata/updateListMetadata';
 export { isNodeOfType, NodeTypeMap } from './domUtils/isNodeOfType';
+export { isElementOfType } from './domUtils/isElementOfType';
+export { getObjectKeys } from './domUtils/getObjectKeys';
+export { default as toArray } from './domUtils/toArray';
 
 export { createBr } from './modelApi/creators/createBr';
 export { createListItem } from './modelApi/creators/createListItem';

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/contentModelToDom.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/contentModelToDom.ts
@@ -1,4 +1,5 @@
-import { createRange, Position, toArray } from 'roosterjs-editor-dom';
+import toArray from '../domUtils/toArray';
+import { createRange, Position } from 'roosterjs-editor-dom';
 import { isNodeOfType } from '../domUtils/isNodeOfType';
 import type {
     ContentModelDocument,

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext.ts
@@ -1,5 +1,5 @@
 import { defaultContentModelHandlers } from './defaultContentModelHandlers';
-import { getObjectKeys } from 'roosterjs-editor-dom';
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
 import {
     defaultFormatAppliers,
     defaultFormatKeysPerCategory,

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleEntity.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleEntity.ts
@@ -1,5 +1,6 @@
-import { addDelimiters, getObjectKeys, wrap } from 'roosterjs-editor-dom';
+import { addDelimiters, wrap } from 'roosterjs-editor-dom';
 import { applyFormat } from '../utils/applyFormat';
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
 import { reuseCachedElement } from '../utils/reuseCachedElement';
 import type {
     ContentModelBlockHandler,

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
@@ -1,8 +1,9 @@
 import { applyFormat } from '../utils/applyFormat';
-import { getObjectKeys, unwrap } from 'roosterjs-editor-dom';
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
 import { optimize } from '../optimizers/optimize';
 import { reuseCachedElement } from '../utils/reuseCachedElement';
 import { stackFormat } from '../utils/stackFormat';
+import { unwrap } from 'roosterjs-editor-dom';
 import type {
     ContentModelBlockHandler,
     ContentModelParagraph,

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/utils/parseValueWithUnitTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/utils/parseValueWithUnitTest.ts
@@ -1,11 +1,17 @@
-import * as getComputedStyles from 'roosterjs-editor-dom/lib/utils/getComputedStyles';
 import { parseValueWithUnit } from '../../../lib/formatHandlers/utils/parseValueWithUnit';
 
 describe('parseValueWithUnit with element', () => {
     function runTest(unit: string, results: number[]) {
-        const mockedElement = {
+        const mockedElement = ({
+            ownerDocument: {
+                defaultView: {
+                    getComputedStyle: () => ({
+                        fontSize: '15pt',
+                    }),
+                },
+            },
             offsetWidth: 1000,
-        } as HTMLElement;
+        } as any) as HTMLElement;
 
         ['0', '1', '1.1', '-1.1'].forEach((value, i) => {
             const input = value + unit;
@@ -14,10 +20,6 @@ describe('parseValueWithUnit with element', () => {
             expect(result).toBe(results[i], input);
         });
     }
-
-    beforeEach(() => {
-        spyOn(getComputedStyles, 'getComputedStyle').and.returnValue('15pt');
-    });
 
     it('empty', () => {
         expect(parseValueWithUnit()).toBe(0);

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -8,8 +8,10 @@ import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor'
 import {
     contentModelToDom,
     createModelToDomContext,
+    isElementOfType,
     isNodeOfType,
     normalizeContentModel,
+    toArray,
 } from 'roosterjs-content-model-dom';
 import type { DOMSelection, OnNodeCreated } from 'roosterjs-content-model-types';
 import {
@@ -18,9 +20,7 @@ import {
     moveChildNodes,
     createRange,
     extractClipboardItems,
-    toArray,
     wrap,
-    safeInstanceOf,
 } from 'roosterjs-editor-dom';
 import type {
     CopyPastePluginState,
@@ -275,7 +275,7 @@ function selectionExToRange(selection: DOMSelection | null, tempDiv: HTMLDivElem
  * Exported only for unit testing
  */
 export const onNodeCreated: OnNodeCreated = (_, node): void => {
-    if (safeInstanceOf(node, 'HTMLTableElement')) {
+    if (isNodeOfType(node, 'ELEMENT_NODE') && isElementOfType(node, 'table')) {
         wrap(node, 'div');
     }
     if (isNodeOfType(node, 'ELEMENT_NODE') && !node.isContentEditable) {

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelFormatPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelFormatPlugin.ts
@@ -1,7 +1,8 @@
 import applyDefaultFormat from '../../publicApi/format/applyDefaultFormat';
 import applyPendingFormat from '../../publicApi/format/applyPendingFormat';
 import { canApplyPendingFormat, clearPendingFormat } from '../../modelApi/format/pendingFormat';
-import { getObjectKeys, isCharacterValue } from 'roosterjs-editor-dom';
+import { getObjectKeys } from 'roosterjs-content-model-dom';
+import { isCharacterValue } from 'roosterjs-editor-dom';
 import { Keys, PluginEventType } from 'roosterjs-editor-types';
 import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import type { IEditor, PluginEvent, PluginWithState } from 'roosterjs-editor-types';

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/Excel/processPastedContentFromExcel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/Excel/processPastedContentFromExcel.ts
@@ -1,5 +1,6 @@
 import addParser from '../utils/addParser';
-import { getTagOfNode, moveChildNodes } from 'roosterjs-editor-dom';
+import { isNodeOfType } from 'roosterjs-content-model-dom';
+import { moveChildNodes } from 'roosterjs-editor-dom';
 import type ContentModelBeforePasteEvent from '../../../../publicTypes/event/ContentModelBeforePasteEvent';
 import type { TrustedHTMLHandler } from 'roosterjs-editor-types';
 
@@ -29,12 +30,20 @@ export function processPastedContentFromExcel(
 
     // For Excel Online
     const firstChild = fragment.firstChild;
-    if (firstChild && firstChild.childNodes.length > 0 && getTagOfNode(firstChild) == 'DIV') {
+    if (
+        isNodeOfType(firstChild, 'ELEMENT_NODE') &&
+        firstChild.tagName == 'div' &&
+        firstChild.firstChild
+    ) {
         const tableFound = Array.from(firstChild.childNodes).every((child: Node) => {
             // Tables pasted from Excel Online should be of the format: 0 to N META tags and 1 TABLE tag
-            return getTagOfNode(child) == 'META'
+            const tagName = isNodeOfType(child, 'ELEMENT_NODE') && child.tagName;
+
+            return tagName == 'META'
                 ? true
-                : getTagOfNode(child) == 'TABLE' && child == firstChild.lastChild;
+                : tagName == 'TABLE'
+                ? child == firstChild.lastChild
+                : false;
         });
 
         // Extract Table from Div

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/WacComponents/processPastedContentWacComponents.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/WacComponents/processPastedContentWacComponents.ts
@@ -1,5 +1,5 @@
 import addParser from '../utils/addParser';
-import { findClosestElementAncestor, getTagOfNode, matchesSelector } from 'roosterjs-editor-dom';
+import { findClosestElementAncestor, matchesSelector } from 'roosterjs-editor-dom';
 import { setProcessor } from '../utils/setProcessor';
 import type ContentModelBeforePasteEvent from '../../../../publicTypes/event/ContentModelBeforePasteEvent';
 import type {
@@ -77,7 +77,7 @@ const wacElementProcessor: ElementProcessor<HTMLElement> = (
     element: HTMLElement,
     context: DomToModelContext
 ): void => {
-    const elementTag = getTagOfNode(element);
+    const elementTag = element.tagName;
     if (matchesSelector(element, WAC_IDENTIFY_SELECTOR)) {
         element.style.removeProperty('display');
         element.style.removeProperty('margin');

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/WordDesktop/processWordComments.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/WordDesktop/processWordComments.ts
@@ -1,4 +1,4 @@
-import { safeInstanceOf } from 'roosterjs-editor-dom';
+import { isElementOfType } from 'roosterjs-content-model-dom';
 
 const MSO_COMMENT_ANCHOR_HREF_REGEX = /#_msocom_/;
 const MSO_SPECIAL_CHARACTER = 'mso-special-character';
@@ -15,8 +15,7 @@ const MSO_ELEMENT_COMMENT_LIST = 'comment-list';
 export function processWordComments(styles: Record<string, string>, element: HTMLElement) {
     return (
         styles[MSO_SPECIAL_CHARACTER] == MSO_SPECIAL_CHARACTER_COMMENT ||
-        (safeInstanceOf(element, 'HTMLAnchorElement') &&
-            MSO_COMMENT_ANCHOR_HREF_REGEX.test(element.href)) ||
+        (isElementOfType(element, 'a') && MSO_COMMENT_ANCHOR_HREF_REGEX.test(element.href)) ||
         styles[MSO_ELEMENT] == MSO_ELEMENT_COMMENT_LIST
     );
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/utils/linkParser.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/utils/linkParser.ts
@@ -1,4 +1,4 @@
-import { safeInstanceOf } from 'roosterjs-editor-dom';
+import { isElementOfType } from 'roosterjs-content-model-dom';
 import type { ContentModelHyperLinkFormat, FormatParser } from 'roosterjs-content-model-types';
 
 const SUPPORTED_PROTOCOLS = ['http:', 'https:', 'notes:', 'mailto:', 'onenote:'];
@@ -8,7 +8,7 @@ const INVALID_LINKS_REGEX = /^file:\/\/\/[a-zA-Z\/]/i;
  * @internal
  */
 export const parseLink: FormatParser<ContentModelHyperLinkFormat> = (format, element) => {
-    if (!safeInstanceOf(element, 'HTMLAnchorElement')) {
+    if (!isElementOfType(element, 'a')) {
         return;
     }
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
@@ -1,7 +1,6 @@
 import { applyTableFormat } from '../table/applyTableFormat';
 import { deleteSelection } from '../edit/deleteSelection';
 import { getClosestAncestorBlockGroupIndex } from './getClosestAncestorBlockGroupIndex';
-import { getObjectKeys } from 'roosterjs-editor-dom';
 import { normalizeTable } from '../table/normalizeTable';
 import {
     addSegment,
@@ -9,6 +8,7 @@ import {
     createParagraph,
     createSelectionMarker,
     createTableCell,
+    getObjectKeys,
     normalizeContentModel,
 } from 'roosterjs-content-model-dom';
 import type { FormatWithContentModelContext } from '../../publicTypes/parameter/FormatWithContentModelContext';

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/format/getFormatState.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/format/getFormatState.ts
@@ -1,4 +1,4 @@
-import { contains, getTagOfNode } from 'roosterjs-editor-dom';
+import { contains } from 'roosterjs-editor-dom';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { getSelectionRootNode } from '../../modelApi/selection/getSelectionRootNode';
 import { retrieveModelFormatState } from '../../modelApi/common/retrieveModelFormatState';
@@ -8,6 +8,7 @@ import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor'
 import {
     getRegularSelectionOffsets,
     handleRegularSelection,
+    isNodeOfType,
     processChildNode,
 } from 'roosterjs-content-model-dom';
 
@@ -96,7 +97,7 @@ function createNodeStack(root: Node, startNode: Node): Node[] {
     let node: Node | null = startNode;
 
     while (node && contains(root, node)) {
-        if (getTagOfNode(node) == 'TABLE') {
+        if (isNodeOfType(node, 'ELEMENT_NODE') && node.tagName == 'TABLE') {
             // For table, we can't do a reduced model creation since we need to handle their cells and indexes,
             // so clean up whatever we already have, and just put table into the stack
             result.splice(0, result.length, node);


### PR DESCRIPTION
Remove the usage of several util functions from content model code:

- getObjectKeys: Create a copy in `roosterjs-content-model-dom`
- toArray: Create a copy in `roosterjs-content-model-dom`
- safeInstanceOf: Replace with a new type checker function `isElementTypeOf` in `roosterjs-content-model-dom`
- getTagOfNode: Removed and retrieve tagName directly instead
- getComputedStyle: Removed and retrieve computed style from element directly instead