### PR TITLE
Standalone editor: Decouple DarkColorHandler

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
@@ -1,4 +1,4 @@
-import { DarkColorHandler } from 'roosterjs-editor-types';
+import { ColorManager } from 'roosterjs-content-model-types';
 import { getColor, setColor } from '../../../lib/formatHandlers/utils/color';
 import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
 
@@ -7,33 +7,33 @@ describe('getColor with darkColorHandler', () => {
         const parseColorValue = jasmine.createSpy().and.returnValue({
             lightModeColor: 'green',
         });
-        const darkColorHandler = ({ parseColorValue } as any) as DarkColorHandler;
+        const darkColorHandler = ({ parseColorValue } as any) as ColorManager;
         const div = document.createElement('div');
         const color = getColor(div, false, darkColorHandler, false);
 
         expect(color).toBe('green');
         expect(parseColorValue).toHaveBeenCalledTimes(1);
-        expect(parseColorValue).toHaveBeenCalledWith(undefined);
+        expect(parseColorValue).toHaveBeenCalledWith(undefined, false);
     });
 
     it('getColor from no color, dark mode', () => {
         const parseColorValue = jasmine.createSpy().and.returnValue({
             lightModeColor: 'green',
         });
-        const darkColorHandler = ({ parseColorValue } as any) as DarkColorHandler;
+        const darkColorHandler = ({ parseColorValue } as any) as ColorManager;
         const div = document.createElement('div');
         const color = getColor(div, false, darkColorHandler, true);
 
         expect(color).toBe('green');
         expect(parseColorValue).toHaveBeenCalledTimes(1);
-        expect(parseColorValue).toHaveBeenCalledWith(undefined);
+        expect(parseColorValue).toHaveBeenCalledWith(undefined, true);
     });
 
-    it('getColor from style color, light mode', () => {
+    it('getColor from style color, dark mode', () => {
         const parseColorValue = jasmine.createSpy().and.returnValue({
             lightModeColor: 'green',
         });
-        const darkColorHandler = ({ parseColorValue } as any) as DarkColorHandler;
+        const darkColorHandler = ({ parseColorValue } as any) as ColorManager;
         const div = document.createElement('div');
 
         div.style.color = 'red';
@@ -42,14 +42,14 @@ describe('getColor with darkColorHandler', () => {
 
         expect(color).toBe('green');
         expect(parseColorValue).toHaveBeenCalledTimes(1);
-        expect(parseColorValue).toHaveBeenCalledWith('red');
+        expect(parseColorValue).toHaveBeenCalledWith('red', true);
     });
 
-    it('getColor from attr color, light mode', () => {
+    it('getColor from attr color, dark mode', () => {
         const parseColorValue = jasmine.createSpy().and.returnValue({
             lightModeColor: 'green',
         });
-        const darkColorHandler = ({ parseColorValue } as any) as DarkColorHandler;
+        const darkColorHandler = ({ parseColorValue } as any) as ColorManager;
         const div = document.createElement('div');
 
         div.setAttribute('color', 'blue');
@@ -57,14 +57,14 @@ describe('getColor with darkColorHandler', () => {
 
         expect(color).toBe('green');
         expect(parseColorValue).toHaveBeenCalledTimes(1);
-        expect(parseColorValue).toHaveBeenCalledWith('blue');
+        expect(parseColorValue).toHaveBeenCalledWith('blue', true);
     });
 
-    it('getColor from attr color with var, light mode', () => {
+    it('getColor from attr color with var, dark mode', () => {
         const parseColorValue = jasmine.createSpy().and.returnValue({
             lightModeColor: 'green',
         });
-        const darkColorHandler = ({ parseColorValue } as any) as DarkColorHandler;
+        const darkColorHandler = ({ parseColorValue } as any) as ColorManager;
         const div = document.createElement('div');
 
         div.style.color = 'var(--varName, blue)';
@@ -72,14 +72,14 @@ describe('getColor with darkColorHandler', () => {
 
         expect(color).toBe('green');
         expect(parseColorValue).toHaveBeenCalledTimes(1);
-        expect(parseColorValue).toHaveBeenCalledWith('var(--varName, blue)');
+        expect(parseColorValue).toHaveBeenCalledWith('var(--varName, blue)', true);
     });
 
-    it('getColor from style color with data-ogsc, light mode', () => {
+    it('getColor from style color with data-ogsc, dark mode', () => {
         const parseColorValue = jasmine.createSpy().and.returnValue({
             lightModeColor: 'green',
         });
-        const darkColorHandler = ({ parseColorValue } as any) as DarkColorHandler;
+        const darkColorHandler = ({ parseColorValue } as any) as ColorManager;
         const div = document.createElement('div');
 
         div.dataset.ogsc = 'yellow';
@@ -88,36 +88,14 @@ describe('getColor with darkColorHandler', () => {
 
         expect(color).toBe('green');
         expect(parseColorValue).toHaveBeenCalledTimes(1);
-        expect(parseColorValue).toHaveBeenCalledWith('red');
-    });
-
-    it('get color from FONT tag in dark mode', () => {
-        const parseColorValue = jasmine.createSpy().and.returnValue({
-            lightModeColor: 'green',
-        });
-        const findLightColorFromDarkColor = jasmine.createSpy().and.returnValue('red');
-        const darkColorHandler = ({
-            parseColorValue,
-            findLightColorFromDarkColor,
-        } as any) as DarkColorHandler;
-        const font = document.createElement('font');
-
-        font.color = '#112233';
-
-        const color = getColor(font, false, darkColorHandler, true);
-
-        expect(color).toBe('green');
-        expect(parseColorValue).toHaveBeenCalledTimes(1);
-        expect(parseColorValue).toHaveBeenCalledWith('red');
-        expect(findLightColorFromDarkColor).toHaveBeenCalledTimes(1);
-        expect(findLightColorFromDarkColor).toHaveBeenCalledWith('#112233');
+        expect(parseColorValue).toHaveBeenCalledWith('red', true);
     });
 });
 
 describe('setColor with darkColorHandler', () => {
     it('setColor from no color, light mode', () => {
         const registerColor = jasmine.createSpy().and.returnValue('green');
-        const darkColorHandler = ({ registerColor } as any) as DarkColorHandler;
+        const darkColorHandler = ({ registerColor } as any) as ColorManager;
         const div = document.createElement('div');
         setColor(div, '', false, darkColorHandler, false);
 
@@ -128,7 +106,7 @@ describe('setColor with darkColorHandler', () => {
 
     it('setColor from no color, dark mode', () => {
         const registerColor = jasmine.createSpy().and.returnValue('green');
-        const darkColorHandler = ({ registerColor } as any) as DarkColorHandler;
+        const darkColorHandler = ({ registerColor } as any) as ColorManager;
         const div = document.createElement('div');
         setColor(div, '', false, darkColorHandler, true);
 
@@ -146,7 +124,7 @@ describe('setColor with darkColorHandler', () => {
 
     itChromeOnly('setColor from a color with existing color, dark mode', () => {
         const registerColor = jasmine.createSpy().and.returnValue('green');
-        const darkColorHandler = ({ registerColor } as any) as DarkColorHandler;
+        const darkColorHandler = ({ registerColor } as any) as ColorManager;
         const div = document.createElement('div');
 
         div.style.color = 'blue';

--- a/packages-content-model/roosterjs-content-model-types/lib/context/ColorManager.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/context/ColorManager.ts
@@ -1,0 +1,36 @@
+/**
+ * Represents a combination of color key, light color and dark color, parsed from existing color value
+ */
+export interface Colors {
+    /**
+     * Light mode color value
+     */
+    lightModeColor: string;
+
+    /**
+     * Dark mode color value, if found, otherwise undefined
+     */
+    darkModeColor?: string;
+}
+
+/**
+ * A handler object for dark color, used for variable-based dark color solution
+ */
+export interface ColorManager {
+    /**
+     * Given a light mode color value and an optional dark mode color value, register this color
+     * so that editor can handle it, then return the CSS color value for current color mode.
+     * @param lightModeColor Light mode color value
+     * @param isDarkMode Whether current color mode is dark mode
+     */
+    registerColor(lightModeColor: string, isDarkMode: boolean): string;
+
+    /**
+     * Parse an existing color value, if it is in variable-based color format, extract color key,
+     * light color and query related dark color if any
+     * @param color The color string to parse
+     * @param isInDarkMode Whether current content is in dark mode. When set to true, if the color value is not in dark var format,
+     * we will treat is as a dark mode color and try to find a matched dark mode color.
+     */
+    parseColorValue(color: string | null | undefined, isInDarkMode?: boolean): Colors;
+}

--- a/packages-content-model/roosterjs-content-model-types/lib/context/EditorContext.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/context/EditorContext.ts
@@ -1,6 +1,6 @@
+import type { ColorManager } from './ColorManager';
 import type { ContentModelDomIndexer } from './ContentModelDomIndexer';
 import type { ContentModelSegmentFormat } from '../format/ContentModelSegmentFormat';
-import type { DarkColorHandler } from 'roosterjs-editor-types';
 
 /**
  * An editor context interface used by ContentModel PAI
@@ -17,9 +17,9 @@ export interface EditorContext {
     defaultFormat?: ContentModelSegmentFormat;
 
     /**
-     * Dark model color handler
+     * Color manager, to help manager color in dark mode
      */
-    darkColorHandler?: DarkColorHandler | null;
+    darkColorHandler?: ColorManager;
 
     /**
      * Whether to handle delimiters in Content Model

--- a/packages-content-model/roosterjs-content-model-types/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/index.ts
@@ -150,3 +150,4 @@ export {
 export { DomToModelOption } from './context/DomToModelOption';
 export { ModelToDomOption } from './context/ModelToDomOption';
 export { ContentModelDomIndexer } from './context/ContentModelDomIndexer';
+export { ColorManager, Colors } from './context/ColorManager';


### PR DESCRIPTION
Remove the dependency to DarkColorHandler type by creating a reduced interface `ColorManager` in `roosterjs-content-model-types` package