### PR TITLE
Enable eslint rule: prefer-const, no-var

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -146,5 +146,7 @@ module.exports = {
             },
         ],
         'import/no-duplicates': 'error',
+        'prefer-const': 'error',
+        'no-var': 'error',
     },
 };

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/tableProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/tableProcessor.ts
@@ -268,7 +268,7 @@ export const tableProcessor: ElementProcessor<HTMLTableElement> = (
 };
 
 function calcSizes(positions: number[]): number[] {
-    let result: number[] = [];
+    const result: number[] = [];
     let lastPos = positions[positions.length - 1];
 
     for (let i = positions.length - 2; i >= 0; i--) {

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/textProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/textProcessor.ts
@@ -22,7 +22,9 @@ export const textProcessor: ElementProcessor<Text> = (
     context: DomToModelContext
 ) => {
     let txt = textNode.nodeValue || '';
-    let [txtStartOffset, txtEndOffset] = getRegularSelectionOffsets(context, textNode);
+    const offsets = getRegularSelectionOffsets(context, textNode);
+    const txtStartOffset = offsets[0];
+    let txtEndOffset = offsets[1];
     const segments: (ContentModelText | undefined)[] = [];
     const paragraph = ensureParagraph(group, context.blockFormat);
 

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/getDefaultStyle.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/getDefaultStyle.ts
@@ -12,7 +12,7 @@ export function getDefaultStyle(
     element: HTMLElement,
     context: DomToModelContext
 ): Partial<CSSStyleDeclaration> {
-    let tag = element.tagName.toLowerCase() as keyof DefaultStyleMap;
+    const tag = element.tagName.toLowerCase() as keyof DefaultStyleMap;
 
     return defaultHTMLStyleMap[tag] || {};
 }

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/getRegularSelectionOffsets.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/getRegularSelectionOffsets.ts
@@ -13,8 +13,8 @@ export function getRegularSelectionOffsets(
 ): [number, number] {
     const range = context.selection?.type == 'range' ? context.selection.range : null;
 
-    let startOffset = range?.startContainer == currentContainer ? range.startOffset : -1;
-    let endOffset = range?.endContainer == currentContainer ? range.endOffset! : -1;
+    const startOffset = range?.startContainer == currentContainer ? range.startOffset : -1;
+    const endOffset = range?.endContainer == currentContainer ? range.endOffset! : -1;
 
     return [startOffset, endOffset];
 }

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listItemMetadataFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/list/listItemMetadataFormatHandler.ts
@@ -94,8 +94,8 @@ function convertDecimalsToAlpha(decimal: number, isLowerCase?: boolean): string 
 
 function convertDecimalsToRoman(decimal: number, isLowerCase?: boolean) {
     let romanValue = '';
-    for (let i of getObjectKeys(RomanValues)) {
-        let timesRomanCharAppear = Math.floor(decimal / RomanValues[i]);
+    for (const i of getObjectKeys(RomanValues)) {
+        const timesRomanCharAppear = Math.floor(decimal / RomanValues[i]);
         decimal = decimal - timesRomanCharAppear * RomanValues[i];
         romanValue = romanValue + i.repeat(timesRomanCharAppear);
     }

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleEntity.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleEntity.ts
@@ -18,7 +18,7 @@ export const handleEntityBlock: ContentModelBlockHandler<ContentModelEntity> = (
     context,
     refNode
 ) => {
-    let { entityFormat, wrapper } = entityModel;
+    const { entityFormat, wrapper } = entityModel;
 
     applyFormat(wrapper, context.formatAppliers.entity, entityFormat, context);
 
@@ -38,7 +38,7 @@ export const handleEntitySegment: ContentModelSegmentHandler<ContentModelEntity>
     context,
     newSegments
 ) => {
-    let { entityFormat, wrapper, format } = entityModel;
+    const { entityFormat, wrapper, format } = entityModel;
 
     parent.appendChild(wrapper);
     newSegments?.push(wrapper);

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleListItem.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleListItem.ts
@@ -23,7 +23,7 @@ export const handleListItem: ContentModelBlockHandler<ContentModelListItem> = (
 
     const { nodeStack } = context.listFormat;
 
-    let listParent = nodeStack?.[nodeStack?.length - 1]?.node || parent;
+    const listParent = nodeStack?.[nodeStack?.length - 1]?.node || parent;
     const li = doc.createElement('li');
     const level = listItem.levels[listItem.levels.length - 1];
 

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleTable.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/handlers/handleTable.ts
@@ -95,7 +95,7 @@ export const handleTable: ContentModelBlockHandler<ContentModelTable> = (
             }
 
             if (!cell.spanAbove && !cell.spanLeft) {
-                let td =
+                const td =
                     (context.allowCacheElement && cell.cachedElement) ||
                     doc.createElement(cell.isHeader ? 'th' : 'td');
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/Excel/processPastedContentFromExcel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/Excel/processPastedContentFromExcel.ts
@@ -88,8 +88,8 @@ export function excelHandler(html: string, htmlBefore: string): string {
         html = tr + html + '</TR>';
     }
     if (html.match(LAST_TR_END_REGEX)) {
-        let tableMatch = htmlBefore.match(LAST_TABLE_REGEX);
-        let table = tableMatch ? tableMatch[0] : '<TABLE>';
+        const tableMatch = htmlBefore.match(LAST_TABLE_REGEX);
+        const table = tableMatch ? tableMatch[0] : '<TABLE>';
         html = table + html + '</TABLE>';
     }
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/WacComponents/processPastedContentWacComponents.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/WacComponents/processPastedContentWacComponents.ts
@@ -120,7 +120,7 @@ const wacLiElementProcessor: ElementProcessor<HTMLLIElement> = (
             const currentLevel = lastblock.levels[lastblock.levels.length - 1];
 
             // Get item level from 'data-aria-level' attribute
-            let level = parseInt(element.getAttribute('data-aria-level') ?? '');
+            const level = parseInt(element.getAttribute('data-aria-level') ?? '');
             if (level > 0) {
                 if (level > lastblock.levels.length) {
                     while (level != lastblock.levels.length) {

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/WordDesktop/processWordLists.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/WordDesktop/processWordLists.ts
@@ -202,7 +202,7 @@ function getFakeBulletText(node: Node, levels?: number): string {
  */
 function isIgnoreNode(node: Node): boolean {
     if (isNodeOfType(node, 'ELEMENT_NODE')) {
-        let listAttribute = getStyles(node as HTMLElement)[MSO_LIST];
+        const listAttribute = getStyles(node as HTMLElement)[MSO_LIST];
         if (
             listAttribute &&
             listAttribute.length > 0 &&

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/block/getLeafSiblingBlock.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/block/getLeafSiblingBlock.ts
@@ -38,7 +38,7 @@ export function getLeafSiblingBlock(
     const newPath = [...path];
 
     while (newPath.length > 0) {
-        let group = newPath[0];
+        const group = newPath[0];
         const index = group.blocks.indexOf(block);
 
         if (index < 0) {

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/deleteSteps/deleteWordSelection.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/deleteSteps/deleteWordSelection.ts
@@ -25,7 +25,7 @@ function getDeleteWordSelection(direction: 'forward' | 'backward'): DeleteSelect
         const startIndex = paragraph.segments.indexOf(marker);
         const deleteNext = direction == 'forward';
 
-        let iterator = iterateSegments(paragraph, startIndex, deleteNext, context);
+        const iterator = iterateSegments(paragraph, startIndex, deleteNext, context);
         let curr = iterator.next();
 
         for (let state = DeleteWordState.Start; state != DeleteWordState.End && !curr.done; ) {

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/link/insertLink.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/link/insertLink.ts
@@ -42,7 +42,7 @@ export default function insertLink(
 ) {
     editor.focus();
 
-    let url = (checkXss(link) || '').trim();
+    const url = (checkXss(link) || '').trim();
     if (url) {
         const linkData = matchLink(url);
         const linkUrl = linkData ? linkData.normalizedUrl : applyLinkPrefix(url);

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/segment/changeFontSize.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/segment/changeFontSize.ts
@@ -42,7 +42,7 @@ function changeFontSizeInternal(
     paragraph: ContentModelParagraph | null
 ) {
     if (format.fontSize) {
-        let sizeInPt = parseValueWithUnit(format.fontSize, undefined /*element*/, 'pt');
+        const sizeInPt = parseValueWithUnit(format.fontSize, undefined /*element*/, 'pt');
 
         if (sizeInPt > 0) {
             const newSize = getNewFontSize(sizeInPt, change == 'increase' ? 1 : -1, FONT_SIZES);
@@ -54,7 +54,7 @@ function changeFontSizeInternal(
 
 function getNewFontSize(pt: number, changeBase: 1 | -1, fontSizes: number[]): number {
     pt = changeBase == 1 ? Math.floor(pt) : Math.ceil(pt);
-    let last = fontSizes[fontSizes.length - 1];
+    const last = fontSizes[fontSizes.length - 1];
     if (pt <= fontSizes[0]) {
         pt = Math.max(pt + changeBase, MIN_FONT_SIZE);
     } else if (pt > last || (pt == last && changeBase == 1)) {

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/paste.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/paste.ts
@@ -173,7 +173,7 @@ function triggerPluginEventAndCreatePasteFragment(
     const { rawHtml, text, imageDataUri } = clipboardData;
     const trustedHTMLHandler = editor.getTrustedHTMLHandler();
 
-    let doc: Document | undefined = rawHtml
+    const doc: Document | undefined = rawHtml
         ? new DOMParser().parseFromString(trustedHTMLHandler(rawHtml), 'text/html')
         : undefined;
 

--- a/packages-content-model/roosterjs-content-model/lib/createContentModelEditor.ts
+++ b/packages-content-model/roosterjs-content-model/lib/createContentModelEditor.ts
@@ -25,7 +25,7 @@ export function createContentModelEditor(
         plugins = plugins.concat(additionalPlugins);
     }
 
-    let options: ContentModelEditorOptions = {
+    const options: ContentModelEditorOptions = {
         plugins: plugins,
         initialContent: initialContent,
         getDarkColor: getDarkColor,

--- a/packages-ui/roosterjs-react/lib/emoji/utils/emojiList.ts
+++ b/packages-ui/roosterjs-react/lib/emoji/utils/emojiList.ts
@@ -761,7 +761,7 @@ export function forEachEmoji(callback: (emoji: Emoji) => boolean): void {
 
 // get emoji code point from an emoji key
 function getEmojiCodePoint(key: string): string | null {
-    let unicode = parseInt(key, 16);
+    const unicode = parseInt(key, 16);
     if (isNaN(unicode)) {
         return null;
     }
@@ -771,8 +771,8 @@ function getEmojiCodePoint(key: string): string | null {
     // 0x00023 - 0x04000 -> does not have surrogate pairs
     let surrogatePairs: number[];
     if (unicode >= 0x1f000 && unicode <= 0x1f700) {
-        let hi = Math.floor((unicode - 0x10000) / 0x400) + 0xd800;
-        let lo = ((unicode - 0x10000) % 0x400) + 0xdc00;
+        const hi = Math.floor((unicode - 0x10000) / 0x400) + 0xd800;
+        const lo = ((unicode - 0x10000) % 0x400) + 0xdc00;
         surrogatePairs = [hi, lo];
     } else if (unicode >= 0x00023 && unicode <= 0x04000) {
         surrogatePairs = [unicode];

--- a/packages-ui/roosterjs-react/lib/ribbon/component/buttons/insertTable.tsx
+++ b/packages-ui/roosterjs-react/lib/ribbon/component/buttons/insertTable.tsx
@@ -107,7 +107,7 @@ function InsertTablePane(props: {
     const ariaLabels = React.useMemo<string[][]>(() => {
         const result: string[][] = [];
         for (let i = 1; i <= MaxCols; i++) {
-            let col: string[] = [];
+            const col: string[] = [];
             for (let j = 1; j <= MaxRows; j++) {
                 col[j] = formatText(item.text ?? '', i, j);
             }

--- a/packages/roosterjs-editor-api/lib/format/changeFontSize.ts
+++ b/packages/roosterjs-editor-api/lib/format/changeFontSize.ts
@@ -23,13 +23,13 @@ export default function changeFontSize(
     change: FontSizeChange | CompatibleFontSizeChange,
     fontSizes: number[] = FONT_SIZES
 ) {
-    let changeBase: 1 | -1 = change == FontSizeChange.Increase ? 1 : -1;
+    const changeBase: 1 | -1 = change == FontSizeChange.Increase ? 1 : -1;
     applyInlineStyle(
         editor,
         element => {
-            let pt = parseFloat(getComputedStyle(element, 'font-size') || element.style.fontSize);
+            const pt = parseFloat(getComputedStyle(element, 'font-size') || element.style.fontSize);
             element.style.fontSize = getNewFontSize(pt, changeBase, fontSizes) + 'pt';
-            let lineHeight = getComputedStyle(element, 'line-height');
+            const lineHeight = getComputedStyle(element, 'line-height');
             if (lineHeight && lineHeight != 'normal') {
                 element.style.lineHeight = 'normal';
             }
@@ -47,7 +47,7 @@ export default function changeFontSize(
  */
 export function getNewFontSize(pt: number, changeBase: 1 | -1, fontSizes: number[]): number {
     pt = changeBase == 1 ? Math.floor(pt) : Math.ceil(pt);
-    let last = fontSizes[fontSizes.length - 1];
+    const last = fontSizes[fontSizes.length - 1];
     if (pt <= fontSizes[0]) {
         pt = Math.max(pt + changeBase, MIN_FONT_SIZE);
     } else if (pt > last || (pt == last && changeBase == 1)) {

--- a/packages/roosterjs-editor-api/lib/format/clearFormat.ts
+++ b/packages/roosterjs-editor-api/lib/format/clearFormat.ts
@@ -43,13 +43,13 @@ const TAGS_TO_STOP_UNWRAP = ['TD', 'TH', 'TR', 'TABLE', 'TBODY', 'THEAD'];
  * @returns if the current selection is composed of two or more block elements
  */
 function isMultiBlockSelection(editor: IEditor): boolean {
-    let transverser = editor.getSelectionTraverser();
-    let blockElement = transverser?.currentBlockElement;
+    const transverser = editor.getSelectionTraverser();
+    const blockElement = transverser?.currentBlockElement;
     if (!blockElement) {
         return false;
     }
 
-    let nextBlockElement = transverser?.getNextBlockElement();
+    const nextBlockElement = transverser?.getNextBlockElement();
 
     //At least two blocks are selected
     return !!nextBlockElement;
@@ -58,8 +58,8 @@ function isMultiBlockSelection(editor: IEditor): boolean {
 function clearNodeFormat(node: Node): boolean {
     // 1. Recursively clear format of all its child nodes
     const areBlockElements = toArray(node.childNodes).map(clearNodeFormat);
-    let areAllChildrenBlock = areBlockElements.every(b => b);
-    let returnBlockElement = isBlockElement(node);
+    const areAllChildrenBlock = areBlockElements.every(b => b);
+    const returnBlockElement = isBlockElement(node);
 
     // 2. Unwrap the tag if necessary
     const tag = getTagOfNode(node);
@@ -87,7 +87,7 @@ function clearAttribute(element: HTMLElement) {
     const isTableCell = safeInstanceOf(element, 'HTMLTableCellElement');
     const isTable = safeInstanceOf(element, 'HTMLTableElement');
 
-    for (let attr of toArray(element.attributes)) {
+    for (const attr of toArray(element.attributes)) {
         if (isTableCell && attr.name == 'style') {
             removeNonBorderStyles(element);
         } else if (isTable && attr.name == 'style') {
@@ -280,7 +280,7 @@ function setDefaultFormat(editor: IEditor) {
                 QueryScope.OnSelection
             );
 
-            let shouldApplyInlineStyle =
+            const shouldApplyInlineStyle =
                 setColorIgnoredElements.length > 0
                     ? (element: HTMLElement) => setColorIgnoredElements.indexOf(element) == -1
                     : undefined;

--- a/packages/roosterjs-editor-api/lib/format/createLink.ts
+++ b/packages/roosterjs-editor-api/lib/format/createLink.ts
@@ -60,16 +60,16 @@ export default function createLink(
     target?: string
 ) {
     editor.focus();
-    let url = (checkXss(link) || '').trim();
+    const url = (checkXss(link) || '').trim();
     if (url) {
-        let linkData = matchLink(url);
+        const linkData = matchLink(url);
         // matchLink can match most links, but not all, i.e. if you pass link a link as "abc", it won't match
         // we know in that case, users will want to insert a link like http://abc
         // so we have separate logic in applyLinkPrefix to add link prefix depending on the format of the link
         // i.e. if the link starts with something like abc@xxx, we will add mailto: prefix
         // if the link starts with ftp.xxx, we will add ftp:// link. For more, see applyLinkPrefix
-        let normalizedUrl = linkData ? linkData.normalizedUrl : applyLinkPrefix(url);
-        let originalUrl = linkData ? linkData.originalUrl : url;
+        const normalizedUrl = linkData ? linkData.normalizedUrl : applyLinkPrefix(url);
+        const originalUrl = linkData ? linkData.originalUrl : url;
 
         editor.addUndoSnapshot(() => {
             const selection = editor.getSelectionRangeEx();
@@ -100,7 +100,7 @@ export default function createLink(
                     let currentInline = traverser?.getNextInlineElement();
 
                     // list for removing unwanted lines
-                    let deletionInlineList: Node[] = [];
+                    const deletionInlineList: Node[] = [];
 
                     while (currentInline) {
                         deletionInlineList.push(currentInline.getContainerNode());

--- a/packages/roosterjs-editor-api/lib/format/getFormatState.ts
+++ b/packages/roosterjs-editor-api/lib/format/getFormatState.ts
@@ -28,8 +28,8 @@ export function getElementBasedFormatState(
     let multiline = false;
 
     if (range && !range.collapsed) {
-        let startingBlock = editor.getBlockElementAtNode(range.startContainer);
-        let endingBlock = editor.getBlockElementAtNode(range.endContainer);
+        const startingBlock = editor.getBlockElementAtNode(range.startContainer);
+        const endingBlock = editor.getBlockElementAtNode(range.endContainer);
         multiline = endingBlock && startingBlock ? !endingBlock.equals(startingBlock) : false;
     }
 

--- a/packages/roosterjs-editor-api/lib/format/setFontSize.ts
+++ b/packages/roosterjs-editor-api/lib/format/setFontSize.ts
@@ -16,7 +16,7 @@ export default function setFontSize(editor: IEditor, fontSize: string) {
         'font-size',
         (element, isInnerNode) => {
             element.style.fontSize = isInnerNode ? '' : fontSize;
-            let lineHeight = getComputedStyle(element, 'line-height');
+            const lineHeight = getComputedStyle(element, 'line-height');
             if (lineHeight && lineHeight != 'normal') {
                 element.style.lineHeight = 'normal';
             }

--- a/packages/roosterjs-editor-api/lib/format/setHeadingLevel.ts
+++ b/packages/roosterjs-editor-api/lib/format/setHeadingLevel.ts
@@ -31,15 +31,15 @@ export default function setHeadingLevel(editor: IEditor, level: number) {
             });
 
             if (level > 0) {
-                let traverser = editor.getSelectionTraverser();
+                const traverser = editor.getSelectionTraverser();
                 let blockElement = traverser?.currentBlockElement;
-                let sanitizer = new HtmlSanitizer({
+                const sanitizer = new HtmlSanitizer({
                     cssStyleCallbacks: {
                         'font-size': () => false,
                     },
                 });
                 while (blockElement) {
-                    let element = blockElement.collapseToSingleElement();
+                    const element = blockElement.collapseToSingleElement();
                     sanitizer.sanitize(element);
                     blockElement = traverser?.getNextBlockElement();
                 }

--- a/packages/roosterjs-editor-api/lib/table/editTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/editTable.ts
@@ -13,12 +13,12 @@ export default function editTable(
     editor: IEditor,
     operation: TableOperation | CompatibleTableOperation
 ) {
-    let td = editor.getElementAtCursor('TD,TH') as HTMLTableCellElement;
+    const td = editor.getElementAtCursor('TD,TH') as HTMLTableCellElement;
     if (td) {
         formatUndoSnapshot(
             editor,
             () => {
-                let vtable = new VTable(td);
+                const vtable = new VTable(td);
 
                 saveTableSelection(editor, vtable);
                 vtable.edit(operation);
@@ -29,7 +29,7 @@ export default function editTable(
                 if (isUndefined(vtable.row) || isUndefined(vtable.col)) {
                     return;
                 }
-                let { newCol, newRow } = calculateCellToSelect(operation, vtable.row, vtable.col);
+                const { newCol, newRow } = calculateCellToSelect(operation, vtable.row, vtable.col);
                 const newTd = vtable.getCell(newRow, newCol).td;
                 if (newTd) {
                     editor.select(newTd, PositionType.Begin);

--- a/packages/roosterjs-editor-api/lib/table/formatTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/formatTable.ts
@@ -22,7 +22,7 @@ export default function formatTable(
                     return;
                 }
 
-                let vtable = new VTable(table);
+                const vtable = new VTable(table);
                 vtable.applyFormat(format);
                 vtable.writeBack(false /** skipApplyFormat */, editor.getDarkColorHandler());
                 editor.transformToDarkColor(vtable.table);

--- a/packages/roosterjs-editor-api/lib/table/insertTable.ts
+++ b/packages/roosterjs-editor-api/lib/table/insertTable.ts
@@ -19,15 +19,15 @@ export default function insertTable(
     rows: number,
     format?: TableFormat
 ) {
-    let document = editor.getDocument();
-    let table = document.createElement('table') as HTMLTableElement;
+    const document = editor.getDocument();
+    const table = document.createElement('table') as HTMLTableElement;
     table.cellSpacing = '0';
     table.cellPadding = '1';
     for (let i = 0; i < rows; i++) {
-        let tr = document.createElement('tr') as HTMLTableRowElement;
+        const tr = document.createElement('tr') as HTMLTableRowElement;
         table.appendChild(tr);
         for (let j = 0; j < columns; j++) {
-            let td = document.createElement('td') as HTMLTableCellElement;
+            const td = document.createElement('td') as HTMLTableCellElement;
             tr.appendChild(td);
             td.appendChild(document.createElement('br'));
             td.style.width = getTableCellWidth(columns);
@@ -42,7 +42,7 @@ export default function insertTable(
             if (element?.style.backgroundColor) {
                 setBackgroundColor(editor, 'transparent');
             }
-            let vtable = new VTable(table);
+            const vtable = new VTable(table);
             // Assign default vertical align
             format = format || { verticalAlign: 'top' };
             vtable.applyFormat(format || {});

--- a/packages/roosterjs-editor-api/lib/utils/applyInlineStyle.ts
+++ b/packages/roosterjs-editor-api/lib/utils/applyInlineStyle.ts
@@ -20,15 +20,15 @@ export default function applyInlineStyle(
     apiName: string
 ) {
     editor.focus();
-    let selection = editor.getSelectionRangeEx();
+    const selection = editor.getSelectionRangeEx();
 
     const safeCallback = (element: HTMLElement, isInnerNode?: boolean) =>
         element.isContentEditable && callback(element, isInnerNode);
 
     if (selection && selection.areAllCollapsed) {
         const range = selection.ranges[0];
-        let node = range.startContainer;
-        let isEmptySpan =
+        const node = range.startContainer;
+        const isEmptySpan =
             getTagOfNode(node) == 'SPAN' &&
             (!node.firstChild ||
                 (getTagOfNode(node.firstChild) == 'BR' && !node.firstChild.nextSibling));
@@ -53,13 +53,13 @@ export default function applyInlineStyle(
                 let firstNode: Node | undefined;
                 let lastNode: Node | undefined;
                 selection.ranges.forEach(range => {
-                    let contentTraverser = editor.getSelectionTraverser(range);
+                    const contentTraverser = editor.getSelectionTraverser(range);
                     if (!contentTraverser) {
                         return;
                     }
                     let inlineElement = contentTraverser && contentTraverser.currentInlineElement;
                     while (inlineElement) {
-                        let nextInlineElement = contentTraverser.getNextInlineElement();
+                        const nextInlineElement = contentTraverser.getNextInlineElement();
                         inlineElement.applyStyle((element, isInnerNode) => {
                             safeCallback(element, isInnerNode);
                             firstNode = firstNode || element;

--- a/packages/roosterjs-editor-api/lib/utils/applyListItemWrap.ts
+++ b/packages/roosterjs-editor-api/lib/utils/applyListItemWrap.ts
@@ -21,7 +21,7 @@ export default function applyListItemStyleWrap(
         (element, isInnerNode) => {
             formatCallback(element, isInnerNode);
 
-            let parent = editor.getElementAtCursor('LI', element);
+            const parent = editor.getElementAtCursor('LI', element);
             if (parent && parentNodes.indexOf(parent) === -1) {
                 parentNodes.push(parent);
             }

--- a/packages/roosterjs-editor-api/lib/utils/collapseSelectedBlocks.ts
+++ b/packages/roosterjs-editor-api/lib/utils/collapseSelectedBlocks.ts
@@ -12,12 +12,12 @@ export default function collapseSelectedBlocks(
     editor: IEditor,
     forEachCallback: (element: HTMLElement) => any
 ) {
-    let traverser = editor.getSelectionTraverser();
+    const traverser = editor.getSelectionTraverser();
     if (!traverser) {
         return;
     }
     let block = traverser.currentBlockElement;
-    let blocks: BlockElement[] = [];
+    const blocks: BlockElement[] = [];
     while (block) {
         if (!isEmptyBlockUnderTR(block)) {
             blocks.push(block);
@@ -26,13 +26,13 @@ export default function collapseSelectedBlocks(
     }
 
     blocks.forEach(block => {
-        let element = block.collapseToSingleElement();
+        const element = block.collapseToSingleElement();
         forEachCallback(element);
     });
 }
 
 function isEmptyBlockUnderTR(block: BlockElement): boolean {
-    let startNode = block.getStartNode();
+    const startNode = block.getStartNode();
 
     return (
         startNode == block.getEndNode() &&

--- a/packages/roosterjs-editor-api/lib/utils/execCommand.ts
+++ b/packages/roosterjs-editor-api/lib/utils/execCommand.ts
@@ -22,9 +22,9 @@ export default function execCommand(
 ) {
     editor.focus();
 
-    let formatter = () => editor.getDocument().execCommand(command, false, undefined);
+    const formatter = () => editor.getDocument().execCommand(command, false, undefined);
 
-    let selection = editor.getSelectionRangeEx();
+    const selection = editor.getSelectionRangeEx();
     if (selection && selection.areAllCollapsed) {
         editor.addUndoSnapshot();
         const formatState = editor.getPendableFormatState(false /* forceGetStateFromDom */);

--- a/packages/roosterjs-editor-core/lib/coreApi/addUndoSnapshot.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/addUndoSnapshot.ts
@@ -46,7 +46,7 @@ export const addUndoSnapshot: AddUndoSnapshot = (
 
     try {
         if (callback) {
-            let range = core.api.getSelectionRange(core, true /*tryGetFromCache*/);
+            const range = core.api.getSelectionRange(core, true /*tryGetFromCache*/);
             data = callback(
                 range && Position.getStart(range).normalize(),
                 range && Position.getEnd(range).normalize()
@@ -64,7 +64,7 @@ export const addUndoSnapshot: AddUndoSnapshot = (
     }
 
     if (callback && changeSource) {
-        let event: ContentChangedEvent = {
+        const event: ContentChangedEvent = {
             eventType: PluginEventType.ContentChanged,
             source: changeSource,
             data: data,

--- a/packages/roosterjs-editor-core/lib/coreApi/attachDomEvent.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/attachDomEvent.ts
@@ -22,7 +22,7 @@ export const attachDomEvent: AttachDomEvent = (
     const disposers = getObjectKeys(eventMap || {}).map(key => {
         const { pluginEventType, beforeDispatch } = extractHandler(eventMap[key]);
         const eventName = key as keyof HTMLElementEventMap;
-        let onEvent = (event: HTMLElementEventMap[typeof eventName]) => {
+        const onEvent = (event: HTMLElementEventMap[typeof eventName]) => {
             if (beforeDispatch) {
                 beforeDispatch(event);
             }

--- a/packages/roosterjs-editor-core/lib/coreApi/createPasteFragment.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/createPasteFragment.ts
@@ -101,7 +101,7 @@ function createFragmentFromClipboardData(
 ) {
     const { fragment } = event;
     const { rawHtml, text, imageDataUri } = clipboardData;
-    let doc: Document | undefined = rawHtml
+    const doc: Document | undefined = rawHtml
         ? new DOMParser().parseFromString(core.trustedHTMLHandler(rawHtml), 'text/html')
         : undefined;
 

--- a/packages/roosterjs-editor-core/lib/coreApi/focus.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/focus.ts
@@ -24,7 +24,7 @@ export const focus: Focus = (core: EditorCore) => {
                 !core.domEvent.selectionRange ||
                 !core.api.selectRange(core, core.domEvent.selectionRange, true /*skipSameRange*/)
             ) {
-                let node = getFirstLeafNode(core.contentDiv) || core.contentDiv;
+                const node = getFirstLeafNode(core.contentDiv) || core.contentDiv;
                 core.api.selectRange(
                     core,
                     createRange(node, PositionType.Begin),

--- a/packages/roosterjs-editor-core/lib/coreApi/getPendableFormatState.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getPendableFormatState.ts
@@ -80,8 +80,8 @@ function queryCommandStateFromDOM(
     currentPosition: NodePosition
 ): PendableFormatState {
     let node: Node | null = currentPosition.node;
-    let formatState: PendableFormatState = {};
-    let pendableKeys: PendableFormatNames[] = [];
+    const formatState: PendableFormatState = {};
+    const pendableKeys: PendableFormatNames[] = [];
     while (node && contains(core.contentDiv, node)) {
         const tag = getTagOfNode(node);
         const style = node.nodeType == NodeType.Element && (node as HTMLElement).style;

--- a/packages/roosterjs-editor-core/lib/coreApi/getSelectionRange.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getSelectionRange.ts
@@ -26,9 +26,9 @@ export const getSelectionRange: GetSelectionRange = (
         return result;
     } else {
         if (!tryGetFromCache || core.api.hasFocus(core)) {
-            let selection = core.contentDiv.ownerDocument.defaultView?.getSelection();
+            const selection = core.contentDiv.ownerDocument.defaultView?.getSelection();
             if (selection && selection.rangeCount > 0) {
-                let range = selection.getRangeAt(0);
+                const range = selection.getRangeAt(0);
                 if (contains(core.contentDiv, range)) {
                     result = range;
                 }

--- a/packages/roosterjs-editor-core/lib/coreApi/getSelectionRangeEx.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/getSelectionRangeEx.ts
@@ -9,7 +9,7 @@ import type { EditorCore, GetSelectionRangeEx, SelectionRangeEx } from 'roosterj
  * @returns A Range object of the selection range
  */
 export const getSelectionRangeEx: GetSelectionRangeEx = (core: EditorCore) => {
-    let result: SelectionRangeEx | null = null;
+    const result: SelectionRangeEx | null = null;
     if (core.lifecycle.shadowEditFragment) {
         const {
             shadowEditTableSelectionPath,
@@ -69,9 +69,9 @@ export const getSelectionRangeEx: GetSelectionRangeEx = (core: EditorCore) => {
                 return core.domEvent.imageSelectionRange;
             }
 
-            let selection = core.contentDiv.ownerDocument.defaultView?.getSelection();
+            const selection = core.contentDiv.ownerDocument.defaultView?.getSelection();
             if (!result && selection && selection.rangeCount > 0) {
-                let range = selection.getRangeAt(0);
+                const range = selection.getRangeAt(0);
                 if (contains(core.contentDiv, range)) {
                     return createNormalSelectionEx([range]);
                 }

--- a/packages/roosterjs-editor-core/lib/coreApi/hasFocus.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/hasFocus.ts
@@ -8,7 +8,7 @@ import type { EditorCore, HasFocus } from 'roosterjs-editor-types';
  * @returns True if the editor has focus, otherwise false
  */
 export const hasFocus: HasFocus = (core: EditorCore) => {
-    let activeElement = core.contentDiv.ownerDocument.activeElement;
+    const activeElement = core.contentDiv.ownerDocument.activeElement;
     return !!(
         activeElement && contains(core.contentDiv, activeElement, true /*treatSameNodeAsContain*/)
     );

--- a/packages/roosterjs-editor-core/lib/coreApi/insertNode.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/insertNode.ts
@@ -66,7 +66,7 @@ export const insertNode: InsertNode = (
         replaceSelection: true,
         insertToRegionRoot: false,
     };
-    let contentDiv = core.contentDiv;
+    const contentDiv = core.contentDiv;
 
     if (option.updateCursor) {
         core.api.focus(core);
@@ -88,11 +88,11 @@ export const insertNode: InsertNode = (
             switch (option.position) {
                 case ContentPosition.Begin:
                 case ContentPosition.End: {
-                    let isBegin = option.position == ContentPosition.Begin;
-                    let block = getFirstLastBlockElement(contentDiv, isBegin);
+                    const isBegin = option.position == ContentPosition.Begin;
+                    const block = getFirstLastBlockElement(contentDiv, isBegin);
                     let insertedNode: Node | Node[] | undefined;
                     if (block) {
-                        let refNode = isBegin ? block.getStartNode() : block.getEndNode();
+                        const refNode = isBegin ? block.getStartNode() : block.getEndNode();
                         if (
                             option.insertOnNewLine ||
                             refNode.nodeType == NodeType.Text ||
@@ -141,7 +141,7 @@ export const insertNode: InsertNode = (
                 }
                 case ContentPosition.DomEnd:
                     // Use appendChild to insert the node at the end of the content div.
-                    let insertedNode = contentDiv.appendChild(node);
+                    const insertedNode = contentDiv.appendChild(node);
                     // Final check to see if the inserted node is a block. If not block and the ask is to insert on new line,
                     // add a DIV wrapping
                     if (insertedNode && option.insertOnNewLine && !isBlockElement(insertedNode)) {
@@ -174,7 +174,7 @@ export const insertNode: InsertNode = (
                         pos = adjustInsertPosition(contentDiv, node, pos, range);
                     }
 
-                    let nodeForCursor =
+                    const nodeForCursor =
                         node.nodeType == NodeType.DocumentFragment ? node.lastChild : node;
 
                     range = createRange(pos);

--- a/packages/roosterjs-editor-core/lib/coreApi/select.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/select.ts
@@ -21,7 +21,7 @@ import type {
  * @param arg4 (optional) An offset number, or a PositionType
  */
 export const select: Select = (core, arg1, arg2, arg3, arg4) => {
-    let rangeEx = buildRangeEx(core, arg1, arg2, arg3, arg4);
+    const rangeEx = buildRangeEx(core, arg1, arg2, arg3, arg4);
 
     if (rangeEx) {
         const skipReselectOnFocus = core.domEvent.skipReselectOnFocus;
@@ -70,7 +70,7 @@ function buildRangeEx(
             image: arg1,
         };
     } else {
-        let range = !arg1
+        const range = !arg1
             ? null
             : safeInstanceOf(arg1, 'Range')
             ? arg1

--- a/packages/roosterjs-editor-core/lib/coreApi/selectRange.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/selectRange.ts
@@ -54,7 +54,7 @@ function restorePendingFormatState(core: EditorCore) {
 
     if (pendingFormatState.pendableFormatState) {
         const document = contentDiv.ownerDocument;
-        let formatState = getPendableFormatState(document);
+        const formatState = getPendableFormatState(document);
         getObjectKeys(PendableFormatCommandMap).forEach(key => {
             if (!!pendingFormatState.pendableFormatState?.[key] != formatState[key]) {
                 document.execCommand(
@@ -66,7 +66,7 @@ function restorePendingFormatState(core: EditorCore) {
         });
 
         const range = getSelectionRange(core, true /*tryGetFromCache*/);
-        let position: Position | null = range && Position.getStart(range);
+        const position: Position | null = range && Position.getStart(range);
         if (position) {
             pendingFormatState.pendableFormatPosition = position;
         }

--- a/packages/roosterjs-editor-core/lib/coreApi/selectTable.ts
+++ b/packages/roosterjs-editor-core/lib/coreApi/selectTable.ts
@@ -199,7 +199,7 @@ function select(
     coordinates: TableSelection
 ): { ranges: Range[]; isWholeTableSelected: boolean } {
     const contentDivSelector = '#' + core.contentDiv.id;
-    let { cssRules, ranges, isWholeTableSelected } = buildCss(
+    const { cssRules, ranges, isWholeTableSelected } = buildCss(
         table,
         coordinates,
         contentDivSelector

--- a/packages/roosterjs-editor-core/lib/corePlugins/PendingFormatStatePlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/PendingFormatStatePlugin.ts
@@ -129,7 +129,7 @@ export default class PendingFormatStatePlugin
     }
 
     private getCurrentPosition() {
-        let range = this.editor?.getSelectionRange();
+        const range = this.editor?.getSelectionRange();
         return (range && Position.getStart(range).normalize()) ?? null;
     }
 

--- a/packages/roosterjs-editor-core/lib/corePlugins/TypeInContainerPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/TypeInContainerPlugin.ts
@@ -68,7 +68,7 @@ export default class TypeInContainerPlugin implements EditorPlugin {
             // there is already content under the selection (e.g. Ctrl+a -> type new content).
             //
             // Only schedule when the range is not collapsed to catch this edge case.
-            let range = this.editor.getSelectionRange();
+            const range = this.editor.getSelectionRange();
 
             const styledAncestor =
                 range &&

--- a/packages/roosterjs-editor-core/lib/corePlugins/UndoPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/UndoPlugin.ts
@@ -140,7 +140,7 @@ export default class UndoPlugin implements PluginWithState<UndoPluginState> {
                 this.state.autoCompletePosition = null;
                 this.lastKeyPress = evt.which;
             } else if (!evt.defaultPrevented) {
-                let selectionRange = this.editor?.getSelectionRange();
+                const selectionRange = this.editor?.getSelectionRange();
 
                 // Add snapshot when
                 // 1. Something has been selected (not collapsed), or
@@ -179,7 +179,7 @@ export default class UndoPlugin implements PluginWithState<UndoPluginState> {
             return;
         }
 
-        let range = this.editor?.getSelectionRange();
+        const range = this.editor?.getSelectionRange();
         if (
             (range && !range.collapsed) ||
             (evt.which == Keys.SPACE && this.lastKeyPress != Keys.SPACE) ||

--- a/packages/roosterjs-editor-core/lib/editor/EditorBase.ts
+++ b/packages/roosterjs-editor-core/lib/editor/EditorBase.ts
@@ -225,10 +225,10 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
     ) {
         const core = this.getCore();
         const result: HTMLElement[] = [];
-        let scope = scopeOrCallback instanceof Function ? QueryScope.Body : scopeOrCallback;
+        const scope = scopeOrCallback instanceof Function ? QueryScope.Body : scopeOrCallback;
         callback = scopeOrCallback instanceof Function ? scopeOrCallback : callback;
 
-        let selectionEx = scope == QueryScope.Body ? null : this.getSelectionRangeEx();
+        const selectionEx = scope == QueryScope.Body ? null : this.getSelectionRangeEx();
         if (selectionEx) {
             selectionEx.ranges.forEach(range => {
                 result.push(...queryElements(core.contentDiv, selector, callback, scope, range));
@@ -315,7 +315,7 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
                 allNodes = [wrap(allNodes)];
             }
 
-            let fragment = doc.createDocumentFragment();
+            const fragment = doc.createDocumentFragment();
             allNodes.forEach(node => fragment.appendChild(node));
 
             this.insertNode(fragment, option);
@@ -449,12 +449,12 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
      * Get current focused position. Return null if editor doesn't have focus at this time.
      */
     public getFocusedPosition(): NodePosition | null {
-        let sel = this.getDocument().defaultView?.getSelection();
+        const sel = this.getDocument().defaultView?.getSelection();
         if (sel?.focusNode && this.contains(sel.focusNode)) {
             return new Position(sel.focusNode, sel.focusOffset);
         }
 
-        let range = this.getSelectionRange();
+        const range = this.getSelectionRange();
         if (range) {
             return Position.getStart(range);
         }
@@ -484,7 +484,7 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
         return (
             cacheGetEventData(event ?? null, 'GET_ELEMENT_AT_CURSOR_' + selector, () => {
                 if (!startFrom) {
-                    let position = this.getFocusedPosition();
+                    const position = this.getFocusedPosition();
                     startFrom = position?.node;
                 }
                 return (
@@ -550,7 +550,7 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
         broadcast: boolean = false
     ): PluginEventFromType<T> {
         const core = this.getCore();
-        let event = ({
+        const event = ({
             eventType,
             ...data,
         } as any) as PluginEventFromType<T>;
@@ -711,7 +711,7 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
     public getBlockTraverser(
         startFrom: ContentPosition | CompatibleContentPosition = ContentPosition.SelectionStart
     ): IContentTraverser | null {
-        let range = this.getSelectionRange();
+        const range = this.getSelectionRange();
         return range
             ? ContentTraverser.createBlockTraverser(this.getCore().contentDiv, range, startFrom)
             : null;
@@ -725,7 +725,7 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
      */
     public getContentSearcherOfCursor(event?: PluginEvent): IPositionContentSearcher | null {
         return cacheGetEventData(event ?? null, 'ContentSearcher', () => {
-            let range = this.getSelectionRange();
+            const range = this.getSelectionRange();
             return (
                 range &&
                 new PositionContentSearcher(this.getCore().contentDiv, Position.getStart(range))
@@ -739,7 +739,7 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
      * @returns a function to cancel this async run
      */
     public runAsync(callback: (editor: IEditor) => void) {
-        let win = this.getCore().contentDiv.ownerDocument.defaultView || window;
+        const win = this.getCore().contentDiv.ownerDocument.defaultView || window;
         const handle = win.requestAnimationFrame(() => {
             if (!this.isDisposed() && callback) {
                 callback(this);
@@ -810,7 +810,7 @@ export class EditorBase<TEditorCore extends EditorCore, TEditorOptions extends E
     public addContentEditFeature(feature: GenericContentEditFeature<PluginEvent>) {
         const core = this.getCore();
         feature?.keys.forEach(key => {
-            let array = core.edit.features[key] || [];
+            const array = core.edit.features[key] || [];
             array.push(feature);
             core.edit.features[key] = array;
         });

--- a/packages/roosterjs-editor-dom/lib/blockElements/StartEndBlockElement.ts
+++ b/packages/roosterjs-editor-dom/lib/blockElements/StartEndBlockElement.ts
@@ -40,7 +40,7 @@ export default class StartEndBlockElement implements BlockElement {
         let nodes = nodeContext
             ? collapseNodes(nodeContext, this.startNode, this.endNode, true /*canSplitParent*/)
             : [];
-        let blockContext = StartEndBlockElement.getBlockContext(this.startNode);
+        const blockContext = StartEndBlockElement.getBlockContext(this.startNode);
         while (
             nodes[0] &&
             nodes[0] != blockContext &&

--- a/packages/roosterjs-editor-dom/lib/blockElements/getBlockElementAtNode.ts
+++ b/packages/roosterjs-editor-dom/lib/blockElements/getBlockElementAtNode.ts
@@ -42,7 +42,7 @@ export default function getBlockElementAtNode(
     // Identify the containing block. This serves as ceiling for traversing down below
     // NOTE: this container block could be just the rootNode,
     // which cannot be used to create block element. We will special case handle it later on
-    let containerBlockNode = StartEndBlockElement.getBlockContext(node!);
+    const containerBlockNode = StartEndBlockElement.getBlockContext(node!);
     if (!containerBlockNode) {
         return null;
     } else if (containerBlockNode == node) {
@@ -62,7 +62,7 @@ export default function getBlockElementAtNode(
     // 2) &lt;root&gt;&lt;div&gt;hello&lt;span style="font-family: Arial"&gt;world&lt;/span&gt;&lt;/div&gt;&lt;/root&gt;, head: hello, tail: world
     // Both are actually completely and exclusively wrapped in a parent div, and can be represented with a Node block
     // So we shall try to collapse as much as we can to the nearest common ancestor
-    let nodes = collapseNodes(rootNode, headNode, tailNode, false /*canSplitParent*/);
+    const nodes = collapseNodes(rootNode, headNode, tailNode, false /*canSplitParent*/);
 
     if (nodes.length === 0) {
         return null;
@@ -77,7 +77,7 @@ export default function getBlockElementAtNode(
     } else {
         // Balanced start and end (point to same parent), need to see if further collapsing can be done
         while (!headNode.previousSibling && !tailNode.nextSibling) {
-            let parentNode = headNode.parentNode;
+            const parentNode = headNode.parentNode;
             if (parentNode == containerBlockNode) {
                 // Has reached the container block
                 if (containerBlockNode != rootNode) {

--- a/packages/roosterjs-editor-dom/lib/clipboard/extractClipboardItemsForIE.ts
+++ b/packages/roosterjs-editor-dom/lib/clipboard/extractClipboardItemsForIE.ts
@@ -31,7 +31,7 @@ export default function extractClipboardItemsForIE(
     };
 
     for (let i = 0; i < (dataTransfer.files ? dataTransfer.files.length : 0); i++) {
-        let file = dataTransfer.files.item(i);
+        const file = dataTransfer.files.item(i);
         if (file?.type?.indexOf(ContentTypePrefix.Image) == 0) {
             clipboardData.image = file;
             break;

--- a/packages/roosterjs-editor-dom/lib/contentTraverser/ContentTraverser.ts
+++ b/packages/roosterjs-editor-dom/lib/contentTraverser/ContentTraverser.ts
@@ -106,19 +106,19 @@ export default class ContentTraverser implements IContentTraverser {
     }
 
     private getPreviousNextBlockElement(isNext: boolean): BlockElement | null {
-        let current = this.currentBlockElement;
+        const current = this.currentBlockElement;
 
         if (!current) {
             return null;
         }
 
-        let leaf = getLeafSibling(
+        const leaf = getLeafSibling(
             this.scoper.rootNode,
             isNext ? current.getEndNode() : current.getStartNode(),
             isNext,
             this.skipTags
         );
-        let newBlock = leaf ? getBlockElementAtNode(this.scoper.rootNode, leaf) : null;
+        const newBlock = leaf ? getBlockElementAtNode(this.scoper.rootNode, leaf) : null;
 
         // Make sure this is right block:
         // 1) the block is in scope per scoper
@@ -164,7 +164,7 @@ export default class ContentTraverser implements IContentTraverser {
     }
 
     private getPreviousNextInlineElement(isNext: boolean): InlineElement | null {
-        let current = this.currentInlineElement || this.currentInline;
+        const current = this.currentInlineElement || this.currentInline;
         let newInline: InlineElement | null;
 
         if (!current) {
@@ -214,7 +214,7 @@ function getNextPreviousInlineElement(
     }
     if (current instanceof PartialInlineElement) {
         // if current is partial, get the other half of the inline unless it is no more
-        let result = isNext ? current.nextInlineElement : current.previousInlineElement;
+        const result = isNext ? current.nextInlineElement : current.previousInlineElement;
 
         if (result) {
             return result;

--- a/packages/roosterjs-editor-dom/lib/contentTraverser/PositionContentSearcher.ts
+++ b/packages/roosterjs-editor-dom/lib/contentTraverser/PositionContentSearcher.ts
@@ -121,7 +121,7 @@ export default class PositionContentSearcher implements IPositionContentSearcher
         let textIndex = text.length - 1;
 
         this.forEachTextInlineElement(textInline => {
-            let nodeContent = textInline.getTextContent() || '';
+            const nodeContent = textInline.getTextContent() || '';
             let nodeIndex = nodeContent.length - 1;
             for (; nodeIndex >= 0 && textIndex >= 0; nodeIndex--) {
                 if (text.charCodeAt(textIndex) == nodeContent.charCodeAt(nodeIndex)) {
@@ -194,13 +194,13 @@ export default class PositionContentSearcher implements IPositionContentSearcher
             this.inlineBefore = this.inlineBefore || previousInline;
 
             if (previousInline && previousInline.isTextualInlineElement()) {
-                let textContent = previousInline.getTextContent();
+                const textContent = previousInline.getTextContent();
 
                 // build the word before position if it is not built yet
                 if (!this.word) {
                     // Match on the white space, the portion after space is on the index of 1 of the matched result
                     // (index at 0 is whole match result, index at 1 is the word)
-                    let matches = WHITESPACE_REGEX.exec(textContent);
+                    const matches = WHITESPACE_REGEX.exec(textContent);
                     if (matches && matches.length == 2) {
                         this.word = matches[1] + this.text;
                     }

--- a/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionBlockScoper.ts
+++ b/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionBlockScoper.ts
@@ -69,7 +69,7 @@ export default class SelectionBlockScoper implements TraversingScoper {
                     );
                 case ContentPosition.SelectionStart:
                     // Get the inline before selection start point, and ensure it falls in the selection block
-                    let startInline = getInlineElementAfter(this.rootNode, this.position);
+                    const startInline = getInlineElementAfter(this.rootNode, this.position);
                     return startInline && this.block.contains(startInline.getContainerNode())
                         ? startInline
                         : new EmptyInlineElement(this.position, this.block);
@@ -110,7 +110,7 @@ function getFirstLastInlineElementFromBlockElement(
     isFirst: boolean
 ): InlineElement | null {
     if (block instanceof NodeBlockElement) {
-        let blockNode = block.getStartNode();
+        const blockNode = block.getStartNode();
         return isFirst ? getFirstInlineElement(blockNode) : getLastInlineElement(blockNode);
     } else {
         return getInlineElementAtNode(block, isFirst ? block.getStartNode() : block.getEndNode());

--- a/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionScoper.ts
+++ b/packages/roosterjs-editor-dom/lib/contentTraverser/SelectionScoper.ts
@@ -60,11 +60,11 @@ export default class SelectionScoper implements TraversingScoper {
             return false;
         }
         let inScope = false;
-        let selStartBlock = this.getStartBlockElement();
+        const selStartBlock = this.getStartBlockElement();
         if (this.start.equalTo(this.end)) {
             inScope = !!selStartBlock && selStartBlock.equals(block);
         } else {
-            let selEndBlock = getBlockElementAtNode(this.rootNode, this.end.node);
+            const selEndBlock = getBlockElementAtNode(this.rootNode, this.end.node);
 
             // There are three cases that are considered as "block in scope"
             // 1) The start of selection falls on the block

--- a/packages/roosterjs-editor-dom/lib/edit/adjustInsertPosition.ts
+++ b/packages/roosterjs-editor-dom/lib/edit/adjustInsertPosition.ts
@@ -48,7 +48,7 @@ function adjustInsertPositionForHyperLink(
     position: NodePosition,
     range: Range
 ): NodePosition {
-    let blockElement = getBlockElementAtNode(root, position.node);
+    const blockElement = getBlockElementAtNode(root, position.node);
 
     if (blockElement) {
         // Find the first <A> tag within current block which covers current selection
@@ -75,9 +75,9 @@ function adjustInsertPositionForHyperLink(
             (<ParentNode>(nodeToInsert as HTMLElement))?.querySelector &&
             (<ParentNode>(nodeToInsert as HTMLElement))?.querySelector('a[href]')
         ) {
-            let normalizedPosition = position.normalize();
-            let parentNode = normalizedPosition.node.parentNode!;
-            let nextNode =
+            const normalizedPosition = position.normalize();
+            const parentNode = normalizedPosition.node.parentNode!;
+            const nextNode =
                 normalizedPosition.node.nodeType == NodeType.Text
                     ? splitTextNode(
                           <Text>normalizedPosition.node,
@@ -118,18 +118,18 @@ function adjustInsertPositionForStructuredNode(
 
     if (rootNodeToInsert.nodeType == NodeType.DocumentFragment) {
         isFragment = true;
-        let rootNodes = toArray(rootNodeToInsert.childNodes).filter(
+        const rootNodes = toArray(rootNodeToInsert.childNodes).filter(
             (n: ChildNode) => getTagOfNode(n) != 'BR'
         );
         rootNodeToInsert = rootNodes.length == 1 ? rootNodes[0] : null;
     }
 
     let tag = getTagOfNode(rootNodeToInsert);
-    let hasBrNextToRoot =
+    const hasBrNextToRoot =
         tag && rootNodeToInsert && getTagOfNode(rootNodeToInsert.nextSibling) == 'BR';
-    let listItem = findClosestElementAncestor(position.node, root, 'LI');
-    let listNode = listItem && findClosestElementAncestor(listItem, root, 'OL,UL');
-    let tdNode = findClosestElementAncestor(position.node, root, 'TD,TH');
+    const listItem = findClosestElementAncestor(position.node, root, 'LI');
+    const listNode = listItem && findClosestElementAncestor(listItem, root, 'OL,UL');
+    const tdNode = findClosestElementAncestor(position.node, root, 'TD,TH');
 
     if (tag == 'LI') {
         tag = listNode ? getTagOfNode(listNode) : 'UL';
@@ -141,7 +141,8 @@ function adjustInsertPositionForStructuredNode(
         rootNodeToInsert &&
         getTagOfNode(rootNodeToInsert.firstChild) == 'LI'
     ) {
-        let shouldInsertListAsText = !rootNodeToInsert.firstChild!.nextSibling && !hasBrNextToRoot;
+        const shouldInsertListAsText =
+            !rootNodeToInsert.firstChild!.nextSibling && !hasBrNextToRoot;
 
         if (hasBrNextToRoot && rootNodeToInsert.parentNode) {
             safeRemove(rootNodeToInsert.nextSibling!);
@@ -188,8 +189,8 @@ function adjustInsertPositionForParagraph(
     if (getTagOfNode(position.node) == 'P') {
         // Insert into a P tag may cause issues when the inserted content contains any block element.
         // Change P tag to DIV to make sure it works well
-        let pos = position.normalize();
-        let div = changeElementTag(<HTMLElement>position.node, 'div');
+        const pos = position.normalize();
+        const div = changeElementTag(<HTMLElement>position.node, 'div');
         if (pos.node != div) {
             position = pos;
         }

--- a/packages/roosterjs-editor-dom/lib/edit/deleteSelectedContent.ts
+++ b/packages/roosterjs-editor-dom/lib/edit/deleteSelectedContent.ts
@@ -61,12 +61,12 @@ export default function deleteSelectedContent(
             // Make sure there are node before and after the merging point.
             // This is required by mergeBlocksInRegion API.
             // This may create some empty text node as anchor
-            let [beforeEnd, afterEnd] = ensureBeforeAndAfter(
+            const [beforeEnd, afterEnd] = ensureBeforeAndAfter(
                 endContainer,
                 endOffset,
                 false /*isStart*/
             );
-            let [beforeStart, afterStart] = ensureBeforeAndAfter(
+            const [beforeStart, afterStart] = ensureBeforeAndAfter(
                 startContainer,
                 startOffset,
                 true /*isStart*/

--- a/packages/roosterjs-editor-dom/lib/edit/getTextContent.ts
+++ b/packages/roosterjs-editor-dom/lib/edit/getTextContent.ts
@@ -8,7 +8,7 @@ import ContentTraverser from '../contentTraverser/ContentTraverser';
 export default function getTextContent(rootNode: Node): string {
     const traverser = ContentTraverser.createBodyTraverser(rootNode);
     let block = traverser && traverser.currentBlockElement;
-    let textContent: string[] = [];
+    const textContent: string[] = [];
 
     while (block) {
         textContent.push(block.getTextContent());

--- a/packages/roosterjs-editor-dom/lib/event/cacheGetEventData.ts
+++ b/packages/roosterjs-editor-dom/lib/event/cacheGetEventData.ts
@@ -12,7 +12,7 @@ export default function cacheGetEventData<T>(
     key: string,
     getter: () => T
 ): T {
-    let result =
+    const result =
         event && event.eventDataCache && event.eventDataCache.hasOwnProperty(key)
             ? <T>event.eventDataCache[key]
             : getter();

--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/HtmlSanitizer.ts
@@ -40,7 +40,7 @@ export default class HtmlSanitizer {
      * @param additionalStyleNodes (Optional) additional HTML STYLE elements used as global CSS
      */
     static convertInlineCss(html: string, additionalStyleNodes?: HTMLStyleElement[]) {
-        let sanitizer = new HtmlSanitizer({
+        const sanitizer = new HtmlSanitizer({
             additionalGlobalStyleNodes: additionalStyleNodes,
         });
         return sanitizer.exec(html, true /*convertCssOnly*/);
@@ -54,8 +54,8 @@ export default class HtmlSanitizer {
      */
     static sanitizeHtml(html: string, options?: SanitizeHtmlOptions) {
         options = options || {};
-        let sanitizer = new HtmlSanitizer(options);
-        let currentStyles = safeInstanceOf(options.currentElementOrStyle, 'HTMLElement')
+        const sanitizer = new HtmlSanitizer(options);
+        const currentStyles = safeInstanceOf(options.currentElementOrStyle, 'HTMLElement')
             ? getInheritableStyles(options.currentElementOrStyle)
             : options.currentElementOrStyle;
         return sanitizer.exec(html, options.convertCssOnly, currentStyles);
@@ -137,26 +137,26 @@ export default class HtmlSanitizer {
      * @param rootNode The HTML Document
      */
     convertGlobalCssToInlineCss(rootNode: ParentNode) {
-        let styleNodes = toArray(rootNode.querySelectorAll('style'));
-        let styleSheets = this.additionalGlobalStyleNodes
+        const styleNodes = toArray(rootNode.querySelectorAll('style'));
+        const styleSheets = this.additionalGlobalStyleNodes
             .reverse()
             .map(node => node.sheet as CSSStyleSheet)
             .concat(styleNodes.map(node => node.sheet as CSSStyleSheet).reverse())
             .filter(sheet => sheet);
-        for (let styleSheet of styleSheets) {
+        for (const styleSheet of styleSheets) {
             for (let j = styleSheet.cssRules.length - 1; j >= 0; j--) {
                 // Skip any none-style rule, i.e. @page
-                let styleRule = styleSheet.cssRules[j] as CSSStyleRule;
-                let text = styleRule && styleRule.style ? styleRule.style.cssText : null;
+                const styleRule = styleSheet.cssRules[j] as CSSStyleRule;
+                const text = styleRule && styleRule.style ? styleRule.style.cssText : null;
                 if (styleRule.type != CSSRule.STYLE_RULE || !text || !styleRule.selectorText) {
                     continue;
                 }
                 // Make sure the selector is not empty
-                for (let selector of styleRule.selectorText.split(',')) {
+                for (const selector of styleRule.selectorText.split(',')) {
                     if (!selector || !selector.trim() || selector.indexOf(':') >= 0) {
                         continue;
                     }
-                    let nodes = toArray(rootNode.querySelectorAll(selector));
+                    const nodes = toArray(rootNode.querySelectorAll(selector));
                     // Always put existing styles after so that they have higher priority
                     // Which means if both global style and inline style apply to the same element,
                     // inline style will have higher priority
@@ -227,8 +227,8 @@ export default class HtmlSanitizer {
                 .replace(/^ /gm, '\u00A0')
                 .replace(/ {2}/g, ' \u00A0');
         } else if (isElement || isFragment) {
-            let thisStyle = cloneObject(currentStyle);
-            let element = <HTMLElement>node;
+            const thisStyle = cloneObject(currentStyle);
+            const element = <HTMLElement>node;
             if (isElement) {
                 this.processAttributes(element, context);
                 this.preprocessCss(element, thisStyle);
@@ -260,8 +260,8 @@ export default class HtmlSanitizer {
         const styles = getStyles(element);
         getObjectKeys(styles).forEach(name => {
             let value = styles[name];
-            let callback = this.styleCallbacks[name];
-            let isInheritable = thisStyle[name] != undefined;
+            const callback = this.styleCallbacks[name];
+            const isInheritable = thisStyle[name] != undefined;
             let keep = true;
 
             if (keep && !!callback) {
@@ -297,10 +297,10 @@ export default class HtmlSanitizer {
 
     private processAttributes(element: HTMLElement, context: Object) {
         for (let i = element.attributes.length - 1; i >= 0; i--) {
-            let attribute = element.attributes[i];
-            let name = attribute.name.toLowerCase().trim();
-            let value = attribute.value;
-            let callback = this.attributeCallbacks[name];
+            const attribute = element.attributes[i];
+            const name = attribute.name.toLowerCase().trim();
+            const value = attribute.value;
+            const callback = this.attributeCallbacks[name];
 
             let newValue = callback
                 ? callback(value, element, context)

--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/cloneObject.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/cloneObject.ts
@@ -11,9 +11,9 @@ function customClone<T>(
     source: Record<string, T> | null | undefined,
     existingObj?: Record<string, T>
 ): Record<string, T> {
-    let result: Record<string, T> = existingObj || {};
+    const result: Record<string, T> = existingObj || {};
     if (source) {
-        for (let key of getObjectKeys(source)) {
+        for (const key of getObjectKeys(source)) {
             result[key] = source[key];
         }
     }

--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/getAllowedValues.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/getAllowedValues.ts
@@ -226,10 +226,10 @@ export function getAllowedCssClassesRegex(
  * @internal
  */
 export function getDefaultStyleValues(additionalDefaultStyles: StringMap | undefined): StringMap {
-    let result = cloneObject(DEFAULT_STYLE_VALUES);
+    const result = cloneObject(DEFAULT_STYLE_VALUES);
     if (additionalDefaultStyles) {
         Object.keys(additionalDefaultStyles).forEach(name => {
-            let value = additionalDefaultStyles[name];
+            const value = additionalDefaultStyles[name];
             if (value !== null && value !== undefined) {
                 result[name] = value;
             } else {
@@ -247,7 +247,7 @@ export function getDefaultStyleValues(additionalDefaultStyles: StringMap | undef
 export function getStyleCallbacks(
     callbacks: CssStyleCallbackMap | null | undefined
 ): CssStyleCallbackMap {
-    let result = cloneObject(callbacks);
+    const result = cloneObject(callbacks);
     result.position = result.position || removeValue;
     result.width = result.width || removeWidthForLiAndDiv;
     return result;
@@ -258,7 +258,7 @@ function removeValue(): null {
 }
 
 function removeWidthForLiAndDiv(value: string, element: HTMLElement) {
-    let tag = element.tagName;
+    const tag = element.tagName;
     return !(tag == 'LI' || tag == 'DIV');
 }
 

--- a/packages/roosterjs-editor-dom/lib/htmlSanitizer/getInheritableStyles.ts
+++ b/packages/roosterjs-editor-dom/lib/htmlSanitizer/getInheritableStyles.ts
@@ -15,9 +15,9 @@ const INHERITABLE_PROPERTIES = (
  * @param element The element to get style from
  */
 export default function getInheritableStyles(element: HTMLElement | null): StringMap {
-    let win = element && element.ownerDocument && element.ownerDocument.defaultView;
-    let styles = win && element && win.getComputedStyle(element);
-    let result: StringMap = {};
+    const win = element && element.ownerDocument && element.ownerDocument.defaultView;
+    const styles = win && element && win.getComputedStyle(element);
+    const result: StringMap = {};
     INHERITABLE_PROPERTIES.forEach(
         name => (result[name] = (styles && styles.getPropertyValue(name)) || '')
     );

--- a/packages/roosterjs-editor-dom/lib/inlineElements/NodeInlineElement.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/NodeInlineElement.ts
@@ -73,8 +73,8 @@ export default class NodeInlineElement implements InlineElement {
      * Checks if the given position is contained in the inline element
      */
     public contains(pos: NodePosition): boolean {
-        let start = this.getStartPosition();
-        let end = this.getEndPosition();
+        const start = this.getStartPosition();
+        const end = this.getEndPosition();
         return pos && pos.isAfter(start) && end.isAfter(pos);
     }
 

--- a/packages/roosterjs-editor-dom/lib/inlineElements/PartialInlineElement.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/PartialInlineElement.ts
@@ -44,7 +44,7 @@ export default class PartialInlineElement implements InlineElement {
      * Gets the text content
      */
     public getTextContent(): string {
-        let range = createRange(this.getStartPosition(), this.getEndPosition());
+        const range = createRange(this.getStartPosition(), this.getEndPosition());
 
         return range.toString();
     }
@@ -97,8 +97,8 @@ export default class PartialInlineElement implements InlineElement {
      * Check if this inline element is after the other inline element
      */
     public isAfter(inlineElement: InlineElement): boolean {
-        let thisStart = this.getStartPosition();
-        let otherEnd = inlineElement && inlineElement.getEndPosition();
+        const thisStart = this.getStartPosition();
+        const otherEnd = inlineElement && inlineElement.getEndPosition();
         return otherEnd && (thisStart.isAfter(otherEnd) || thisStart.equalTo(otherEnd));
     }
 
@@ -108,14 +108,14 @@ export default class PartialInlineElement implements InlineElement {
     public applyStyle(styler: (element: HTMLElement, isInnerNode?: boolean) => any) {
         let from: NodePosition | null = this.getStartPosition().normalize();
         let to: NodePosition | null = this.getEndPosition().normalize();
-        let container = this.getContainerNode();
+        const container = this.getContainerNode();
 
         if (from.isAtEnd) {
-            let nextNode = getNextLeafSibling(container, from.node);
+            const nextNode = getNextLeafSibling(container, from.node);
             from = nextNode ? new Position(nextNode, PositionType.Begin) : null;
         }
         if (to.offset == 0) {
-            let previousNode = getPreviousLeafSibling(container, to.node);
+            const previousNode = getPreviousLeafSibling(container, to.node);
             to = previousNode ? new Position(previousNode, PositionType.End) : null;
         }
 

--- a/packages/roosterjs-editor-dom/lib/inlineElements/applyTextStyle.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/applyTextStyle.ts
@@ -25,14 +25,14 @@ export default function applyTextStyle(
 ) {
     let formatNodes: Node[] = [];
     let fromPosition: NodePosition | null = from;
-    let toPosition: NodePosition | null = to;
+    const toPosition: NodePosition | null = to;
 
     while (fromPosition && toPosition && toPosition.isAfter(fromPosition)) {
         let formatNode = fromPosition.node;
-        let parentTag = getTagOfNode(formatNode.parentNode);
+        const parentTag = getTagOfNode(formatNode.parentNode);
 
         // The code below modifies DOM. Need to get the next sibling first otherwise you won't be able to reliably get a good next sibling node
-        let nextNode = getNextLeafSibling(container, formatNode);
+        const nextNode = getNextLeafSibling(container, formatNode);
 
         if (formatNode.nodeType == NodeType.Text && ['TR', 'TABLE'].indexOf(parentTag) < 0) {
             if (formatNode == toPosition.node && !toPosition.isAtEnd) {
@@ -59,7 +59,7 @@ export default function applyTextStyle(
 
     if (formatNodes.length > 0) {
         if (formatNodes.every(node => node.parentNode == formatNodes[0].parentNode)) {
-            let newNode = formatNodes.shift()!;
+            const newNode = formatNodes.shift()!;
             formatNodes.forEach(node => {
                 const newNodeValue = (newNode.nodeValue || '') + (node.nodeValue || '');
                 newNode.nodeValue = newNodeValue;

--- a/packages/roosterjs-editor-dom/lib/inlineElements/getFirstLastInlineElement.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/getFirstLastInlineElement.ts
@@ -9,7 +9,7 @@ import type { InlineElement } from 'roosterjs-editor-types';
 export function getFirstInlineElement(rootNode: Node): InlineElement | null {
     // getFirstLeafNode can return null for empty container
     // do check null before passing on to get inline from the node
-    let node = getFirstLeafNode(rootNode);
+    const node = getFirstLeafNode(rootNode);
     return node ? getInlineElementAtNode(rootNode, node) : null;
 }
 
@@ -20,6 +20,6 @@ export function getFirstInlineElement(rootNode: Node): InlineElement | null {
 export function getLastInlineElement(rootNode: Node): InlineElement | null {
     // getLastLeafNode can return null for empty container
     // do check null before passing on to get inline from the node
-    let node = getLastLeafNode(rootNode);
+    const node = getLastLeafNode(rootNode);
     return node ? getInlineElementAtNode(rootNode, node) : null;
 }

--- a/packages/roosterjs-editor-dom/lib/inlineElements/getInlineElementAtNode.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/getInlineElementAtNode.ts
@@ -28,7 +28,9 @@ export default function getInlineElementAtNode(
     node: Node | null
 ): InlineElement | null {
     // An inline element has to be in a block element, get the block first and then resolve through the factory
-    let parentBlock = safeInstanceOf(parent, 'Node') ? getBlockElementAtNode(parent, node) : parent;
+    const parentBlock = safeInstanceOf(parent, 'Node')
+        ? getBlockElementAtNode(parent, node)
+        : parent;
     return node && parentBlock && resolveInlineElement(node, parentBlock);
 }
 
@@ -38,7 +40,7 @@ export default function getInlineElementAtNode(
  * @param parentBlock The parent block element
  */
 function resolveInlineElement(node: Node, parentBlock: BlockElement): InlineElement {
-    let nodeChain = [node];
+    const nodeChain = [node];
     for (
         let parent = node.parentNode;
         parent && parentBlock.contains(parent);
@@ -50,8 +52,8 @@ function resolveInlineElement(node: Node, parentBlock: BlockElement): InlineElem
     let inlineElement: InlineElement | undefined;
 
     for (let i = nodeChain.length - 1; i >= 0 && !inlineElement; i--) {
-        let currentNode = nodeChain[i];
-        let tag = getTagOfNode(currentNode);
+        const currentNode = nodeChain[i];
+        const tag = getTagOfNode(currentNode);
         if (tag == 'A') {
             inlineElement = new LinkInlineElement(currentNode, parentBlock);
         } else if (tag == 'IMG') {

--- a/packages/roosterjs-editor-dom/lib/inlineElements/getInlineElementBeforeAfter.ts
+++ b/packages/roosterjs-editor-dom/lib/inlineElements/getInlineElementBeforeAfter.ts
@@ -42,7 +42,7 @@ export function getInlineElementBeforeAfter(root: Node, position: NodePosition, 
     }
 
     position = position.normalize();
-    let { offset, isAtEnd } = position;
+    const { offset, isAtEnd } = position;
     let node: Node | null = position.node;
     let isPartial = false;
 

--- a/packages/roosterjs-editor-dom/lib/list/convertDecimalsToRomans.ts
+++ b/packages/roosterjs-editor-dom/lib/list/convertDecimalsToRomans.ts
@@ -24,8 +24,8 @@ const RomanValues: Record<string, number> = {
  */
 export default function convertDecimalsToRoman(decimal: number, isLowerCase?: boolean) {
     let romanValue = '';
-    for (let i of getObjectKeys(RomanValues)) {
-        let timesRomanCharAppear = Math.floor(decimal / RomanValues[i]);
+    for (const i of getObjectKeys(RomanValues)) {
+        const timesRomanCharAppear = Math.floor(decimal / RomanValues[i]);
         decimal = decimal - timesRomanCharAppear * RomanValues[i];
         romanValue = romanValue + i.repeat(timesRomanCharAppear);
     }

--- a/packages/roosterjs-editor-dom/lib/region/mergeBlocksInRegion.ts
+++ b/packages/roosterjs-editor-dom/lib/region/mergeBlocksInRegion.ts
@@ -51,7 +51,7 @@ export default function mergeBlocksInRegion(region: RegionBase, refNode: Node, t
     }
 
     let nodeToRemove: Node | null = null;
-    let nodeToMerge =
+    const nodeToMerge =
         blockRoot.childNodes.length == 1 && blockRoot.attributes.length == 0
             ? blockRoot.firstChild!
             : changeElementTag(blockRoot, 'SPAN')!;

--- a/packages/roosterjs-editor-dom/lib/selection/Position.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/Position.ts
@@ -68,7 +68,7 @@ export default class Position implements NodePosition {
                 break;
 
             default:
-                let endOffset = getEndOffset(this.node);
+                const endOffset = getEndOffset(this.node);
                 this.offset = Math.max(0, Math.min(<number>offsetOrPosType, endOffset));
                 this.isAtEnd = offsetOrPosType > 0 && offsetOrPosType >= endOffset;
                 break;

--- a/packages/roosterjs-editor-dom/lib/selection/createRange.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/createRange.ts
@@ -84,7 +84,7 @@ export default function createRange(
     }
 
     if (start?.node?.ownerDocument) {
-        let range = start.node.ownerDocument.createRange();
+        const range = start.node.ownerDocument.createRange();
         start = getFocusablePosition(start);
         end = getFocusablePosition(end || start);
         range.setStart(start.node, start.offset);

--- a/packages/roosterjs-editor-dom/lib/selection/getPositionRect.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/getPositionRect.ts
@@ -47,7 +47,7 @@ export default function getPositionRect(position: NodePosition): Rect | null {
     }
 
     // 4) try getBoundingClientRect on element
-    let element = position.element;
+    const element = position.element;
     if (element && element.getBoundingClientRect) {
         rect = normalizeRect(element.getBoundingClientRect());
         if (rect) {

--- a/packages/roosterjs-editor-dom/lib/selection/getSelectionPath.ts
+++ b/packages/roosterjs-editor-dom/lib/selection/getSelectionPath.ts
@@ -16,7 +16,7 @@ export default function getSelectionPath(
         return null;
     }
 
-    let selectionPath: SelectionPath = {
+    const selectionPath: SelectionPath = {
         start: getPositionPath(Position.getStart(range), rootNode),
         end: getPositionPath(Position.getEnd(range), rootNode),
     };
@@ -43,7 +43,7 @@ function getPositionPath(position: NodePosition, rootNode: Node): number[] {
 
     let node: Node | null = position.node;
     let offset = position.offset;
-    let result: number[] = [];
+    const result: number[] = [];
     let parent: Node | null;
 
     if (!contains(rootNode, node, true)) {

--- a/packages/roosterjs-editor-dom/lib/snapshots/canMoveCurrentSnapshot.ts
+++ b/packages/roosterjs-editor-dom/lib/snapshots/canMoveCurrentSnapshot.ts
@@ -10,6 +10,6 @@ export default function canMoveCurrentSnapshot<T = string>(
     snapshots: Snapshots<T>,
     step: number
 ): boolean {
-    let newIndex = snapshots.currentIndex + step;
+    const newIndex = snapshots.currentIndex + step;
     return newIndex >= 0 && newIndex < snapshots.snapshots.length;
 }

--- a/packages/roosterjs-editor-dom/lib/table/VTable.ts
+++ b/packages/roosterjs-editor-dom/lib/table/VTable.ts
@@ -79,15 +79,15 @@ export default class VTable {
     ) {
         this.table = safeInstanceOf(node, 'HTMLTableElement') ? node : getTableFromTd(node);
         if (this.table) {
-            let currentTd = safeInstanceOf(node, 'HTMLTableElement') ? null : node;
-            let trs = toArray(this.table.rows);
+            const currentTd = safeInstanceOf(node, 'HTMLTableElement') ? null : node;
+            const trs = toArray(this.table.rows);
             this.cells = trs.map(row => []);
             trs.forEach((tr, rowIndex) => {
                 this.trs[rowIndex % 2] = tr;
                 for (let sourceCol = 0, targetCol = 0; sourceCol < tr.cells.length; sourceCol++) {
                     // Skip the cells which already initialized
                     for (; this.cells![rowIndex][targetCol]; targetCol++) {}
-                    let td = tr.cells[sourceCol];
+                    const td = tr.cells[sourceCol];
 
                     if (td == currentTd) {
                         this.col = targetCol;
@@ -154,7 +154,7 @@ export default class VTable {
         if (this.cells) {
             moveChildNodes(this.table);
             this.cells.forEach((row, r) => {
-                let tr = cloneNode(this.trs[r % 2] || this.trs[0]);
+                const tr = cloneNode(this.trs[r % 2] || this.trs[0]);
 
                 if (tr) {
                     this.table.appendChild(tr);
@@ -226,8 +226,8 @@ export default class VTable {
             return;
         }
 
-        let currentRow = this.cells[this.row];
-        let currentCell = currentRow[this.col];
+        const currentRow = this.cells[this.row];
+        const currentCell = currentRow[this.col];
         const firstRow = this.selection ? this.selection.firstCell.y : this.row;
         const lastRow = this.selection ? this.selection.lastCell.y : this.row;
         const firstColumn = this.selection ? this.selection.firstCell.x : this.col;
@@ -240,17 +240,17 @@ export default class VTable {
                 break;
             case TableOperation.InsertBelow:
                 for (let i = firstRow; i <= lastRow; i++) {
-                    let newRow = lastRow + this.countSpanAbove(lastRow, this.col);
+                    const newRow = lastRow + this.countSpanAbove(lastRow, this.col);
                     this.cells.splice(
                         newRow,
                         0,
                         this.cells[newRow - 1].map((cell, colIndex) => {
-                            let nextCell = this.getCell(newRow, colIndex);
+                            const nextCell = this.getCell(newRow, colIndex);
 
                             if (nextCell.spanAbove) {
                                 return cloneCell(nextCell);
                             } else if (cell.spanLeft) {
-                                let newCell = cloneCell(cell);
+                                const newCell = cloneCell(cell);
                                 newCell.spanAbove = false;
                                 return newCell;
                             } else {
@@ -274,9 +274,9 @@ export default class VTable {
                 break;
             case TableOperation.InsertRight:
                 for (let i = firstColumn; i <= lastColumn; i++) {
-                    let newCol = lastColumn + this.countSpanLeft(this.row, lastColumn);
+                    const newCol = lastColumn + this.countSpanLeft(this.row, lastColumn);
                     this.forEachCellOfColumn(newCol - 1, (cell, row, i) => {
-                        let nextCell = this.getCell(i, newCol);
+                        const nextCell = this.getCell(i, newCol);
                         let newCell: VCell;
                         if (nextCell.spanLeft) {
                             newCell = cloneCell(nextCell);
@@ -298,7 +298,7 @@ export default class VTable {
             case TableOperation.DeleteRow:
                 for (let rowIndex = firstRow; rowIndex <= lastRow; rowIndex++) {
                     this.forEachCellOfRow(rowIndex, (cell: VCell, i: number) => {
-                        let nextCell = this.getCell(rowIndex + 1, i);
+                        const nextCell = this.getCell(rowIndex + 1, i);
                         if (cell.td && cell.td.rowSpan > 1 && nextCell.spanAbove) {
                             nextCell.td = cell.td;
                         }
@@ -317,7 +317,7 @@ export default class VTable {
                 let deletedColumns = 0;
                 for (let colIndex = firstColumn; colIndex <= lastColumn; colIndex++) {
                     this.forEachCellOfColumn(colIndex, (cell, row, i) => {
-                        let nextCell = this.getCell(i, colIndex + 1);
+                        const nextCell = this.getCell(i, colIndex + 1);
                         if (cell.td && cell.td.colSpan > 1 && nextCell.spanLeft) {
                             nextCell.td = cell.td;
                         }
@@ -335,16 +335,16 @@ export default class VTable {
 
             case TableOperation.MergeAbove:
             case TableOperation.MergeBelow:
-                let rowStep = operation == TableOperation.MergeAbove ? -1 : 1;
+                const rowStep = operation == TableOperation.MergeAbove ? -1 : 1;
                 for (
                     let rowIndex = this.row + rowStep;
                     rowIndex >= 0 && rowIndex < this.cells.length;
                     rowIndex += rowStep
                 ) {
-                    let cell = this.getCell(rowIndex, this.col);
+                    const cell = this.getCell(rowIndex, this.col);
                     if (cell.td && !cell.spanAbove) {
-                        let aboveCell = rowIndex < this.row ? cell : currentCell;
-                        let belowCell = rowIndex < this.row ? currentCell : cell;
+                        const aboveCell = rowIndex < this.row ? cell : currentCell;
+                        const belowCell = rowIndex < this.row ? currentCell : cell;
                         this.mergeCells(aboveCell, belowCell);
                         break;
                     }
@@ -353,16 +353,16 @@ export default class VTable {
 
             case TableOperation.MergeLeft:
             case TableOperation.MergeRight:
-                let colStep = operation == TableOperation.MergeLeft ? -1 : 1;
+                const colStep = operation == TableOperation.MergeLeft ? -1 : 1;
                 for (
                     let colIndex = this.col + colStep;
                     colIndex >= 0 && colIndex < this.cells[this.row].length;
                     colIndex += colStep
                 ) {
-                    let cell = this.getCell(this.row, colIndex);
+                    const cell = this.getCell(this.row, colIndex);
                     if (cell.td && !cell.spanLeft) {
-                        let leftCell = colIndex < this.col ? cell : currentCell;
-                        let rightCell = colIndex < this.col ? currentCell : cell;
+                        const leftCell = colIndex < this.col ? cell : currentCell;
+                        const rightCell = colIndex < this.col ? currentCell : cell;
                         this.mergeCells(leftCell, rightCell, true /** horizontally */);
                         break;
                     }
@@ -372,14 +372,14 @@ export default class VTable {
             case TableOperation.MergeCells:
                 for (let colIndex = firstColumn; colIndex <= lastColumn; colIndex++) {
                     for (let rowIndex = firstRow + 1; rowIndex <= lastRow; rowIndex++) {
-                        let cell = this.getCell(firstRow, colIndex);
-                        let nextCellBelow = this.getCell(rowIndex, colIndex);
+                        const cell = this.getCell(firstRow, colIndex);
+                        const nextCellBelow = this.getCell(rowIndex, colIndex);
                         this.mergeCells(cell, nextCellBelow);
                     }
                 }
                 for (let colIndex = firstColumn + 1; colIndex <= lastColumn; colIndex++) {
-                    let cell = this.getCell(firstRow, firstColumn);
-                    let nextCellRight = this.getCell(firstRow, colIndex);
+                    const cell = this.getCell(firstRow, firstColumn);
+                    const nextCellRight = this.getCell(firstRow, colIndex);
                     this.mergeCells(cell, nextCellRight, true /** horizontally */);
                 }
 
@@ -392,7 +392,7 @@ export default class VTable {
                 if (currentCell.td && currentCell.td.rowSpan > 1) {
                     this.getCell(this.row + 1, this.col).td = cloneNode(currentCell.td);
                 } else {
-                    let splitRow = currentRow.map(cell => {
+                    const splitRow = currentRow.map(cell => {
                         return {
                             td: cell == currentCell ? cloneNode(cell.td) : null,
                             spanAbove: cell != currentCell,
@@ -641,7 +641,7 @@ export default class VTable {
             col = this.cells[row] ? Math.min(this.cells[row].length - 1, col) : col;
             if (!isNaN(row) && !isNaN(col)) {
                 while (row >= 0 && col >= 0) {
-                    let cell = this.getCell(row, col);
+                    const cell = this.getCell(row, col);
                     if (cell.td) {
                         return cell.td;
                     } else if (cell.spanLeft) {
@@ -677,7 +677,7 @@ export default class VTable {
     }
 
     private recalculateSpans(row: number, col: number) {
-        let td = this.getCell(row, col).td;
+        const td = this.getCell(row, col).td;
         if (td) {
             td.colSpan = this.countSpanLeft(row, col);
             td.rowSpan = this.countSpanAbove(row, col);
@@ -693,7 +693,7 @@ export default class VTable {
     private countSpanLeft(row: number, col: number) {
         let result = 1;
         for (let i = col + 1; this.cells && i < this.cells[row].length; i++) {
-            let cell = this.getCell(row, i);
+            const cell = this.getCell(row, i);
             if (cell.td || !cell.spanLeft) {
                 break;
             }
@@ -705,7 +705,7 @@ export default class VTable {
     private countSpanAbove(row: number, col: number) {
         let result = 1;
         for (let i = row + 1; this.cells && i < this.cells.length; i++) {
-            let cell = this.getCell(i, col);
+            const cell = this.getCell(i, col);
             if (cell.td || !cell.spanAbove) {
                 break;
             }
@@ -808,7 +808,7 @@ function cloneCell(cell: VCell): VCell {
  * @param node The node to clone
  */
 function cloneNode<T extends Node>(node: T | null | undefined): T | null {
-    let newNode = node ? <T>node.cloneNode(false /*deep*/) : null;
+    const newNode = node ? <T>node.cloneNode(false /*deep*/) : null;
     if (safeInstanceOf(newNode, 'HTMLTableCellElement')) {
         newNode.removeAttribute('id');
         if (!newNode.firstChild) {

--- a/packages/roosterjs-editor-dom/lib/table/pasteTable.ts
+++ b/packages/roosterjs-editor-dom/lib/table/pasteTable.ts
@@ -21,17 +21,17 @@ export default function pasteTable(
     range?: Range
 ) {
     // This is the table on the clipboard
-    let newTable = new VTable(rootNodeToInsert);
+    const newTable = new VTable(rootNodeToInsert);
     // This table is already on the editor
-    let currentTable = new VTable(currentTd);
+    const currentTable = new VTable(currentTd);
 
     // Which cell in the currentTable is the cursor placed
-    let cursorRow = currentTable.row!;
-    let cursorCol = currentTable.col!;
+    const cursorRow = currentTable.row!;
+    const cursorCol = currentTable.col!;
 
     // Total rows and columns of the final table
-    let rows = cursorRow + newTable.cells?.length! ?? 0;
-    let columns = cursorCol + newTable.cells?.[0].length! ?? 0;
+    const rows = cursorRow + newTable.cells?.length! ?? 0;
+    const columns = cursorCol + newTable.cells?.[0].length! ?? 0;
 
     // Add new rows
     currentTable.row = currentTable.cells!.length! - 1;
@@ -48,8 +48,8 @@ export default function pasteTable(
     // Create final table
     for (let i = cursorRow; i < rows; i++) {
         for (let j = cursorCol; j < columns; j++) {
-            let cell = currentTable.getCell(i, j);
-            let newCell = newTable.getTd(i - cursorRow, j - cursorCol);
+            const cell = currentTable.getCell(i, j);
+            const newCell = newTable.getTd(i - cursorRow, j - cursorCol);
             if (cell.td && newCell) {
                 moveChildNodes(cell.td, newCell);
                 cloneCellStyles(cell.td, newCell);

--- a/packages/roosterjs-editor-dom/lib/utils/Browser.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/Browser.ts
@@ -18,8 +18,8 @@ export function getBrowserInfo(
     // IE11 will use rv in UA instead of MSIE. Unfortunately Firefox also uses this. We should also look for "Trident" to confirm this.
     // There have been cases where companies using older version of IE and custom UserAgents have broken this logic (e.g. IE 10 and KellyServices)
     // therefore we should check that the Trident/rv combo is not just from an older IE browser
-    let isIE11OrGreater = userAgent.indexOf('rv:') != -1 && userAgent.indexOf('Trident') != -1;
-    let isIE = userAgent.indexOf('MSIE') != -1 || isIE11OrGreater;
+    const isIE11OrGreater = userAgent.indexOf('rv:') != -1 && userAgent.indexOf('Trident') != -1;
+    const isIE = userAgent.indexOf('MSIE') != -1 || isIE11OrGreater;
 
     // IE11+ may also have 'Chrome', 'Firefox' and 'Safari' in user agent. But it will have 'trident' as well
     let isChrome = false;
@@ -62,9 +62,9 @@ export function getBrowserInfo(
         }
     }
 
-    let isMac = appVersion.indexOf('Mac') != -1;
-    let isWin = appVersion.indexOf('Win') != -1 || appVersion.indexOf('NT') != -1;
-    let isAndroid = isAndroidRegex.test(userAgent);
+    const isMac = appVersion.indexOf('Mac') != -1;
+    const isWin = appVersion.indexOf('Win') != -1 || appVersion.indexOf('NT') != -1;
+    const isAndroid = isAndroidRegex.test(userAgent);
 
     return {
         isMac,

--- a/packages/roosterjs-editor-dom/lib/utils/applyFormat.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/applyFormat.ts
@@ -15,8 +15,8 @@ export default function applyFormat(
     darkColorHandler?: DarkColorHandler | null
 ) {
     if (format) {
-        let elementStyle = element.style;
-        let {
+        const elementStyle = element.style;
+        const {
             fontFamily,
             fontSize,
             textColor,

--- a/packages/roosterjs-editor-dom/lib/utils/changeElementTag.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/changeElementTag.ts
@@ -33,10 +33,10 @@ export default function changeElementTag(element: HTMLElement, newTag: string): 
         return element;
     }
 
-    let newElement = element.ownerDocument.createElement(newTag);
+    const newElement = element.ownerDocument.createElement(newTag);
 
     for (let i = 0; i < element.attributes.length; i++) {
-        let attr = element.attributes[i];
+        const attr = element.attributes[i];
         newElement.setAttribute(attr.name, attr.value);
     }
 

--- a/packages/roosterjs-editor-dom/lib/utils/collapseNodes.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/collapseNodes.ts
@@ -32,9 +32,9 @@ export default function collapseNodes(
     } else if (contains(end, start)) {
         return [end];
     } else if (start.parentNode == end.parentNode) {
-        let nodes: Node[] = start.parentNode ? toArray(start.parentNode?.childNodes) : [];
-        let startIndex = nodes.indexOf(start);
-        let endIndex = nodes.indexOf(end);
+        const nodes: Node[] = start.parentNode ? toArray(start.parentNode?.childNodes) : [];
+        const startIndex = nodes.indexOf(start);
+        const endIndex = nodes.indexOf(end);
         return nodes.slice(startIndex, endIndex + 1);
     } else {
         return [start, end];

--- a/packages/roosterjs-editor-dom/lib/utils/fromHtml.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/fromHtml.ts
@@ -8,7 +8,7 @@ import toArray from '../jsUtils/toArray';
  * @returns An HTML node array to represent the given html string
  */
 export default function fromHtml(html: string, ownerDocument: HTMLDocument): Node[] {
-    let element = ownerDocument.createElement('DIV');
+    const element = ownerDocument.createElement('DIV');
     element.innerHTML = html;
 
     return toArray(element.childNodes);

--- a/packages/roosterjs-editor-dom/lib/utils/getComputedStyles.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/getComputedStyles.ts
@@ -11,15 +11,15 @@ export default function getComputedStyles(
     node: Node,
     styleNames: string | string[] = ['font-family', 'font-size', 'color', 'background-color']
 ): string[] {
-    let element = findClosestElementAncestor(node);
-    let result: string[] = [];
+    const element = findClosestElementAncestor(node);
+    const result: string[] = [];
     styleNames = Array.isArray(styleNames) ? styleNames : [styleNames];
     if (element) {
-        let win = element.ownerDocument.defaultView || window;
-        let styles = win.getComputedStyle(element);
+        const win = element.ownerDocument.defaultView || window;
+        const styles = win.getComputedStyle(element);
 
         if (styles) {
-            for (let style of styleNames) {
+            for (const style of styleNames) {
                 let value = styles.getPropertyValue(style) || '';
                 value = style != 'font-family' ? value.toLowerCase() : value;
                 value = style == 'font-size' ? px2Pt(value) : value;

--- a/packages/roosterjs-editor-dom/lib/utils/getLeafNode.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/getLeafNode.ts
@@ -7,7 +7,7 @@ import { getLeafSibling } from './getLeafSibling';
  * @param isFirst True to get first leaf node, false to get last leaf node
  */
 function getLeafNode(rootNode: Node, isFirst: boolean): Node | null {
-    let getChild = (node: Node): Node | null => (isFirst ? node.firstChild : node.lastChild);
+    const getChild = (node: Node): Node | null => (isFirst ? node.firstChild : node.lastChild);
     let result = getChild(rootNode);
     while (result && getChild(result)) {
         result = getChild(result);

--- a/packages/roosterjs-editor-dom/lib/utils/getLeafSibling.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/getLeafSibling.ts
@@ -19,10 +19,10 @@ export function getLeafSibling(
     ignoreSpace?: boolean
 ): Node | null {
     let result = null;
-    let getSibling = isNext
+    const getSibling = isNext
         ? (node: Node | null) => node?.nextSibling || null
         : (node: Node | null) => node?.previousSibling || null;
-    let getChild = isNext ? (node: Node) => node.firstChild : (node: Node) => node.lastChild;
+    const getChild = isNext ? (node: Node) => node.firstChild : (node: Node) => node.lastChild;
     if (contains(rootNode, startNode)) {
         let curNode: Node | null = startNode;
         let shouldContinue: boolean = true;

--- a/packages/roosterjs-editor-dom/lib/utils/getPendableFormatState.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/getPendableFormatState.ts
@@ -48,7 +48,7 @@ export const PendableFormatCommandMap: { [key in PendableFormatNames]: DocumentC
  * @returns A PendableFormatState object which contains the values of pendable format states
  */
 export default function getPendableFormatState(document: Document): PendableFormatState {
-    let keys = getObjectKeys(PendableFormatCommandMap);
+    const keys = getObjectKeys(PendableFormatCommandMap);
 
     return keys.reduce((state, key) => {
         state[key] = document.queryCommandState(PendableFormatCommandMap[key]);

--- a/packages/roosterjs-editor-dom/lib/utils/isBlockElement.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/isBlockElement.ts
@@ -11,7 +11,7 @@ const BLOCK_DISPLAY_STYLES = ['block', 'list-item', 'table-cell'];
  * @returns True if the node is a block element, otherwise false
  */
 export default function isBlockElement(node: Node): node is HTMLElement {
-    let tag = getTagOfNode(node);
+    const tag = getTagOfNode(node);
     return !!(
         tag &&
         (BLOCK_DISPLAY_STYLES.indexOf((<HTMLElement>node).style.display) >= 0 ||

--- a/packages/roosterjs-editor-dom/lib/utils/isNodeEmpty.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/isNodeEmpty.ts
@@ -22,8 +22,8 @@ export default function isNodeEmpty(
     } else if (node.nodeType == NodeType.Text) {
         return trim(node.nodeValue || '', trimContent) == '';
     } else if (node.nodeType == NodeType.Element) {
-        let element = node as Element;
-        let textContent = trim(element.textContent || '', trimContent);
+        const element = node as Element;
+        const textContent = trim(element.textContent || '', trimContent);
         const visibleSelector = shouldCountBrAsVisible
             ? `${VISIBLE_CHILD_ELEMENT_SELECTOR},BR`
             : VISIBLE_CHILD_ELEMENT_SELECTOR;

--- a/packages/roosterjs-editor-dom/lib/utils/matchLink.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/matchLink.ts
@@ -77,9 +77,9 @@ const linkMatchRules: Record<string, LinkMatchRule> = {
  */
 export default function matchLink(url: string): LinkData | null {
     if (url) {
-        for (let schema of getObjectKeys(linkMatchRules)) {
-            let rule = linkMatchRules[schema];
-            let matches = url.match(rule.match);
+        for (const schema of getObjectKeys(linkMatchRules)) {
+            const rule = linkMatchRules[schema];
+            const matches = url.match(rule.match);
             if (matches && matches[0] == url && (!rule.except || !rule.except.test(url))) {
                 return {
                     scheme: schema,

--- a/packages/roosterjs-editor-dom/lib/utils/normalizeRect.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/normalizeRect.ts
@@ -5,7 +5,7 @@ import type { Rect } from 'roosterjs-editor-types';
  * We validate that and only return a rect when the passed in ClientRect is valid
  */
 export default function normalizeRect(clientRect: DOMRect): Rect | null {
-    let { left, right, top, bottom } =
+    const { left, right, top, bottom } =
         clientRect || <DOMRect>{ left: 0, right: 0, top: 0, bottom: 0 };
     return left === 0 && right === 0 && top === 0 && bottom === 0
         ? null

--- a/packages/roosterjs-editor-dom/lib/utils/queryElements.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/queryElements.ts
@@ -25,7 +25,8 @@ export default function queryElements(
     let elements = toArray(container.querySelectorAll<HTMLElement>(selector));
 
     if (scope != QueryScope.Body && range) {
-        let { startContainer, startOffset, endContainer, endOffset } = range;
+        const { startOffset, endOffset } = range;
+        let { startContainer, endContainer } = range;
         if (startContainer.nodeType == NodeType.Element && startContainer.firstChild) {
             const child = startContainer.childNodes[startOffset];
 
@@ -61,9 +62,9 @@ function isIntersectWithNodeRange(
     endNode: Node,
     nodeContainedByRangeOnly: boolean
 ): boolean {
-    let startPosition = node.compareDocumentPosition(startNode);
-    let endPosition = node.compareDocumentPosition(endNode);
-    let targetPositions = [DocumentPosition.Same, DocumentPosition.Contains];
+    const startPosition = node.compareDocumentPosition(startNode);
+    const endPosition = node.compareDocumentPosition(endNode);
+    const targetPositions = [DocumentPosition.Same, DocumentPosition.Contains];
 
     if (!nodeContainedByRangeOnly) {
         targetPositions.push(DocumentPosition.ContainedBy);

--- a/packages/roosterjs-editor-dom/lib/utils/setColor.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/setColor.ts
@@ -113,7 +113,7 @@ function adaptFontColorToBackgroundColor(
 }
 
 function isADarkOrBrightColor(color: string): ColorTones {
-    let lightness = calculateLightness(color);
+    const lightness = calculateLightness(color);
     if (lightness < DARK_COLORS_LIGHTNESS) {
         return ColorTones.DARK;
     } else if (lightness > BRIGHT_COLORS_LIGHTNESS) {

--- a/packages/roosterjs-editor-dom/lib/utils/splitParentNode.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/splitParentNode.ts
@@ -16,7 +16,7 @@ export default function splitParentNode(node: Node, splitBefore: boolean): Node 
         return null;
     }
 
-    let parentNode = node.parentNode;
+    const parentNode = node.parentNode;
     let newParent: HTMLElement | null = parentNode.cloneNode(false /*deep*/) as HTMLElement;
     newParent.removeAttribute('id');
     if (splitBefore) {
@@ -54,7 +54,7 @@ export function splitBalancedNodeRange(nodes: Node | Node[]): Node | null {
     const parentNode = start && end && start.parentNode == end.parentNode ? start.parentNode : null;
     if (parentNode) {
         if (isNodeAfter(start, end)) {
-            let temp = end;
+            const temp = end;
             end = start;
             start = temp;
         }

--- a/packages/roosterjs-editor-dom/lib/utils/unwrap.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/unwrap.ts
@@ -4,7 +4,7 @@
  */
 export default function unwrap(node: Node): Node | null {
     // Unwrap requires a parentNode
-    let parentNode = node ? node.parentNode : null;
+    const parentNode = node ? node.parentNode : null;
     if (!parentNode) {
         return null;
     }

--- a/packages/roosterjs-editor-dom/lib/utils/wrap.ts
+++ b/packages/roosterjs-editor-dom/lib/utils/wrap.ts
@@ -64,7 +64,7 @@ export default function wrap(
     }
 
     if (!safeInstanceOf(wrapper, 'HTMLElement')) {
-        let document = nodes[0].ownerDocument;
+        const document = nodes[0].ownerDocument;
 
         if (typeof wrapper === 'string') {
             wrapper = /^\w+$/.test(wrapper)
@@ -75,13 +75,13 @@ export default function wrap(
         }
     }
 
-    let parentNode = nodes[0].parentNode;
+    const parentNode = nodes[0].parentNode;
 
     if (parentNode) {
         parentNode.insertBefore(wrapper, nodes[0]);
     }
 
-    for (let node of nodes) {
+    for (const node of nodes) {
         wrapper.appendChild(node);
     }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/Announce/AnnouncePlugin.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Announce/AnnouncePlugin.ts
@@ -131,7 +131,7 @@ export default class Announce implements EditorPlugin {
 
     protected announce(announceData: AnnounceData, editor: IEditor) {
         const { text, defaultStrings, formatStrings = [] } = announceData;
-        let textToAnnounce = formatString(this.getString(defaultStrings) || text, formatStrings);
+        const textToAnnounce = formatString(this.getString(defaultStrings) || text, formatStrings);
         if (textToAnnounce) {
             if (!this.ariaLiveElement || textToAnnounce == this.ariaLiveElement?.textContent) {
                 this.ariaLiveElement?.parentElement?.removeChild(this.ariaLiveElement);

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/autoLinkFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/autoLinkFeatures.ts
@@ -55,13 +55,13 @@ function cacheGetLinkData(event: PluginEvent, editor: IEditor): LinkData | null 
               // This helps when we paste a link next to some existing character, and the text we got
               // from clipboard will only contain what we pasted, any existing characters will not
               // be included.
-              let clipboardData =
+              const clipboardData =
                   (event.eventType == PluginEventType.ContentChanged &&
                       event.source == ChangeSource.Paste &&
                       (event.data as ClipboardData)) ||
                   null;
-              let link = matchLink((clipboardData?.text || '').trim());
-              let searcher = editor.getContentSearcherOfCursor(event);
+              const link = matchLink((clipboardData?.text || '').trim());
+              const searcher = editor.getContentSearcherOfCursor(event);
 
               // In case the matched link is already inside a <A> tag, we do a range search.
               // getRangeFromText will return null if the given text is already in a LinkInlineElement
@@ -69,11 +69,11 @@ function cacheGetLinkData(event: PluginEvent, editor: IEditor): LinkData | null 
                   return link;
               }
 
-              let word = searcher && searcher.getWordBefore();
+              const word = searcher && searcher.getWordBefore();
               if (word && word.length > MINIMUM_LENGTH) {
                   // Check for trailing punctuation
-                  let trailingPunctuations = word.match(TRAILING_PUNCTUATION_REGEX);
-                  let trailingPunctuation = (trailingPunctuations || [])[0] || '';
+                  const trailingPunctuations = word.match(TRAILING_PUNCTUATION_REGEX);
+                  const trailingPunctuation = (trailingPunctuations || [])[0] || '';
                   let candidate = word.substring(0, word.length - trailingPunctuation.length);
 
                   // Do special handling for ')', '}', ']'
@@ -95,8 +95,8 @@ function cacheGetLinkData(event: PluginEvent, editor: IEditor): LinkData | null 
 }
 
 function hasLinkBeforeCursor(event: PluginKeyboardEvent, editor: IEditor): boolean {
-    let contentSearcher = editor.getContentSearcherOfCursor(event);
-    let inline = contentSearcher?.getInlineElementBefore();
+    const contentSearcher = editor.getContentSearcherOfCursor(event);
+    const inline = contentSearcher?.getInlineElementBefore();
     return inline instanceof LinkInlineElement;
 }
 
@@ -105,10 +105,10 @@ function autoLink(event: PluginEvent, editor: IEditor) {
     if (!linkData) {
         return;
     }
-    let anchor = editor.getDocument().createElement('a');
+    const anchor = editor.getDocument().createElement('a');
     // Need to get searcher before we enter the async callback since the callback can happen when cursor is moved to next line
     // and at that time a new searcher won't be able to find the link text to replace
-    let searcher = editor.getContentSearcherOfCursor();
+    const searcher = editor.getContentSearcherOfCursor();
     anchor.textContent = linkData.originalUrl;
     anchor.href = linkData.normalizedUrl;
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/cursorFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/cursorFeatures.ts
@@ -23,8 +23,8 @@ const NoCycleCursorMove: BuildInEditFeature<PluginKeyboardEvent> = {
             return false;
         }
 
-        let rtl = getComputedStyle(position.element, 'direction') == 'rtl';
-        let rawEvent = event.rawEvent;
+        const rtl = getComputedStyle(position.element, 'direction') == 'rtl';
+        const rawEvent = event.rawEvent;
 
         return (!rtl && rawEvent.which == Keys.LEFT) || (rtl && rawEvent.which == Keys.RIGHT);
     },

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/listFeatures.ts
@@ -166,12 +166,12 @@ const OutdentWhenAltShiftLeft: BuildInEditFeature<PluginKeyboardEvent> = {
 const MergeInNewLine: BuildInEditFeature<PluginKeyboardEvent> = {
     keys: [Keys.BACKSPACE],
     shouldHandleEvent: (event, editor) => {
-        let li = editor.getElementAtCursor('LI', undefined /*startFrom*/, event);
-        let range = editor.getSelectionRange();
+        const li = editor.getElementAtCursor('LI', undefined /*startFrom*/, event);
+        const range = editor.getSelectionRange();
         return li && range?.collapsed && isPositionAtBeginningOf(Position.getStart(range), li);
     },
     handleEvent: (event, editor) => {
-        let li = editor.getElementAtCursor('LI', undefined /*startFrom*/, event);
+        const li = editor.getElementAtCursor('LI', undefined /*startFrom*/, event);
         if (li?.previousSibling) {
             blockFormat(editor, (region, start, end) => {
                 const vList = createVListFromRegion(
@@ -202,7 +202,7 @@ const MergeInNewLine: BuildInEditFeature<PluginKeyboardEvent> = {
 const OutdentWhenBackOn1stEmptyLine: BuildInEditFeature<PluginKeyboardEvent> = {
     keys: [Keys.BACKSPACE],
     shouldHandleEvent: (event, editor) => {
-        let li = editor.getElementAtCursor('LI', undefined /*startFrom*/, event);
+        const li = editor.getElementAtCursor('LI', undefined /*startFrom*/, event);
         return (
             li &&
             isNodeEmpty(li) &&
@@ -243,7 +243,7 @@ const MaintainListChainWhenDelete: BuildInEditFeature<PluginKeyboardEvent> = {
 const OutdentWhenEnterOnEmptyLine: BuildInEditFeature<PluginKeyboardEvent> = {
     keys: [Keys.ENTER],
     shouldHandleEvent: (event, editor) => {
-        let li = editor.getElementAtCursor('LI', undefined /*startFrom*/, event);
+        const li = editor.getElementAtCursor('LI', undefined /*startFrom*/, event);
         return !event.rawEvent.shiftKey && li && isNodeEmpty(li);
     },
     handleEvent: (event, editor) => {
@@ -284,12 +284,12 @@ const AutoBulletList: BuildInEditFeature<PluginKeyboardEvent> = {
         event.rawEvent.preventDefault();
         editor.addUndoSnapshot(
             () => {
-                let searcher = editor.getContentSearcherOfCursor();
+                const searcher = editor.getContentSearcherOfCursor();
                 if (!searcher) {
                     return;
                 }
-                let textBeforeCursor = searcher.getSubStringBefore(5);
-                let textRange = searcher.getRangeFromText(textBeforeCursor, true /*exactMatch*/);
+                const textBeforeCursor = searcher.getSubStringBefore(5);
+                const textRange = searcher.getRangeFromText(textBeforeCursor, true /*exactMatch*/);
                 const listStyle = getAutoBulletListStyle(textBeforeCursor);
 
                 if (textRange) {
@@ -438,10 +438,10 @@ function toggleListAndPreventDefault(
     editor: IEditor,
     includeSiblingLists: boolean = true
 ) {
-    let listInfo = cacheGetListElement(event, editor);
+    const listInfo = cacheGetListElement(event, editor);
     if (listInfo) {
-        let listElement = listInfo[0];
-        let tag = getTagOfNode(listElement);
+        const listElement = listInfo[0];
+        const tag = getTagOfNode(listElement);
 
         if (tag == 'UL' || tag == 'OL') {
             toggleListType(
@@ -458,8 +458,8 @@ function toggleListAndPreventDefault(
 }
 
 function cacheGetListElement(event: PluginKeyboardEvent, editor: IEditor) {
-    let li = editor.getElementAtCursor('LI,TABLE', undefined /*startFrom*/, event);
-    let listElement = li && getTagOfNode(li) == 'LI' && editor.getElementAtCursor('UL,OL', li);
+    const li = editor.getElementAtCursor('LI,TABLE', undefined /*startFrom*/, event);
+    const listElement = li && getTagOfNode(li) == 'LI' && editor.getElementAtCursor('UL,OL', li);
     return listElement ? [listElement, li] : null;
 }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/quoteFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/quoteFeatures.ts
@@ -27,7 +27,7 @@ const STRUCTURED_TAGS = [QUOTE_TAG, 'LI', 'TD', 'TH'].join(',');
 const UnquoteWhenBackOnEmpty1stLine: BuildInEditFeature<PluginKeyboardEvent> = {
     keys: [Keys.BACKSPACE],
     shouldHandleEvent: (event, editor) => {
-        let childOfQuote = cacheGetQuoteChild(event, editor);
+        const childOfQuote = cacheGetQuoteChild(event, editor);
         return childOfQuote && isNodeEmpty(childOfQuote) && !childOfQuote.previousSibling;
     },
     handleEvent: splitQuote,
@@ -40,8 +40,8 @@ const UnquoteWhenBackOnEmpty1stLine: BuildInEditFeature<PluginKeyboardEvent> = {
 const UnquoteWhenEnterOnEmptyLine: BuildInEditFeature<PluginKeyboardEvent> = {
     keys: [Keys.ENTER],
     shouldHandleEvent: (event, editor) => {
-        let childOfQuote = cacheGetQuoteChild(event, editor);
-        let shift = event.rawEvent.shiftKey;
+        const childOfQuote = cacheGetQuoteChild(event, editor);
+        const shift = event.rawEvent.shiftKey;
         return !shift && childOfQuote && isNodeEmpty(childOfQuote);
     },
     handleEvent: (event, editor) =>
@@ -54,12 +54,12 @@ const UnquoteWhenEnterOnEmptyLine: BuildInEditFeature<PluginKeyboardEvent> = {
 
 function cacheGetQuoteChild(event: PluginKeyboardEvent, editor: IEditor): Node | null {
     return cacheGetEventData(event, 'QUOTE_CHILD', () => {
-        let quote = editor.getElementAtCursor(STRUCTURED_TAGS);
+        const quote = editor.getElementAtCursor(STRUCTURED_TAGS);
         if (quote && getTagOfNode(quote) == QUOTE_TAG) {
-            let pos = editor.getFocusedPosition();
-            let block = pos && editor.getBlockElementAtNode(pos.normalize().node);
+            const pos = editor.getFocusedPosition();
+            const block = pos && editor.getBlockElementAtNode(pos.normalize().node);
             if (block) {
-                let node =
+                const node =
                     block.getStartNode() == quote
                         ? block.getStartNode()
                         : block.collapseToSingleElement();

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/shortcutFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/shortcutFeatures.ts
@@ -95,7 +95,7 @@ const DefaultShortcut: BuildInEditFeature<PluginKeyboardEvent> = {
     ],
     shouldHandleEvent: cacheGetCommand,
     handleEvent: (event, editor) => {
-        let command = cacheGetCommand(event);
+        const command = cacheGetCommand(event);
         if (command) {
             command.action(editor);
             event.rawEvent.preventDefault();
@@ -106,8 +106,8 @@ const DefaultShortcut: BuildInEditFeature<PluginKeyboardEvent> = {
 
 function cacheGetCommand(event: PluginKeyboardEvent) {
     return cacheGetEventData(event, 'DEFAULT_SHORT_COMMAND', () => {
-        let e = event.rawEvent;
-        let key =
+        const e = event.rawEvent;
+        const key =
             // Need to check AltGraph isn't being pressed since some languages (e.g. Polski) use AltGr
             // to input some special characters. In that case, ctrlKey and altKey are both true in Edge,
             // but we should not trigger any shortcut function here. However, we still want to capture

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/structuredNodeFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/structuredNodeFeatures.ts
@@ -30,8 +30,8 @@ const InsertLineBeforeStructuredNodeFeature: BuildInEditFeature<PluginKeyboardEv
     keys: [Keys.ENTER],
     shouldHandleEvent: cacheGetStructuredElement,
     handleEvent: (event, editor) => {
-        let element = cacheGetStructuredElement(event, editor);
-        let div = createElement(
+        const element = cacheGetStructuredElement(event, editor);
+        const div = createElement(
             KnownCreateElementDataIndex.EmptyLine,
             editor.getDocument()
         ) as HTMLElement;
@@ -50,10 +50,10 @@ const InsertLineBeforeStructuredNodeFeature: BuildInEditFeature<PluginKeyboardEv
 function cacheGetStructuredElement(event: PluginKeyboardEvent, editor: IEditor) {
     return cacheGetEventData(event, 'FIRST_STRUCTURE', () => {
         // Provide a chance to keep browser default behavior by pressing SHIFT
-        let element = event.rawEvent.shiftKey ? null : editor.getElementAtCursor(CHILD_SELECTOR);
+        const element = event.rawEvent.shiftKey ? null : editor.getElementAtCursor(CHILD_SELECTOR);
 
         if (element) {
-            let range = editor.getSelectionRange();
+            const range = editor.getSelectionRange();
             if (
                 range &&
                 range.collapsed &&

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/tableFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/tableFeatures.ts
@@ -34,12 +34,12 @@ const TabInTable: BuildInEditFeature<PluginKeyboardEvent> = {
     shouldHandleEvent: (event: PluginKeyboardEvent, editor: IEditor) =>
         cacheGetTableCell(event, editor) && !cacheIsWholeTableSelected(event, editor),
     handleEvent: (event, editor) => {
-        let shift = event.rawEvent.shiftKey;
-        let td = cacheGetTableCell(event, editor);
+        const shift = event.rawEvent.shiftKey;
+        const td = cacheGetTableCell(event, editor);
         if (!td) {
             return;
         }
-        let vtable = cacheVTable(event, td);
+        const vtable = cacheVTable(event, td);
 
         for (
             let step = shift ? -1 : 1, row = vtable.row ?? 0, col = (vtable.col ?? 0) + step;
@@ -58,7 +58,7 @@ const TabInTable: BuildInEditFeature<PluginKeyboardEvent> = {
                 }
                 col = shift ? tableCells[row].length - 1 : 0;
             }
-            let cell = vtable.getCell(row, col);
+            const cell = vtable.getCell(row, col);
             if (cell.td) {
                 const newPos = new Position(cell.td, PositionType.Begin).normalize();
                 editor.select(newPos);
@@ -80,13 +80,13 @@ const IndentTableOnTab: BuildInEditFeature<PluginKeyboardEvent> = {
         event.rawEvent.preventDefault();
 
         editor.addUndoSnapshot(() => {
-            let shift = event.rawEvent.shiftKey;
-            let selection = editor.getSelectionRangeEx() as TableSelectionRange;
-            let td = cacheGetTableCell(event, editor);
+            const shift = event.rawEvent.shiftKey;
+            const selection = editor.getSelectionRangeEx() as TableSelectionRange;
+            const td = cacheGetTableCell(event, editor);
             if (!td) {
                 return;
             }
-            let vtable = cacheVTable(event, td);
+            const vtable = cacheVTable(event, td);
 
             if (shift && editor.getElementAtCursor('blockquote', vtable.table, event)) {
                 setIndentation(editor, Indentation.Decrease);
@@ -122,14 +122,14 @@ const UpDownInTable: BuildInEditFeature<PluginKeyboardEvent> = {
         let targetTd: HTMLTableCellElement | null = null;
 
         if (selection) {
-            let { anchorNode, anchorOffset } = selection;
+            const { anchorNode, anchorOffset } = selection;
 
             for (
                 let row = vtable.row ?? 0;
                 row >= 0 && vtable.cells && row < vtable.cells.length;
                 row += step
             ) {
-                let cell = vtable.getCell(row, vtable.col ?? 0);
+                const cell = vtable.getCell(row, vtable.col ?? 0);
                 if (cell.td && cell.td != td) {
                     targetTd = cell.td;
                     break;
@@ -137,7 +137,7 @@ const UpDownInTable: BuildInEditFeature<PluginKeyboardEvent> = {
             }
 
             editor.runAsync(editor => {
-                let newContainer = editor.getElementAtCursor();
+                const newContainer = editor.getElementAtCursor();
                 if (
                     contains(vtable.table, newContainer) &&
                     !contains(td, newContainer, true /*treatSameNodeAsContain*/)
@@ -197,8 +197,8 @@ const DeleteTableWithBackspace: BuildInEditFeature<PluginKeyboardEvent> = {
 
 function cacheGetTableCell(event: PluginEvent, editor: IEditor): HTMLTableCellElement | null {
     return cacheGetEventData(event, 'TABLE_CELL_FOR_TABLE_FEATURES', () => {
-        let pos = editor.getFocusedPosition();
-        let firstTd = pos && editor.getElementAtCursor('TD,TH,LI', pos.node);
+        const pos = editor.getFocusedPosition();
+        const firstTd = pos && editor.getElementAtCursor('TD,TH,LI', pos.node);
         return (
             firstTd && (getTagOfNode(firstTd) == 'LI' ? null : (firstTd as HTMLTableCellElement))
         );
@@ -211,8 +211,8 @@ function cacheIsWholeTableSelected(event: PluginEvent, editor: IEditor) {
         if (!td) {
             return false;
         }
-        let vtable = cacheVTable(event, td);
-        let selection = editor.getSelectionRangeEx();
+        const vtable = cacheVTable(event, td);
+        const selection = editor.getSelectionRangeEx();
         return (
             selection.type == SelectionRangeTypes.TableSelection &&
             selection.coordinates &&

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/textFeatures.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/features/textFeatures.ts
@@ -40,7 +40,7 @@ const IndentWhenTabText: BuildInEditFeature<PluginKeyboardEvent> = {
             editor.isFeatureEnabled(ExperimentalFeatures.TabKeyTextFeatures) &&
             !event.rawEvent.shiftKey
         ) {
-            let activeElement = editor.getDocument().activeElement as HTMLElement;
+            const activeElement = editor.getDocument().activeElement as HTMLElement;
             const listOrTable = editor.getElementAtCursor(
                 'LI,TABLE',
                 undefined /*startFrom*/,
@@ -189,7 +189,7 @@ function isRangeEmpty(range: Range) {
 
 function insertTab(editor: IEditor, event: PluginKeyboardEvent) {
     const span = editor.getDocument().createElement('span');
-    let searcher = editor.getContentSearcherOfCursor(event);
+    const searcher = editor.getContentSearcherOfCursor(event);
     if (!searcher) {
         return;
     }

--- a/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/utils/getAutoNumberingListStyle.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ContentEdit/utils/getAutoNumberingListStyle.ts
@@ -146,7 +146,7 @@ export default function getAutoNumberingListStyle(
     const listIndex = isDoubleParenthesis ? trigger.slice(1, -1) : trigger.slice(0, -1);
 
     const indexNumber = parseInt(listIndex);
-    let index = !isNaN(indexNumber) ? indexNumber : convertAlphaToDecimals(listIndex);
+    const index = !isNaN(indexNumber) ? indexNumber : convertAlphaToDecimals(listIndex);
 
     if (!index || index < 1) {
         return null;

--- a/packages/roosterjs-editor-plugins/lib/plugins/CustomReplace/CustomReplace.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/CustomReplace/CustomReplace.ts
@@ -164,7 +164,7 @@ function getLongestReplacementSourceLength(replacements: CustomReplacement[]): n
 
 function getReplacementEndCharacters(replacements: CustomReplacement[]): Set<string> {
     const endChars = new Set<string>();
-    for (let replacement of replacements) {
+    for (const replacement of replacements) {
         const sourceString = replacement.sourceString;
         if (sourceString.length == 0) {
             continue;

--- a/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/HyperLink/HyperLink.ts
@@ -206,13 +206,13 @@ export default class HyperLink implements EditorPlugin {
      */
     private doesLinkDisplayMatchHref(element: HTMLAnchorElement): boolean {
         if (element) {
-            let display = element.innerText.trim();
+            const display = element.innerText.trim();
 
             // We first escape the display text so that any text passed into the regex is not
             // treated as a special character.
-            let escapedDisplay = display.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-            let rule = new RegExp(`^(?:https?:\\/\\/)?${escapedDisplay}\\/?`, 'i');
-            let href = this.tryGetHref(element);
+            const escapedDisplay = display.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+            const rule = new RegExp(`^(?:https?:\\/\\/)?${escapedDisplay}\\/?`, 'i');
+            const href = this.tryGetHref(element);
             if (href !== null) {
                 return rule.test(href);
             }
@@ -226,7 +226,7 @@ export default class HyperLink implements EditorPlugin {
      */
     private updateLinkHref() {
         if (this.trackedLink) {
-            let linkData = matchLink(this.trackedLink.innerText.trim());
+            const linkData = matchLink(this.trackedLink.innerText.trim());
             if (linkData !== null) {
                 this.editor?.addUndoSnapshot(() => {
                     this.trackedLink!.href = linkData!.normalizedUrl;

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/ImageEdit.ts
@@ -713,7 +713,7 @@ function isRtl(element: Node): boolean {
 }
 
 function handleRadIndexCalculator(angleRad: number): number {
-    let idx = Math.round(angleRad / DirectionRad) % DIRECTIONS;
+    const idx = Math.round(angleRad / DirectionRad) % DIRECTIONS;
     return idx < 0 ? idx + DIRECTIONS : idx;
 }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/ImageEdit/imageEditors/Resizer.ts
@@ -135,7 +135,7 @@ export function getCornerResizeHTML(
 
     Xs.forEach(x =>
         Ys.forEach(y => {
-            let elementData =
+            const elementData =
                 (x == '') == (y == '')
                     ? getResizeHandleHTML(
                           x,
@@ -166,7 +166,7 @@ export function getSideResizeHTML(
     const result: CreateElementData[] = [];
     Xs.forEach(x =>
         Ys.forEach(y => {
-            let elementData =
+            const elementData =
                 (x == '') != (y == '')
                     ? getResizeHandleHTML(
                           x,

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/excelConverter/convertPastedContentFromExcel.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/excelConverter/convertPastedContentFromExcel.ts
@@ -59,8 +59,8 @@ export function excelHandler(html: string, htmlBefore: string): string {
         html = tr + html + '</TR>';
     }
     if (html.match(LAST_TR_END_REGEX)) {
-        let tableMatch = htmlBefore.match(LAST_TABLE_REGEX);
-        let table = tableMatch ? tableMatch[0] : '<TABLE>';
+        const tableMatch = htmlBefore.match(LAST_TABLE_REGEX);
+        const table = tableMatch ? tableMatch[0] : '<TABLE>';
         html = table + html + '</TABLE>';
     }
 

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/officeOnlineConverter/convertPastedContentFromWordOnline.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/officeOnlineConverter/convertPastedContentFromWordOnline.ts
@@ -107,7 +107,7 @@ export default function convertPastedContentFromWordOnline(fragment: DocumentFra
         const doc = fragment.ownerDocument;
 
         itemBlock.listItemContainers.forEach(listItemContainer => {
-            let listType: 'OL' | 'UL' | null = getContainerListType(listItemContainer); // list type that is contained by iterator.
+            const listType: 'OL' | 'UL' | null = getContainerListType(listItemContainer); // list type that is contained by iterator.
             if (listType) {
                 // Initialize processed element with proper listType if this is the first element
                 if (!convertedListElement) {
@@ -215,7 +215,7 @@ function getListItemBlocks(fragment: DocumentFragment): ListItemBlock[] {
     const result: ListItemBlock[] = [];
     let curListItemBlock: ListItemBlock | null = null;
     for (let i = 0; i < listElements.length; i++) {
-        let curItem = listElements[i];
+        const curItem = listElements[i];
         if (!curListItemBlock) {
             curListItemBlock = createListItemBlock(curItem);
         } else {
@@ -294,7 +294,7 @@ function insertListItem(
     let itemLevel = parseInt(itemToInsert.getAttribute('data-aria-level') ?? '');
 
     // Try to reuse the List Marker
-    let style = itemToInsert.getAttribute('data-leveltext');
+    const style = itemToInsert.getAttribute('data-leveltext');
     if (
         listType == 'UL' &&
         style &&
@@ -316,8 +316,8 @@ function insertListItem(
         } else {
             // If the current level is not empty, the last item in the needs to be a UL or OL
             // and the level iterator should move to the UL/OL at the last position.
-            let lastChild = curListLevel.lastElementChild;
-            let lastChildTag = getTagOfNode(lastChild);
+            const lastChild = curListLevel.lastElementChild;
+            const lastChildTag = getTagOfNode(lastChild);
             if (lastChild && (lastChildTag == 'UL' || lastChildTag == 'OL')) {
                 // If the last child is a list(UL/OL), then move the level iterator to last child.
                 curListLevel = lastChild;

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/WordCustomData.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/WordCustomData.ts
@@ -33,7 +33,7 @@ export function createCustomData(): WordCustomData {
 export function setObject(wordCustomData: WordCustomData, element: Node, key: string, value: any) {
     // Get the id for the element
     if (element.nodeType == NodeType.Element) {
-        let id = getAndSetNodeId(wordCustomData, element as HTMLElement);
+        const id = getAndSetNodeId(wordCustomData, element as HTMLElement);
         if (id != '') {
             // Get the values for the element
             if (!wordCustomData.dict[id]) {
@@ -51,7 +51,7 @@ export function setObject(wordCustomData: WordCustomData, element: Node, key: st
  */
 export function getObject(wordCustomData: WordCustomData, element: Node, key: string): any {
     if (element.nodeType == NodeType.Element) {
-        let id = getAndSetNodeId(wordCustomData, element as HTMLElement);
+        const id = getAndSetNodeId(wordCustomData, element as HTMLElement);
         if (id != '') {
             return wordCustomData.dict[id] && wordCustomData.dict[id][key];
         }

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/convertPastedContentFromWord.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/convertPastedContentFromWord.ts
@@ -23,12 +23,12 @@ export default function convertPastedContentFromWord(event: BeforePasteEvent) {
         return true;
     });
 
-    let wordConverter = createWordConverter();
+    const wordConverter = createWordConverter();
 
     // First find all the nodes that we need to check for list item information
     // This call will return all the p and heading elements under the root node.. These are the elements that
     // Word uses a list items, so we'll only process them and avoid walking the whole tree.
-    let elements = fragment.querySelectorAll(LIST_ELEMENTS_SELECTOR) as NodeListOf<HTMLElement>;
+    const elements = fragment.querySelectorAll(LIST_ELEMENTS_SELECTOR) as NodeListOf<HTMLElement>;
     if (elements.length > 0) {
         wordConverter.wordConverterArgs = createWordConverterArguments(elements);
         if (processNodesDiscovery(wordConverter)) {

--- a/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/converterUtils.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Paste/wordConverter/converterUtils.ts
@@ -27,17 +27,17 @@ const LINE_BREAKS = /[\n|\r]/gi;
  * for numbered headers, and we don't want to convert those, because the numbering would be completely wrong.
  */
 export function processNodesDiscovery(wordConverter: WordConverter): boolean {
-    let args = wordConverter.wordConverterArgs;
+    const args = wordConverter.wordConverterArgs;
     if (!args) {
         return false;
     }
     while (args.currentIndex < args.nodes.length) {
-        let node = args.nodes.item(args.currentIndex);
+        const node = args.nodes.item(args.currentIndex);
 
         // Try to get the list metadata for the specified node
-        let itemMetadata = getListItemMetadata(node);
+        const itemMetadata = getListItemMetadata(node);
         if (itemMetadata) {
-            let levelInfo =
+            const levelInfo =
                 args.currentListIdsByLevels[itemMetadata.level - 1] || createLevelLists();
             args.currentListIdsByLevels[itemMetadata.level - 1] = levelInfo;
 
@@ -52,7 +52,7 @@ export function processNodesDiscovery(wordConverter: WordConverter): boolean {
             let listMetadata = levelInfo.listsMetadata[itemMetadata.wordListId];
             if (!listMetadata) {
                 // Get the first item fake bullet.. This will be used later to check what is the right type of list
-                let firstFakeBullet = getFakeBulletText(node, LOOKUP_DEPTH);
+                const firstFakeBullet = getFakeBulletText(node, LOOKUP_DEPTH);
 
                 // This is a the first item of a list.. We'll create the list metadata using the information
                 // we already have from this first item
@@ -77,7 +77,7 @@ export function processNodesDiscovery(wordConverter: WordConverter): boolean {
                 // items we have an decide if we create ordered or unordered lists based on this.
                 // This is the best way we can do this since we cannot read the metadata that Word
                 // puts in the head of the HTML...
-                let secondFakeBullet = getFakeBulletText(node, LOOKUP_DEPTH);
+                const secondFakeBullet = getFakeBulletText(node, LOOKUP_DEPTH);
                 listMetadata.tagName =
                     listMetadata.firstFakeBullet == secondFakeBullet ? 'UL' : 'OL';
             }
@@ -123,7 +123,7 @@ export function processNodesDiscovery(wordConverter: WordConverter): boolean {
             // be no bullet and the list will continue correctly after that. Visually, it looks like the previous item has multiple lines, but
             // the HTML generated has multiple paragraphs with the same class. We'll merge these when we find them, so the logic doesn't skips
             // the list conversion thinking that the list items are not together...
-            let last = args.lastProcessedItem;
+            const last = args.lastProcessedItem;
             if (
                 last &&
                 getRealPreviousSibling(node) == last &&
@@ -153,24 +153,24 @@ export function processNodesDiscovery(wordConverter: WordConverter): boolean {
  * conversion needed
  */
 export function processNodeConvert(wordConverter: WordConverter): boolean {
-    let args = wordConverter.wordConverterArgs;
+    const args = wordConverter.wordConverterArgs;
     if (args) {
         args.currentIndex = 0;
 
         while (args.currentIndex < args.listItems.length) {
-            let metadata = args.listItems[args.currentIndex];
-            let node = metadata.originalNode;
-            let listMetadata = args.lists[metadata.uniqueListId.toString()];
+            const metadata = args.listItems[args.currentIndex];
+            const node = metadata.originalNode;
+            const listMetadata = args.lists[metadata.uniqueListId.toString()];
             if (!listMetadata.ignore) {
                 // We have a list item that we need to convert, get or create the list
                 // that hold this item out
-                let list = getOrCreateListForNode(wordConverter, node, metadata, listMetadata);
+                const list = getOrCreateListForNode(wordConverter, node, metadata, listMetadata);
                 if (list) {
                     // Clean the element out.. this call gets rid of the fake bullet and unneeded nodes
                     cleanupListIgnore(node, LOOKUP_DEPTH);
 
                     // Create a new list item and transfer the children
-                    let li = node.ownerDocument.createElement('LI');
+                    const li = node.ownerDocument.createElement('LI');
                     if (getTagOfNode(node).startsWith('H')) {
                         const clone = node.cloneNode(true /* deep */) as HTMLHeadingElement;
                         clone.style.textIndent = '';
@@ -217,12 +217,12 @@ function getOrCreateListForNode(
     // Here use the unique list ID to detect if we have the right list...
     // it is possible to have 2 different lists next to each other with different formats, so
     // we want to detect this an create separate lists for those cases
-    let listId = getObject(wordConverter.wordCustomData, list, UNIQUE_LIST_ID_CUSTOM_DATA);
+    const listId = getObject(wordConverter.wordCustomData, list, UNIQUE_LIST_ID_CUSTOM_DATA);
 
     // If we have a list with and ID, but the ID is different than the ID for this list item, this
     // is a completely new list, so we'll append a new list for that
     if ((listId && listId != metadata.uniqueListId) || (!listId && list.firstChild)) {
-        let newList = node.ownerDocument.createElement(listMetadata.tagName);
+        const newList = node.ownerDocument.createElement(listMetadata.tagName);
         list.parentNode?.insertBefore(newList, list.nextSibling);
         list = newList;
     }
@@ -253,7 +253,7 @@ function convertListIfNeeded(
     // Check if we need to convert the list out
     if (listMetadata.tagName != getTagOfNode(list)) {
         // We have the wrong list type.. convert it, set the id again and transfer all the children
-        let newList = list.ownerDocument?.createElement(listMetadata.tagName);
+        const newList = list.ownerDocument?.createElement(listMetadata.tagName);
         if (newList) {
             setObject(
                 wordConverter.wordCustomData,
@@ -296,7 +296,7 @@ function recurringGetOrCreateListAtNode(
 
     // Check the element that we got and verify that it is a list
     if (possibleList && possibleList.nodeType == NodeType.Element) {
-        let tag = getTagOfNode(possibleList);
+        const tag = getTagOfNode(possibleList);
         if (tag == 'UL' || tag == 'OL') {
             // We have a list.. use it
             return possibleList;
@@ -305,7 +305,7 @@ function recurringGetOrCreateListAtNode(
 
     // If we get here, it means we don't have a list and we need to create one
     // this code path will always create new lists as UL lists
-    let newList = node.ownerDocument?.createElement(listMetadata ? listMetadata.tagName : 'UL');
+    const newList = node.ownerDocument?.createElement(listMetadata ? listMetadata.tagName : 'UL');
     if (level == 1) {
         // For level 1, we'll insert the list before the node
         node.parentNode?.insertBefore(newList, node);
@@ -324,7 +324,7 @@ function recurringGetOrCreateListAtNode(
  * conversion is happening, we want to get rid of these elements
  */
 function cleanupListIgnore(node: Node, levels: number) {
-    let nodesToRemove: Node[] = [];
+    const nodesToRemove: Node[] = [];
 
     for (let child: Node | null = node.firstChild; child; child = child.nextSibling) {
         if (child) {
@@ -352,7 +352,7 @@ function cleanupListIgnore(node: Node, levels: number) {
  */
 function getListItemMetadata(node: HTMLElement): ListItemMetadata | null {
     if (node.nodeType == NodeType.Element) {
-        let listAttribute = getStyleValue(node, MSO_LIST_STYLE_NAME);
+        const listAttribute = getStyleValue(node, MSO_LIST_STYLE_NAME);
         if (listAttribute && listAttribute.length > 0) {
             try {
                 // Word mso-list property holds 3 space separated values in the following format: lst1 level1 lfo0
@@ -363,7 +363,7 @@ function getListItemMetadata(node: HTMLElement): ListItemMetadata | null {
                 // list indentation value
                 // (2) Contains a specific list identifier.
                 // Example value: "l0 level1 lfo1"
-                let listProps = listAttribute.split(' ');
+                const listProps = listAttribute.split(' ');
                 if (listProps.length == 3) {
                     return <ListItemMetadata>{
                         level: parseInt(listProps[1].substr('level'.length)),
@@ -461,7 +461,7 @@ function fixWordListComments(child: Node, removeComments: boolean): Node {
 
             // if we found the end node, wrap everything out
             if (endComment) {
-                let newSpan = child.ownerDocument?.createElement('span');
+                const newSpan = child.ownerDocument?.createElement('span');
                 newSpan?.setAttribute('style', 'mso-list: ignore');
 
                 nextElement = getRealNextSibling(child);
@@ -520,7 +520,7 @@ function getRealNextSibling(node: Node): Node | null {
  */
 function isIgnoreNode(node: Node): boolean {
     if (node.nodeType == NodeType.Element) {
-        let listAttribute = getStyleValue(node as HTMLElement, MSO_LIST_STYLE_NAME);
+        const listAttribute = getStyleValue(node as HTMLElement, MSO_LIST_STYLE_NAME);
         if (
             listAttribute &&
             listAttribute.length > 0 &&
@@ -562,7 +562,7 @@ function isEmptyTextNode(node: Node): boolean {
     }
 
     // Span or Font with an empty child node is empty
-    let tagName = getTagOfNode(node);
+    const tagName = getTagOfNode(node);
     if (
         node.firstChild &&
         node.firstChild == node.lastChild &&
@@ -578,7 +578,7 @@ function isEmptyTextNode(node: Node): boolean {
 /** Resets the list */
 function resetCurrentLists(args: WordConverterArguments) {
     for (let i = 0; i < args.currentListIdsByLevels.length; i++) {
-        let ll = args.currentListIdsByLevels[i];
+        const ll = args.currentListIdsByLevels[i];
         if (ll) {
             ll.currentUniqueListId = -1;
         }

--- a/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
@@ -92,7 +92,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                         wordToReplace = this.getWord(null);
                     }
 
-                    let insertNode = () => {
+                    const insertNode = () => {
                         if (wordToReplace && this.editor) {
                             replaceWithNode(
                                 this.editor,
@@ -167,7 +167,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
 
                     // Undo and other major changes to document content fire this type of event.
                     // Inform the data provider of the current picker placed elements in the body.
-                    let elementIds: string[] = [];
+                    const elementIds: string[] = [];
                     this.editor?.queryElements(
                         "[id^='" + this.pickerOptions.elementIdPrefix + "']",
                         element => {
@@ -255,7 +255,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
     }
 
     private getWordBeforeCursor(event: PluginKeyboardEvent | null): string | null {
-        let searcher = this.editor?.getContentSearcherOfCursor(event);
+        const searcher = this.editor?.getContentSearcherOfCursor(event);
         return searcher ? searcher.getWordBefore() : null;
     }
 
@@ -269,12 +269,12 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
     }
 
     private getRangeUntilAt(event: PluginKeyboardEvent | null): Range | null {
-        let positionContentSearcher = this.editor?.getContentSearcherOfCursor(event);
+        const positionContentSearcher = this.editor?.getContentSearcherOfCursor(event);
         let startPos: NodePosition | undefined = undefined;
         let endPos: NodePosition | undefined = undefined;
         positionContentSearcher?.forEachTextInlineElement(textInline => {
             let hasMatched = false;
-            let nodeContent = textInline.getTextContent();
+            const nodeContent = textInline.getTextContent();
             let nodeIndex = nodeContent ? nodeContent.length : -1;
             while (nodeIndex >= 0) {
                 if (nodeContent[nodeIndex] == this.pickerOptions.triggerCharacter) {
@@ -339,7 +339,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                     }
                 }
             } else {
-                let wordBeforeCursor = this.getWordBeforeCursor(event);
+                const wordBeforeCursor = this.getWordBeforeCursor(event);
                 if (!this.blockSuggestions) {
                     if (
                         wordBeforeCursor != null &&
@@ -348,7 +348,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                     ) {
                         this.setIsSuggesting(true);
                         const wordBeforeCursorWithoutTriggerChar = wordBeforeCursor.substring(1);
-                        let trimmedWordBeforeCursor = wordBeforeCursorWithoutTriggerChar.trim();
+                        const trimmedWordBeforeCursor = wordBeforeCursorWithoutTriggerChar.trim();
                         this.dataProvider.queryStringUpdated(
                             trimmedWordBeforeCursor,
                             wordBeforeCursorWithoutTriggerChar == trimmedWordBeforeCursor
@@ -356,14 +356,14 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                         this.setLastKnownRange(this.editor.getSelectionRange() ?? null);
                         if (this.dataProvider.setCursorPoint) {
                             // Determine the bounding rectangle for the @mention
-                            let searcher = this.editor.getContentSearcherOfCursor(event);
-                            let rangeNode = this.editor.getDocument().createRange();
+                            const searcher = this.editor.getContentSearcherOfCursor(event);
+                            const rangeNode = this.editor.getDocument().createRange();
 
                             if (rangeNode) {
-                                let nodeBeforeCursor =
+                                const nodeBeforeCursor =
                                     searcher?.getInlineElementBefore()?.getContainerNode() ?? null;
 
-                                let rangeStartSuccessfullySet = this.setRangeStart(
+                                const rangeStartSuccessfullySet = this.setRangeStart(
                                     rangeNode,
                                     nodeBeforeCursor,
                                     wordBeforeCursor
@@ -372,7 +372,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                                     // VSO 24891: Out of range error is occurring because nodeBeforeCursor
                                     // is not including the trigger character. In this case, the node before
                                     // the node before cursor is the trigger character, and this is where the range should start.
-                                    let nodeBeforeNodeBeforeCursor =
+                                    const nodeBeforeNodeBeforeCursor =
                                         nodeBeforeCursor?.previousSibling ?? null;
                                     this.setRangeStart(
                                         rangeNode,
@@ -392,11 +392,11 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                                     rangeNode.detach();
 
                                     // Display the @mention popup in the correct place
-                                    let targetPoint = {
+                                    const targetPoint = {
                                         x: rect.left,
                                         y: (rect.bottom + rect.top) / 2,
                                     };
-                                    let bufferZone = (rect.bottom - rect.top) / 2;
+                                    const bufferZone = (rect.bottom - rect.top) / 2;
                                     this.dataProvider.setCursorPoint(targetPoint, bufferZone);
                                 }
                             }
@@ -415,7 +415,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
     }
 
     private onKeyDownEvent(event: PluginKeyboardEvent) {
-        let keyboardEvent = event.rawEvent;
+        const keyboardEvent = event.rawEvent;
         if (this.isSuggesting) {
             if (keyboardEvent.key == ESC_CHAR_CODE) {
                 this.setIsSuggesting(false);
@@ -463,20 +463,20 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                     this.cancelDefaultKeyDownEvent(event);
                 }
             } else if (keyboardEvent.key == DELETE_CHAR_CODE) {
-                let searcher = this.editor?.getContentSearcherOfCursor(event);
+                const searcher = this.editor?.getContentSearcherOfCursor(event);
                 if (searcher) {
                     const inlineElementAfter = searcher.getInlineElementAfter();
                     let nodeAfterCursor = inlineElementAfter
                         ? inlineElementAfter.getContainerNode()
                         : null;
                     nodeAfterCursor = this.getParentNodeIfTextNode(nodeAfterCursor);
-                    let nodeId = nodeAfterCursor ? this.getIdValue(nodeAfterCursor) : null;
+                    const nodeId = nodeAfterCursor ? this.getIdValue(nodeAfterCursor) : null;
                     if (
                         nodeId &&
                         nodeId.indexOf(this.pickerOptions.elementIdPrefix) == 0 &&
                         nodeAfterCursor
                     ) {
-                        let replacementNode = this.dataProvider.onRemove(nodeAfterCursor, false);
+                        const replacementNode = this.dataProvider.onRemove(nodeAfterCursor, false);
                         this.replaceNode(nodeAfterCursor, replacementNode);
                         this.cancelDefaultKeyDownEvent(event);
                     }
@@ -554,8 +554,8 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
     }
 
     private getWord(event: PluginKeyboardEvent | null) {
-        let wordFromRange = this.getRangeUntilAt(event)?.toString() ?? '';
-        let wordFromCache = this.getWordBeforeCursor(event);
+        const wordFromRange = this.getRangeUntilAt(event)?.toString() ?? '';
+        const wordFromCache = this.getWordBeforeCursor(event);
         // VSO 24891: In picker, trigger and mention are separated into two nodes.
         // In this case, wordFromRange is the trigger character while wordFromCache is the whole string,
         // so wordFromCache is what we want to return.
@@ -569,7 +569,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
     }
 
     private setRangeStart(rangeNode: Range, node: Node | null, target: string) {
-        let nodeOffset = node?.textContent ? node.textContent.lastIndexOf(target) : -1;
+        const nodeOffset = node?.textContent ? node.textContent.lastIndexOf(target) : -1;
         if (node && nodeOffset > -1) {
             rangeNode.setStart(node, nodeOffset);
             return true;

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyDownEvent.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyDownEvent.ts
@@ -169,7 +169,7 @@ function getNextTD(
         state.lastTarget && editor.getElementAtCursor(TABLE_CELL_SELECTOR, state.lastTarget);
 
     if (safeInstanceOf(state.lastTarget, 'HTMLTableCellElement') && state.vTable?.cells) {
-        let coordinates = getCellCoordinates(state.vTable, state.lastTarget);
+        const coordinates = getCellCoordinates(state.vTable, state.lastTarget);
 
         if (state.tableSelection && coordinates) {
             switch (event.rawEvent.which) {

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/utils/normalizeTableSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/utils/normalizeTableSelection.ts
@@ -16,11 +16,11 @@ export default function normalizeTableSelection(vTable: VTable): TableSelection 
 
     const cells = vTable.cells;
 
-    let newFirst = {
+    const newFirst = {
         x: Math.min(firstCell.x, lastCell.x),
         y: Math.min(firstCell.y, lastCell.y),
     };
-    let newLast = {
+    const newLast = {
         x: Math.max(firstCell.x, lastCell.x),
         y: Math.max(firstCell.y, lastCell.y),
     };

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableResize/editors/TableInserter.ts
@@ -106,7 +106,7 @@ class TableInsertHandler implements Disposable {
     }
 
     private insertTd = () => {
-        let vtable = new VTable(this.td);
+        const vtable = new VTable(this.td);
         if (!this.isHorizontal) {
             vtable.normalizeTableCellSize(this.editor.getZoomScale());
 

--- a/packages/roosterjs/lib/createEditor.ts
+++ b/packages/roosterjs/lib/createEditor.ts
@@ -22,7 +22,7 @@ export default function createEditor(
         plugins = plugins.concat(additionalPlugins);
     }
 
-    let options: EditorOptions = {
+    const options: EditorOptions = {
         plugins: plugins,
         initialContent: initialContent,
         getDarkColor: getDarkColor,


### PR DESCRIPTION
Enable eslint rules:
- prefer-const: If a variable is not changed, use `const` rather than `let`
- no-var: Do not use `var` to declare variables