### PR TITLE
Paste/Insert Image according to the visible viewport

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
@@ -146,8 +146,14 @@ function mergeParagraph(
 
             newParagraph.segments.splice(segmentIndex + i, 0, segment);
 
-            if (context && segment.segmentType == 'Entity') {
-                context.newEntities.push(segment);
+            if (context) {
+                if (segment.segmentType == 'Entity') {
+                    context.newEntities.push(segment);
+                }
+
+                if (segment.segmentType == 'Image') {
+                    context.images.push(segment);
+                }
             }
         }
     }

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
@@ -152,7 +152,7 @@ function mergeParagraph(
                 }
 
                 if (segment.segmentType == 'Image') {
-                    context.images.push(segment);
+                    context.newImages.push(segment);
                 }
             }
         }

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
@@ -151,7 +151,7 @@ function mergeParagraph(
                     context.newEntities.push(segment);
                 }
 
-                if (segment.segmentType == 'Image' && context.images) {
+                if (segment.segmentType == 'Image') {
                     context.images.push(segment);
                 }
             }

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/mergeModel.ts
@@ -151,7 +151,7 @@ function mergeParagraph(
                     context.newEntities.push(segment);
                 }
 
-                if (segment.segmentType == 'Image') {
+                if (segment.segmentType == 'Image' && context.images) {
                     context.images.push(segment);
                 }
             }

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
@@ -42,7 +42,7 @@ export function formatWithContentModel(
         newEntities: [],
         deletedEntities: [],
         rawEvent,
-        images: [],
+        newImages: [],
     };
     let selection: DOMSelection | undefined;
 
@@ -134,14 +134,14 @@ function handleDeletedEntities(
 }
 
 function handleImages(editor: IContentModelEditor, context: FormatWithContentModelContext) {
-    if (context.images.length > 0) {
+    if (context.newImages.length > 0) {
         const viewport = editor.getVisibleViewport();
         if (viewport) {
             const { top, bottom, left, right } = viewport;
             const minMaxImageSize = 10;
             const maxWidth = Math.max(right - left, minMaxImageSize);
             const maxHeight = Math.max(bottom - top, minMaxImageSize);
-            context.images.forEach(image => {
+            context.newImages.forEach(image => {
                 image.format.maxHeight = `${maxHeight}px`;
                 image.format.maxWidth = `${maxWidth}px`;
             });

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
@@ -42,6 +42,7 @@ export function formatWithContentModel(
         newEntities: [],
         deletedEntities: [],
         rawEvent,
+        images: [],
     };
     let selection: DOMSelection | undefined;
 
@@ -49,6 +50,7 @@ export function formatWithContentModel(
         const writeBack = () => {
             handleNewEntities(editor, context);
             handleDeletedEntities(editor, context);
+            handleImages(editor, context);
 
             selection =
                 editor.setContentModel(model, undefined /*options*/, onNodeCreated) || undefined;
@@ -129,4 +131,17 @@ function handleDeletedEntities(
             }
         }
     );
+}
+
+function handleImages(editor: IContentModelEditor, context: FormatWithContentModelContext) {
+    const viewport = editor.getVisibleViewport();
+    if (viewport) {
+        const { top, bottom, left, right } = viewport;
+        const maxWidth = right - left;
+        const maxHeight = bottom - top;
+        context.images.forEach(image => {
+            image.format.maxHeight = `${maxHeight}px`;
+            image.format.maxWidth = `${maxWidth}px`;
+        });
+    }
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
@@ -135,7 +135,7 @@ function handleDeletedEntities(
 
 function handleImages(editor: IContentModelEditor, context: FormatWithContentModelContext) {
     const viewport = editor.getVisibleViewport();
-    if (viewport) {
+    if (viewport && context.images) {
         const { top, bottom, left, right } = viewport;
         const maxWidth = right - left;
         const maxHeight = bottom - top;

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
@@ -134,14 +134,17 @@ function handleDeletedEntities(
 }
 
 function handleImages(editor: IContentModelEditor, context: FormatWithContentModelContext) {
-    const viewport = editor.getVisibleViewport();
-    if (viewport && context.images) {
-        const { top, bottom, left, right } = viewport;
-        const maxWidth = right - left;
-        const maxHeight = bottom - top;
-        context.images.forEach(image => {
-            image.format.maxHeight = `${maxHeight}px`;
-            image.format.maxWidth = `${maxWidth}px`;
-        });
+    if (context.images.length > 0) {
+        const viewport = editor.getVisibleViewport();
+        if (viewport) {
+            const { top, bottom, left, right } = viewport;
+            const minMaxImageSize = 10;
+            const maxWidth = Math.max(right - left, minMaxImageSize);
+            const maxHeight = Math.max(bottom - top, minMaxImageSize);
+            context.images.forEach(image => {
+                image.format.maxHeight = `${maxHeight}px`;
+                image.format.maxWidth = `${maxWidth}px`;
+            });
+        }
     }
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
@@ -39,7 +39,7 @@ export interface FormatWithContentModelContext {
     /**
      * Images inserted in the editor that needs to have their size adjusted
      */
-    readonly images: ContentModelImage[];
+    readonly newImages: ContentModelImage[];
 
     /**
      * Raw Event that triggers this format call

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
@@ -37,7 +37,7 @@ export interface FormatWithContentModelContext {
     readonly deletedEntities: DeletedEntity[];
 
     /**
-     * Entities got deleted during formatting. Need to be set by the formatter function
+     * Images inserted in the editor that needs to have their size adjusted
      */
     readonly images: ContentModelImage[];
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
@@ -39,7 +39,7 @@ export interface FormatWithContentModelContext {
     /**
      * Images inserted in the editor that needs to have their size adjusted
      */
-    readonly images?: ContentModelImage[];
+    readonly images: ContentModelImage[];
 
     /**
      * Raw Event that triggers this format call

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
@@ -39,7 +39,7 @@ export interface FormatWithContentModelContext {
     /**
      * Images inserted in the editor that needs to have their size adjusted
      */
-    readonly images: ContentModelImage[];
+    readonly images?: ContentModelImage[];
 
     /**
      * Raw Event that triggers this format call

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
@@ -2,6 +2,7 @@ import type { EntityOperation } from 'roosterjs-editor-types';
 import type {
     ContentModelDocument,
     ContentModelEntity,
+    ContentModelImage,
     DOMSelection,
     OnNodeCreated,
 } from 'roosterjs-content-model-types';
@@ -34,6 +35,11 @@ export interface FormatWithContentModelContext {
      * Entities got deleted during formatting. Need to be set by the formatter function
      */
     readonly deletedEntities: DeletedEntity[];
+
+    /**
+     * Entities got deleted during formatting. Need to be set by the formatter function
+     */
+    readonly images: ContentModelImage[];
 
     /**
      * Raw Event that triggers this format call

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/corePlugins/ContentModelFormatPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/corePlugins/ContentModelFormatPluginTest.ts
@@ -164,6 +164,7 @@ describe('ContentModelFormatPlugin', () => {
             cacheContentModel: () => {},
             isDarkMode: () => false,
             triggerPluginEvent: jasmine.createSpy('triggerPluginEvent'),
+            getVisibleViewport: jasmine.createSpy('getVisibleViewport'),
         } as any) as IContentModelEditor;
         const state = {
             defaultFormat: {},
@@ -215,6 +216,7 @@ describe('ContentModelFormatPlugin', () => {
 
         const setContentModel = jasmine.createSpy('setContentModel');
         const triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        const getVisibleViewport = jasmine.createSpy('getVisibleViewport');
         const model = createContentModelDocument();
         const text = createText('test a test', { fontFamily: 'Arial' });
         const marker = createSelectionMarker();
@@ -232,6 +234,7 @@ describe('ContentModelFormatPlugin', () => {
             cacheContentModel: () => {},
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
         const state = {
             defaultFormat: {},

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelCopyPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelCopyPastePluginTest.ts
@@ -48,6 +48,7 @@ describe('ContentModelCopyPastePlugin |', () => {
     let pasteSpy: jasmine.Spy;
     let cloneModelSpy: jasmine.Spy;
     let transformToDarkColorSpy: jasmine.Spy;
+    let getVisibleViewportSpy: jasmine.Spy;
 
     beforeEach(() => {
         div = document.createElement('div');
@@ -64,6 +65,7 @@ describe('ContentModelCopyPastePlugin |', () => {
         setContentModelSpy = jasmine.createSpy('setContentModel');
         pasteSpy = jasmine.createSpy('paste_');
         isDisposed = jasmine.createSpy('isDisposed');
+        getVisibleViewportSpy = jasmine.createSpy('getVisibleViewport');
 
         cloneModelSpy = spyOn(cloneModelFile, 'cloneModel').and.callFake(
             (model: any) => pasteModelValue
@@ -123,6 +125,7 @@ describe('ContentModelCopyPastePlugin |', () => {
             },
             transformToDarkColor: transformToDarkColorSpy,
             isDisposed,
+            getVisibleViewport: getVisibleViewportSpy,
         });
 
         plugin.initialize(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
@@ -67,7 +67,10 @@ describe(ID, () => {
                         {
                             segmentType: 'Image',
                             src: 'https://github.com/microsoft/roosterjs',
-                            format: { maxWidth: '1169px', maxHeight: '18px' },
+                            format: {
+                                maxWidth: Browser.isChrome ? '1019px' : '1169px',
+                                maxHeight: '18px',
+                            },
                             dataset: {},
                         },
                         {

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
@@ -44,7 +44,7 @@ describe(ID, () => {
         expect(processPastedContentFromExcel.processPastedContentFromExcel).toHaveBeenCalled();
     });
 
-    it('E2E paste a simage', () => {
+    it('E2E paste as image', () => {
         if (Browser.isFirefox) {
             return;
         }
@@ -67,7 +67,7 @@ describe(ID, () => {
                         {
                             segmentType: 'Image',
                             src: 'https://github.com/microsoft/roosterjs',
-                            format: { maxWidth: '100%' },
+                            format: { maxWidth: '1169px', maxHeight: '18px' },
                             dataset: {},
                         },
                         {

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
@@ -69,8 +69,8 @@ describe(ID, () => {
                             segmentType: 'Image',
                             src: 'https://github.com/microsoft/roosterjs',
                             format: {
-                                maxWidth: Browser.isChrome ? '1019px' : '1169px',
-                                maxHeight: '18px',
+                                maxWidth: '100px',
+                                maxHeight: '100px',
                             },
                             dataset: {},
                         },

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/testUtils.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/testUtils.ts
@@ -14,6 +14,14 @@ export function initEditor(id: string) {
 
     let options: ContentModelEditorOptions = {
         plugins: [new ContentModelPastePlugin()],
+        getVisibleViewport: () => {
+            return {
+                top: 100,
+                bottom: 200,
+                left: 100,
+                right: 200,
+            };
+        },
     };
 
     let editor = new ContentModelEditor(node as HTMLDivElement, options);

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/utils/handleKeyboardEventCommonTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/utils/handleKeyboardEventCommonTest.ts
@@ -45,7 +45,7 @@ describe('handleKeyboardEventResult', () => {
         const context: FormatWithContentModelContext = {
             newEntities: [],
             deletedEntities: [],
-            images: [],
+            newImages: [],
         };
         const result = handleKeyboardEventResult(
             mockedEditor,
@@ -71,7 +71,7 @@ describe('handleKeyboardEventResult', () => {
         const context: FormatWithContentModelContext = {
             newEntities: [],
             deletedEntities: [],
-            images: [],
+            newImages: [],
         };
         const result = handleKeyboardEventResult(
             mockedEditor,
@@ -95,7 +95,7 @@ describe('handleKeyboardEventResult', () => {
         const context: FormatWithContentModelContext = {
             newEntities: [],
             deletedEntities: [],
-            images: [],
+            newImages: [],
         };
         const result = handleKeyboardEventResult(
             mockedEditor,
@@ -121,7 +121,7 @@ describe('handleKeyboardEventResult', () => {
         const context: FormatWithContentModelContext = {
             newEntities: [],
             deletedEntities: [],
-            images: [],
+            newImages: [],
         };
         const result = handleKeyboardEventResult(
             mockedEditor,

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/utils/handleKeyboardEventCommonTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/utils/handleKeyboardEventCommonTest.ts
@@ -42,7 +42,11 @@ describe('handleKeyboardEventResult', () => {
         const mockedModel = 'MODEL' as any;
         const which = 'WHICH' as any;
         (<any>mockedEvent).which = which;
-        const context: FormatWithContentModelContext = { newEntities: [], deletedEntities: [] };
+        const context: FormatWithContentModelContext = {
+            newEntities: [],
+            deletedEntities: [],
+            images: [],
+        };
         const result = handleKeyboardEventResult(
             mockedEditor,
             mockedModel,
@@ -64,7 +68,11 @@ describe('handleKeyboardEventResult', () => {
 
     it('DeleteResult.NotDeleted', () => {
         const mockedModel = 'MODEL' as any;
-        const context: FormatWithContentModelContext = { newEntities: [], deletedEntities: [] };
+        const context: FormatWithContentModelContext = {
+            newEntities: [],
+            deletedEntities: [],
+            images: [],
+        };
         const result = handleKeyboardEventResult(
             mockedEditor,
             mockedModel,
@@ -84,7 +92,11 @@ describe('handleKeyboardEventResult', () => {
 
     it('DeleteResult.Range', () => {
         const mockedModel = 'MODEL' as any;
-        const context: FormatWithContentModelContext = { newEntities: [], deletedEntities: [] };
+        const context: FormatWithContentModelContext = {
+            newEntities: [],
+            deletedEntities: [],
+            images: [],
+        };
         const result = handleKeyboardEventResult(
             mockedEditor,
             mockedModel,
@@ -106,7 +118,11 @@ describe('handleKeyboardEventResult', () => {
 
     it('DeleteResult.NothingToDelete', () => {
         const mockedModel = 'MODEL' as any;
-        const context: FormatWithContentModelContext = { newEntities: [], deletedEntities: [] };
+        const context: FormatWithContentModelContext = {
+            newEntities: [],
+            deletedEntities: [],
+            images: [],
+        };
         const result = handleKeyboardEventResult(
             mockedEditor,
             mockedModel,

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
@@ -28,7 +28,11 @@ describe('mergeModel', () => {
         para.segments.push(marker);
         majorModel.blocks.push(para);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -68,7 +72,11 @@ describe('mergeModel', () => {
         para2.segments.push(text1, text2);
         sourceModel.blocks.push(para2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -118,7 +126,11 @@ describe('mergeModel', () => {
         majorModel.blocks.push(para1);
         sourceModel.blocks.push(para2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -197,7 +209,11 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newPara1);
         sourceModel.blocks.push(newPara2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -292,7 +308,11 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newPara2);
         sourceModel.blocks.push(newPara3);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -439,7 +459,11 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newList1);
         sourceModel.blocks.push(newList2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -605,7 +629,11 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newList1);
         sourceModel.blocks.push(newList2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -793,7 +821,11 @@ describe('mergeModel', () => {
 
         sourceModel.blocks.push(newTable1);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -894,7 +926,11 @@ describe('mergeModel', () => {
         spyOn(applyTableFormat, 'applyTableFormat');
         spyOn(normalizeTable, 'normalizeTable');
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(normalizeTable.normalizeTable).not.toHaveBeenCalled();
         expect(majorModel).toEqual({
@@ -1014,7 +1050,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeTable: true,
             }
@@ -1156,7 +1192,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeTable: true,
             }
@@ -1287,7 +1323,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeTable: true,
             }
@@ -1401,7 +1437,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 insertPosition: {
                     marker: marker2,
@@ -1484,7 +1520,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeFormat: 'mergeAll',
             }
@@ -1546,7 +1582,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -1614,7 +1650,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -1709,7 +1745,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -1785,7 +1821,11 @@ describe('mergeModel', () => {
 
         sourceModel.blocks.push(divider);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -1852,7 +1892,11 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newPara1);
         sourceModel.blocks.push(newPara2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
+        mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -1952,7 +1996,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -2033,7 +2077,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeFormat: 'mergeAll',
             }
@@ -2130,7 +2174,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeFormat: 'none',
             }
@@ -2320,7 +2364,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeFormat: 'mergeAll',
             }
@@ -2860,7 +2904,7 @@ describe('mergeModel', () => {
         });
         const context: FormatWithContentModelContext = {
             deletedEntities: [],
-            images: [],
+            newImages: [],
             newEntities: [],
         };
 
@@ -2923,7 +2967,7 @@ describe('mergeModel', () => {
         expect(context).toEqual({
             newEntities: [newEntity],
             deletedEntities: [],
-            images: [],
+            newImages: [],
         });
     });
 
@@ -2948,7 +2992,7 @@ describe('mergeModel', () => {
 
         const context: FormatWithContentModelContext = {
             deletedEntities: [],
-            images: [],
+            newImages: [],
             newEntities: [],
         };
         mergeModel(majorModel, sourceModel, context);
@@ -2980,7 +3024,7 @@ describe('mergeModel', () => {
                     operation: EntityOperation.Overwrite,
                 },
             ],
-            images: [],
+            newImages: [],
         });
     });
 
@@ -3011,7 +3055,7 @@ describe('mergeModel', () => {
 
         const context: FormatWithContentModelContext = {
             deletedEntities: [],
-            images: [],
+            newImages: [],
             newEntities: [],
         };
 
@@ -3040,7 +3084,7 @@ describe('mergeModel', () => {
         expect(context).toEqual({
             deletedEntities: [],
             newEntities: [],
-            images: [newImage],
+            newImages: [newImage],
         });
     });
 
@@ -3077,7 +3121,7 @@ describe('mergeModel', () => {
 
         const context: FormatWithContentModelContext = {
             deletedEntities: [],
-            images: [],
+            newImages: [],
             newEntities: [],
         };
 
@@ -3107,7 +3151,7 @@ describe('mergeModel', () => {
         expect(context).toEqual({
             deletedEntities: [],
             newEntities: [],
-            images: [newImage, newImage1],
+            newImages: [newImage, newImage1],
         });
     });
 
@@ -3145,7 +3189,7 @@ describe('mergeModel', () => {
         const context: FormatWithContentModelContext = {
             deletedEntities: [],
             newEntities: [],
-            images: [image],
+            newImages: [image],
         };
 
         mergeModel(majorModel, sourceModel, context, {
@@ -3174,7 +3218,7 @@ describe('mergeModel', () => {
         expect(context).toEqual({
             deletedEntities: [],
             newEntities: [],
-            images: [image, newImage],
+            newImages: [image, newImage],
         });
     });
 });

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
@@ -1,6 +1,6 @@
 import * as applyTableFormat from '../../../lib/modelApi/table/applyTableFormat';
 import * as normalizeTable from '../../../lib/modelApi/table/normalizeTable';
-import { ContentModelDocument } from 'roosterjs-content-model-types';
+import { ContentModelDocument, ContentModelImage } from 'roosterjs-content-model-types';
 import { EntityOperation } from 'roosterjs-editor-types';
 import { FormatWithContentModelContext } from '../../../lib/publicTypes/parameter/FormatWithContentModelContext';
 import { mergeModel } from '../../../lib/modelApi/common/mergeModel';
@@ -2977,6 +2977,200 @@ describe('mergeModel', () => {
                     operation: EntityOperation.Overwrite,
                 },
             ],
+        });
+    });
+
+    it('Merge Image', () => {
+        const majorModel = createContentModelDocument();
+        const newImage: ContentModelImage = {
+            segmentType: 'Image',
+            src: 'test',
+            format: {},
+            dataset: {},
+        };
+        const sourceModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [newImage],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const para1 = createParagraph();
+        const marker = createSelectionMarker();
+
+        para1.segments.push(marker);
+        majorModel.blocks.push(para1);
+
+        const context: FormatWithContentModelContext = {
+            deletedEntities: [],
+            newEntities: [],
+            images: [],
+        };
+
+        mergeModel(majorModel, sourceModel, context, {
+            mergeFormat: 'mergeAll',
+        });
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        newImage,
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+        });
+
+        expect(context).toEqual({
+            deletedEntities: [],
+            newEntities: [],
+            images: [newImage],
+        });
+    });
+
+    it('Merge two Images', () => {
+        const majorModel = createContentModelDocument();
+        const newImage: ContentModelImage = {
+            segmentType: 'Image',
+            src: 'test',
+            format: {},
+            dataset: {},
+        };
+        const newImage1: ContentModelImage = {
+            segmentType: 'Image',
+            src: 'test1',
+            format: {},
+            dataset: {},
+        };
+        const sourceModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [newImage, newImage1],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const para1 = createParagraph();
+        const marker = createSelectionMarker();
+
+        para1.segments.push(marker);
+        majorModel.blocks.push(para1);
+
+        const context: FormatWithContentModelContext = {
+            deletedEntities: [],
+            newEntities: [],
+            images: [],
+        };
+
+        mergeModel(majorModel, sourceModel, context, {
+            mergeFormat: 'mergeAll',
+        });
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        newImage,
+                        newImage1,
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+        });
+
+        expect(context).toEqual({
+            deletedEntities: [],
+            newEntities: [],
+            images: [newImage, newImage1],
+        });
+    });
+
+    it('Merge into a paragraph with image', () => {
+        const majorModel = createContentModelDocument();
+        const newImage: ContentModelImage = {
+            segmentType: 'Image',
+            src: 'test',
+            format: {},
+            dataset: {},
+        };
+        const sourceModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [newImage],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const para1 = createParagraph();
+        const image: ContentModelImage = {
+            segmentType: 'Image',
+            src: 'test1',
+            format: {},
+            dataset: {},
+        };
+        const marker = createSelectionMarker();
+
+        para1.segments.push(image, marker);
+        majorModel.blocks.push(para1);
+
+        const context: FormatWithContentModelContext = {
+            deletedEntities: [],
+            newEntities: [],
+            images: [image],
+        };
+
+        mergeModel(majorModel, sourceModel, context, {
+            mergeFormat: 'mergeAll',
+        });
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        image,
+                        newImage,
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+        });
+
+        expect(context).toEqual({
+            deletedEntities: [],
+            newEntities: [],
+            images: [image, newImage],
         });
     });
 });

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
@@ -28,7 +28,7 @@ describe('mergeModel', () => {
         para.segments.push(marker);
         majorModel.blocks.push(para);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -68,7 +68,7 @@ describe('mergeModel', () => {
         para2.segments.push(text1, text2);
         sourceModel.blocks.push(para2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -118,7 +118,7 @@ describe('mergeModel', () => {
         majorModel.blocks.push(para1);
         sourceModel.blocks.push(para2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -197,7 +197,7 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newPara1);
         sourceModel.blocks.push(newPara2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -292,7 +292,7 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newPara2);
         sourceModel.blocks.push(newPara3);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -439,7 +439,7 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newList1);
         sourceModel.blocks.push(newList2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -605,7 +605,7 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newList1);
         sourceModel.blocks.push(newList2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -793,7 +793,7 @@ describe('mergeModel', () => {
 
         sourceModel.blocks.push(newTable1);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -894,7 +894,7 @@ describe('mergeModel', () => {
         spyOn(applyTableFormat, 'applyTableFormat');
         spyOn(normalizeTable, 'normalizeTable');
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(normalizeTable.normalizeTable).not.toHaveBeenCalled();
         expect(majorModel).toEqual({
@@ -1014,7 +1014,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeTable: true,
             }
@@ -1156,7 +1156,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeTable: true,
             }
@@ -1287,7 +1287,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeTable: true,
             }
@@ -1401,7 +1401,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 insertPosition: {
                     marker: marker2,
@@ -1484,7 +1484,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeFormat: 'mergeAll',
             }
@@ -1546,7 +1546,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -1614,7 +1614,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -1709,7 +1709,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -1785,7 +1785,7 @@ describe('mergeModel', () => {
 
         sourceModel.blocks.push(divider);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -1852,7 +1852,7 @@ describe('mergeModel', () => {
         sourceModel.blocks.push(newPara1);
         sourceModel.blocks.push(newPara2);
 
-        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [] });
+        mergeModel(majorModel, sourceModel, { newEntities: [], deletedEntities: [], images: [] });
 
         expect(majorModel).toEqual({
             blockGroupType: 'Document',
@@ -1952,7 +1952,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
             }
@@ -2033,7 +2033,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeFormat: 'mergeAll',
             }
@@ -2130,7 +2130,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeFormat: 'none',
             }
@@ -2320,7 +2320,7 @@ describe('mergeModel', () => {
         mergeModel(
             majorModel,
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeFormat: 'mergeAll',
             }
@@ -2860,6 +2860,7 @@ describe('mergeModel', () => {
         });
         const context: FormatWithContentModelContext = {
             deletedEntities: [],
+            images: [],
             newEntities: [],
         };
 
@@ -2922,6 +2923,7 @@ describe('mergeModel', () => {
         expect(context).toEqual({
             newEntities: [newEntity],
             deletedEntities: [],
+            images: [],
         });
     });
 
@@ -2946,6 +2948,7 @@ describe('mergeModel', () => {
 
         const context: FormatWithContentModelContext = {
             deletedEntities: [],
+            images: [],
             newEntities: [],
         };
         mergeModel(majorModel, sourceModel, context);
@@ -2977,6 +2980,7 @@ describe('mergeModel', () => {
                     operation: EntityOperation.Overwrite,
                 },
             ],
+            images: [],
         });
     });
 
@@ -3007,8 +3011,8 @@ describe('mergeModel', () => {
 
         const context: FormatWithContentModelContext = {
             deletedEntities: [],
-            newEntities: [],
             images: [],
+            newEntities: [],
         };
 
         mergeModel(majorModel, sourceModel, context, {
@@ -3073,8 +3077,8 @@ describe('mergeModel', () => {
 
         const context: FormatWithContentModelContext = {
             deletedEntities: [],
-            newEntities: [],
             images: [],
+            newEntities: [],
         };
 
         mergeModel(majorModel, sourceModel, context, {

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/edit/deleteSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/edit/deleteSelectionTest.ts
@@ -527,7 +527,7 @@ describe('deleteSelection - selectionOnly', () => {
 
         entity.isSelected = true;
 
-        const result = deleteSelection(model, [], { newEntities: [], deletedEntities });
+        const result = deleteSelection(model, [], { newEntities: [], deletedEntities, images: [] });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
         expect(result.insertPoint).toEqual({
@@ -582,7 +582,7 @@ describe('deleteSelection - selectionOnly', () => {
         entity.isSelected = true;
 
         const deletedEntities: DeletedEntity[] = [];
-        const result = deleteSelection(model, [], { newEntities: [], deletedEntities });
+        const result = deleteSelection(model, [], { newEntities: [], deletedEntities, images: [] });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
         expect(result.insertPoint).toEqual({
@@ -1487,6 +1487,7 @@ describe('deleteSelection - forward', () => {
         const result = deleteSelection(model, [forwardDeleteCollapsedSelection], {
             newEntities: [],
             deletedEntities,
+            images: [],
         });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
@@ -1534,6 +1535,7 @@ describe('deleteSelection - forward', () => {
         const result = deleteSelection(model, [forwardDeleteCollapsedSelection], {
             newEntities: [],
             deletedEntities,
+            images: [],
         });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
@@ -3243,6 +3245,7 @@ describe('deleteSelection - backward', () => {
         const result = deleteSelection(model, [backwardDeleteCollapsedSelection], {
             newEntities: [],
             deletedEntities,
+            images: [],
         });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
@@ -3291,6 +3294,7 @@ describe('deleteSelection - backward', () => {
         const result = deleteSelection(model, [backwardDeleteCollapsedSelection], {
             newEntities,
             deletedEntities,
+            images: [],
         });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/edit/deleteSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/edit/deleteSelectionTest.ts
@@ -527,7 +527,11 @@ describe('deleteSelection - selectionOnly', () => {
 
         entity.isSelected = true;
 
-        const result = deleteSelection(model, [], { newEntities: [], deletedEntities, images: [] });
+        const result = deleteSelection(model, [], {
+            newEntities: [],
+            deletedEntities,
+            newImages: [],
+        });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
         expect(result.insertPoint).toEqual({
@@ -582,7 +586,11 @@ describe('deleteSelection - selectionOnly', () => {
         entity.isSelected = true;
 
         const deletedEntities: DeletedEntity[] = [];
-        const result = deleteSelection(model, [], { newEntities: [], deletedEntities, images: [] });
+        const result = deleteSelection(model, [], {
+            newEntities: [],
+            deletedEntities,
+            newImages: [],
+        });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
         expect(result.insertPoint).toEqual({
@@ -1487,7 +1495,7 @@ describe('deleteSelection - forward', () => {
         const result = deleteSelection(model, [forwardDeleteCollapsedSelection], {
             newEntities: [],
             deletedEntities,
-            images: [],
+            newImages: [],
         });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
@@ -1535,7 +1543,7 @@ describe('deleteSelection - forward', () => {
         const result = deleteSelection(model, [forwardDeleteCollapsedSelection], {
             newEntities: [],
             deletedEntities,
-            images: [],
+            newImages: [],
         });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
@@ -3245,7 +3253,7 @@ describe('deleteSelection - backward', () => {
         const result = deleteSelection(model, [backwardDeleteCollapsedSelection], {
             newEntities: [],
             deletedEntities,
-            images: [],
+            newImages: [],
         });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);
@@ -3294,7 +3302,7 @@ describe('deleteSelection - backward', () => {
         const result = deleteSelection(model, [backwardDeleteCollapsedSelection], {
             newEntities,
             deletedEntities,
-            images: [],
+            newImages: [],
         });
 
         expect(result.deleteResult).toBe(DeleteResult.Range);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/block/paragraphTestCommon.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/block/paragraphTestCommon.ts
@@ -19,6 +19,7 @@ export function paragraphTestCommon(
         expect(model).toEqual(result);
     });
     const triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+    const getVisibleViewport = jasmine.createSpy('getVisibleViewport');
     const editor = ({
         createContentModel: () => model,
         addUndoSnapshot,
@@ -28,6 +29,7 @@ export function paragraphTestCommon(
         getFocusedPosition: () => ({}),
         isDarkMode: () => false,
         triggerPluginEvent,
+        getVisibleViewport,
     } as any) as IContentModelEditor;
 
     executionCallback(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/block/setAlignmentTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/block/setAlignmentTest.ts
@@ -17,7 +17,9 @@ describe('setAlignment', () => {
     ) {
         paragraphTestCommon(
             'setAlignment',
-            editor => setAlignment(editor, 'right'),
+            editor => {
+                setAlignment(editor, 'right');
+            },
             model,
             result,
             calledTimes
@@ -415,11 +417,13 @@ describe('setAlignment in table', () => {
     let setContentModel: jasmine.Spy<IContentModelEditor['setContentModel']>;
     let createContentModel: jasmine.Spy<IContentModelEditor['createContentModel']>;
     let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
 
     beforeEach(() => {
         setContentModel = jasmine.createSpy('setContentModel');
         createContentModel = jasmine.createSpy('createContentModel');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
 
         spyOn(normalizeTable, 'normalizeTable');
 
@@ -430,6 +434,7 @@ describe('setAlignment in table', () => {
             createContentModel,
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
     });
 
@@ -813,11 +818,13 @@ describe('setAlignment in list', () => {
     let setContentModel: jasmine.Spy<IContentModelEditor['setContentModel']>;
     let createContentModel: jasmine.Spy<IContentModelEditor['createContentModel']>;
     let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
 
     beforeEach(() => {
         setContentModel = jasmine.createSpy('setContentModel');
         createContentModel = jasmine.createSpy('createContentModel');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
 
         editor = ({
             focus: () => {},
@@ -826,6 +833,7 @@ describe('setAlignment in list', () => {
             createContentModel,
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/editingTestCommon.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/editingTestCommon.ts
@@ -14,6 +14,7 @@ export function editingTestCommon(
     spyOn(pendingFormat, 'getPendingFormat').and.returnValue(null);
 
     const triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+    const getVisibleViewport = jasmine.createSpy('getVisibleViewport');
     const triggerContentChangedEvent = jasmine.createSpy('triggerContentChangedEvent');
 
     const addUndoSnapshot = jasmine
@@ -38,6 +39,7 @@ export function editingTestCommon(
         isDisposed: () => false,
         getFocusedPosition: () => null! as NodePosition,
         triggerContentChangedEvent,
+        getVisibleViewport,
         isDarkMode: () => false,
     } as any) as IContentModelEditor;
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/keyboardDeleteTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/keyboardDeleteTest.ts
@@ -71,6 +71,7 @@ describe('keyboardDelete', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: mockedEvent,
+            images: [],
             skipUndoSnapshot: true,
         });
     }

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/keyboardDeleteTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/keyboardDeleteTest.ts
@@ -71,7 +71,7 @@ describe('keyboardDelete', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: mockedEvent,
-            images: [],
+            newImages: [],
             skipUndoSnapshot: true,
         });
     }

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
@@ -30,6 +30,7 @@ describe('insertEntity', () => {
         context = {
             newEntities: [],
             deletedEntities: [],
+            images: [],
         };
 
         setPropertySpy = jasmine.createSpy('setPropertySpy');

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
@@ -30,7 +30,7 @@ describe('insertEntity', () => {
         context = {
             newEntities: [],
             deletedEntities: [],
-            images: [],
+            newImages: [],
         };
 
         setPropertySpy = jasmine.createSpy('setPropertySpy');

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/applyPendingFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/applyPendingFormatTest.ts
@@ -50,7 +50,7 @@ describe('applyPendingFormat', () => {
                 callback(model, {
                     newEntities: [],
                     deletedEntities: [],
-                    images: [],
+                    newImages: [],
                 });
             }
         );
@@ -120,7 +120,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { newEntities: [], deletedEntities: [], images: [] });
+                callback(model, { newEntities: [], deletedEntities: [], newImages: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
@@ -180,7 +180,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { newEntities: [], deletedEntities: [], images: [] });
+                callback(model, { newEntities: [], deletedEntities: [], newImages: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
@@ -238,7 +238,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { newEntities: [], deletedEntities: [], images: [] });
+                callback(model, { newEntities: [], deletedEntities: [], newImages: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
@@ -283,7 +283,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { newEntities: [], deletedEntities: [], images: [] });
+                callback(model, { newEntities: [], deletedEntities: [], newImages: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/applyPendingFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/applyPendingFormatTest.ts
@@ -50,6 +50,7 @@ describe('applyPendingFormat', () => {
                 callback(model, {
                     newEntities: [],
                     deletedEntities: [],
+                    images: [],
                 });
             }
         );
@@ -119,7 +120,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { newEntities: [], deletedEntities: [] });
+                callback(model, { newEntities: [], deletedEntities: [], images: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
@@ -179,7 +180,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { newEntities: [], deletedEntities: [] });
+                callback(model, { newEntities: [], deletedEntities: [], images: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
@@ -237,7 +238,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { newEntities: [], deletedEntities: [] });
+                callback(model, { newEntities: [], deletedEntities: [], images: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
@@ -282,7 +283,7 @@ describe('applyPendingFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('applyPendingFormat');
-                callback(model, { newEntities: [], deletedEntities: [] });
+                callback(model, { newEntities: [], deletedEntities: [], images: [] });
             }
         );
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/clearFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/clearFormatTest.ts
@@ -13,7 +13,7 @@ describe('clearFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('clearFormat');
-                callback(model, { newEntities: [], deletedEntities: [] });
+                callback(model, { newEntities: [], deletedEntities: [], images: [] });
             }
         );
         spyOn(clearModelFormat, 'clearModelFormat');

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/clearFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/clearFormatTest.ts
@@ -13,7 +13,7 @@ describe('clearFormat', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (_, apiName, callback) => {
                 expect(apiName).toEqual('clearFormat');
-                callback(model, { newEntities: [], deletedEntities: [], images: [] });
+                callback(model, { newEntities: [], deletedEntities: [], newImages: [] });
             }
         );
         spyOn(clearModelFormat, 'clearModelFormat');

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/changeImageTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/changeImageTest.ts
@@ -42,6 +42,7 @@ describe('changeImage', () => {
             .createSpy()
             .and.returnValues({ type: 'image', image: image });
         const triggerPluginEvent = jasmine.createSpy().and.callThrough();
+        const getVisibleViewport = jasmine.createSpy().and.callThrough();
 
         const editor = ({
             createContentModel: () => model,
@@ -52,6 +53,7 @@ describe('changeImage', () => {
             getDocument: () => document,
             getDOMSelection,
             triggerPluginEvent,
+            getVisibleViewport,
             isDarkMode: () => false,
         } as any) as IContentModelEditor;
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/insertImageTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/image/insertImageTest.ts
@@ -31,6 +31,7 @@ describe('insertImage', () => {
             expect(model).toEqual(result);
         });
         const triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        const getVisibleViewport = jasmine.createSpy('getVisibleViewport');
         const editor = ({
             createContentModel: () => model,
             addUndoSnapshot,
@@ -40,6 +41,7 @@ describe('insertImage', () => {
             getDocument: () => document,
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
 
         executionCallback(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/adjustLinkSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/adjustLinkSelectionTest.ts
@@ -16,11 +16,13 @@ describe('adjustLinkSelection', () => {
     let setContentModel: jasmine.Spy<IContentModelEditor['setContentModel']>;
     let createContentModel: jasmine.Spy<IContentModelEditor['createContentModel']>;
     let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
 
     beforeEach(() => {
         setContentModel = jasmine.createSpy('setContentModel');
         createContentModel = jasmine.createSpy('createContentModel');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
 
         editor = ({
             focus: () => {},
@@ -29,6 +31,7 @@ describe('adjustLinkSelection', () => {
             createContentModel,
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/insertLinkTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/insertLinkTest.ts
@@ -16,11 +16,13 @@ describe('insertLink', () => {
     let setContentModel: jasmine.Spy<IContentModelEditor['setContentModel']>;
     let createContentModel: jasmine.Spy<IContentModelEditor['createContentModel']>;
     let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
 
     beforeEach(() => {
         setContentModel = jasmine.createSpy('setContentModel');
         createContentModel = jasmine.createSpy('createContentModel');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
 
         editor = ({
             focus: () => {},
@@ -31,6 +33,7 @@ describe('insertLink', () => {
             getFocusedPosition: () => ({}),
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/removeLinkTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/removeLinkTest.ts
@@ -14,11 +14,13 @@ describe('removeLink', () => {
     let setContentModel: jasmine.Spy<IContentModelEditor['setContentModel']>;
     let createContentModel: jasmine.Spy<IContentModelEditor['createContentModel']>;
     let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
 
     beforeEach(() => {
         setContentModel = jasmine.createSpy('setContentModel');
         createContentModel = jasmine.createSpy('createContentModel');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
 
         editor = ({
             focus: () => {},
@@ -27,6 +29,7 @@ describe('removeLink', () => {
             createContentModel,
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStartNumberTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStartNumberTest.ts
@@ -14,7 +14,7 @@ describe('setListStartNumber', () => {
                 const result = callback(input, {
                     newEntities: [],
                     deletedEntities: [],
-                    images: [],
+                    newImages: [],
                 });
 
                 expect(result).toBe(expectedResult);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStartNumberTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStartNumberTest.ts
@@ -11,7 +11,11 @@ describe('setListStartNumber', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (editor, apiName, callback) => {
                 expect(apiName).toBe('setListStartNumber');
-                const result = callback(input, { newEntities: [], deletedEntities: [] });
+                const result = callback(input, {
+                    newEntities: [],
+                    deletedEntities: [],
+                    images: [],
+                });
 
                 expect(result).toBe(expectedResult);
             }

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStyleTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStyleTest.ts
@@ -12,7 +12,11 @@ describe('setListStyle', () => {
         spyOn(formatWithContentModel, 'formatWithContentModel').and.callFake(
             (editor, apiName, callback) => {
                 expect(apiName).toBe('setListStyle');
-                const result = callback(input, { newEntities: [], deletedEntities: [] });
+                const result = callback(input, {
+                    newEntities: [],
+                    deletedEntities: [],
+                    images: [],
+                });
 
                 expect(result).toBe(expectedResult);
             }

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStyleTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/setListStyleTest.ts
@@ -15,7 +15,7 @@ describe('setListStyle', () => {
                 const result = callback(input, {
                     newEntities: [],
                     deletedEntities: [],
-                    images: [],
+                    newImages: [],
                 });
 
                 expect(result).toBe(expectedResult);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/toggleBulletTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/toggleBulletTest.ts
@@ -11,6 +11,7 @@ describe('toggleBullet', () => {
     let focus: jasmine.Spy;
     let mockedModel: ContentModelDocument;
     let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
 
     beforeEach(() => {
         mockedModel = ({} as any) as ContentModelDocument;
@@ -20,6 +21,7 @@ describe('toggleBullet', () => {
         setContentModel = jasmine.createSpy('setContentModel');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
         focus = jasmine.createSpy('focus');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
 
         editor = ({
             focus,
@@ -30,6 +32,7 @@ describe('toggleBullet', () => {
             getFocusedPosition: () => ({}),
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
 
         spyOn(setListType, 'setListType').and.returnValue(true);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/toggleNumberingTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/list/toggleNumberingTest.ts
@@ -11,6 +11,7 @@ describe('toggleNumbering', () => {
     let triggerPluginEvent: jasmine.Spy;
     let focus: jasmine.Spy;
     let mockedModel: ContentModelDocument;
+    let getVisibleViewport: jasmine.Spy;
 
     beforeEach(() => {
         mockedModel = ({} as any) as ContentModelDocument;
@@ -20,6 +21,7 @@ describe('toggleNumbering', () => {
         setContentModel = jasmine.createSpy('setContentModel');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
         focus = jasmine.createSpy('focus');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
 
         editor = ({
             focus,
@@ -30,6 +32,7 @@ describe('toggleNumbering', () => {
             getFocusedPosition: () => ({}),
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
 
         spyOn(setListType, 'setListType').and.returnValue(true);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/segment/changeFontSizeTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/segment/changeFontSizeTest.ts
@@ -15,7 +15,9 @@ describe('changeFontSize', () => {
     ) {
         segmentTestCommon(
             'changeFontSize',
-            editor => changeFontSize(editor, change),
+            editor => {
+                changeFontSize(editor, change);
+            },
             model,
             result,
             calledTimes
@@ -329,6 +331,7 @@ describe('changeFontSize', () => {
         spyOn(pendingFormat, 'setPendingFormat');
         spyOn(pendingFormat, 'getPendingFormat').and.returnValue(null);
         const triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        const getVisibleViewport = jasmine.createSpy('getVisibleViewport');
 
         const addUndoSnapshot = jasmine.createSpy().and.callFake((callback: () => void) => {
             callback();
@@ -352,6 +355,7 @@ describe('changeFontSize', () => {
             setContentModel,
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
 
         changeFontSize(editor, 'increase');

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/segment/segmentTestCommon.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/segment/segmentTestCommon.ts
@@ -24,6 +24,7 @@ export function segmentTestCommon(
         expect(model).toEqual(result);
     });
     const triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+    const getVisibleViewport = jasmine.createSpy('getVisibleViewport');
     const editor = ({
         createContentModel: () => model,
         addUndoSnapshot,
@@ -33,6 +34,7 @@ export function segmentTestCommon(
         getFocusedPosition: () => null as NodePosition,
         isDarkMode: () => false,
         triggerPluginEvent,
+        getVisibleViewport,
     } as any) as IContentModelEditor;
 
     executionCallback(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/table/setTableCellShadeTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/table/setTableCellShadeTest.ts
@@ -9,11 +9,13 @@ describe('setTableCellShade', () => {
     let setContentModel: jasmine.Spy<IContentModelEditor['setContentModel']>;
     let createContentModel: jasmine.Spy<IContentModelEditor['createContentModel']>;
     let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
 
     beforeEach(() => {
         setContentModel = jasmine.createSpy('setContentModel');
         createContentModel = jasmine.createSpy('createContentModel');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
 
         spyOn(normalizeTable, 'normalizeTable');
 
@@ -24,6 +26,7 @@ describe('setTableCellShade', () => {
             createContentModel,
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatImageWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatImageWithContentModelTest.ts
@@ -20,8 +20,9 @@ describe('formatImageWithContentModel', () => {
     ) {
         segmentTestForPluginEvent(
             'apiTest',
-            editor =>
-                formatImageWithContentModel(editor, 'apiTest', callback, shouldCallPluginEvent),
+            editor => {
+                formatImageWithContentModel(editor, 'apiTest', callback, shouldCallPluginEvent);
+            },
             model,
             result,
             shouldCallPluginEvent,
@@ -214,6 +215,7 @@ function segmentTestForPluginEvent(
             callback();
         });
     const triggerPluginEvent = jasmine.createSpy().and.callFake(() => {});
+    const getVisibleViewport = jasmine.createSpy().and.callFake(() => {});
     const setContentModel = jasmine.createSpy().and.callFake((model: ContentModelDocument) => {
         expect(model).toEqual(result);
     });
@@ -226,6 +228,7 @@ function segmentTestForPluginEvent(
         getFocusedPosition: () => null as NodePosition,
         triggerPluginEvent,
         isDarkMode: () => false,
+        getVisibleViewport,
     } as any) as IContentModelEditor;
 
     executionCallback(editor);

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatParagraphWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatParagraphWithContentModelTest.ts
@@ -14,6 +14,7 @@ describe('formatParagraphWithContentModel', () => {
     let setContentModel: jasmine.Spy;
     let triggerPluginEvent: jasmine.Spy;
     let focus: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
     let model: ContentModelDocument;
 
     const apiName = 'mockedApi';
@@ -22,6 +23,7 @@ describe('formatParagraphWithContentModel', () => {
         addUndoSnapshot = jasmine.createSpy('addUndoSnapshot').and.callFake(callback => callback());
         setContentModel = jasmine.createSpy('setContentModel');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
         focus = jasmine.createSpy('focus');
 
         editor = ({
@@ -33,6 +35,7 @@ describe('formatParagraphWithContentModel', () => {
             getCustomData: () => ({}),
             getFocusedPosition: () => 'NewPosition',
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatSegmentWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatSegmentWithContentModelTest.ts
@@ -19,6 +19,7 @@ describe('formatSegmentWithContentModel', () => {
     let getPendingFormat: jasmine.Spy;
     let setPendingFormat: jasmine.Spy;
     let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
 
     const apiName = 'mockedApi';
 
@@ -26,6 +27,7 @@ describe('formatSegmentWithContentModel', () => {
         addUndoSnapshot = jasmine.createSpy('addUndoSnapshot').and.callFake(callback => callback());
         setContentModel = jasmine.createSpy('setContentModel');
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
         focus = jasmine.createSpy('focus');
 
         setPendingFormat = spyOn(pendingFormat, 'setPendingFormat');
@@ -39,6 +41,7 @@ describe('formatSegmentWithContentModel', () => {
             getFocusedPosition: () => null as NodePosition,
             isDarkMode: () => false,
             triggerPluginEvent,
+            getVisibleViewport,
         } as any) as IContentModelEditor;
     });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
@@ -1,6 +1,7 @@
 import * as pendingFormat from '../../../lib/modelApi/format/pendingFormat';
 import { ChangeSource, EntityOperation, PluginEventType } from 'roosterjs-editor-types';
 import { ContentModelDocument } from 'roosterjs-content-model-types';
+import { createImage } from 'roosterjs-content-model-dom';
 import { formatWithContentModel } from '../../../lib/publicApi/utils/formatWithContentModel';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 
@@ -14,6 +15,7 @@ describe('formatWithContentModel', () => {
     let cacheContentModel: jasmine.Spy;
     let getFocusedPosition: jasmine.Spy;
     let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
 
     const apiName = 'mockedApi';
     const mockedPos = 'POS' as any;
@@ -28,6 +30,7 @@ describe('formatWithContentModel', () => {
         cacheContentModel = jasmine.createSpy('cacheContentModel');
         getFocusedPosition = jasmine.createSpy('getFocusedPosition').and.returnValue(mockedPos);
         triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
 
         editor = ({
             focus,
@@ -37,6 +40,7 @@ describe('formatWithContentModel', () => {
             cacheContentModel,
             getFocusedPosition,
             triggerPluginEvent,
+            getVisibleViewport,
             isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });
@@ -50,6 +54,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
+            images: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).not.toHaveBeenCalled();
@@ -66,6 +71,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
+            images: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).toHaveBeenCalledTimes(1);
@@ -94,6 +100,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
+            images: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).toHaveBeenCalledTimes(1);
@@ -127,6 +134,7 @@ describe('formatWithContentModel', () => {
             deletedEntities: [],
             rawEvent: undefined,
             skipUndoSnapshot: true,
+            images: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).not.toHaveBeenCalled();
@@ -141,6 +149,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
+            images: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).toHaveBeenCalled();
@@ -163,6 +172,7 @@ describe('formatWithContentModel', () => {
             deletedEntities: [],
             rawEvent: undefined,
             skipUndoSnapshot: true,
+            images: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).not.toHaveBeenCalled();
@@ -178,6 +188,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
+            images: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).toHaveBeenCalled();
@@ -195,6 +206,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
+            images: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(setContentModel).toHaveBeenCalledWith(mockedModel, undefined, undefined);
@@ -301,5 +313,33 @@ describe('formatWithContentModel', () => {
         });
 
         expect(createContentModel).toHaveBeenCalledWith(undefined, range);
+    });
+
+    it('Has image', () => {
+        const image = createImage('test');
+        const rawEvent = 'RawEvent' as any;
+        const getVisibleViewportSpy = jasmine
+            .createSpy('getVisibleViewport')
+            .and.returnValue({ top: 100, bottom: 200, left: 100, right: 200 });
+        const mockedData = 'DATA';
+        editor.getVisibleViewport = getVisibleViewportSpy;
+
+        formatWithContentModel(
+            editor,
+            apiName,
+            (model, context) => {
+                context = {
+                    ...context,
+                    images: [image],
+                };
+                return true;
+            },
+            {
+                rawEvent: rawEvent,
+                getChangeData: () => mockedData,
+            }
+        );
+
+        expect(getVisibleViewportSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
@@ -54,7 +54,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
-            images: [],
+            newImages: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).not.toHaveBeenCalled();
@@ -71,7 +71,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
-            images: [],
+            newImages: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).toHaveBeenCalledTimes(1);
@@ -100,7 +100,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
-            images: [],
+            newImages: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).toHaveBeenCalledTimes(1);
@@ -134,7 +134,7 @@ describe('formatWithContentModel', () => {
             deletedEntities: [],
             rawEvent: undefined,
             skipUndoSnapshot: true,
-            images: [],
+            newImages: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).not.toHaveBeenCalled();
@@ -149,7 +149,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
-            images: [],
+            newImages: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).toHaveBeenCalled();
@@ -172,7 +172,7 @@ describe('formatWithContentModel', () => {
             deletedEntities: [],
             rawEvent: undefined,
             skipUndoSnapshot: true,
-            images: [],
+            newImages: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).not.toHaveBeenCalled();
@@ -188,7 +188,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
-            images: [],
+            newImages: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(addUndoSnapshot).toHaveBeenCalled();
@@ -206,7 +206,7 @@ describe('formatWithContentModel', () => {
             newEntities: [],
             deletedEntities: [],
             rawEvent: undefined,
-            images: [],
+            newImages: [],
         });
         expect(createContentModel).toHaveBeenCalledTimes(1);
         expect(setContentModel).toHaveBeenCalledWith(mockedModel, undefined, undefined);
@@ -328,7 +328,7 @@ describe('formatWithContentModel', () => {
             editor,
             apiName,
             (model, context) => {
-                context.images.push(image);
+                context.newImages.push(image);
                 return true;
             },
             {

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
@@ -328,10 +328,7 @@ describe('formatWithContentModel', () => {
             editor,
             apiName,
             (model, context) => {
-                context = {
-                    ...context,
-                    images: [image],
-                };
+                context.images.push(image);
                 return true;
             },
             {

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
@@ -448,7 +448,7 @@ describe('mergePasteContent', () => {
 
         pasteF.mergePasteContent(
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             pasteModel,
             false /* applyCurrentFormat */,
             undefined /* customizedMerge */
@@ -457,7 +457,7 @@ describe('mergePasteContent', () => {
         expect(mergeModelFile.mergeModel).toHaveBeenCalledWith(
             sourceModel,
             pasteModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeFormat: 'none',
                 mergeTable: true,
@@ -536,7 +536,7 @@ describe('mergePasteContent', () => {
 
         pasteF.mergePasteContent(
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             pasteModel,
             false /* applyCurrentFormat */,
             customizedMerge /* customizedMerge */
@@ -554,7 +554,7 @@ describe('mergePasteContent', () => {
 
         pasteF.mergePasteContent(
             sourceModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             pasteModel,
             true /* applyCurrentFormat */,
             undefined /* customizedMerge */
@@ -563,7 +563,7 @@ describe('mergePasteContent', () => {
         expect(mergeModelFile.mergeModel).toHaveBeenCalledWith(
             sourceModel,
             pasteModel,
-            { newEntities: [], deletedEntities: [], images: [] },
+            { newEntities: [], deletedEntities: [], newImages: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
                 mergeTable: false,

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
@@ -43,6 +43,7 @@ describe('Paste ', () => {
     let getDocument: jasmine.Spy;
     let getTrustedHTMLHandler: jasmine.Spy;
     let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
 
     const mockedPos = 'POS' as any;
 
@@ -95,6 +96,8 @@ describe('Paste ', () => {
         getTrustedHTMLHandler = jasmine
             .createSpy('getTrustedHTMLHandler')
             .and.returnValue((html: string) => html);
+
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
         spyOn(mergeModelFile, 'mergeModel').and.callFake(() => (mockedModel = mockedMergeModel));
         spyOn(getSelectedSegmentsF, 'default').and.returnValue([
             {
@@ -116,6 +119,7 @@ describe('Paste ', () => {
             getDocument,
             getTrustedHTMLHandler,
             triggerPluginEvent,
+            getVisibleViewport,
             isDarkMode: () => false,
         } as any) as IContentModelEditor;
     });

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
@@ -448,7 +448,7 @@ describe('mergePasteContent', () => {
 
         pasteF.mergePasteContent(
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             pasteModel,
             false /* applyCurrentFormat */,
             undefined /* customizedMerge */
@@ -457,7 +457,7 @@ describe('mergePasteContent', () => {
         expect(mergeModelFile.mergeModel).toHaveBeenCalledWith(
             sourceModel,
             pasteModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeFormat: 'none',
                 mergeTable: true,
@@ -536,7 +536,7 @@ describe('mergePasteContent', () => {
 
         pasteF.mergePasteContent(
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             pasteModel,
             false /* applyCurrentFormat */,
             customizedMerge /* customizedMerge */
@@ -554,7 +554,7 @@ describe('mergePasteContent', () => {
 
         pasteF.mergePasteContent(
             sourceModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             pasteModel,
             true /* applyCurrentFormat */,
             undefined /* customizedMerge */
@@ -563,7 +563,7 @@ describe('mergePasteContent', () => {
         expect(mergeModelFile.mergeModel).toHaveBeenCalledWith(
             sourceModel,
             pasteModel,
-            { newEntities: [], deletedEntities: [] },
+            { newEntities: [], deletedEntities: [], images: [] },
             {
                 mergeFormat: 'keepSourceEmphasisFormat',
                 mergeTable: false,


### PR DESCRIPTION
When insert or paste image, add max height/width to the image, so large images can be resized to the size of the editor.   
![adaptImageSize](https://github.com/microsoft/roosterjs/assets/87443959/c1498450-32e8-465c-a234-d749ff46338e)

