### PR TITLE
Catch error and continue when dispose editor

### DIFF
--- a/packages/roosterjs-editor-core/lib/editor/EditorBase.ts
+++ b/packages/roosterjs-editor-core/lib/editor/EditorBase.ts
@@ -111,8 +111,14 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
      */
     public dispose(): void {
         const core = this.getCore();
+
         for (let i = core.plugins.length - 1; i >= 0; i--) {
-            core.plugins[i].dispose();
+            try {
+                core.plugins[i].dispose();
+            } catch (e) {
+                // Cache the error and pass it out, then keep going since dispose should always succeed
+                core.disposeErrorHandler?.(e as Error);
+            }
         }
 
         core.darkColorHandler.reset();

--- a/packages/roosterjs-editor-core/lib/editor/EditorBase.ts
+++ b/packages/roosterjs-editor-core/lib/editor/EditorBase.ts
@@ -113,11 +113,13 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
         const core = this.getCore();
 
         for (let i = core.plugins.length - 1; i >= 0; i--) {
+            const plugin = core.plugins[i];
+
             try {
-                core.plugins[i].dispose();
+                plugin.dispose();
             } catch (e) {
                 // Cache the error and pass it out, then keep going since dispose should always succeed
-                core.disposeErrorHandler?.(e as Error);
+                core.disposeErrorHandler?.(plugin, e as Error);
             }
         }
 

--- a/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
+++ b/packages/roosterjs-editor-core/lib/editor/createEditorCore.ts
@@ -52,6 +52,7 @@ export const createEditorCore: CoreCreator<EditorCore, EditorOptions> = (content
         getVisibleViewport,
         imageSelectionBorderColor: options.imageSelectionBorderColor,
         darkColorHandler: new DarkColorHandlerImpl(contentDiv, pluginState.lifecycle.getDarkColor),
+        disposeErrorHandler: options.disposeErrorHandler,
     };
 
     return core;

--- a/packages/roosterjs-editor-core/test/editor/EditorTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/EditorTest.ts
@@ -1,6 +1,7 @@
 import * as getSelectionRange from '../../lib/coreApi/getSelectionRange';
 import * as TestHelper from '../TestHelper';
-import { ContentPosition, IEditor } from 'roosterjs-editor-types';
+import Editor from '../../lib/editor/Editor';
+import { ContentPosition, EditorPlugin, IEditor } from 'roosterjs-editor-types';
 
 let editor: IEditor;
 let testID = 'EditorTest';
@@ -507,5 +508,42 @@ describe('Editor getCustomData()', () => {
 
         editor.dispose();
         expect(objCount).toBe(0);
+    });
+});
+
+describe('Dispose with exception', () => {
+    it('handle exception when dispose', () => {
+        const errorMsg = 'Test error';
+        const disposeSpy1 = jasmine.createSpy('dispose1');
+        const disposeSpy2 = jasmine.createSpy('dispose2').and.throwError(errorMsg);
+        const disposeSpy3 = jasmine.createSpy('dispose3');
+        const handlerSpy = jasmine.createSpy('disposeErrorhandler');
+
+        const plugin1 = ({
+            initialize: () => {},
+            dispose: disposeSpy1,
+        } as any) as EditorPlugin;
+        const plugin2 = ({
+            initialize: () => {},
+            dispose: disposeSpy2,
+        } as any) as EditorPlugin;
+        const plugin3 = ({
+            initialize: () => {},
+            dispose: disposeSpy3,
+        } as any) as EditorPlugin;
+
+        const div = document.createElement('div');
+        const editor = new Editor(div, {
+            plugins: [plugin1, plugin2, plugin3],
+            disposeErrorHandler: handlerSpy,
+        });
+
+        editor.dispose();
+
+        expect(disposeSpy1).toHaveBeenCalledTimes(1);
+        expect(disposeSpy2).toHaveBeenCalledTimes(1);
+        expect(disposeSpy3).toHaveBeenCalledTimes(1);
+        expect(handlerSpy).toHaveBeenCalledTimes(1);
+        expect(handlerSpy).toHaveBeenCalledWith(new Error(errorMsg));
     });
 });

--- a/packages/roosterjs-editor-core/test/editor/EditorTest.ts
+++ b/packages/roosterjs-editor-core/test/editor/EditorTest.ts
@@ -544,6 +544,6 @@ describe('Dispose with exception', () => {
         expect(disposeSpy2).toHaveBeenCalledTimes(1);
         expect(disposeSpy3).toHaveBeenCalledTimes(1);
         expect(handlerSpy).toHaveBeenCalledTimes(1);
-        expect(handlerSpy).toHaveBeenCalledWith(new Error(errorMsg));
+        expect(handlerSpy).toHaveBeenCalledWith(plugin2, new Error(errorMsg));
     });
 });

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -84,6 +84,12 @@ export default interface EditorCore extends PluginState {
      * If keep it null, editor will still use original dataset-based dark mode solution.
      */
     darkColorHandler: DarkColorHandler;
+
+    /**
+     * A callback to be invoked when any exception is thrown during disposing editor
+     * @param error The error object we got
+     */
+    disposeErrorHandler?: (error: Error) => void;
 }
 
 /**

--- a/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorCore.ts
@@ -87,9 +87,10 @@ export default interface EditorCore extends PluginState {
 
     /**
      * A callback to be invoked when any exception is thrown during disposing editor
+     * @param plugin The plugin that causes exception
      * @param error The error object we got
      */
-    disposeErrorHandler?: (error: Error) => void;
+    disposeErrorHandler?: (plugin: EditorPlugin, error: Error) => void;
 }
 
 /**

--- a/packages/roosterjs-editor-types/lib/interface/EditorOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorOptions.ts
@@ -147,7 +147,8 @@ export default interface EditorOptions {
 
     /**
      * A callback to be invoked when any exception is thrown during disposing editor
+     * @param plugin The plugin that causes exception
      * @param error The error object we got
      */
-    disposeErrorHandler?: (error: Error) => void;
+    disposeErrorHandler?: (plugin: EditorPlugin, error: Error) => void;
 }

--- a/packages/roosterjs-editor-types/lib/interface/EditorOptions.ts
+++ b/packages/roosterjs-editor-types/lib/interface/EditorOptions.ts
@@ -144,4 +144,10 @@ export default interface EditorOptions {
      * Color of the border of a selectedImage. Default color: '#DB626C'
      */
     imageSelectionBorderColor?: string;
+
+    /**
+     * A callback to be invoked when any exception is thrown during disposing editor
+     * @param error The error object we got
+     */
+    disposeErrorHandler?: (error: Error) => void;
 }


### PR DESCRIPTION
When dispose editor, if any plugin throws exception from its dispose() method, we should catch it and keep going to make sure dispose is always success.