### PR TITLE
Standalone editor: Remove dependencies to enums Part 1

### DIFF
--- a/demo/scripts/controls/contentModel/components/format/formatPart/TableMetadataFormatRenders.ts
+++ b/demo/scripts/controls/contentModel/components/format/formatPart/TableMetadataFormatRenders.ts
@@ -1,9 +1,8 @@
-import { CompatibleTableBorderFormat } from 'roosterjs-editor-types/lib/compatibleTypes';
 import { createCheckboxFormatRenderer } from '../utils/createCheckboxFormatRenderer';
 import { createColorFormatRenderer } from '../utils/createColorFormatRender';
 import { createDropDownFormatRenderer } from '../utils/createDropDownFormatRenderer';
 import { FormatRenderer } from '../utils/FormatRenderer';
-import { TableMetadataFormat } from 'roosterjs-content-model-types';
+import { TableBorderFormat, TableMetadataFormat } from 'roosterjs-content-model-types';
 
 export const TableMetadataFormatRenders: FormatRenderer<TableMetadataFormat>[] = [
     createColorFormatRenderer<TableMetadataFormat>(
@@ -58,7 +57,7 @@ export const TableMetadataFormatRenders: FormatRenderer<TableMetadataFormat>[] =
         format => format.bgColorOdd,
         (format, value) => (format.bgColorOdd = value)
     ),
-    createDropDownFormatRenderer<TableMetadataFormat, keyof typeof CompatibleTableBorderFormat>(
+    createDropDownFormatRenderer<TableMetadataFormat, keyof typeof TableBorderFormat>(
         'TableBorderFormat',
         [
             'DEFAULT',
@@ -71,10 +70,7 @@ export const TableMetadataFormatRenders: FormatRenderer<TableMetadataFormat>[] =
             'ESPECIAL_TYPE_3',
             'CLEAR',
         ],
-        format =>
-            CompatibleTableBorderFormat[
-                format.tableBorderFormat
-            ] as keyof typeof CompatibleTableBorderFormat,
-        (format, newValue) => (format.tableBorderFormat = CompatibleTableBorderFormat[newValue])
+        format => TableBorderFormat[format.tableBorderFormat] as keyof typeof TableBorderFormat,
+        (format, newValue) => (format.tableBorderFormat = TableBorderFormat[newValue])
     ),
 ];

--- a/demo/scripts/controls/ribbonButtons/contentModel/ContentModelRibbonPlugin.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/ContentModelRibbonPlugin.ts
@@ -1,6 +1,6 @@
+import { FormatState, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import { getObjectKeys } from 'roosterjs-editor-dom';
 import { LocalizedStrings, RibbonButton, RibbonPlugin, UIUtilities } from 'roosterjs-react';
-import { PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import {
     ContentModelFormatState,
     getFormatState,
@@ -9,7 +9,7 @@ import {
 
 export class ContentModelRibbonPlugin implements RibbonPlugin {
     private editor: IContentModelEditor | null = null;
-    private onFormatChanged: ((formatState: ContentModelFormatState) => void) | null = null;
+    private onFormatChanged: ((formatState: FormatState) => void) | null = null;
     private timer = 0;
     private formatState: ContentModelFormatState | null = null;
     private uiUtilities: UIUtilities | null = null;
@@ -72,7 +72,7 @@ export class ContentModelRibbonPlugin implements RibbonPlugin {
     /**
      * Register a callback to be invoked when format state of editor is changed, returns a disposer function.
      */
-    registerFormatChangedCallback(callback: (formatState: ContentModelFormatState) => void) {
+    registerFormatChangedCallback(callback: (formatState: FormatState) => void) {
         this.onFormatChanged = callback;
 
         return () => {
@@ -162,7 +162,7 @@ export class ContentModelRibbonPlugin implements RibbonPlugin {
                 )
             ) {
                 this.formatState = newFormatState;
-                this.onFormatChanged(newFormatState);
+                this.onFormatChanged((newFormatState as any) as FormatState);
             }
         }
     }

--- a/demo/scripts/controls/ribbonButtons/contentModel/formatTableButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/formatTableButton.ts
@@ -1,6 +1,194 @@
 import { formatTable, isContentModelEditor } from 'roosterjs-content-model-editor';
-import { PREDEFINED_STYLES } from '../../sidePane/shared/PredefinedTableStyles';
 import { RibbonButton } from 'roosterjs-react';
+import { TableBorderFormat, TableMetadataFormat } from 'roosterjs-content-model-types';
+
+const PREDEFINED_STYLES: Record<
+    string,
+    (color?: string, lightColor?: string) => TableMetadataFormat
+> = {
+    DEFAULT: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            color /** verticalColors*/,
+            false /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.DEFAULT /** tableBorderFormat */,
+            null /** bgColorEven */,
+            lightColor /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+    DEFAULT_WITH_BACKGROUND_COLOR: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            color /** verticalColors*/,
+            false /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.DEFAULT /** tableBorderFormat */,
+            null /** bgColorEven */,
+            lightColor /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+    GRID_WITHOUT_BORDER: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            color /** verticalColors*/,
+            true /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.NO_SIDE_BORDERS /** tableBorderFormat */,
+            null /** bgColorEven */,
+            lightColor /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+    LIST: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            null /** verticalColors*/,
+            false /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.DEFAULT /** tableBorderFormat */,
+            null /** bgColorEven */,
+            lightColor /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+    BANDED_ROWS_FIRST_COLUMN_NO_BORDER: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            color /** verticalColors*/,
+            false /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.FIRST_COLUMN_HEADER_EXTERNAL /** tableBorderFormat */,
+            null /** bgColorEven */,
+            lightColor /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+    EXTERNAL: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            color /** verticalColors*/,
+            false /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.LIST_WITH_SIDE_BORDERS /** tableBorderFormat */,
+            null /** bgColorEven */,
+            lightColor /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+    NO_HEADER_VERTICAL: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            color /** verticalColors*/,
+            false /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.NO_HEADER_BORDERS /** tableBorderFormat */,
+            null /** bgColorEven */,
+            lightColor /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+    ESPECIAL_TYPE_1: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            color /** verticalColors*/,
+            false /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.ESPECIAL_TYPE_1 /** tableBorderFormat */,
+            null /** bgColorEven */,
+            lightColor /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+    ESPECIAL_TYPE_2: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            color /** verticalColors*/,
+            false /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.ESPECIAL_TYPE_2 /** tableBorderFormat */,
+            null /** bgColorEven */,
+            lightColor /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+    ESPECIAL_TYPE_3: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            color /** verticalColors*/,
+            false /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.ESPECIAL_TYPE_3 /** tableBorderFormat */,
+            lightColor /** bgColorEven */,
+            null /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+    CLEAR: (color, lightColor) =>
+        createTableFormat(
+            color /**topBorder */,
+            color /**bottomBorder */,
+            color /** verticalColors*/,
+            false /** bandedRows */,
+            false /** bandedColumns */,
+            false /** headerRow */,
+            false /** firstColumn */,
+            TableBorderFormat.CLEAR /** tableBorderFormat */,
+            lightColor /** bgColorEven */,
+            null /** bgColorOdd */,
+            color /** headerRowColor */
+        ),
+};
+
+export function createTableFormat(
+    topBorder?: string,
+    bottomBorder?: string,
+    verticalBorder?: string,
+    bandedRows?: boolean,
+    bandedColumns?: boolean,
+    headerRow?: boolean,
+    firstColumn?: boolean,
+    borderFormat?: TableBorderFormat,
+    bgColorEven?: string,
+    bgColorOdd?: string,
+    headerRowColor?: string
+): TableMetadataFormat {
+    return {
+        topBorderColor: topBorder,
+        bottomBorderColor: bottomBorder,
+        verticalBorderColor: verticalBorder,
+        hasBandedRows: bandedRows,
+        bgColorEven: bgColorEven,
+        bgColorOdd: bgColorOdd,
+        hasBandedColumns: bandedColumns,
+        hasHeaderRow: headerRow,
+        headerRowColor: headerRowColor,
+        hasFirstColumn: firstColumn,
+        tableBorderFormat: borderFormat,
+    };
+}
 
 export const formatTableButton: RibbonButton<'ribbonButtonTableFormat'> = {
     key: 'ribbonButtonTableFormat',

--- a/demo/scripts/controls/ribbonButtons/contentModel/setBulletedListStyleButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/setBulletedListStyleButton.ts
@@ -1,4 +1,4 @@
-import { BulletListType } from 'roosterjs-editor-types';
+import { BulletListType } from 'roosterjs-content-model-types';
 import { isContentModelEditor, setListStyle } from 'roosterjs-content-model-editor';
 import { RibbonButton } from 'roosterjs-react';
 const dropDownMenuItems = {

--- a/demo/scripts/controls/ribbonButtons/contentModel/setNumberedListStyleButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/setNumberedListStyleButton.ts
@@ -1,5 +1,5 @@
 import { isContentModelEditor, setListStyle } from 'roosterjs-content-model-editor';
-import { NumberingListType } from 'roosterjs-editor-types';
+import { NumberingListType } from 'roosterjs-content-model-types';
 import { RibbonButton } from 'roosterjs-react';
 
 const dropDownMenuItems = {

--- a/demo/scripts/controls/sidePane/apiPlayground/vtable/PredefinedTableStyles.ts
+++ b/demo/scripts/controls/sidePane/apiPlayground/vtable/PredefinedTableStyles.ts
@@ -1,9 +1,8 @@
 import { TableBorderFormat, TableFormat } from 'roosterjs-editor-types';
-import { TableMetadataFormat } from 'roosterjs-content-model-types';
 
 export const PREDEFINED_STYLES: Record<
     string,
-    (color?: string, lightColor?: string) => TableFormat & TableMetadataFormat
+    (color?: string, lightColor?: string) => TableFormat
 > = {
     DEFAULT: (color, lightColor) =>
         createTableFormat(
@@ -173,7 +172,7 @@ export function createTableFormat(
     bgColorEven?: string,
     bgColorOdd?: string,
     headerRowColor?: string
-): TableFormat & TableMetadataFormat {
+): TableFormat {
     return {
         topBorderColor: topBorder,
         bottomBorderColor: bottomBorder,

--- a/demo/scripts/controls/sidePane/apiPlayground/vtable/VTablePane.tsx
+++ b/demo/scripts/controls/sidePane/apiPlayground/vtable/VTablePane.tsx
@@ -2,7 +2,7 @@ import * as Color from 'color';
 import * as React from 'react';
 import ApiPaneProps from '../ApiPaneProps';
 import ColorPicker from '../../../colorPicker/ColorPicker';
-import { createTableFormat, PREDEFINED_STYLES } from '../../shared/PredefinedTableStyles';
+import { createTableFormat, PREDEFINED_STYLES } from './PredefinedTableStyles';
 import { editTable, formatTable } from 'roosterjs-editor-api';
 import { getTagOfNode, VTable } from 'roosterjs-editor-dom';
 import { IEditor, PositionType, TableFormat, TableOperation, VCell } from 'roosterjs-editor-types';

--- a/demo/scripts/controls/sidePane/formatState/ContentModelFormatStatePlugin.ts
+++ b/demo/scripts/controls/sidePane/formatState/ContentModelFormatStatePlugin.ts
@@ -1,4 +1,5 @@
 import FormatStatePlugin from './FormatStatePlugin';
+import { FormatState } from 'roosterjs-editor-types';
 import { getFormatState, IContentModelEditor } from 'roosterjs-content-model-editor';
 import { getPositionRect } from 'roosterjs-editor-dom';
 
@@ -8,7 +9,7 @@ export default class ContentModelFormatStatePlugin extends FormatStatePlugin {
             return null;
         }
 
-        const format = getFormatState(this.editor as IContentModelEditor);
+        const format = (getFormatState(this.editor as IContentModelEditor) as any) as FormatState;
         const position = this.editor && this.editor.getFocusedPosition();
         const rect = position && getPositionRect(position);
         return {

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/listProcessorTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/listProcessorTest.ts
@@ -1,10 +1,14 @@
 import * as stackFormat from '../../../lib/domToModel/utils/stackFormat';
-import { BulletListType, NumberingListType } from 'roosterjs-editor-types';
 import { childProcessor as originalChildProcessor } from '../../../lib/domToModel/processors/childProcessor';
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
-import { DomToModelContext, ElementProcessor } from 'roosterjs-content-model-types';
 import { listProcessor } from '../../../lib/domToModel/processors/listProcessor';
+import {
+    BulletListType,
+    DomToModelContext,
+    ElementProcessor,
+    NumberingListType,
+} from 'roosterjs-content-model-types';
 
 describe('listProcessor', () => {
     let context: DomToModelContext;

--- a/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleListTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleListTest.ts
@@ -1,10 +1,14 @@
-import { BulletListType, NumberingListType } from 'roosterjs-editor-types';
-import { ContentModelListItem, ModelToDomContext } from 'roosterjs-content-model-types';
 import { createListItem } from '../../../lib/modelApi/creators/createListItem';
 import { createListLevel } from '../../../lib/modelApi/creators/createListLevel';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { expectHtml } from 'roosterjs-editor-dom/test/DomTestHelper';
 import { handleList } from '../../../lib/modelToDom/handlers/handleList';
+import {
+    BulletListType,
+    ContentModelListItem,
+    ModelToDomContext,
+    NumberingListType,
+} from 'roosterjs-content-model-types';
 
 describe('handleList without format handlers', () => {
     let context: ModelToDomContext;

--- a/packages-content-model/roosterjs-content-model-editor/lib/domUtils/metadata/updateListMetadata.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/domUtils/metadata/updateListMetadata.ts
@@ -1,4 +1,4 @@
-import { BulletListType, NumberingListType } from 'roosterjs-editor-types';
+import { BulletListType, NumberingListType } from 'roosterjs-content-model-types';
 import { createNumberDefinition, createObjectDefinition } from './definitionCreators';
 import { getObjectKeys, updateMetadata } from 'roosterjs-content-model-dom';
 import type {

--- a/packages-content-model/roosterjs-content-model-editor/lib/domUtils/metadata/updateTableCellMetadata.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/domUtils/metadata/updateTableCellMetadata.ts
@@ -1,7 +1,6 @@
 import { createBooleanDefinition, createObjectDefinition } from './definitionCreators';
 import { updateMetadata } from 'roosterjs-content-model-dom';
-import type { ContentModelTableCell } from 'roosterjs-content-model-types';
-import type { TableCellMetadataFormat } from 'roosterjs-editor-types';
+import type { ContentModelTableCell, TableCellMetadataFormat } from 'roosterjs-content-model-types';
 
 const TableCellMetadataFormatDefinition = createObjectDefinition<Required<TableCellMetadataFormat>>(
     {

--- a/packages-content-model/roosterjs-content-model-editor/lib/domUtils/metadata/updateTableMetadata.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/domUtils/metadata/updateTableMetadata.ts
@@ -1,11 +1,11 @@
+import { TableBorderFormat } from 'roosterjs-content-model-types';
+import { updateMetadata } from 'roosterjs-content-model-dom';
 import {
     createBooleanDefinition,
     createNumberDefinition,
     createObjectDefinition,
     createStringDefinition,
 } from './definitionCreators';
-import { TableBorderFormat } from 'roosterjs-editor-types';
-import { updateMetadata } from 'roosterjs-content-model-dom';
 import type { ContentModelTable, TableMetadataFormat } from 'roosterjs-content-model-types';
 
 const NullStringDefinition = createStringDefinition(

--- a/packages-content-model/roosterjs-content-model-editor/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/index.ts
@@ -33,6 +33,9 @@ export {
     FormatWithContentModelContext,
     FormatWithContentModelOptions,
     ContentModelFormatter,
+    EntityLifecycleOperation,
+    EntityOperation,
+    EntityRemovalOperation,
 } from './publicTypes/parameter/FormatWithContentModelContext';
 export {
     InsertEntityOptions,

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/retrieveModelFormatState.ts
@@ -168,7 +168,6 @@ function retrieveParagraphFormat(
     mergeValue(result, 'marginBottom', paragraph.format.marginBottom, isFirst);
     mergeValue(result, 'marginTop', paragraph.format.marginTop, isFirst);
     mergeValue(result, 'headingLevel', validHeadingLevel, isFirst);
-    mergeValue(result, 'headerLevel', validHeadingLevel, isFirst);
     mergeValue(result, 'textAlign', paragraph.format.textAlign, isFirst);
     mergeValue(result, 'direction', paragraph.format.direction, isFirst);
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/utils/deleteBlock.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/utils/deleteBlock.ts
@@ -1,6 +1,8 @@
-import { EntityOperation } from 'roosterjs-editor-types';
 import type { ContentModelBlock } from 'roosterjs-content-model-types';
-import type { FormatWithContentModelContext } from '../../../publicTypes/parameter/FormatWithContentModelContext';
+import type {
+    EntityRemovalOperation,
+    FormatWithContentModelContext,
+} from '../../../publicTypes/parameter/FormatWithContentModelContext';
 
 /**
  * @internal
@@ -21,12 +23,12 @@ export function deleteBlock(
             return true;
 
         case 'Entity':
-            const operation = blockToDelete.isSelected
-                ? EntityOperation.Overwrite
+            const operation: EntityRemovalOperation | undefined = blockToDelete.isSelected
+                ? 'overwrite'
                 : direction == 'forward'
-                ? EntityOperation.RemoveFromStart
+                ? 'removeFromStart'
                 : direction == 'backward'
-                ? EntityOperation.RemoveFromEnd
+                ? 'removeFromEnd'
                 : undefined;
 
             if (operation !== undefined) {

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/utils/deleteSegment.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/utils/deleteSegment.ts
@@ -1,9 +1,11 @@
 import { deleteSingleChar } from './deleteSingleChar';
-import { EntityOperation } from 'roosterjs-editor-types';
 import { isWhiteSpacePreserved, normalizeSingleSegment } from 'roosterjs-content-model-dom';
 import { normalizeText } from '../../../domUtils/stringUtil';
 import type { ContentModelParagraph, ContentModelSegment } from 'roosterjs-content-model-types';
-import type { FormatWithContentModelContext } from '../../../publicTypes/parameter/FormatWithContentModelContext';
+import type {
+    EntityRemovalOperation,
+    FormatWithContentModelContext,
+} from '../../../publicTypes/parameter/FormatWithContentModelContext';
 
 /**
  * @internal
@@ -32,12 +34,12 @@ export function deleteSegment(
             return true;
 
         case 'Entity':
-            const operation = segmentToDelete.isSelected
-                ? EntityOperation.Overwrite
+            const operation: EntityRemovalOperation | undefined = segmentToDelete.isSelected
+                ? 'overwrite'
                 : isForward
-                ? EntityOperation.RemoveFromStart
+                ? 'removeFromStart'
                 : isBackward
-                ? EntityOperation.RemoveFromEnd
+                ? 'removeFromEnd'
                 : undefined;
             if (operation !== undefined) {
                 segments.splice(index, 1);

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/table/applyTableFormat.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/table/applyTableFormat.ts
@@ -1,7 +1,7 @@
 import { BorderKeys } from 'roosterjs-content-model-dom';
 import { combineBorderValue, extractBorderValues } from '../../domUtils/borderValues';
 import { setTableCellBackgroundColor } from './setTableCellBackgroundColor';
-import { TableBorderFormat } from 'roosterjs-editor-types';
+import { TableBorderFormat } from 'roosterjs-content-model-types';
 import { updateTableCellMetadata } from '../../domUtils/metadata/updateTableCellMetadata';
 import { updateTableMetadata } from '../../domUtils/metadata/updateTableMetadata';
 import type {

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
@@ -1,10 +1,11 @@
-import { ChangeSource, PluginEventType } from 'roosterjs-editor-types';
+import { ChangeSource, EntityOperation, PluginEventType } from 'roosterjs-editor-types';
 import { getPendingFormat, setPendingFormat } from '../../modelApi/format/pendingFormat';
 import type { Entity } from 'roosterjs-editor-types';
 import type { ContentModelContentChangedEventData } from '../../publicTypes/event/ContentModelContentChangedEvent';
 import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import type {
     ContentModelFormatter,
+    EntityRemovalOperation,
     FormatWithContentModelContext,
     FormatWithContentModelOptions,
 } from '../../publicTypes/parameter/FormatWithContentModelContext';
@@ -101,6 +102,14 @@ function handleNewEntities(editor: IContentModelEditor, context: FormatWithConte
     }
 }
 
+// This is only used for compatibility with old editor
+// TODO: Remove this map once we have standalone editor
+const EntityOperationMap: Record<EntityRemovalOperation, EntityOperation> = {
+    overwrite: EntityOperation.Overwrite,
+    removeFromEnd: EntityOperation.RemoveFromEnd,
+    removeFromStart: EntityOperation.RemoveFromStart,
+};
+
 function handleDeletedEntities(
     editor: IContentModelEditor,
     context: FormatWithContentModelContext
@@ -123,7 +132,7 @@ function handleDeletedEntities(
                 };
                 editor.triggerPluginEvent(PluginEventType.EntityOperation, {
                     entity,
-                    operation,
+                    operation: EntityOperationMap[operation],
                     rawEvent: context.rawEvent,
                 });
             }

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/format/formatState/ContentModelFormatState.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/format/formatState/ContentModelFormatState.ts
@@ -1,10 +1,155 @@
-import type { FormatState } from 'roosterjs-editor-types';
+import type { TableMetadataFormat } from 'roosterjs-content-model-types';
 import type { ImageFormatState } from './ImageFormatState';
 
 /**
  * The format object state in Content Model
  */
-export interface ContentModelFormatState extends FormatState {
+export interface ContentModelFormatState {
+    /**
+     * Whether the text is bolded
+     */
+    isBold?: boolean;
+
+    /**
+     * Whether the text is italic
+     */
+    isItalic?: boolean;
+
+    /**
+     * Whether the text has underline
+     */
+    isUnderline?: boolean;
+
+    /**
+     * Whether the text has strike through line
+     */
+    isStrikeThrough?: boolean;
+
+    /**
+     * Whether the text is in subscript mode
+     */
+    isSubscript?: boolean;
+
+    /**
+     * Whether the text is in superscript mode
+     */
+    isSuperscript?: boolean;
+
+    /**
+     * Whether the text is in bullet mode
+     */
+    isBullet?: boolean;
+
+    /**
+     * Whether the text is in numbering mode
+     */
+    isNumbering?: boolean;
+
+    /**
+     * Whether the text is in block quote
+     */
+    isBlockQuote?: boolean;
+
+    /**
+     * Whether the text is in Code element
+     */
+    isCodeInline?: boolean;
+
+    /**
+     * Whether the text is in Code block
+     */
+    isCodeBlock?: boolean;
+
+    /**
+     * Whether unlink command can be called to the text
+     */
+    canUnlink?: boolean;
+
+    /**
+     * Whether the selected text is multiline
+     */
+    isMultilineSelection?: boolean;
+
+    /**
+     * Whether add image alt text command can be called to the text
+     */
+    canAddImageAltText?: boolean;
+
+    /**
+     * Heading level (0-6, 0 means no heading)
+     */
+    headingLevel?: number;
+
+    /**
+     * Whether the cursor is in table
+     */
+    isInTable?: boolean;
+
+    /**
+     * Format of table, if there is table at cursor position
+     */
+    tableFormat?: TableMetadataFormat;
+
+    /**
+     * If there is a table, whether the table has header row
+     */
+    tableHasHeader?: boolean;
+
+    /**
+     * Whether we can execute table cell merge operation
+     */
+    canMergeTableCell?: boolean;
+
+    /**
+     * Font name
+     */
+    fontName?: string;
+
+    /**
+     * Font size
+     */
+    fontSize?: string;
+
+    /**
+     * Background color
+     */
+    backgroundColor?: string;
+
+    /**
+     * Text color
+     */
+    textColor?: string;
+
+    /**
+     * Line height
+     */
+    lineHeight?: string;
+
+    /**
+     * Margin Top
+     */
+    marginTop?: string;
+
+    /**
+     * Margin Bottom
+     */
+    marginBottom?: string;
+
+    /**
+     * Text Align
+     */
+    textAlign?: string;
+
+    /**
+     * Direction of the element ('ltr' or 'rtl')
+     */
+    direction?: string;
+
+    /**
+     * Font weight
+     */
+    fontWeight?: string;
+
     /**
      * Format of image, if there is table at cursor position
      */
@@ -14,4 +159,24 @@ export interface ContentModelFormatState extends FormatState {
      * Letter spacing
      */
     letterSpacing?: string;
+
+    /**
+     * Whether the content can be undone
+     */
+    canUndo?: boolean;
+
+    /**
+     * Whether the content ca nbe redone
+     */
+    canRedo?: boolean;
+
+    /**
+     * Whether editor is in dark mode
+     */
+    isDarkMode?: boolean;
+
+    /**
+     * Current zoom scale of editor
+     */
+    zoomScale?: number;
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/FormatWithContentModelContext.ts
@@ -1,4 +1,3 @@
-import type { EntityOperation } from 'roosterjs-editor-types';
 import type {
     ContentModelDocument,
     ContentModelEntity,
@@ -6,20 +5,66 @@ import type {
     DOMSelection,
     OnNodeCreated,
 } from 'roosterjs-content-model-types';
-import type { CompatibleEntityOperation } from 'roosterjs-editor-types/lib/compatibleTypes';
+
+/**
+ * Define entity lifecycle related operations
+ */
+export type EntityLifecycleOperation =
+    /**
+     * Notify plugins that there is a new plugin was added into editor.
+     * Plugin can handle this event to entity hydration.
+     * This event will be only fired once for each entity DOM node.
+     * After undo, or copy/paste, since new DOM nodes were added, this event will be fired
+     * for those entities represented by newly added nodes.
+     */
+    | 'newEntity'
+
+    /**
+     * Notify plugins that editor is generating HTML content for save.
+     * Plugin should use this event to remove any temporary content, and only leave DOM nodes that
+     * should be saved as HTML string.
+     * This event will provide a cloned DOM tree for each entity, do NOT compare the DOM nodes with cached nodes
+     * because it will always return false.
+     */
+    | 'replaceTemporaryContent'
+    /**
+     * Notify plugins that a new entity state need to be updated to an entity.
+     * This is normally happened when user undo/redo the content with an entity snapshot added by a plugin that handles entity
+     */
+    | 'UpdateEntityState';
+
+/**
+ * Define entity removal related operations
+ */
+export type EntityRemovalOperation =
+    /**
+     * Notify plugins that user is removing an entity from its start position using DELETE key
+     */
+    | 'removeFromStart'
+
+    /**
+     * Notify plugins that user is remove an entity from its end position using BACKSPACE key
+     */
+    | 'removeFromEnd'
+
+    /**
+     * Notify plugins that an entity is being overwritten.
+     * This can be caused by key in, cut, paste, delete, backspace ... on a selection
+     * which contains some entities.
+     */
+    | 'overwrite';
+
+/**
+ * Define possible operations to an entity
+ */
+export type EntityOperation = EntityLifecycleOperation | EntityRemovalOperation;
 
 /**
  * Represents an entity that is deleted by a specified entity operation
  */
 export interface DeletedEntity {
     entity: ContentModelEntity;
-    operation:
-        | EntityOperation.RemoveFromStart
-        | EntityOperation.RemoveFromEnd
-        | EntityOperation.Overwrite
-        | CompatibleEntityOperation.RemoveFromStart
-        | CompatibleEntityOperation.RemoveFromEnd
-        | CompatibleEntityOperation.Overwrite;
+    operation: EntityRemovalOperation;
 }
 
 /**

--- a/packages-content-model/roosterjs-content-model-editor/test/domUtils/metadata/updateListMetadataTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/domUtils/metadata/updateListMetadataTest.ts
@@ -1,16 +1,17 @@
-import { BulletListType, NumberingListType } from 'roosterjs-editor-types';
 import { createModelToDomContext } from 'roosterjs-content-model-dom';
+import {
+    BulletListType,
+    ContentModelListItemFormat,
+    ContentModelWithDataset,
+    ListMetadataFormat,
+    ModelToDomContext,
+    NumberingListType,
+} from 'roosterjs-content-model-types';
 import {
     listItemMetadataApplier,
     listLevelMetadataApplier,
     updateListMetadata,
 } from '../../../lib/domUtils/metadata/updateListMetadata';
-import {
-    ContentModelListItemFormat,
-    ContentModelWithDataset,
-    ListMetadataFormat,
-    ModelToDomContext,
-} from 'roosterjs-content-model-types';
 
 describe('updateListMetadata', () => {
     it('No value', () => {

--- a/packages-content-model/roosterjs-content-model-editor/test/domUtils/metadata/updateTableCellMetadataTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/domUtils/metadata/updateTableCellMetadataTest.ts
@@ -1,5 +1,4 @@
-import { ContentModelTableCell } from 'roosterjs-content-model-types';
-import { TableCellMetadataFormat } from 'roosterjs-editor-types';
+import { ContentModelTableCell, TableCellMetadataFormat } from 'roosterjs-content-model-types';
 import { updateTableCellMetadata } from '../../../lib/domUtils/metadata/updateTableCellMetadata';
 
 describe('updateTableCellMetadata', () => {

--- a/packages-content-model/roosterjs-content-model-editor/test/domUtils/metadata/updateTableMetadataTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/domUtils/metadata/updateTableMetadataTest.ts
@@ -1,6 +1,9 @@
-import { ContentModelTable, TableMetadataFormat } from 'roosterjs-content-model-types';
-import { TableBorderFormat } from 'roosterjs-editor-types';
 import { updateTableMetadata } from '../../../lib/domUtils/metadata/updateTableMetadata';
+import {
+    ContentModelTable,
+    TableBorderFormat,
+    TableMetadataFormat,
+} from 'roosterjs-content-model-types';
 
 describe('updateTableMetadata', () => {
     it('No value', () => {

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/mergeModelTest.ts
@@ -1,7 +1,6 @@
 import * as applyTableFormat from '../../../lib/modelApi/table/applyTableFormat';
 import * as normalizeTable from '../../../lib/modelApi/table/normalizeTable';
 import { ContentModelDocument, ContentModelImage } from 'roosterjs-content-model-types';
-import { EntityOperation } from 'roosterjs-editor-types';
 import { FormatWithContentModelContext } from '../../../lib/publicTypes/parameter/FormatWithContentModelContext';
 import { mergeModel } from '../../../lib/modelApi/common/mergeModel';
 import {
@@ -3021,7 +3020,7 @@ describe('mergeModel', () => {
             deletedEntities: [
                 {
                     entity: sourceEntity,
-                    operation: EntityOperation.Overwrite,
+                    operation: 'overwrite',
                 },
             ],
             newImages: [],

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/retrieveModelFormatStateTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/retrieveModelFormatStateTest.ts
@@ -159,7 +159,6 @@ describe('retrieveModelFormatState', () => {
         expect(result).toEqual({
             ...baseFormatResult,
             headingLevel: 1,
-            headerLevel: 1,
             isBlockQuote: false,
             isCodeInline: false,
         });

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/edit/deleteSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/edit/deleteSelectionTest.ts
@@ -2,7 +2,6 @@ import { ContentModelEntity, ContentModelSelectionMarker } from 'roosterjs-conte
 import { DeletedEntity } from '../../../lib/publicTypes/parameter/FormatWithContentModelContext';
 import { DeleteResult } from '../../../lib/modelApi/edit/utils/DeleteSelectionStep';
 import { deleteSelection } from '../../../lib/modelApi/edit/deleteSelection';
-import { EntityOperation } from 'roosterjs-editor-types';
 import {
     createBr,
     createContentModelDocument,
@@ -574,7 +573,7 @@ describe('deleteSelection - selectionOnly', () => {
             ],
         });
 
-        expect(deletedEntities).toEqual([{ entity, operation: EntityOperation.Overwrite }]);
+        expect(deletedEntities).toEqual([{ entity, operation: 'overwrite' }]);
     });
 
     it('Entity selection, callback returns true', () => {
@@ -633,7 +632,7 @@ describe('deleteSelection - selectionOnly', () => {
             ],
         });
 
-        expect(deletedEntities).toEqual([{ entity, operation: EntityOperation.Overwrite }]);
+        expect(deletedEntities).toEqual([{ entity, operation: 'overwrite' }]);
     });
 
     it('delete with default format', () => {
@@ -1525,7 +1524,7 @@ describe('deleteSelection - forward', () => {
                 },
             ],
         });
-        expect(deletedEntities).toEqual([{ entity, operation: EntityOperation.RemoveFromStart }]);
+        expect(deletedEntities).toEqual([{ entity, operation: 'removeFromStart' }]);
     });
 
     it('Single selection marker before entity, with callback returns true', () => {
@@ -1573,7 +1572,7 @@ describe('deleteSelection - forward', () => {
                 },
             ],
         });
-        expect(deletedEntities).toEqual([{ entity, operation: EntityOperation.RemoveFromStart }]);
+        expect(deletedEntities).toEqual([{ entity, operation: 'removeFromStart' }]);
     });
 
     it('Single selection marker before list item', () => {
@@ -3283,7 +3282,7 @@ describe('deleteSelection - backward', () => {
                 },
             ],
         });
-        expect(deletedEntities).toEqual([{ entity, operation: EntityOperation.RemoveFromEnd }]);
+        expect(deletedEntities).toEqual([{ entity, operation: 'removeFromEnd' }]);
     });
 
     it('Single selection marker after entity, with callback returns true', () => {
@@ -3332,7 +3331,7 @@ describe('deleteSelection - backward', () => {
                 },
             ],
         });
-        expect(deletedEntities).toEqual([{ entity, operation: EntityOperation.RemoveFromEnd }]);
+        expect(deletedEntities).toEqual([{ entity, operation: 'removeFromEnd' }]);
     });
 
     it('Single selection marker after list item', () => {

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/table/applyTableFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/table/applyTableFormatTest.ts
@@ -1,9 +1,9 @@
 import { applyTableFormat } from '../../../lib/modelApi/table/applyTableFormat';
-import { TableBorderFormat } from 'roosterjs-editor-types';
 import {
     ContentModelTable,
     ContentModelTableCell,
     ContentModelTableRow,
+    TableBorderFormat,
     TableMetadataFormat,
 } from 'roosterjs-content-model-types';
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/getFormatStateTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/format/getFormatStateTest.ts
@@ -1,7 +1,7 @@
 import * as getPendingFormat from '../../../lib/modelApi/format/pendingFormat';
 import * as retrieveModelFormatState from '../../../lib/modelApi/common/retrieveModelFormatState';
+import { ContentModelFormatState } from '../../../lib/publicTypes/format/formatState/ContentModelFormatState';
 import { DomToModelContext } from 'roosterjs-content-model-types';
-import { FormatState } from 'roosterjs-editor-types';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 import getFormatState, {
     reducedModelChildProcessor,
@@ -28,7 +28,7 @@ describe('getFormatState', () => {
         html: string,
         pendingFormat: ContentModelSegmentFormat | null,
         expectedModel: ContentModelDocument,
-        expectedFormat: FormatState
+        expectedFormat: ContentModelFormatState
     ) {
         const editor = ({
             getUndoState: () => ({

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
@@ -231,11 +231,11 @@ describe('formatWithContentModel', () => {
                 context.deletedEntities.push(
                     {
                         entity: entity1,
-                        operation: EntityOperation.RemoveFromStart,
+                        operation: 'removeFromStart',
                     },
                     {
                         entity: entity2,
-                        operation: EntityOperation.RemoveFromEnd,
+                        operation: 'removeFromEnd',
                     }
                 );
                 return true;

--- a/packages-content-model/roosterjs-content-model-types/lib/format/metadata/ListMetadataFormat.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/format/metadata/ListMetadataFormat.ts
@@ -1,4 +1,146 @@
-import type { BulletListType, NumberingListType } from 'roosterjs-editor-types';
+/**
+ *  Enum used to control the different types of bullet list
+ */
+export enum BulletListType {
+    /**
+     * Minimum value of the enum
+     */
+    Min = 1,
+    /**
+     * Bullet triggered by *
+     */
+    Disc = 1,
+    /**
+     * Bullet triggered by -
+     */
+    Dash = 2,
+    /**
+     * Bullet triggered by --
+     */
+    Square = 3,
+    /**
+     * Bullet triggered by >
+     */
+    ShortArrow = 4,
+    /**
+     * Bullet triggered by ->
+     */
+    LongArrow = 5,
+    /**
+     * Bullet triggered by =>
+     */
+    UnfilledArrow = 6,
+    /**
+     * Bullet triggered by —
+     */
+    Hyphen = 7,
+    /**
+     * Bullet triggered by -->
+     */
+    DoubleLongArrow = 8,
+    /**
+     * Bullet type circle
+     */
+    Circle = 9,
+    /**
+     * Maximum value of the enum
+     */
+    Max = 9,
+}
+
+/**
+ *  Enum used to control the different types of numbering list
+ */
+export enum NumberingListType {
+    /**
+     * Minimum value of the enum
+     */
+    Min = 1,
+    /**
+     * Numbering triggered by 1.
+     */
+    Decimal = 1,
+    /**
+     * Numbering triggered by 1-
+     */
+    DecimalDash = 2,
+    /**
+     * Numbering triggered by 1)
+     */
+    DecimalParenthesis = 3,
+    /**
+     * Numbering triggered by (1)
+     */
+    DecimalDoubleParenthesis = 4,
+    /**
+     * Numbering triggered by a.
+     */
+    LowerAlpha = 5,
+    /**
+     * Numbering triggered by a)
+     */
+    LowerAlphaParenthesis = 6,
+    /**
+     * Numbering triggered by (a)
+     */
+    LowerAlphaDoubleParenthesis = 7,
+    /**
+     * Numbering triggered by a-
+     */
+    LowerAlphaDash = 8,
+    /**
+     * Numbering triggered by A.
+     */
+    UpperAlpha = 9,
+    /**
+     * Numbering triggered by A)
+     */
+    UpperAlphaParenthesis = 10,
+    /**
+     * Numbering triggered by (A)
+     */
+    UpperAlphaDoubleParenthesis = 11,
+    /**
+     * Numbering triggered by A-
+     */
+    UpperAlphaDash = 12,
+    /**
+     * Numbering triggered by i.
+     */
+    LowerRoman = 13,
+    /**
+     * Numbering triggered by i)
+     */
+    LowerRomanParenthesis = 14,
+    /**
+     * Numbering triggered by (i)
+     */
+    LowerRomanDoubleParenthesis = 15,
+    /**
+     * Numbering triggered by i-
+     */
+    LowerRomanDash = 16,
+    /**
+     * Numbering triggered by I.
+     */
+    UpperRoman = 17,
+    /**
+     * Numbering triggered by I)
+     */
+    UpperRomanParenthesis = 18,
+    /**
+     * Numbering triggered by (I)
+     */
+    UpperRomanDoubleParenthesis = 19,
+    /**
+     * Numbering triggered by I-
+     */
+    UpperRomanDash = 20,
+    /**
+     * Maximum value of the enum
+     */
+    Max = 20,
+}
 
 /**
  * Format of list / list item that stored as metadata

--- a/packages-content-model/roosterjs-content-model-types/lib/format/metadata/TableCellMetadataFormat.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/format/metadata/TableCellMetadataFormat.ts
@@ -1,0 +1,13 @@
+/**
+ * Format of table cell that stored as metadata
+ */
+export type TableCellMetadataFormat = {
+    /**
+     * Override default background color
+     */
+    bgColorOverride?: boolean;
+    /**
+     * Override default vertical align value
+     */
+    vAlignOverride?: boolean;
+};

--- a/packages-content-model/roosterjs-content-model-types/lib/format/metadata/TableMetadataFormat.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/format/metadata/TableMetadataFormat.ts
@@ -1,5 +1,84 @@
-import type { TableBorderFormat } from 'roosterjs-editor-types';
-import type { CompatibleTableBorderFormat } from 'roosterjs-editor-types/lib/compatibleTypes';
+/**
+ * Table format border
+ */
+export enum TableBorderFormat {
+    /**
+     * All border of the table are displayed
+     *  __ __ __
+     * |__|__|__|
+     * |__|__|__|
+     * |__|__|__|
+     */
+    DEFAULT,
+
+    /**
+     * Middle vertical border are not displayed
+     *  __ __ __
+     * |__ __ __|
+     * |__ __ __|
+     * |__ __ __|
+     */
+    LIST_WITH_SIDE_BORDERS,
+
+    /**
+     * All borders except header rows borders are displayed
+     *  __ __ __
+     *  __|__|__
+     *  __|__|__
+     */
+    NO_HEADER_BORDERS,
+
+    /**
+     * The left and right border of the table are not displayed
+     *  __ __ __
+     *  __|__|__
+     *  __|__|__
+     *  __|__|__
+     */
+    NO_SIDE_BORDERS,
+
+    /**
+     * Only the borders that divides the header row, first column and externals are displayed
+     *  __ __ __
+     * |__ __ __|
+     * |  |     |
+     * |__|__ __|
+     */
+    FIRST_COLUMN_HEADER_EXTERNAL,
+
+    /**
+     * The header row has no vertical border, except for the first one
+     * The first column has no horizontal border, except for the first one
+     *  __ __ __
+     * |__ __ __
+     * |  |__|__|
+     * |  |__|__|
+     */
+    ESPECIAL_TYPE_1,
+
+    /**
+     * The header row has no vertical border, except for the first one
+     * The only horizontal border of the table is the top and bottom of header row
+     *  __ __ __
+     * |__ __ __
+     * |  |     |
+     * |  |     |
+     */
+    ESPECIAL_TYPE_2,
+
+    /**
+     * The only borders are the bottom of header row and the right border of first column
+     *  __ __ __
+     *    |
+     *    |
+     */
+    ESPECIAL_TYPE_3,
+
+    /**
+     * No border
+     */
+    CLEAR,
+}
 
 /**
  * Format of table that stored as metadata
@@ -58,7 +137,7 @@ export type TableMetadataFormat = {
     /**
      * Table Borders Type
      */
-    tableBorderFormat?: TableBorderFormat | CompatibleTableBorderFormat;
+    tableBorderFormat?: TableBorderFormat;
     /**
      * Vertical alignment for each row
      */

--- a/packages-content-model/roosterjs-content-model-types/lib/group/ContentModelTableCell.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/group/ContentModelTableCell.ts
@@ -1,10 +1,10 @@
+import type { TableCellMetadataFormat } from '../format/metadata/TableCellMetadataFormat';
 import type { ContentModelBlockGroupBase } from './ContentModelBlockGroupBase';
 import type { ContentModelBlockWithCache } from '../block/ContentModelBlockWithCache';
 import type { ContentModelTableCellFormat } from '../format/ContentModelTableCellFormat';
 import type { ContentModelWithDataset } from '../format/ContentModelWithDataset';
 import type { ContentModelWithFormat } from '../format/ContentModelWithFormat';
 import type { Selectable } from '../selection/Selectable';
-import type { TableCellMetadataFormat } from 'roosterjs-editor-types';
 
 /**
  * Content Model of Table Cell

--- a/packages-content-model/roosterjs-content-model-types/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/index.ts
@@ -50,14 +50,19 @@ export { FloatFormat } from './format/formatParts/FloatFormat';
 export { EntityInfoFormat } from './format/formatParts/EntityInfoFormat';
 
 export { DatasetFormat } from './format/metadata/DatasetFormat';
-export { TableMetadataFormat } from './format/metadata/TableMetadataFormat';
-export { ListMetadataFormat } from './format/metadata/ListMetadataFormat';
+export { TableMetadataFormat, TableBorderFormat } from './format/metadata/TableMetadataFormat';
+export {
+    ListMetadataFormat,
+    NumberingListType,
+    BulletListType,
+} from './format/metadata/ListMetadataFormat';
 export {
     ImageResizeMetadataFormat,
     ImageCropMetadataFormat,
     ImageMetadataFormat,
     ImageRotateMetadataFormat,
 } from './format/metadata/ImageMetadataFormat';
+export { TableCellMetadataFormat } from './format/metadata/TableCellMetadataFormat';
 
 export { ContentModelBlockGroupType } from './enum/BlockGroupType';
 export { ContentModelBlockType } from './enum/BlockType';


### PR DESCRIPTION
Remove dependencies to existing enums from old code. Some enums can be converted into string literal type, some are used for persist content so we need to keep them for compatibility and convert to regular enum (non-const) instead so that we don't need to general "Compatible*" types any more.

- EntityOperation: Create a string literal type in `roosterjs-content-model-editor` package instead
- BulletListType: Create a new enum (non-const) type in `roosterjs-content-model-types` package
- NumberingListType: Create a new enum (non-const) type in `roosterjs-content-model-types` package
- TableCellMetadataFormat: Create a copy in `roosterjs-content-model-editor` package
- TableBorderFormat: Create a new enum (non-const) type in `roosterjs-content-model-types` package
- FormatState: Move the content into `ContentModelFormatState` type