### PR TITLE
Image Selection: Keyboard event

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/ImageSelection.ts
@@ -80,7 +80,7 @@ export default class ImageSelection implements EditorPlugin {
                         } else {
                             const position = new Position(
                                 keyDownSelection.image,
-                                PositionType.Begin
+                                PositionType.Before
                             );
 
                             this.editor.select(position);


### PR DESCRIPTION
Instead of use `position.Begin` use `position.Before` to set cursor before the image when a key is pressed. 