### PR TITLE
Standalone editor: Remove dependencies to enums Part 2

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCachePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCachePlugin.ts
@@ -1,6 +1,6 @@
 import { areSameRangeEx } from '../../modelApi/selection/areSameRangeEx';
 import { isCharacterValue } from '../../domUtils/eventUtils';
-import { Keys, PluginEventType } from 'roosterjs-editor-types';
+import { PluginEventType } from 'roosterjs-editor-types';
 import type ContentModelContentChangedEvent from '../../publicTypes/event/ContentModelContentChangedEvent';
 import type { ContentModelCachePluginState } from '../../publicTypes/pluginState/ContentModelCachePluginState';
 import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
@@ -167,7 +167,7 @@ export default class ContentModelCachePlugin
         // 3. ENTER key is pressed. ENTER key will create new paragraph, so need to update cache to reflect this change
         // TODO: Handle ENTER key to better reuse content model
 
-        if (rawEvent.which == Keys.ENTER) {
+        if (rawEvent.key == 'Enter') {
             return true;
         }
 

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -1,7 +1,8 @@
 import paste from '../../publicApi/utils/paste';
 import { addRangeToSelection, extractClipboardItems } from 'roosterjs-editor-dom';
-import { ChangeSource, ColorTransformDirection, PluginEventType } from 'roosterjs-editor-types';
+import { ChangeSource } from '../../publicTypes/event/ContentModelContentChangedEvent';
 import { cloneModel } from '../../modelApi/common/cloneModel';
+import { ColorTransformDirection, PluginEventType } from 'roosterjs-editor-types';
 import { DeleteResult } from '../../modelApi/edit/utils/DeleteSelectionStep';
 import { deleteSelection } from '../../modelApi/edit/deleteSelection';
 import { formatWithContentModel } from '../../publicApi/utils/formatWithContentModel';

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelEditPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelEditPlugin.ts
@@ -1,5 +1,5 @@
 import keyboardDelete from '../../publicApi/editing/keyboardDelete';
-import { Keys, PluginEventType } from 'roosterjs-editor-types';
+import { PluginEventType } from 'roosterjs-editor-types';
 import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import type {
     EditorPlugin,
@@ -62,13 +62,12 @@ export default class ContentModelEditPlugin implements EditorPlugin {
 
     private handleKeyDownEvent(editor: IContentModelEditor, event: PluginKeyDownEvent) {
         const rawEvent = event.rawEvent;
-        const which = rawEvent.which;
 
         if (!rawEvent.defaultPrevented && !event.handledByEditFeature) {
             // TODO: Consider use ContentEditFeature and need to hide other conflict features that are not based on Content Model
-            switch (which) {
-                case Keys.BACKSPACE:
-                case Keys.DELETE:
+            switch (rawEvent.key) {
+                case 'Backspace':
+                case 'Delete':
                     // Use our API to handle BACKSPACE/DELETE key.
                     // No need to clear cache here since if we rely on browser's behavior, there will be Input event and its handler will reconcile cache
                     keyboardDelete(editor, rawEvent);

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelFormatPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelFormatPlugin.ts
@@ -3,13 +3,23 @@ import applyPendingFormat from '../../publicApi/format/applyPendingFormat';
 import { canApplyPendingFormat, clearPendingFormat } from '../../modelApi/format/pendingFormat';
 import { getObjectKeys } from 'roosterjs-content-model-dom';
 import { isCharacterValue } from '../../domUtils/eventUtils';
-import { Keys, PluginEventType } from 'roosterjs-editor-types';
+import { PluginEventType } from 'roosterjs-editor-types';
 import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import type { IEditor, PluginEvent, PluginWithState } from 'roosterjs-editor-types';
 import type { ContentModelFormatPluginState } from '../../publicTypes/pluginState/ContentModelFormatPluginState';
 
 // During IME input, KeyDown event will have "Process" as key
 const ProcessKey = 'Process';
+const CursorMovingKeys = new Set<string>([
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'Home',
+    'End',
+    'PageUp',
+    'PageDown',
+]);
 
 /**
  * ContentModelFormat plugins helps editor to do formatting on top of content model.
@@ -92,7 +102,7 @@ export default class ContentModelFormatPlugin
                 break;
 
             case PluginEventType.KeyDown:
-                if (event.rawEvent.which >= Keys.PAGEUP && event.rawEvent.which <= Keys.DOWN) {
+                if (CursorMovingKeys.has(event.rawEvent.key)) {
                     clearPendingFormat(this.editor);
                 } else if (
                     this.hasDefaultFormat &&

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/ContentModelPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/ContentModelPastePlugin.ts
@@ -3,12 +3,13 @@ import { chainSanitizerCallback } from 'roosterjs-editor-dom';
 import { deprecatedBorderColorParser } from './utils/deprecatedColorParser';
 import { getPasteSource } from './pasteSourceValidations/getPasteSource';
 import { parseLink } from './utils/linkParser';
-import { PasteType } from '../../../publicTypes/parameter/PasteType';
+import { PastePropertyNames } from './pasteSourceValidations/constants';
 import { PasteType as OldPasteType, PluginEventType } from 'roosterjs-editor-types';
 import { processPastedContentFromExcel } from './Excel/processPastedContentFromExcel';
 import { processPastedContentFromPowerPoint } from './PowerPoint/processPastedContentFromPowerPoint';
 import { processPastedContentFromWordDesktop } from './WordDesktop/processPastedContentFromWordDesktop';
 import { processPastedContentWacComponents } from './WacComponents/processPastedContentWacComponents';
+import type { PasteType } from '../../../publicTypes/parameter/PasteType';
 import type ContentModelBeforePasteEvent from '../../../publicTypes/event/ContentModelBeforePasteEvent';
 import type { ContentModelBlockFormat, FormatParser } from 'roosterjs-content-model-types';
 import type { IContentModelEditor } from '../../../publicTypes/IContentModelEditor';
@@ -18,8 +19,6 @@ import type {
     IEditor,
     PluginEvent,
 } from 'roosterjs-editor-types';
-
-const GOOGLE_SHEET_NODE_NAME = 'google-sheets-html-origin';
 
 // Map old PasteType to new PasteType
 // TODO: We can remove this once we have standalone editor
@@ -109,7 +108,9 @@ export default class ContentModelPastePlugin implements EditorPlugin {
                 }
                 break;
             case 'googleSheets':
-                ev.sanitizingOption.additionalTagReplacements[GOOGLE_SHEET_NODE_NAME] = '*';
+                ev.sanitizingOption.additionalTagReplacements[
+                    PastePropertyNames.GOOGLE_SHEET_NODE_NAME
+                ] = '*';
                 break;
             case 'powerPointDesktop':
                 processPastedContentFromPowerPoint(ev, this.editor.getTrustedHTMLHandler());

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/constants.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * @internal
+ * Node attribute used to identify if the content is from Google Sheets.
+ */
+export const GOOGLE_SHEET_NODE_NAME = 'google-sheets-html-origin';
+/**
+ * @internal
+ * Name of the HTMLMeta Property that provides the Office App Source of the pasted content
+ */
+export const PROG_ID_NAME = 'ProgId';
+/**
+ * @internal
+ * Name of the HTMLMeta Property that identifies pated content as from Excel Desktop
+ */
+export const EXCEL_DESKTOP_ATTRIBUTE_NAME = 'xmlns:x';

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/constants.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/constants.ts
@@ -1,15 +1,19 @@
 /**
  * @internal
- * Node attribute used to identify if the content is from Google Sheets.
  */
-export const GOOGLE_SHEET_NODE_NAME = 'google-sheets-html-origin';
-/**
- * @internal
- * Name of the HTMLMeta Property that provides the Office App Source of the pasted content
- */
-export const PROG_ID_NAME = 'ProgId';
-/**
- * @internal
- * Name of the HTMLMeta Property that identifies pated content as from Excel Desktop
- */
-export const EXCEL_DESKTOP_ATTRIBUTE_NAME = 'xmlns:x';
+export const enum PastePropertyNames {
+    /**
+     * Node attribute used to identify if the content is from Google Sheets.
+     */
+    GOOGLE_SHEET_NODE_NAME = 'google-sheets-html-origin',
+
+    /**
+     * Name of the HTMLMeta Property that provides the Office App Source of the pasted content
+     */
+    PROG_ID_NAME = 'ProgId',
+
+    /**
+     * Name of the HTMLMeta Property that identifies pated content as from Excel Desktop
+     */
+    EXCEL_DESKTOP_ATTRIBUTE_NAME = 'xmlns:x',
+}

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/documentContainWacElements.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/documentContainWacElements.ts
@@ -1,0 +1,25 @@
+import type { GetSourceFunction } from './getPasteSource';
+
+const WORD_ONLINE_TABLE_TEMP_ELEMENT_CLASSES = [
+    'TableInsertRowGapBlank',
+    'TableColumnResizeHandle',
+    'TableCellTopBorderHandle',
+    'TableCellLeftBorderHandle',
+    'TableHoverColumnHandle',
+    'TableHoverRowHandle',
+];
+
+const WAC_IDENTIFY_SELECTOR =
+    'ul[class^="BulletListStyle"]>.OutlineElement,ol[class^="NumberListStyle"]>.OutlineElement,span.WACImageContainer,' +
+    WORD_ONLINE_TABLE_TEMP_ELEMENT_CLASSES.map(c => `table div[class^="${c}"]`).join(',');
+
+/**
+ * @internal
+ * Check whether the fragment provided contain Wac Elements
+ * @param props Properties related to the PasteEvent
+ * @returns
+ */
+export const documentContainWacElements: GetSourceFunction = props => {
+    const { fragment } = props;
+    return !!fragment.querySelector(WAC_IDENTIFY_SELECTOR);
+};

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource.ts
@@ -18,6 +18,7 @@ export type GetSourceInputParams = {
 };
 
 /**
+ * @internal
  * Represent the types of sources to handle in the Paste Plugin
  */
 export type KnownPasteSourceType =
@@ -46,6 +47,7 @@ const getSourceFunctions = new Map<KnownPasteSourceType, GetSourceFunction>([
 ]);
 
 /**
+ * @internal
  * This function tries to get the source of the Pasted content
  * @param event the before paste event
  * @param shouldConvertSingleImage Whether convert single image is enabled.

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource.ts
@@ -1,0 +1,75 @@
+import { documentContainWacElements } from './documentContainWacElements';
+import { isExcelDesktopDocument } from './isExcelDesktopDocument';
+import { isExcelOnlineDocument } from './isExcelOnlineDocument';
+import { isGoogleSheetDocument } from './isGoogleSheetDocument';
+import { isPowerPointDesktopDocument } from './isPowerPointDesktopDocument';
+import { isWordDesktopDocument } from './isWordDesktopDocument';
+import { shouldConvertToSingleImage } from './shouldConvertToSingleImage';
+import type { BeforePasteEvent, ClipboardData } from 'roosterjs-editor-types';
+
+/**
+ * @internal
+ */
+export type GetSourceInputParams = {
+    htmlAttributes: Record<string, string>;
+    fragment: DocumentFragment;
+    shouldConvertSingleImage: boolean;
+    clipboardData: ClipboardData;
+};
+
+/**
+ * Represent the types of sources to handle in the Paste Plugin
+ */
+export type KnownPasteSourceType =
+    | 'wordDesktop'
+    | 'excelDesktop'
+    | 'excelOnline'
+    | 'powerPointDesktop'
+    | 'googleSheets'
+    | 'wacComponents'
+    | 'default'
+    | 'singleImage';
+
+/**
+ * @internal
+ */
+export type GetSourceFunction = (props: GetSourceInputParams) => boolean;
+
+const getSourceFunctions = new Map<KnownPasteSourceType, GetSourceFunction>([
+    ['wordDesktop', isWordDesktopDocument],
+    ['excelDesktop', isExcelDesktopDocument],
+    ['excelOnline', isExcelOnlineDocument],
+    ['powerPointDesktop', isPowerPointDesktopDocument],
+    ['wacComponents', documentContainWacElements],
+    ['googleSheets', isGoogleSheetDocument],
+    ['singleImage', shouldConvertToSingleImage],
+]);
+
+/**
+ * This function tries to get the source of the Pasted content
+ * @param event the before paste event
+ * @param shouldConvertSingleImage Whether convert single image is enabled.
+ * @returns The Type of pasted content, if no type found will return {KnownSourceType.Default}
+ */
+export function getPasteSource(
+    event: BeforePasteEvent,
+    shouldConvertSingleImage: boolean
+): KnownPasteSourceType {
+    const { htmlAttributes, clipboardData, fragment } = event;
+
+    let result: KnownPasteSourceType | null = null;
+    const param: GetSourceInputParams = {
+        htmlAttributes,
+        fragment,
+        shouldConvertSingleImage,
+        clipboardData,
+    };
+
+    getSourceFunctions.forEach((func, key) => {
+        if (!result && func(param)) {
+            result = key;
+        }
+    });
+
+    return result ?? 'default';
+}

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isExcelDesktopDocument.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isExcelDesktopDocument.ts
@@ -1,4 +1,4 @@
-import { EXCEL_DESKTOP_ATTRIBUTE_NAME } from './constants';
+import { PastePropertyNames } from './constants';
 import type { GetSourceFunction } from './getPasteSource';
 
 const EXCEL_ATTRIBUTE_VALUE = 'urn:schemas-microsoft-com:office:excel';
@@ -12,5 +12,5 @@ const EXCEL_ATTRIBUTE_VALUE = 'urn:schemas-microsoft-com:office:excel';
 export const isExcelDesktopDocument: GetSourceFunction = props => {
     const { htmlAttributes } = props;
     // The presence of this attribute confirms its origin from Excel Desktop
-    return htmlAttributes[EXCEL_DESKTOP_ATTRIBUTE_NAME] == EXCEL_ATTRIBUTE_VALUE;
+    return htmlAttributes[PastePropertyNames.EXCEL_DESKTOP_ATTRIBUTE_NAME] == EXCEL_ATTRIBUTE_VALUE;
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isExcelDesktopDocument.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isExcelDesktopDocument.ts
@@ -1,0 +1,16 @@
+import { EXCEL_DESKTOP_ATTRIBUTE_NAME } from './constants';
+import type { GetSourceFunction } from './getPasteSource';
+
+const EXCEL_ATTRIBUTE_VALUE = 'urn:schemas-microsoft-com:office:excel';
+
+/**
+ * @internal
+ * Checks whether the Array provided contains strings that identify Excel Desktop documents
+ * @param props Properties related to the PasteEvent
+ * @returns
+ */
+export const isExcelDesktopDocument: GetSourceFunction = props => {
+    const { htmlAttributes } = props;
+    // The presence of this attribute confirms its origin from Excel Desktop
+    return htmlAttributes[EXCEL_DESKTOP_ATTRIBUTE_NAME] == EXCEL_ATTRIBUTE_VALUE;
+};

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isExcelOnlineDocument.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isExcelOnlineDocument.ts
@@ -1,4 +1,4 @@
-import { EXCEL_DESKTOP_ATTRIBUTE_NAME, PROG_ID_NAME } from './constants';
+import { PastePropertyNames } from './constants';
 import type { GetSourceFunction } from './getPasteSource';
 
 // Excel Desktop also has this attribute
@@ -14,7 +14,7 @@ export const isExcelOnlineDocument: GetSourceFunction = props => {
     const { htmlAttributes } = props;
     // The presence of Excel.Sheet confirms its origin from Excel, the absence of EXCEL_DESKTOP_ATTRIBUTE_NAME confirms it is from the Online version
     return (
-        htmlAttributes[PROG_ID_NAME] == EXCEL_ONLINE_ATTRIBUTE_VALUE &&
-        htmlAttributes[EXCEL_DESKTOP_ATTRIBUTE_NAME] == undefined
+        htmlAttributes[PastePropertyNames.PROG_ID_NAME] == EXCEL_ONLINE_ATTRIBUTE_VALUE &&
+        htmlAttributes[PastePropertyNames.EXCEL_DESKTOP_ATTRIBUTE_NAME] == undefined
     );
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isExcelOnlineDocument.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isExcelOnlineDocument.ts
@@ -1,0 +1,20 @@
+import { EXCEL_DESKTOP_ATTRIBUTE_NAME, PROG_ID_NAME } from './constants';
+import type { GetSourceFunction } from './getPasteSource';
+
+// Excel Desktop also has this attribute
+const EXCEL_ONLINE_ATTRIBUTE_VALUE = 'Excel.Sheet';
+
+/**
+ * @internal
+ * Checks whether the Array provided contains strings that identify Excel Online documents
+ * @param props Properties related to the PasteEvent
+ * @returns
+ */
+export const isExcelOnlineDocument: GetSourceFunction = props => {
+    const { htmlAttributes } = props;
+    // The presence of Excel.Sheet confirms its origin from Excel, the absence of EXCEL_DESKTOP_ATTRIBUTE_NAME confirms it is from the Online version
+    return (
+        htmlAttributes[PROG_ID_NAME] == EXCEL_ONLINE_ATTRIBUTE_VALUE &&
+        htmlAttributes[EXCEL_DESKTOP_ATTRIBUTE_NAME] == undefined
+    );
+};

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isGoogleSheetDocument.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isGoogleSheetDocument.ts
@@ -1,4 +1,4 @@
-import { GOOGLE_SHEET_NODE_NAME } from './constants';
+import { PastePropertyNames } from './constants';
 import type { GetSourceFunction } from './getPasteSource';
 
 /**
@@ -9,5 +9,5 @@ import type { GetSourceFunction } from './getPasteSource';
  */
 export const isGoogleSheetDocument: GetSourceFunction = props => {
     const { fragment } = props;
-    return !!fragment.querySelector(GOOGLE_SHEET_NODE_NAME);
+    return !!fragment.querySelector(PastePropertyNames.GOOGLE_SHEET_NODE_NAME);
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isGoogleSheetDocument.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isGoogleSheetDocument.ts
@@ -1,0 +1,13 @@
+import { GOOGLE_SHEET_NODE_NAME } from './constants';
+import type { GetSourceFunction } from './getPasteSource';
+
+/**
+ * @internal
+ * Checks whether the fragment provided contain elements from Google sheets
+ * @param props Properties related to the PasteEvent
+ * @returns
+ */
+export const isGoogleSheetDocument: GetSourceFunction = props => {
+    const { fragment } = props;
+    return !!fragment.querySelector(GOOGLE_SHEET_NODE_NAME);
+};

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isPowerPointDesktopDocument.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isPowerPointDesktopDocument.ts
@@ -1,0 +1,14 @@
+import { PROG_ID_NAME } from './constants';
+import type { GetSourceFunction } from './getPasteSource';
+
+const POWERPOINT_ATTRIBUTE_VALUE = 'PowerPoint.Slide';
+
+/**
+ * @internal
+ * Checks whether the Array provided contains strings that identify Power Point Desktop documents
+ * @param props Properties related to the PasteEvent
+ * @returns
+ */
+export const isPowerPointDesktopDocument: GetSourceFunction = props => {
+    return props.htmlAttributes[PROG_ID_NAME] == POWERPOINT_ATTRIBUTE_VALUE;
+};

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isPowerPointDesktopDocument.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isPowerPointDesktopDocument.ts
@@ -1,4 +1,4 @@
-import { PROG_ID_NAME } from './constants';
+import { PastePropertyNames } from './constants';
 import type { GetSourceFunction } from './getPasteSource';
 
 const POWERPOINT_ATTRIBUTE_VALUE = 'PowerPoint.Slide';
@@ -10,5 +10,5 @@ const POWERPOINT_ATTRIBUTE_VALUE = 'PowerPoint.Slide';
  * @returns
  */
 export const isPowerPointDesktopDocument: GetSourceFunction = props => {
-    return props.htmlAttributes[PROG_ID_NAME] == POWERPOINT_ATTRIBUTE_VALUE;
+    return props.htmlAttributes[PastePropertyNames.PROG_ID_NAME] == POWERPOINT_ATTRIBUTE_VALUE;
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isWordDesktopDocument.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isWordDesktopDocument.ts
@@ -1,4 +1,4 @@
-import { PROG_ID_NAME } from './constants';
+import { PastePropertyNames } from './constants';
 import type { GetSourceFunction } from './getPasteSource';
 
 const WORD_ATTRIBUTE_NAME = 'xmlns:w';
@@ -15,6 +15,6 @@ export const isWordDesktopDocument: GetSourceFunction = props => {
     const { htmlAttributes } = props;
     return (
         htmlAttributes[WORD_ATTRIBUTE_NAME] == WORD_ATTRIBUTE_VALUE ||
-        htmlAttributes[PROG_ID_NAME] == WORD_PROG_ID
+        htmlAttributes[PastePropertyNames.PROG_ID_NAME] == WORD_PROG_ID
     );
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isWordDesktopDocument.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/isWordDesktopDocument.ts
@@ -1,0 +1,20 @@
+import { PROG_ID_NAME } from './constants';
+import type { GetSourceFunction } from './getPasteSource';
+
+const WORD_ATTRIBUTE_NAME = 'xmlns:w';
+const WORD_ATTRIBUTE_VALUE = 'urn:schemas-microsoft-com:office:word';
+const WORD_PROG_ID = 'Word.Document';
+
+/**
+ * @internal
+ * Checks whether the Array provided contains strings that identify Word Desktop documents
+ * @param props Properties related to the PasteEvent
+ * @returns
+ */
+export const isWordDesktopDocument: GetSourceFunction = props => {
+    const { htmlAttributes } = props;
+    return (
+        htmlAttributes[WORD_ATTRIBUTE_NAME] == WORD_ATTRIBUTE_VALUE ||
+        htmlAttributes[PROG_ID_NAME] == WORD_PROG_ID
+    );
+};

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/shouldConvertToSingleImage.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/plugins/PastePlugin/pasteSourceValidations/shouldConvertToSingleImage.ts
@@ -1,0 +1,17 @@
+import type { GetSourceFunction } from './getPasteSource';
+
+/**
+ * @internal
+ * Checks whether the fragment only contains a single image to paste
+ * and the editor have the ConvertSingleImageBody Experimental feature
+ * @param props Properties related to the PasteEvent
+ * @returns
+ */
+export const shouldConvertToSingleImage: GetSourceFunction = props => {
+    const { shouldConvertSingleImage, clipboardData } = props;
+    return (
+        shouldConvertSingleImage &&
+        clipboardData.htmlFirstLevelChildTags?.length == 1 &&
+        clipboardData.htmlFirstLevelChildTags[0] == 'IMG'
+    );
+};

--- a/packages-content-model/roosterjs-content-model-editor/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/index.ts
@@ -19,6 +19,7 @@ export {
     default as ContentModelContentChangedEvent,
     CompatibleContentModelContentChangedEvent,
     ContentModelContentChangedEventData,
+    ChangeSource,
 } from './publicTypes/event/ContentModelContentChangedEvent';
 
 export {
@@ -51,6 +52,7 @@ export {
     TableCellHorizontalAlignOperation,
     TableCellVerticalAlignOperation,
 } from './publicTypes/parameter/TableOperation';
+export { PasteType } from './publicTypes/parameter/PasteType';
 
 export { default as insertTable } from './publicApi/table/insertTable';
 export { default as formatTable } from './publicApi/table/formatTable';

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/editing/keyboardDelete.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/editing/keyboardDelete.ts
@@ -1,4 +1,4 @@
-import { ChangeSource, Keys } from 'roosterjs-editor-types';
+import { ChangeSource } from '../../publicTypes/event/ContentModelContentChangedEvent';
 import { deleteAllSegmentBefore } from '../../modelApi/edit/deleteSteps/deleteAllSegmentBefore';
 import { DeleteResult } from '../../modelApi/edit/utils/DeleteSelectionStep';
 import { deleteSelection } from '../../modelApi/edit/deleteSelection';
@@ -32,7 +32,6 @@ export default function keyboardDelete(
     editor: IContentModelEditor,
     rawEvent: KeyboardEvent
 ): boolean {
-    const which = rawEvent.which;
     const selection = editor.getDOMSelection();
     const range = selection?.type == 'range' ? selection.range : null;
     let isDeleted = false;
@@ -40,7 +39,7 @@ export default function keyboardDelete(
     if (shouldDeleteWithContentModel(range, rawEvent)) {
         formatWithContentModel(
             editor,
-            which == Keys.DELETE ? 'handleDeleteKey' : 'handleBackspaceKey',
+            rawEvent.key == 'Delete' ? 'handleDeleteKey' : 'handleBackspaceKey',
             (model, context) => {
                 const result = deleteSelection(
                     model,
@@ -55,7 +54,7 @@ export default function keyboardDelete(
             {
                 rawEvent,
                 changeSource: ChangeSource.Keyboard,
-                getChangeData: () => which,
+                getChangeData: () => rawEvent.which,
             }
         );
 
@@ -66,7 +65,7 @@ export default function keyboardDelete(
 }
 
 function getDeleteSteps(rawEvent: KeyboardEvent, isMac: boolean): (DeleteSelectionStep | null)[] {
-    const isForward = rawEvent.which == Keys.DELETE;
+    const isForward = rawEvent.key == 'Delete';
     const deleteAllSegmentBeforeStep =
         shouldDeleteAllSegmentsBefore(rawEvent) && !isForward ? deleteAllSegmentBefore : null;
     const deleteWordSelection = shouldDeleteWord(rawEvent, isMac)
@@ -91,14 +90,14 @@ function shouldDeleteWithContentModel(range: Range | null, rawEvent: KeyboardEve
 
 function canDeleteBefore(rawEvent: KeyboardEvent, range: Range) {
     return (
-        rawEvent.which == Keys.BACKSPACE &&
+        rawEvent.key == 'Backspace' &&
         (range.startOffset > 1 || range.startContainer.previousSibling)
     );
 }
 
 function canDeleteAfter(rawEvent: KeyboardEvent, range: Range) {
     return (
-        rawEvent.which == Keys.DELETE &&
+        rawEvent.key == 'Delete' &&
         (range.startOffset < (range.startContainer.nodeValue?.length ?? 0) - 1 ||
             range.startContainer.nextSibling)
     );

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/entity/insertEntity.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/entity/insertEntity.ts
@@ -1,4 +1,4 @@
-import { ChangeSource } from 'roosterjs-editor-types';
+import { ChangeSource } from '../../publicTypes/event/ContentModelContentChangedEvent';
 import { createEntity, normalizeContentModel } from 'roosterjs-content-model-dom';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { insertEntityModel } from '../../modelApi/entity/insertEntityModel';

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/link/insertLink.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/link/insertLink.ts
@@ -1,5 +1,5 @@
 import getSelectedSegments from '../selection/getSelectedSegments';
-import { ChangeSource } from 'roosterjs-editor-types';
+import { ChangeSource } from '../../publicTypes/event/ContentModelContentChangedEvent';
 import { formatWithContentModel } from '../utils/formatWithContentModel';
 import { getPendingFormat } from '../../modelApi/format/pendingFormat';
 import { HtmlSanitizer, matchLink } from 'roosterjs-editor-dom';

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/formatWithContentModel.ts
@@ -1,5 +1,6 @@
-import { ChangeSource, PluginEventType } from 'roosterjs-editor-types';
+import { ChangeSource } from '../../publicTypes/event/ContentModelContentChangedEvent';
 import { getPendingFormat, setPendingFormat } from '../../modelApi/format/pendingFormat';
+import { PluginEventType } from 'roosterjs-editor-types';
 import type { Entity } from 'roosterjs-editor-types';
 import type { ContentModelContentChangedEventData } from '../../publicTypes/event/ContentModelContentChangedEvent';
 import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor';

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/paste.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/utils/paste.ts
@@ -1,9 +1,8 @@
 import getSelectedSegments from '../selection/getSelectedSegments';
 import { ChangeSource } from '../../publicTypes/event/ContentModelContentChangedEvent';
 import { formatWithContentModel } from './formatWithContentModel';
-import { GetContentMode, PluginEventType } from 'roosterjs-editor-types';
+import { GetContentMode, PasteType as OldPasteType, PluginEventType } from 'roosterjs-editor-types';
 import { mergeModel } from '../../modelApi/common/mergeModel';
-import { PasteType as OldPasteType } from 'roosterjs-editor-types';
 import type {
     ContentModelDocument,
     ContentModelSegmentFormat,

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/event/ContentModelContentChangedEvent.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/event/ContentModelContentChangedEvent.ts
@@ -6,6 +6,66 @@ import type {
 } from 'roosterjs-editor-types';
 
 /**
+ * Possible change sources. Here are the predefined sources.
+ * It can also be other string if the change source can't fall into these sources.
+ */
+export enum ChangeSource {
+    /**
+     * Content changed by auto link
+     */
+    AutoLink = 'AutoLink',
+    /**
+     * Content changed by create link
+     */
+    CreateLink = 'CreateLink',
+    /**
+     * Content changed by format
+     */
+    Format = 'Format',
+    /**
+     * Content changed by image resize
+     */
+    ImageResize = 'ImageResize',
+    /**
+     * Content changed by paste
+     */
+    Paste = 'Paste',
+    /**
+     * Content changed by setContent API
+     */
+    SetContent = 'SetContent',
+    /**
+     * Content changed by cut operation
+     */
+    Cut = 'Cut',
+    /**
+     * Content changed by drag & drop operation
+     */
+    Drop = 'Drop',
+    /**
+     * Insert a new entity into editor
+     */
+    InsertEntity = 'InsertEntity',
+    /**
+     * Editor is switched to dark mode, content color is changed
+     */
+    SwitchToDarkMode = 'SwitchToDarkMode',
+    /**
+     * Editor is switched to light mode, content color is changed
+     */
+    SwitchToLightMode = 'SwitchToLightMode',
+    /**
+     * List chain reorganized numbers of lists
+     */
+    ListChain = 'ListChain',
+    /**
+     * Keyboard event, used by Content Model.
+     * Data of this event will be the key code number
+     */
+    Keyboard = 'Keyboard',
+}
+
+/**
  * Data of ContentModelContentChangedEvent
  */
 export interface ContentModelContentChangedEventData extends ContentChangedEventData {

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/PasteType.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/parameter/PasteType.ts
@@ -1,0 +1,23 @@
+/**
+ * Specify what type of content to paste
+ */
+export type PasteType =
+    /**
+     * Default paste behavior
+     */
+    | 'normal'
+
+    /**
+     * Paste only the plain text
+     */
+    | 'asPlainText'
+
+    /**
+     * Apply the current style to pasted content
+     */
+    | 'mergeFormat'
+
+    /**
+     * If there is a image uri in the clipboard, paste the content as image element
+     */
+    | 'asImage';

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/corePlugins/ContentModelEditPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/corePlugins/ContentModelEditPluginTest.ts
@@ -1,6 +1,6 @@
 import * as keyboardDelete from '../../../lib/publicApi/editing/keyboardDelete';
 import ContentModelEditPlugin from '../../../lib/editor/corePlugins/ContentModelEditPlugin';
-import { EntityOperation, Keys, PluginEventType } from 'roosterjs-editor-types';
+import { EntityOperation, PluginEventType } from 'roosterjs-editor-types';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 
 describe('ContentModelEditPlugin', () => {
@@ -24,7 +24,7 @@ describe('ContentModelEditPlugin', () => {
 
         it('Backspace', () => {
             const plugin = new ContentModelEditPlugin();
-            const rawEvent = { which: Keys.BACKSPACE } as any;
+            const rawEvent = { key: 'Backspace' } as any;
 
             plugin.initialize(editor);
 
@@ -38,7 +38,7 @@ describe('ContentModelEditPlugin', () => {
 
         it('Delete', () => {
             const plugin = new ContentModelEditPlugin();
-            const rawEvent = { which: Keys.DELETE } as any;
+            const rawEvent = { key: 'Delete' } as any;
 
             plugin.initialize(editor);
 
@@ -66,7 +66,7 @@ describe('ContentModelEditPlugin', () => {
 
         it('Default prevented', () => {
             const plugin = new ContentModelEditPlugin();
-            const rawEvent = { which: Keys.DELETE, defaultPrevented: true } as any;
+            const rawEvent = { key: 'Delete', defaultPrevented: true } as any;
 
             plugin.initialize(editor);
             plugin.onPluginEvent({
@@ -94,21 +94,21 @@ describe('ContentModelEditPlugin', () => {
 
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
-                rawEvent: { which: Keys.DELETE } as any,
+                rawEvent: { key: 'Delete' } as any,
             });
 
             expect(keyboardDeleteSpy).toHaveBeenCalledWith(editor, {
-                which: Keys.DELETE,
+                key: 'Delete',
             } as any);
 
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
-                rawEvent: { which: Keys.DELETE } as any,
+                rawEvent: { key: 'Delete' } as any,
             });
 
             expect(keyboardDeleteSpy).toHaveBeenCalledTimes(2);
             expect(keyboardDeleteSpy).toHaveBeenCalledWith(editor, {
-                which: Keys.DELETE,
+                key: 'Delete',
             } as any);
         });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/corePlugins/ContentModelFormatPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/corePlugins/ContentModelFormatPluginTest.ts
@@ -1,9 +1,10 @@
 import * as formatWithContentModel from '../../../lib/publicApi/utils/formatWithContentModel';
 import * as pendingFormat from '../../../lib/modelApi/format/pendingFormat';
 import ContentModelFormatPlugin from '../../../lib/editor/corePlugins/ContentModelFormatPlugin';
-import { ChangeSource, PluginEventType } from 'roosterjs-editor-types';
+import { ChangeSource } from '../../../lib/publicTypes/event/ContentModelContentChangedEvent';
 import { ContentModelFormatPluginState } from '../../../lib/publicTypes/pluginState/ContentModelFormatPluginState';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
+import { PluginEventType } from 'roosterjs-editor-types';
 import {
     addSegment,
     createContentModelDocument,
@@ -28,7 +29,7 @@ describe('ContentModelFormatPlugin', () => {
 
         plugin.onPluginEvent({
             eventType: PluginEventType.KeyDown,
-            rawEvent: ({ which: 33 } as any) as KeyboardEvent,
+            rawEvent: ({ key: 'PageUp' } as any) as KeyboardEvent,
         });
 
         plugin.dispose();

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelCachePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelCachePluginTest.ts
@@ -2,7 +2,7 @@ import { ContentModelCachePluginState } from '../../../lib/publicTypes/pluginSta
 import { ContentModelDomIndexer } from 'roosterjs-content-model-types';
 import { default as ContentModelCachePlugin } from '../../../lib/editor/corePlugins/ContentModelCachePlugin';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
-import { Keys, PluginEventType } from 'roosterjs-editor-types';
+import { PluginEventType } from 'roosterjs-editor-types';
 
 describe('ContentModelCachePlugin', () => {
     let plugin: ContentModelCachePlugin;
@@ -64,7 +64,7 @@ describe('ContentModelCachePlugin', () => {
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
                 rawEvent: {
-                    which: Keys.ENTER,
+                    key: 'Enter',
                 } as any,
             });
 
@@ -78,7 +78,6 @@ describe('ContentModelCachePlugin', () => {
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
                 rawEvent: {
-                    which: Keys.B,
                     key: 'B',
                 } as any,
             });
@@ -95,7 +94,7 @@ describe('ContentModelCachePlugin', () => {
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
                 rawEvent: {
-                    which: Keys.B,
+                    key: 'B',
                 } as any,
             });
 
@@ -113,7 +112,6 @@ describe('ContentModelCachePlugin', () => {
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
                 rawEvent: {
-                    which: Keys.B,
                     key: 'B',
                 } as any,
             });
@@ -130,8 +128,7 @@ describe('ContentModelCachePlugin', () => {
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
                 rawEvent: {
-                    which: Keys.UP,
-                    key: 'Up',
+                    key: 'ArrowUp',
                 } as any,
             });
 
@@ -151,7 +148,6 @@ describe('ContentModelCachePlugin', () => {
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
                 rawEvent: {
-                    which: Keys.B,
                     key: 'B',
                 } as any,
             });
@@ -167,7 +163,6 @@ describe('ContentModelCachePlugin', () => {
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
                 rawEvent: {
-                    which: Keys.B,
                     key: 'B',
                 } as any,
             });
@@ -181,7 +176,7 @@ describe('ContentModelCachePlugin', () => {
             plugin.onPluginEvent({
                 eventType: PluginEventType.KeyDown,
                 rawEvent: {
-                    which: Keys.ENTER,
+                    key: 'Enter',
                 } as any,
             });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelPastePluginTest.ts
@@ -1,7 +1,7 @@
 import * as addParser from '../../../lib/editor/plugins/PastePlugin/utils/addParser';
 import * as chainSanitizerCallbackFile from 'roosterjs-editor-dom/lib/htmlSanitizer/chainSanitizerCallback';
 import * as ExcelFile from '../../../lib/editor/plugins/PastePlugin/Excel/processPastedContentFromExcel';
-import * as getPasteSource from 'roosterjs-editor-dom/lib/pasteSourceValidations/getPasteSource';
+import * as getPasteSource from '../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
 import * as PowerPointFile from '../../../lib/editor/plugins/PastePlugin/PowerPoint/processPastedContentFromPowerPoint';
 import * as setProcessor from '../../../lib/editor/plugins/PastePlugin/utils/setProcessor';
 import * as WacFile from '../../../lib/editor/plugins/PastePlugin/WacComponents/processPastedContentWacComponents';
@@ -9,7 +9,7 @@ import * as WordDesktopFile from '../../../lib/editor/plugins/PastePlugin/WordDe
 import ContentModelBeforePasteEvent from '../../../lib/publicTypes/event/ContentModelBeforePasteEvent';
 import ContentModelPastePlugin from '../../../lib/editor/plugins/PastePlugin/ContentModelPastePlugin';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
-import { KnownPasteSourceType, PasteType, PluginEventType } from 'roosterjs-editor-types';
+import { PasteType, PluginEventType } from 'roosterjs-editor-types';
 
 const trustedHTMLHandler = <any>'mock';
 const GOOGLE_SHEET_NODE_NAME = 'google-sheets-html-origin';
@@ -80,7 +80,7 @@ describe('Content Model Paste Plugin Test', () => {
         });
 
         it('WordDesktop', () => {
-            spyOn(getPasteSource, 'default').and.returnValue(KnownPasteSourceType.WordDesktop);
+            spyOn(getPasteSource, 'getPasteSource').and.returnValue('wordDesktop');
             spyOn(WordDesktopFile, 'processPastedContentFromWordDesktop').and.callThrough();
 
             plugin.initialize(editor);
@@ -96,7 +96,7 @@ describe('Content Model Paste Plugin Test', () => {
         });
 
         it('Excel | merge format', () => {
-            spyOn(getPasteSource, 'default').and.returnValue(KnownPasteSourceType.ExcelDesktop);
+            spyOn(getPasteSource, 'getPasteSource').and.returnValue('excelDesktop');
             spyOn(ExcelFile, 'processPastedContentFromExcel').and.callThrough();
 
             (<any>event).pasteType = PasteType.MergeFormat;
@@ -113,7 +113,7 @@ describe('Content Model Paste Plugin Test', () => {
         });
 
         it('Excel | image', () => {
-            spyOn(getPasteSource, 'default').and.returnValue(KnownPasteSourceType.ExcelDesktop);
+            spyOn(getPasteSource, 'getPasteSource').and.returnValue('excelDesktop');
             spyOn(ExcelFile, 'processPastedContentFromExcel').and.callThrough();
 
             (<any>event).pasteType = PasteType.AsImage;
@@ -130,7 +130,7 @@ describe('Content Model Paste Plugin Test', () => {
         });
 
         it('Excel', () => {
-            spyOn(getPasteSource, 'default').and.returnValue(KnownPasteSourceType.ExcelDesktop);
+            spyOn(getPasteSource, 'getPasteSource').and.returnValue('excelDesktop');
             spyOn(ExcelFile, 'processPastedContentFromExcel').and.callThrough();
 
             plugin.initialize(editor);
@@ -146,7 +146,7 @@ describe('Content Model Paste Plugin Test', () => {
         });
 
         it('Excel Online', () => {
-            spyOn(getPasteSource, 'default').and.returnValue(KnownPasteSourceType.ExcelOnline);
+            spyOn(getPasteSource, 'getPasteSource').and.returnValue('excelOnline');
             spyOn(ExcelFile, 'processPastedContentFromExcel').and.callThrough();
 
             plugin.initialize(editor);
@@ -162,9 +162,7 @@ describe('Content Model Paste Plugin Test', () => {
         });
 
         it('Power Point', () => {
-            spyOn(getPasteSource, 'default').and.returnValue(
-                KnownPasteSourceType.PowerPointDesktop
-            );
+            spyOn(getPasteSource, 'getPasteSource').and.returnValue('powerPointDesktop');
             spyOn(PowerPointFile, 'processPastedContentFromPowerPoint').and.callThrough();
 
             plugin.initialize(editor);
@@ -180,7 +178,7 @@ describe('Content Model Paste Plugin Test', () => {
         });
 
         it('Wac', () => {
-            spyOn(getPasteSource, 'default').and.returnValue(KnownPasteSourceType.WacComponents);
+            spyOn(getPasteSource, 'getPasteSource').and.returnValue('wacComponents');
             spyOn(WacFile, 'processPastedContentWacComponents').and.callThrough();
 
             plugin.initialize(editor);
@@ -193,7 +191,7 @@ describe('Content Model Paste Plugin Test', () => {
         });
 
         it('Default', () => {
-            spyOn(getPasteSource, 'default').and.returnValue(KnownPasteSourceType.Default);
+            spyOn(getPasteSource, 'getPasteSource').and.returnValue('default');
 
             plugin.initialize(editor);
             plugin.onPluginEvent(event);
@@ -204,7 +202,7 @@ describe('Content Model Paste Plugin Test', () => {
         });
 
         it('Google Sheets', () => {
-            spyOn(getPasteSource, 'default').and.returnValue(KnownPasteSourceType.GoogleSheets);
+            spyOn(getPasteSource, 'getPasteSource').and.returnValue('googleSheets');
 
             plugin.initialize(editor);
             plugin.onPluginEvent(event);

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/ContentModelPastePluginTest.ts
@@ -9,10 +9,10 @@ import * as WordDesktopFile from '../../../lib/editor/plugins/PastePlugin/WordDe
 import ContentModelBeforePasteEvent from '../../../lib/publicTypes/event/ContentModelBeforePasteEvent';
 import ContentModelPastePlugin from '../../../lib/editor/plugins/PastePlugin/ContentModelPastePlugin';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
+import { PastePropertyNames } from '../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/constants';
 import { PasteType, PluginEventType } from 'roosterjs-editor-types';
 
 const trustedHTMLHandler = <any>'mock';
-const GOOGLE_SHEET_NODE_NAME = 'google-sheets-html-origin';
 const DEFAULT_TIMES_ADD_PARSER_CALLED = 3;
 
 describe('Content Model Paste Plugin Test', () => {
@@ -211,7 +211,9 @@ describe('Content Model Paste Plugin Test', () => {
             expect(setProcessor.setProcessor).toHaveBeenCalledTimes(0);
             expect(chainSanitizerCallbackFile.default).toHaveBeenCalledTimes(1);
             expect(
-                event.sanitizingOption.additionalTagReplacements[GOOGLE_SHEET_NODE_NAME]
+                event.sanitizingOption.additionalTagReplacements[
+                    PastePropertyNames.GOOGLE_SHEET_NODE_NAME
+                ]
             ).toEqual('*');
         });
     });

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/e2e/cmPasteFromExcelTest.ts
@@ -51,7 +51,7 @@ describe(ID, () => {
         }
         spyOn(processPastedContentFromExcel, 'processPastedContentFromExcel').and.callThrough();
 
-        paste(editor, clipboardData, false, false, true);
+        paste(editor, clipboardData, 'asImage');
 
         const model = editor.createContentModel({
             processorOverride: {

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/documentContainWacElementsTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/documentContainWacElementsTest.ts
@@ -1,0 +1,94 @@
+import { documentContainWacElements } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/documentContainWacElements';
+import { GetSourceInputParams } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
+import { getWacElement } from './pasteTestUtils';
+
+describe('documentContainWacElements |', () => {
+    it('Fragment contain Wac elements', () => {
+        const fragment = document.createDocumentFragment();
+        fragment.appendChild(getWacElement());
+
+        const result = documentContainWacElements(<GetSourceInputParams>{ fragment });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Fragment does not contain Wac elements', () => {
+        const fragment = document.createDocumentFragment();
+
+        const result = documentContainWacElements(<GetSourceInputParams>{ fragment });
+
+        expect(result).toBeFalse();
+    });
+
+    [
+        'TableInsertRowGapBlank',
+        'TableColumnResizeHandle',
+        'TableCellTopBorderHandle',
+        'TableCellLeftBorderHandle',
+        'TableHoverColumnHandle',
+        'TableHoverRowHandle',
+    ].forEach(className => {
+        it('documentContainWacElementsTest_' + className, () => {
+            const fragment = document.createDocumentFragment();
+
+            const div = document.createElement('div');
+            div.className = className;
+            const table = document.createElement('table');
+            const row = document.createElement('tr');
+            const cell = document.createElement('td');
+
+            cell.appendChild(div);
+            row.appendChild(cell);
+            table.appendChild(row);
+            fragment.appendChild(table);
+
+            const result = documentContainWacElements(<GetSourceInputParams>{ fragment });
+
+            expect(result).toBeTrue();
+        });
+
+        it('documentContainWacElementsTest_element not contained in table_' + className, () => {
+            const fragment = document.createDocumentFragment();
+
+            const div = document.createElement('div');
+            div.className = className;
+            fragment.appendChild(div);
+
+            const result = documentContainWacElements(<GetSourceInputParams>{ fragment });
+
+            expect(result).toBeFalse();
+        });
+    });
+
+    it('ul[class^="BulletListStyle"]>.OutlineElement', () => {
+        const fragment = document.createDocumentFragment();
+
+        const ul = document.createElement('ul');
+        const li = document.createElement('li');
+        ul.className = 'BulletListStyle';
+        li.className = 'OutlineElement';
+
+        ul.appendChild(li);
+        fragment.appendChild(ul);
+
+        const result = documentContainWacElements(<GetSourceInputParams>{ fragment });
+
+        expect(result).toBeTrue();
+    });
+
+    it('ol[class^="NumberListStyle"]>.OutlineElement', () => {
+        const fragment = document.createDocumentFragment();
+
+        const ol = document.createElement('ol');
+        const li = document.createElement('li');
+        ol.className = 'NumberListStyle';
+        li.className = 'OutlineElement';
+
+        ol.appendChild(li);
+        fragment.appendChild(ol);
+
+        const result = documentContainWacElements(<GetSourceInputParams>{ fragment });
+
+        expect(result).toBeTrue();
+    });
+});

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/getPasteSourceTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/getPasteSourceTest.ts
@@ -1,6 +1,6 @@
 import { BeforePasteEvent, ClipboardData } from 'roosterjs-editor-types';
 import { getPasteSource } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
-import { GOOGLE_SHEET_NODE_NAME } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/constants';
+import { PastePropertyNames } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/constants';
 import {
     EXCEL_ATTRIBUTE_VALUE,
     getWacElement,
@@ -67,7 +67,7 @@ function excelParam(): BeforePasteEvent {
 
 function googleSheetParam(): BeforePasteEvent {
     const fragment = document.createDocumentFragment();
-    fragment.appendChild(document.createElement(GOOGLE_SHEET_NODE_NAME));
+    fragment.appendChild(document.createElement(PastePropertyNames.GOOGLE_SHEET_NODE_NAME));
 
     return <BeforePasteEvent>{ fragment, htmlAttributes: {}, clipboardData: {} };
 }

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/getPasteSourceTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/getPasteSourceTest.ts
@@ -1,0 +1,111 @@
+import { BeforePasteEvent, ClipboardData } from 'roosterjs-editor-types';
+import { getPasteSource } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
+import { GOOGLE_SHEET_NODE_NAME } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/constants';
+import {
+    EXCEL_ATTRIBUTE_VALUE,
+    getWacElement,
+    POWERPOINT_ATTRIBUTE_VALUE,
+    WORD_ATTRIBUTE_VALUE,
+} from 'roosterjs-editor-plugins/test/paste/pasteTestUtils';
+
+describe('getPasteSourceTest | ', () => {
+    it('Is Word', () => {
+        const result = getPasteSource(wordParam(), false /* shouldConvertSingleImage */);
+        expect(result).toBe('wordDesktop');
+    });
+    it('Is Wac Doc', () => {
+        const result = getPasteSource(wacParam(), false /* shouldConvertSingleImage */);
+        expect(result).toBe('wacComponents');
+    });
+    it('Is Excel Doc', () => {
+        const result = getPasteSource(excelParam(), false /* shouldConvertSingleImage */);
+        expect(result).toBe('excelDesktop');
+    });
+    it('Is GoogleSheet Doc', () => {
+        const result = getPasteSource(googleSheetParam(), false /* shouldConvertSingleImage */);
+        expect(result).toBe('googleSheets');
+    });
+    it('Is PowerPoint Doc', () => {
+        const result = getPasteSource(powerPointParam(), false /* shouldConvertSingleImage */);
+        expect(result).toBe('powerPointDesktop');
+    });
+    it('Is SingleImage', () => {
+        const result = getPasteSource(
+            converSingleImageParam(),
+            true /* shouldConvertSingleImage */
+        );
+        expect(result).toBe('singleImage');
+    });
+    it('Is SingleImage, but should not convert single image', () => {
+        const result = getPasteSource(
+            converSingleImageParam(),
+            false /* shouldConvertSingleImage */
+        );
+        expect(result).toBe('default');
+    });
+    it('Is Default', () => {
+        const result = getPasteSource(defaultParam(), false /* shouldConvertSingleImage */);
+        expect(result).toBe('default');
+    });
+});
+
+function wacParam(): BeforePasteEvent {
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(getWacElement());
+
+    return <BeforePasteEvent>{ fragment, htmlAttributes: {}, clipboardData: {} };
+}
+
+function excelParam(): BeforePasteEvent {
+    const fragment = document.createDocumentFragment();
+    const htmlAttributes: Record<string, string> = {
+        'xmlns:x': EXCEL_ATTRIBUTE_VALUE,
+    };
+
+    return <BeforePasteEvent>{ htmlAttributes, fragment, clipboardData: {} };
+}
+
+function googleSheetParam(): BeforePasteEvent {
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(document.createElement(GOOGLE_SHEET_NODE_NAME));
+
+    return <BeforePasteEvent>{ fragment, htmlAttributes: {}, clipboardData: {} };
+}
+
+function converSingleImageParam(): BeforePasteEvent {
+    const fragment = document.createDocumentFragment();
+    const clipboardData = <ClipboardData>{
+        htmlFirstLevelChildTags: ['IMG'],
+    };
+
+    return <BeforePasteEvent>{
+        fragment,
+        clipboardData,
+        htmlAttributes: {},
+    };
+}
+
+function powerPointParam(): BeforePasteEvent {
+    const fragment = document.createDocumentFragment();
+
+    const htmlAttributes: Record<string, string> = {
+        ProgId: POWERPOINT_ATTRIBUTE_VALUE,
+    };
+
+    return <BeforePasteEvent>{ htmlAttributes, fragment, clipboardData: {} };
+}
+
+function wordParam(): BeforePasteEvent {
+    const fragment = document.createDocumentFragment();
+    const htmlAttributes: Record<string, string> = {
+        'xmlns:w': WORD_ATTRIBUTE_VALUE,
+    };
+
+    return <BeforePasteEvent>{ htmlAttributes, fragment, clipboardData: {} };
+}
+
+function defaultParam(): BeforePasteEvent {
+    const fragment = document.createDocumentFragment();
+
+    return <BeforePasteEvent>{ htmlAttributes: {}, fragment, clipboardData: {} };
+}

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isExcelDesktopDocumentTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isExcelDesktopDocumentTest.ts
@@ -1,0 +1,43 @@
+import { EXCEL_ATTRIBUTE_VALUE } from './pasteTestUtils';
+import { GetSourceInputParams } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
+import { isExcelDesktopDocument } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/isExcelDesktopDocument';
+
+const EXCEL_ONLINE_ATTRIBUTE_VALUE = 'Excel.Sheet';
+
+describe('isExcelDesktopDocument |', () => {
+    it('Is an ambiguous Excel document, unconfirmed if Desktop', () => {
+        const htmlAttributes: Record<string, string> = {
+            ProgId: EXCEL_ONLINE_ATTRIBUTE_VALUE,
+        };
+
+        const result = isExcelDesktopDocument(<GetSourceInputParams>{ htmlAttributes });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Is an Excel Desktop document 1', () => {
+        const htmlAttributes: Record<string, string> = {
+            'xmlns:x': EXCEL_ATTRIBUTE_VALUE,
+            ProgId: EXCEL_ONLINE_ATTRIBUTE_VALUE,
+        };
+
+        const result = isExcelDesktopDocument(<GetSourceInputParams>{ htmlAttributes });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Is an Excel Desktop document 2', () => {
+        const htmlAttributes: Record<string, string> = {
+            'xmlns:x': EXCEL_ATTRIBUTE_VALUE,
+        };
+        const result = isExcelDesktopDocument(<GetSourceInputParams>{ htmlAttributes });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Is not a Excel Document', () => {
+        const result = isExcelDesktopDocument(<GetSourceInputParams>{ htmlAttributes: {} });
+
+        expect(result).toBeFalse();
+    });
+});

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isExcelOnlineDocumentTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isExcelOnlineDocumentTest.ts
@@ -1,0 +1,34 @@
+import { EXCEL_ATTRIBUTE_VALUE } from './pasteTestUtils';
+import { GetSourceInputParams } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
+import { isExcelOnlineDocument } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/isExcelOnlineDocument';
+
+const EXCEL_ONLINE_ATTRIBUTE_VALUE = 'Excel.Sheet';
+
+describe('isExcelOnlineDocument |', () => {
+    it('Is not an Excel Online document', () => {
+        const htmlAttributes: Record<string, string> = {
+            'xmlns:x': EXCEL_ATTRIBUTE_VALUE,
+            ProgId: EXCEL_ONLINE_ATTRIBUTE_VALUE,
+        };
+
+        const result = isExcelOnlineDocument(<GetSourceInputParams>{ htmlAttributes });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Is an Excel Online document', () => {
+        const htmlAttributes: Record<string, string> = {
+            ProgId: EXCEL_ONLINE_ATTRIBUTE_VALUE,
+        };
+
+        const result = isExcelOnlineDocument(<GetSourceInputParams>{ htmlAttributes });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Is not a Excel Document', () => {
+        const result = isExcelOnlineDocument(<GetSourceInputParams>{ htmlAttributes: {} });
+
+        expect(result).toBeFalse();
+    });
+});

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isGoogleSheetDocumentTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isGoogleSheetDocumentTest.ts
@@ -1,0 +1,32 @@
+import { GetSourceInputParams } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
+import { getWacElement } from './pasteTestUtils';
+import { GOOGLE_SHEET_NODE_NAME } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/constants';
+import { isGoogleSheetDocument } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/isGoogleSheetDocument';
+
+describe('isGoogleSheetDocument |', () => {
+    it('Is from Google Sheets', () => {
+        const fragment = document.createDocumentFragment();
+        fragment.appendChild(document.createElement(GOOGLE_SHEET_NODE_NAME));
+
+        const result = isGoogleSheetDocument(<GetSourceInputParams>{ fragment });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Is not from Google Sheets', () => {
+        const fragment = document.createDocumentFragment();
+
+        const result = isGoogleSheetDocument(<GetSourceInputParams>{ fragment });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Is not from Google Sheets 2', () => {
+        const fragment = document.createDocumentFragment();
+        fragment.appendChild(getWacElement());
+
+        const result = isGoogleSheetDocument(<GetSourceInputParams>{ fragment });
+
+        expect(result).toBeFalse();
+    });
+});

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isGoogleSheetDocumentTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isGoogleSheetDocumentTest.ts
@@ -1,12 +1,12 @@
 import { GetSourceInputParams } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
 import { getWacElement } from './pasteTestUtils';
-import { GOOGLE_SHEET_NODE_NAME } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/constants';
 import { isGoogleSheetDocument } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/isGoogleSheetDocument';
+import { PastePropertyNames } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/constants';
 
 describe('isGoogleSheetDocument |', () => {
     it('Is from Google Sheets', () => {
         const fragment = document.createDocumentFragment();
-        fragment.appendChild(document.createElement(GOOGLE_SHEET_NODE_NAME));
+        fragment.appendChild(document.createElement(PastePropertyNames.GOOGLE_SHEET_NODE_NAME));
 
         const result = isGoogleSheetDocument(<GetSourceInputParams>{ fragment });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isPowerPointDesktopDocumentTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isPowerPointDesktopDocumentTest.ts
@@ -1,0 +1,21 @@
+import { GetSourceInputParams } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
+import { isPowerPointDesktopDocument } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/isPowerPointDesktopDocument';
+import { POWERPOINT_ATTRIBUTE_VALUE } from './pasteTestUtils';
+
+describe('isPowerPointDesktopDocument |', () => {
+    it('Is a PPT document 1', () => {
+        const htmlAttributes: Record<string, string> = {
+            ProgId: POWERPOINT_ATTRIBUTE_VALUE,
+        };
+
+        const result = isPowerPointDesktopDocument(<GetSourceInputParams>{ htmlAttributes });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Is not a PPT Document', () => {
+        const result = isPowerPointDesktopDocument(<GetSourceInputParams>{ htmlAttributes: {} });
+
+        expect(result).toBeFalse();
+    });
+});

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isWordDesktopDocumentTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/isWordDesktopDocumentTest.ts
@@ -1,0 +1,44 @@
+import { GetSourceInputParams } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
+import { isWordDesktopDocument } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/isWordDesktopDocument';
+import { WORD_ATTRIBUTE_VALUE } from './pasteTestUtils';
+
+const WORD_PROG_ID = 'Word.Document';
+
+describe('isWordDesktopDocument |', () => {
+    it('Is a Word document 1', () => {
+        const htmlAttributes: Record<string, string> = {
+            ProgId: WORD_PROG_ID,
+        };
+
+        const result = isWordDesktopDocument(<GetSourceInputParams>{ htmlAttributes });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Is a Word document 2', () => {
+        const htmlAttributes: Record<string, string> = {
+            'xmlns:w': WORD_ATTRIBUTE_VALUE,
+            ProgId: WORD_PROG_ID,
+        };
+
+        const result = isWordDesktopDocument(<GetSourceInputParams>{ htmlAttributes });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Is a Word document 3', () => {
+        const htmlAttributes: Record<string, string> = {
+            'xmlns:w': WORD_ATTRIBUTE_VALUE,
+        };
+
+        const result = isWordDesktopDocument(<GetSourceInputParams>{ htmlAttributes });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Is not a Word Document', () => {
+        const result = isWordDesktopDocument(<GetSourceInputParams>{ htmlAttributes: {} });
+
+        expect(result).toBeFalse();
+    });
+});

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/pasteTestUtils.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/pasteTestUtils.ts
@@ -1,0 +1,9 @@
+export const EXCEL_ATTRIBUTE_VALUE = 'urn:schemas-microsoft-com:office:excel';
+export const POWERPOINT_ATTRIBUTE_VALUE = 'PowerPoint.Slide';
+export const WORD_ATTRIBUTE_VALUE = 'urn:schemas-microsoft-com:office:word';
+
+export const getWacElement = (): HTMLElement => {
+    const element = document.createElement('span');
+    element.classList.add('WACImageContainer');
+    return element;
+};

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/shouldConvertToSingleImageTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/plugins/paste/pasteSourceValidations/shouldConvertToSingleImageTest.ts
@@ -1,0 +1,40 @@
+import { ClipboardData } from 'roosterjs-editor-types';
+import { GetSourceInputParams } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
+import { shouldConvertToSingleImage } from '../../../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/shouldConvertToSingleImage';
+
+describe('shouldConvertToSingleImage |', () => {
+    it('Is Single Image', () => {
+        runTest(['IMG'], true, true /* shouldConvertToSingleImage */);
+    });
+
+    it('Is Single Image, feature is not enabled', () => {
+        runTest(['IMG'], false, false /* shouldConvertToSingleImage */);
+    });
+
+    it('Is Not single Image, feature is not enabled', () => {
+        runTest(['IMG', 'DIV'], false, false /* shouldConvertToSingleImage */);
+    });
+
+    it('Is Not single Image, feature is enabled', () => {
+        runTest(['IMG', 'DIV'], false, true /* shouldConvertToSingleImage */);
+    });
+
+    function runTest(
+        htmlFirstLevelChildTags: string[],
+        resultExpected: boolean,
+        shouldConvertToSingleImageInput: boolean
+    ) {
+        const fragment = document.createDocumentFragment();
+        const clipboardData = <ClipboardData>{
+            htmlFirstLevelChildTags,
+        };
+
+        const result = shouldConvertToSingleImage(<GetSourceInputParams>{
+            fragment,
+            shouldConvertSingleImage: shouldConvertToSingleImageInput,
+            clipboardData,
+        });
+
+        expect(result).toEqual(resultExpected);
+    }
+});

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/keyboardDeleteTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/editing/keyboardDeleteTest.ts
@@ -2,11 +2,12 @@ import * as deleteSelection from '../../../lib/modelApi/edit/deleteSelection';
 import * as formatWithContentModel from '../../../lib/publicApi/utils/formatWithContentModel';
 import * as handleKeyboardEventResult from '../../../lib/editor/utils/handleKeyboardEventCommon';
 import keyboardDelete from '../../../lib/publicApi/editing/keyboardDelete';
-import { ChangeSource, Keys } from 'roosterjs-editor-types';
+import { ChangeSource } from '../../../lib/publicTypes/event/ContentModelContentChangedEvent';
 import { ContentModelDocument, DOMSelection } from 'roosterjs-content-model-types';
 import { deleteAllSegmentBefore } from '../../../lib/modelApi/edit/deleteSteps/deleteAllSegmentBefore';
 import { editingTestCommon } from './editingTestCommon';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
+import { Keys } from 'roosterjs-editor-types';
 import {
     backwardDeleteWordSelection,
     forwardDeleteWordSelection,
@@ -29,7 +30,7 @@ describe('keyboardDelete', () => {
 
     function runTest(
         input: ContentModelDocument,
-        key: number,
+        key: string,
         expectedResult: ContentModelDocument,
         expectedSteps: DeleteSelectionStep[],
         expectedDelete: DeleteResult,
@@ -41,7 +42,7 @@ describe('keyboardDelete', () => {
 
         const preventDefault = jasmine.createSpy('preventDefault');
         const mockedEvent = ({
-            which: key,
+            key,
             preventDefault,
         } as any) as KeyboardEvent;
 
@@ -82,7 +83,7 @@ describe('keyboardDelete', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            Keys.DELETE,
+            'Delete',
             {
                 blockGroupType: 'Document',
                 blocks: [],
@@ -99,7 +100,7 @@ describe('keyboardDelete', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            Keys.BACKSPACE,
+            'Backspace',
             {
                 blockGroupType: 'Document',
                 blocks: [],
@@ -118,7 +119,7 @@ describe('keyboardDelete', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            Keys.DELETE,
+            'Delete',
             {
                 blockGroupType: 'Document',
                 blocks: [],
@@ -137,7 +138,7 @@ describe('keyboardDelete', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            Keys.BACKSPACE,
+            'Backspace',
             {
                 blockGroupType: 'Document',
                 blocks: [],
@@ -156,7 +157,7 @@ describe('keyboardDelete', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            Keys.DELETE,
+            'Delete',
             {
                 blockGroupType: 'Document',
                 blocks: [],
@@ -175,7 +176,7 @@ describe('keyboardDelete', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            Keys.BACKSPACE,
+            'Backspace',
             {
                 blockGroupType: 'Document',
                 blocks: [],
@@ -204,7 +205,7 @@ describe('keyboardDelete', () => {
                     },
                 ],
             },
-            Keys.DELETE,
+            'Delete',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -245,7 +246,7 @@ describe('keyboardDelete', () => {
                     },
                 ],
             },
-            Keys.BACKSPACE,
+            'Backspace',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -291,7 +292,7 @@ describe('keyboardDelete', () => {
                     },
                 ],
             },
-            Keys.DELETE,
+            'Delete',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -342,7 +343,7 @@ describe('keyboardDelete', () => {
                     },
                 ],
             },
-            Keys.BACKSPACE,
+            'Backspace',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -381,9 +382,9 @@ describe('keyboardDelete', () => {
                 range: { collapsed: false },
             }),
         } as any) as IContentModelEditor;
-        const which = Keys.DELETE;
         const event = {
-            which,
+            which: Keys.DELETE,
+            key: 'Delete',
         } as any;
 
         keyboardDelete(editor, event);
@@ -392,7 +393,7 @@ describe('keyboardDelete', () => {
         expect(spy.calls.argsFor(0)[1]).toBe('handleDeleteKey');
         expect(addUndoSnapshot).not.toHaveBeenCalled();
         expect(spy.calls.argsFor(0)[3]?.changeSource).toBe(ChangeSource.Keyboard);
-        expect(spy.calls.argsFor(0)[3]?.getChangeData?.()).toBe(which);
+        expect(spy.calls.argsFor(0)[3]?.getChangeData?.()).toBe(Keys.DELETE);
     });
 
     it('Check parameter of formatWithContentModel, backward', () => {
@@ -407,6 +408,7 @@ describe('keyboardDelete', () => {
         } as any;
         const which = Keys.BACKSPACE;
         const event = {
+            key: 'Backspace',
             which,
             preventDefault,
         } as any;
@@ -420,7 +422,7 @@ describe('keyboardDelete', () => {
     });
 
     it('No need to delete - Backspace', () => {
-        const rawEvent = { which: Keys.BACKSPACE } as any;
+        const rawEvent = { key: 'Backspace' } as any;
         const range: DOMSelection = {
             type: 'range',
             range: ({
@@ -441,7 +443,7 @@ describe('keyboardDelete', () => {
     });
 
     it('No need to delete - Delete', () => {
-        const rawEvent = { which: Keys.DELETE } as any;
+        const rawEvent = { key: 'Delete' } as any;
         const range: DOMSelection = {
             type: 'range',
             range: ({
@@ -462,7 +464,7 @@ describe('keyboardDelete', () => {
     });
 
     it('Backspace from the beginning', () => {
-        const rawEvent = { which: Keys.BACKSPACE } as any;
+        const rawEvent = { key: 'Backspace' } as any;
         const range: DOMSelection = {
             type: 'range',
             range: ({
@@ -484,7 +486,7 @@ describe('keyboardDelete', () => {
     });
 
     it('Delete from the last', () => {
-        const rawEvent = { which: Keys.DELETE } as any;
+        const rawEvent = { key: 'Delete' } as any;
         const range: DOMSelection = {
             type: 'range',
             range: ({

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/entity/insertEntityTest.ts
@@ -2,7 +2,7 @@ import * as formatWithContentModel from '../../../lib/publicApi/utils/formatWith
 import * as insertEntityModel from '../../../lib/modelApi/entity/insertEntityModel';
 import * as normalizeContentModel from 'roosterjs-content-model-dom/lib/modelApi/common/normalizeContentModel';
 import insertEntity from '../../../lib/publicApi/entity/insertEntity';
-import { ChangeSource } from 'roosterjs-editor-types';
+import { ChangeSource } from '../../../lib/publicTypes/event/ContentModelContentChangedEvent';
 import { FormatWithContentModelContext } from '../../../lib/publicTypes/parameter/FormatWithContentModelContext';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/insertLinkTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/link/insertLinkTest.ts
@@ -1,8 +1,9 @@
 import ContentModelEditor from '../../../lib/editor/ContentModelEditor';
 import insertLink from '../../../lib/publicApi/link/insertLink';
-import { ChangeSource, PluginEventType } from 'roosterjs-editor-types';
+import { ChangeSource } from '../../../lib/publicTypes/event/ContentModelContentChangedEvent';
 import { ContentModelDocument, ContentModelLink } from 'roosterjs-content-model-types';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
+import { PluginEventType } from 'roosterjs-editor-types';
 import {
     addSegment,
     createContentModelDocument,

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/formatWithContentModelTest.ts
@@ -1,7 +1,8 @@
 import * as pendingFormat from '../../../lib/modelApi/format/pendingFormat';
-import { ChangeSource, EntityOperation, PluginEventType } from 'roosterjs-editor-types';
+import { ChangeSource } from '../../../lib/publicTypes/event/ContentModelContentChangedEvent';
 import { ContentModelDocument } from 'roosterjs-content-model-types';
 import { createImage } from 'roosterjs-content-model-dom';
+import { EntityOperation, PluginEventType } from 'roosterjs-editor-types';
 import { formatWithContentModel } from '../../../lib/publicApi/utils/formatWithContentModel';
 import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
 

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/utils/pasteTest.ts
@@ -1,7 +1,7 @@
 import * as addParserF from '../../../lib/editor/plugins/PastePlugin/utils/addParser';
 import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
 import * as ExcelF from '../../../lib/editor/plugins/PastePlugin/Excel/processPastedContentFromExcel';
-import * as getPasteSourceF from 'roosterjs-editor-dom/lib/pasteSourceValidations/getPasteSource';
+import * as getPasteSourceF from '../../../lib/editor/plugins/PastePlugin/pasteSourceValidations/getPasteSource';
 import * as getSelectedSegmentsF from '../../../lib/publicApi/selection/getSelectedSegments';
 import * as mergeModelFile from '../../../lib/modelApi/common/mergeModel';
 import * as PPT from '../../../lib/editor/plugins/PastePlugin/PowerPoint/processPastedContentFromPowerPoint';
@@ -10,6 +10,7 @@ import * as WacComponents from '../../../lib/editor/plugins/PastePlugin/WacCompo
 import * as WordDesktopFile from '../../../lib/editor/plugins/PastePlugin/WordDesktop/processPastedContentFromWordDesktop';
 import ContentModelEditor from '../../../lib/editor/ContentModelEditor';
 import ContentModelPastePlugin from '../../../lib/editor/plugins/PastePlugin/ContentModelPastePlugin';
+import { ChangeSource } from '../../../lib/publicTypes/event/ContentModelContentChangedEvent';
 import { ContentModelDocument, DomToModelOption } from 'roosterjs-content-model-types';
 import { createContentModelDocument, tableProcessor } from 'roosterjs-content-model-dom';
 import { expectEqual, initEditor } from '../../editor/plugins/paste/e2e/testUtils';
@@ -17,9 +18,7 @@ import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEdito
 import paste, * as pasteF from '../../../lib/publicApi/utils/paste';
 import {
     BeforePasteEvent,
-    ChangeSource,
     ClipboardData,
-    KnownPasteSourceType,
     PasteType,
     PluginEvent,
     PluginEventType,
@@ -130,7 +129,7 @@ describe('Paste ', () => {
     });
 
     it('Execute', () => {
-        pasteF.default(editor, clipboardData, false, false, false);
+        pasteF.default(editor, clipboardData);
 
         expect(setContentModel).toHaveBeenCalled();
         expect(focus).toHaveBeenCalled();
@@ -144,7 +143,7 @@ describe('Paste ', () => {
     });
 
     it('Execute | As plain text', () => {
-        pasteF.default(editor, clipboardData, true /* asPlainText */, false, false);
+        pasteF.default(editor, clipboardData, 'asPlainText');
 
         expect(setContentModel).toHaveBeenCalled();
         expect(focus).toHaveBeenCalled();
@@ -197,7 +196,7 @@ describe('paste with content model & paste plugin', () => {
     });
 
     it('Word Desktop', () => {
-        spyOn(getPasteSourceF, 'default').and.returnValue(KnownPasteSourceType.WordDesktop);
+        spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('wordDesktop');
         spyOn(WordDesktopFile, 'processPastedContentFromWordDesktop').and.callThrough();
 
         pasteF.default(editor!, clipboardData);
@@ -208,7 +207,7 @@ describe('paste with content model & paste plugin', () => {
     });
 
     it('Word Online', () => {
-        spyOn(getPasteSourceF, 'default').and.returnValue(KnownPasteSourceType.WacComponents);
+        spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('wacComponents');
         spyOn(WacComponents, 'processPastedContentWacComponents').and.callThrough();
 
         pasteF.default(editor!, clipboardData);
@@ -219,7 +218,7 @@ describe('paste with content model & paste plugin', () => {
     });
 
     it('Excel Online', () => {
-        spyOn(getPasteSourceF, 'default').and.returnValue(KnownPasteSourceType.ExcelOnline);
+        spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('excelOnline');
         spyOn(ExcelF, 'processPastedContentFromExcel').and.callThrough();
 
         pasteF.default(editor!, clipboardData);
@@ -230,7 +229,7 @@ describe('paste with content model & paste plugin', () => {
     });
 
     it('Excel Desktop', () => {
-        spyOn(getPasteSourceF, 'default').and.returnValue(KnownPasteSourceType.ExcelDesktop);
+        spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('excelDesktop');
         spyOn(ExcelF, 'processPastedContentFromExcel').and.callThrough();
 
         pasteF.default(editor!, clipboardData);
@@ -241,7 +240,7 @@ describe('paste with content model & paste plugin', () => {
     });
 
     it('PowerPoint', () => {
-        spyOn(getPasteSourceF, 'default').and.returnValue(KnownPasteSourceType.PowerPointDesktop);
+        spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('powerPointDesktop');
         spyOn(PPT, 'processPastedContentFromPowerPoint').and.callThrough();
 
         pasteF.default(editor!, clipboardData);
@@ -253,10 +252,10 @@ describe('paste with content model & paste plugin', () => {
 
     // Plain Text
     it('Word Desktop | Plain Text', () => {
-        spyOn(getPasteSourceF, 'default').and.returnValue(KnownPasteSourceType.WordDesktop);
+        spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('wordDesktop');
         spyOn(WordDesktopFile, 'processPastedContentFromWordDesktop').and.callThrough();
 
-        pasteF.default(editor!, clipboardData, true /* pasteAsText */);
+        pasteF.default(editor!, clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(0);
@@ -264,10 +263,10 @@ describe('paste with content model & paste plugin', () => {
     });
 
     it('Word Online | Plain Text', () => {
-        spyOn(getPasteSourceF, 'default').and.returnValue(KnownPasteSourceType.WacComponents);
+        spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('wacComponents');
         spyOn(WacComponents, 'processPastedContentWacComponents').and.callThrough();
 
-        pasteF.default(editor!, clipboardData, true /* pasteAsText */);
+        pasteF.default(editor!, clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(0);
@@ -275,10 +274,10 @@ describe('paste with content model & paste plugin', () => {
     });
 
     it('Excel Online | Plain Text', () => {
-        spyOn(getPasteSourceF, 'default').and.returnValue(KnownPasteSourceType.ExcelOnline);
+        spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('excelOnline');
         spyOn(ExcelF, 'processPastedContentFromExcel').and.callThrough();
 
-        pasteF.default(editor!, clipboardData, true /* pasteAsText */);
+        pasteF.default(editor!, clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(0);
@@ -286,10 +285,10 @@ describe('paste with content model & paste plugin', () => {
     });
 
     it('Excel Desktop | Plain Text', () => {
-        spyOn(getPasteSourceF, 'default').and.returnValue(KnownPasteSourceType.ExcelDesktop);
+        spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('excelDesktop');
         spyOn(ExcelF, 'processPastedContentFromExcel').and.callThrough();
 
-        pasteF.default(editor!, clipboardData, true /* pasteAsText */);
+        pasteF.default(editor!, clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(0);
@@ -297,10 +296,10 @@ describe('paste with content model & paste plugin', () => {
     });
 
     it('PowerPoint | Plain Text', () => {
-        spyOn(getPasteSourceF, 'default').and.returnValue(KnownPasteSourceType.PowerPointDesktop);
+        spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('powerPointDesktop');
         spyOn(PPT, 'processPastedContentFromPowerPoint').and.callThrough();
 
-        pasteF.default(editor!, clipboardData, true /* pasteAsText */);
+        pasteF.default(editor!, clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
- Keys: Use KeyboardEvent.key instead
- ChangeSource: Create a copy of non-const enum in `roosterjs-content-model-editor`
- KnownPasteSourceType: Create a string literal type instead, and copy paste source related code into content model
- PasteType: Create a string lteral type instead