### PR TITLE
Recreate Content Model for table and image selection

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/utils/contentModelDomIndexer.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/utils/contentModelDomIndexer.ts
@@ -41,12 +41,6 @@ function isIndexedSegment(node: Node): node is IndexedSegmentNode {
     );
 }
 
-function isIndexedTable(element: HTMLTableElement): element is IndexedTableElement {
-    const { tableRows } = (element as IndexedTableElement).__roosterjsContentModel ?? {};
-
-    return Array.isArray(tableRows) && tableRows.every(row => Array.isArray(row.cells));
-}
-
 function onSegment(
     segmentNode: Node,
     paragraph: ContentModelParagraph,
@@ -112,34 +106,9 @@ function reconcileSelection(
 
     switch (newSelection.type) {
         case 'image':
-            const imageModel = isIndexedSegment(newSelection.image)
-                ? newSelection.image.__roosterjsContentModel.segments[0]
-                : null;
-
-            if (imageModel?.segmentType == 'Image') {
-                imageModel.isSelected = true;
-                imageModel.isSelectedAsImageSelection = true;
-
-                return true;
-            }
-
-            break;
-
         case 'table':
-            const rows = isIndexedTable(newSelection.table)
-                ? newSelection.table.__roosterjsContentModel.tableRows
-                : null;
-            rows?.forEach((row, rowIndex) => {
-                row.cells.forEach((cell, colIndex) => {
-                    cell.isSelected =
-                        rowIndex >= newSelection.firstRow &&
-                        rowIndex <= newSelection.lastRow &&
-                        colIndex >= newSelection.firstColumn &&
-                        colIndex <= newSelection.lastColumn;
-                });
-            });
-
-            return true;
+            // For image and table selection, we just clear the cached model since during selecting the element id might be changed
+            return false;
 
         case 'range':
             const newRange = newSelection.range;

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/utils/contentModelDomIndexerTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/utils/contentModelDomIndexerTest.ts
@@ -445,7 +445,7 @@ describe('contentModelDomIndexer.reconcileSelection', () => {
 
         const result = contentModelDomIndexer.reconcileSelection(model, newRangeEx);
 
-        expect(result).toBeTrue();
+        expect(result).toBeFalse();
         expect(node1.__roosterjsContentModel).toEqual({
             paragraph,
             segments: [oldSegment1],
@@ -465,8 +465,6 @@ describe('contentModelDomIndexer.reconcileSelection', () => {
             src: 'test',
             format: {},
             dataset: {},
-            isSelected: true,
-            isSelectedAsImageSelection: true,
         });
     });
 
@@ -503,7 +501,7 @@ describe('contentModelDomIndexer.reconcileSelection', () => {
 
         const result = contentModelDomIndexer.reconcileSelection(model, newRangeEx);
 
-        expect(result).toBeTrue();
+        expect(result).toBeFalse();
         expect(node1.__roosterjsContentModel).toEqual({
             tableRows: tableModel.rows,
         });
@@ -512,15 +510,6 @@ describe('contentModelDomIndexer.reconcileSelection', () => {
             blockGroupType: 'Document',
             blocks: [tableModel],
         });
-        expect(cell00.isSelected).toBeFalse();
-        expect(cell01.isSelected).toBeFalse();
-        expect(cell02.isSelected).toBeFalse();
-        expect(cell10.isSelected).toBeTrue();
-        expect(cell11.isSelected).toBeTrue();
-        expect(cell12.isSelected).toBeFalse();
-        expect(cell20.isSelected).toBeTrue();
-        expect(cell21.isSelected).toBeTrue();
-        expect(cell22.isSelected).toBeFalse();
     });
 
     it('no old range, collapsed range after last node', () => {


### PR DESCRIPTION
With advanced cache enabled in Content Model editor, when we start a table selection, table id can be modified. When that happens, we need to update cached model to reflect this change.

For now the easiest way is to clear cache and rebuild content model when new selection is table/image.