### PR TITLE
Add Tests and more Table Borders operations

### DIFF
--- a/demo/scripts/controls/ribbonButtons/contentModel/tableBorderApplyButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/tableBorderApplyButton.ts
@@ -2,10 +2,17 @@ import MainPaneBase from '../../MainPaneBase';
 import { applyTableBorderFormat, isContentModelEditor } from 'roosterjs-content-model-editor';
 import { RibbonButton } from 'roosterjs-react';
 
-/**
- * UNFINISHED
- * A map for all Border options and keys in yet to be made dropdown menu.
- */
+const TABLE_OPERATIONS = {
+    menuNameTableAllBorder: 'AllBorders',
+    menuNameTableNoBorder: 'NoBorders',
+    menuNameTableLeftBorder: 'LeftBorders',
+    menuNameTableRightBorder: 'RightBorders',
+    menuNameTableTopBorder: 'TopBorders',
+    menuNameTableBottomBorder: 'BottomBorders',
+    menuNameTableInsideBorder: 'InsideBorders',
+    menuNameTableOutsideBorder: 'OutsideBorders',
+};
+
 export const tableBorderApplyButton: RibbonButton<'ribbonButtonTableBorder'> = {
     key: 'ribbonButtonTableBorder',
     iconName: 'TableComputed',
@@ -13,13 +20,20 @@ export const tableBorderApplyButton: RibbonButton<'ribbonButtonTableBorder'> = {
     isDisabled: formatState => !formatState.isInTable,
     dropDownMenu: {
         items: {
-            menuNameTableBorder: 'All Borders',
+            menuNameTableAllBorder: 'All Borders',
+            menuNameTableNoBorder: 'No Borders',
+            menuNameTableLeftBorder: 'Left Borders',
+            menuNameTableRightBorder: 'Right Borders',
+            menuNameTableTopBorder: 'Top Borders',
+            menuNameTableBottomBorder: 'Bottom Borders',
+            menuNameTableInsideBorder: 'Inside Borders',
+            menuNameTableOutsideBorder: 'Outside Borders',
         },
     },
     onClick: (editor, key) => {
         if (isContentModelEditor(editor) && key != 'ribbonButtonTableBorder') {
             const border = MainPaneBase.getInstance().getTableBorder();
-            applyTableBorderFormat(editor, border, 'AllBorders');
+            applyTableBorderFormat(editor, border, TABLE_OPERATIONS[key]);
         }
     },
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/applyTableBorderFormat.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/applyTableBorderFormat.ts
@@ -83,15 +83,15 @@ export default function applyTableBorderFormat(
             }
 
             if (sel) {
-                const operations = [operation];
+                const operations: BorderOperations[] = [operation];
                 while (operations.length) {
                     switch (operations.pop()) {
-                        case 'NoBorders':
+                        case 'noBorders':
                             // Do All borders but with empty border format
                             borderFormat = '';
-                            operations.push('AllBorders');
+                            operations.push('allBorders');
                             break;
-                        case 'AllBorders':
+                        case 'allBorders':
                             const allBorders: BorderPositions[] = [
                                 'borderTop',
                                 'borderBottom',
@@ -116,7 +116,7 @@ export default function applyTableBorderFormat(
                             perimeter.Left = true;
                             perimeter.Right = true;
                             break;
-                        case 'LeftBorders':
+                        case 'leftBorders':
                             const leftBorder: BorderPositions[] = ['borderLeft'];
                             for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
                                 const cell = tableModel.rows[rowIndex].cells[sel.firstCol];
@@ -127,7 +127,7 @@ export default function applyTableBorderFormat(
                             // Format perimeter
                             perimeter.Left = true;
                             break;
-                        case 'RightBorders':
+                        case 'rightBorders':
                             const rightBorder: BorderPositions[] = ['borderRight'];
                             for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
                                 const cell = tableModel.rows[rowIndex].cells[sel.lastCol];
@@ -138,7 +138,7 @@ export default function applyTableBorderFormat(
                             // Format perimeter
                             perimeter.Right = true;
                             break;
-                        case 'TopBorders':
+                        case 'topBorders':
                             const topBorder: BorderPositions[] = ['borderTop'];
                             for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
                                 const cell = tableModel.rows[sel.firstRow].cells[colIndex];
@@ -149,7 +149,7 @@ export default function applyTableBorderFormat(
                             // Format perimeter
                             perimeter.Top = true;
                             break;
-                        case 'BottomBorders':
+                        case 'bottomBorders':
                             const bottomBorder: BorderPositions[] = ['borderBottom'];
                             for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
                                 const cell = tableModel.rows[sel.lastRow].cells[colIndex];
@@ -160,7 +160,7 @@ export default function applyTableBorderFormat(
                             // Format perimeter
                             perimeter.Bottom = true;
                             break;
-                        case 'InsideBorders':
+                        case 'insideBorders':
                             // Format cells - Inside borders
                             // Top left cell
                             applyBorderFormat(
@@ -243,14 +243,14 @@ export default function applyTableBorderFormat(
                             sel.firstRow++;
                             sel.lastCol--;
                             sel.lastRow--;
-                            operations.push('AllBorders');
+                            operations.push('allBorders');
                             break;
-                        case 'OutsideBorders':
+                        case 'outsideBorders':
                             // Format cells - Outside borders
-                            operations.push('TopBorders');
-                            operations.push('BottomBorders');
-                            operations.push('LeftBorders');
-                            operations.push('RightBorders');
+                            operations.push('topBorders');
+                            operations.push('bottomBorders');
+                            operations.push('leftBorders');
+                            operations.push('rightBorders');
                             break;
                         default:
                             break;

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/applyTableBorderFormat.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/applyTableBorderFormat.ts
@@ -7,10 +7,29 @@ import { updateTableCellMetadata } from '../../domUtils/metadata/updateTableCell
 import type { BorderOperations } from '../../publicTypes/enum/BorderOperations';
 import type { IContentModelEditor } from '../../publicTypes/IContentModelEditor';
 import type { Border } from '../../publicTypes/interface/Border';
-import type { ContentModelTableCell } from 'roosterjs-content-model-types';
+import type { ContentModelTable, ContentModelTableCell } from 'roosterjs-content-model-types';
+import type { TableSelectionCoordinates } from '../../modelApi/table/getSelectedCells';
 
 /**
- * UNFINISHED - only All Borders is implemented
+ * @internal
+ * Border positions
+ */
+type BorderPositions = 'borderTop' | 'borderBottom' | 'borderLeft' | 'borderRight';
+
+/**
+ * @internal
+ * Perimeter of the table selection
+ * Used to determine where to apply border to the cells adjacent to the selection.
+ */
+type Perimeter = {
+    Top: boolean;
+    Bottom: boolean;
+    Left: boolean;
+    Right: boolean;
+};
+
+/**
+ * Operations to apply border
  * @param editor The editor instance
  * @param border The border to apply
  * @param operation The operation to apply
@@ -25,7 +44,7 @@ export default function applyTableBorderFormat(
 
         if (tableModel) {
             const sel = getSelectedCells(tableModel);
-            const perimeter = {
+            const perimeter: Perimeter = {
                 Top: false,
                 Bottom: false,
                 Left: false,
@@ -64,56 +83,182 @@ export default function applyTableBorderFormat(
             }
 
             if (sel) {
-                switch (operation) {
-                    case 'AllBorders':
-                        for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
-                            for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
-                                const cell = tableModel.rows[rowIndex].cells[colIndex];
-                                // Format cells - All borders
-                                applyAllBorderFormat(cell, borderFormat);
+                const operations = [operation];
+                while (operations.length) {
+                    switch (operations.pop()) {
+                        case 'NoBorders':
+                            // Do All borders but with empty border format
+                            borderFormat = '';
+                            operations.push('AllBorders');
+                            break;
+                        case 'AllBorders':
+                            const allBorders: BorderPositions[] = [
+                                'borderTop',
+                                'borderBottom',
+                                'borderLeft',
+                                'borderRight',
+                            ];
+                            for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
+                                for (
+                                    let colIndex = sel.firstCol;
+                                    colIndex <= sel.lastCol;
+                                    colIndex++
+                                ) {
+                                    const cell = tableModel.rows[rowIndex].cells[colIndex];
+                                    // Format cells - All borders
+                                    applyBorderFormat(cell, borderFormat, allBorders);
+                                }
                             }
-                        }
 
-                        // Format perimeter
-                        perimeter.Top = true;
-                        perimeter.Bottom = true;
-                        perimeter.Left = true;
-                        perimeter.Right = true;
-                        break;
+                            // Format perimeter
+                            perimeter.Top = true;
+                            perimeter.Bottom = true;
+                            perimeter.Left = true;
+                            perimeter.Right = true;
+                            break;
+                        case 'LeftBorders':
+                            const leftBorder: BorderPositions[] = ['borderLeft'];
+                            for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
+                                const cell = tableModel.rows[rowIndex].cells[sel.firstCol];
+                                // Format cells - Left border
+                                applyBorderFormat(cell, borderFormat, leftBorder);
+                            }
 
-                    default:
-                        break;
+                            // Format perimeter
+                            perimeter.Left = true;
+                            break;
+                        case 'RightBorders':
+                            const rightBorder: BorderPositions[] = ['borderRight'];
+                            for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
+                                const cell = tableModel.rows[rowIndex].cells[sel.lastCol];
+                                // Format cells - Right border
+                                applyBorderFormat(cell, borderFormat, rightBorder);
+                            }
+
+                            // Format perimeter
+                            perimeter.Right = true;
+                            break;
+                        case 'TopBorders':
+                            const topBorder: BorderPositions[] = ['borderTop'];
+                            for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
+                                const cell = tableModel.rows[sel.firstRow].cells[colIndex];
+                                // Format cells - Top border
+                                applyBorderFormat(cell, borderFormat, topBorder);
+                            }
+
+                            // Format perimeter
+                            perimeter.Top = true;
+                            break;
+                        case 'BottomBorders':
+                            const bottomBorder: BorderPositions[] = ['borderBottom'];
+                            for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
+                                const cell = tableModel.rows[sel.lastRow].cells[colIndex];
+                                // Format cells - Bottom border
+                                applyBorderFormat(cell, borderFormat, bottomBorder);
+                            }
+
+                            // Format perimeter
+                            perimeter.Bottom = true;
+                            break;
+                        case 'InsideBorders':
+                            // Format cells - Inside borders
+                            // Top left cell
+                            applyBorderFormat(
+                                tableModel.rows[sel.firstRow].cells[sel.firstCol],
+                                borderFormat,
+                                ['borderBottom', 'borderRight']
+                            );
+                            // Top right cell
+                            applyBorderFormat(
+                                tableModel.rows[sel.firstRow].cells[sel.lastCol],
+                                borderFormat,
+                                ['borderBottom', 'borderLeft']
+                            );
+                            // Bottom left cell
+                            applyBorderFormat(
+                                tableModel.rows[sel.lastRow].cells[sel.firstCol],
+                                borderFormat,
+                                ['borderTop', 'borderRight']
+                            );
+                            // Bottom right cell
+                            applyBorderFormat(
+                                tableModel.rows[sel.lastRow].cells[sel.lastCol],
+                                borderFormat,
+                                ['borderTop', 'borderLeft']
+                            );
+                            // First row
+                            for (
+                                let colIndex = sel.firstCol + 1;
+                                colIndex < sel.lastCol;
+                                colIndex++
+                            ) {
+                                const cell = tableModel.rows[sel.firstRow].cells[colIndex];
+                                applyBorderFormat(cell, borderFormat, [
+                                    'borderBottom',
+                                    'borderLeft',
+                                    'borderRight',
+                                ]);
+                            }
+                            // Last row
+                            for (
+                                let colIndex = sel.firstCol + 1;
+                                colIndex < sel.lastCol;
+                                colIndex++
+                            ) {
+                                const cell = tableModel.rows[sel.lastRow].cells[colIndex];
+                                applyBorderFormat(cell, borderFormat, [
+                                    'borderTop',
+                                    'borderLeft',
+                                    'borderRight',
+                                ]);
+                            }
+                            // First column
+                            for (
+                                let rowIndex = sel.firstRow + 1;
+                                rowIndex < sel.lastRow;
+                                rowIndex++
+                            ) {
+                                const cell = tableModel.rows[rowIndex].cells[sel.firstCol];
+                                applyBorderFormat(cell, borderFormat, [
+                                    'borderTop',
+                                    'borderBottom',
+                                    'borderRight',
+                                ]);
+                            }
+                            // Last column
+                            for (
+                                let rowIndex = sel.firstRow + 1;
+                                rowIndex < sel.lastRow;
+                                rowIndex++
+                            ) {
+                                const cell = tableModel.rows[rowIndex].cells[sel.lastCol];
+                                applyBorderFormat(cell, borderFormat, [
+                                    'borderTop',
+                                    'borderBottom',
+                                    'borderLeft',
+                                ]);
+                            }
+                            // Inner cells
+                            sel.firstCol++;
+                            sel.firstRow++;
+                            sel.lastCol--;
+                            sel.lastRow--;
+                            operations.push('AllBorders');
+                            break;
+                        case 'OutsideBorders':
+                            // Format cells - Outside borders
+                            operations.push('TopBorders');
+                            operations.push('BottomBorders');
+                            operations.push('LeftBorders');
+                            operations.push('RightBorders');
+                            break;
+                        default:
+                            break;
+                    }
                 }
 
-                //Format perimeter if necessary
-                // Top of selection
-                if (perimeter.Top && sel.firstRow - 1 >= 0) {
-                    for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
-                        const cell = tableModel.rows[sel.firstRow - 1].cells[colIndex];
-                        applySingleBorderFormat(cell, borderFormat, 'borderBottom');
-                    }
-                }
-                // Bottom of selection
-                if (perimeter.Bottom && sel.lastRow + 1 < tableModel.rows.length) {
-                    for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
-                        const cell = tableModel.rows[sel.lastRow + 1].cells[colIndex];
-                        applySingleBorderFormat(cell, borderFormat, 'borderTop');
-                    }
-                }
-                // Left of selection
-                if (perimeter.Left && sel.firstCol - 1 >= 0) {
-                    for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
-                        const cell = tableModel.rows[rowIndex].cells[sel.firstCol - 1];
-                        applySingleBorderFormat(cell, borderFormat, 'borderRight');
-                    }
-                }
-                // Right of selection
-                if (perimeter.Right && sel.lastCol + 1 < tableModel.rows[0].cells.length) {
-                    for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
-                        const cell = tableModel.rows[rowIndex].cells[sel.lastCol + 1];
-                        applySingleBorderFormat(cell, borderFormat, 'borderLeft');
-                    }
-                }
+                //Format perimeter if necessary or possible
+                modifyPerimeter(tableModel, sel, borderFormat, perimeter);
             }
 
             return true;
@@ -123,24 +268,22 @@ export default function applyTableBorderFormat(
     });
 }
 
-function applySingleBorderFormat(
+/**
+ * @internal
+ * Apply border format to a cell
+ * @param cell The cell to apply border format
+ * @param borderFormat The border format to apply
+ * @param positions The positions to apply
+ */
+function applyBorderFormat(
     cell: ContentModelTableCell,
     borderFormat: string,
-    position: 'borderTop' | 'borderBottom' | 'borderLeft' | 'borderRight'
+    positions: BorderPositions[]
 ) {
-    cell.format[position] = borderFormat;
-    updateBorderMetaOverride(cell);
-}
+    positions.forEach(pos => {
+        cell.format[pos] = borderFormat;
+    });
 
-function applyAllBorderFormat(cell: ContentModelTableCell, borderFormat: string) {
-    cell.format.borderTop = borderFormat;
-    cell.format.borderBottom = borderFormat;
-    cell.format.borderLeft = borderFormat;
-    cell.format.borderRight = borderFormat;
-    updateBorderMetaOverride(cell);
-}
-
-function updateBorderMetaOverride(cell: ContentModelTableCell) {
     updateTableCellMetadata(cell, metadata => {
         metadata = metadata || {};
         metadata.borderOverride = true;
@@ -149,4 +292,49 @@ function updateBorderMetaOverride(cell: ContentModelTableCell) {
 
     // Cell was modified, so delete cached element
     delete cell.cachedElement;
+}
+
+/**
+ * @internal
+ * Modify the perimeter of the table selection
+ * @param tableModel The table model
+ * @param sel The table selection
+ * @param borderFormat The border format to apply
+ * If borderFormat is empty, the border will be removed
+ * @param perimeter Where in the perimeter to apply
+ */
+function modifyPerimeter(
+    tableModel: ContentModelTable,
+    sel: TableSelectionCoordinates,
+    borderFormat: string,
+    perimeter: Perimeter
+) {
+    // Top of selection
+    if (perimeter.Top && sel.firstRow - 1 >= 0) {
+        for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
+            const cell = tableModel.rows[sel.firstRow - 1].cells[colIndex];
+            applyBorderFormat(cell, borderFormat, ['borderBottom']);
+        }
+    }
+    // Bottom of selection
+    if (perimeter.Bottom && sel.lastRow + 1 < tableModel.rows.length) {
+        for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
+            const cell = tableModel.rows[sel.lastRow + 1].cells[colIndex];
+            applyBorderFormat(cell, borderFormat, ['borderTop']);
+        }
+    }
+    // Left of selection
+    if (perimeter.Left && sel.firstCol - 1 >= 0) {
+        for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
+            const cell = tableModel.rows[rowIndex].cells[sel.firstCol - 1];
+            applyBorderFormat(cell, borderFormat, ['borderRight']);
+        }
+    }
+    // Right of selection
+    if (perimeter.Right && sel.lastCol + 1 < tableModel.rows[0].cells.length) {
+        for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
+            const cell = tableModel.rows[rowIndex].cells[sel.lastCol + 1];
+            applyBorderFormat(cell, borderFormat, ['borderLeft']);
+        }
+    }
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/enum/BorderOperations.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/enum/BorderOperations.ts
@@ -5,32 +5,32 @@ export type BorderOperations =
     /**
      * Apply border format to all borders
      */
-    | 'AllBorders'
+    | 'allBorders'
     /**
      * Remove al borders
      */
-    | 'NoBorders'
+    | 'noBorders'
     /**
      * Apply border format to left borders
      */
-    | 'LeftBorders'
+    | 'leftBorders'
     /**
      * Apply border format to right borders
      */
-    | 'RightBorders'
+    | 'rightBorders'
     /**
      * Apply border format to top borders
      */
-    | 'TopBorders'
+    | 'topBorders'
     /**
      * Apply border format to bottom borders
      */
-    | 'BottomBorders'
+    | 'bottomBorders'
     /**
      * Apply border format to inside borders
      */
-    | 'InsideBorders'
+    | 'insideBorders'
     /**
      * Apply border format to outside borders
      */
-    | 'OutsideBorders';
+    | 'outsideBorders';

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/enum/BorderOperations.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/enum/BorderOperations.ts
@@ -5,4 +5,32 @@ export type BorderOperations =
     /**
      * Apply border format to all borders
      */
-    'AllBorders';
+    | 'AllBorders'
+    /**
+     * Remove al borders
+     */
+    | 'NoBorders'
+    /**
+     * Apply border format to left borders
+     */
+    | 'LeftBorders'
+    /**
+     * Apply border format to right borders
+     */
+    | 'RightBorders'
+    /**
+     * Apply border format to top borders
+     */
+    | 'TopBorders'
+    /**
+     * Apply border format to bottom borders
+     */
+    | 'BottomBorders'
+    /**
+     * Apply border format to inside borders
+     */
+    | 'InsideBorders'
+    /**
+     * Apply border format to outside borders
+     */
+    | 'OutsideBorders';

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/table/applyTableFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/table/applyTableFormatTest.ts
@@ -486,4 +486,28 @@ describe('applyTableFormat', () => {
         expect(table.rows[0].cells[0].format.backgroundColor).toBe('blue');
         expect(table.rows[0].cells[0].dataset.editingInfo).toBe('{"bgColorOverride":true}');
     });
+    it('Has borderOverride', () => {
+        const table = createTable(1, 1);
+        table.rows[0].cells[0].format.borderLeft = '1px solid red';
+
+        // Try to apply green
+        applyTableFormat(table, {
+            topBorderColor: 'green',
+        });
+
+        // Should apply green
+        expect(table.rows[0].cells[0].format.borderTop).toBe('1px solid green');
+        expect(table.rows[0].cells[0].dataset.editingInfo).toBeUndefined();
+
+        table.rows[0].cells[0].dataset.editingInfo = '{"borderOverride":true}';
+
+        // Try to apply blue
+        applyTableFormat(table, {
+            topBorderColor: 'blue',
+        });
+
+        // Should not apply blue
+        expect(table.rows[0].cells[0].format.borderTop).toBe('1px solid green');
+        expect(table.rows[0].cells[0].dataset.editingInfo).toBe('{"borderOverride":true}');
+    });
 });

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/table/applyTableBorderFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/table/applyTableBorderFormatTest.ts
@@ -71,7 +71,6 @@ describe('applyTableBorderFormat', () => {
 
         applyTableBorderFormat(editor, border, operation);
 
-        console.log('>>', operation, table);
         if (expectedTable) {
             expect(setContentModel).toHaveBeenCalledTimes(1);
             expect(setContentModel).toHaveBeenCalledWith(

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/table/applyTableBorderFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/table/applyTableBorderFormatTest.ts
@@ -329,7 +329,7 @@ describe('applyTableBorderFormat', () => {
                 widths: [],
             },
             testBorder,
-            'AllBorders'
+            'allBorders'
         );
     });
     it('No Borders', () => {
@@ -625,7 +625,7 @@ describe('applyTableBorderFormat', () => {
                 dataset: {},
             },
             testBorder,
-            'NoBorders'
+            'noBorders'
         );
     });
     it('Top Borders', () => {
@@ -748,7 +748,7 @@ describe('applyTableBorderFormat', () => {
                 dataset: {},
             },
             testBorder,
-            'TopBorders'
+            'topBorders'
         );
     });
     it('Bottom Borders', () => {
@@ -871,7 +871,7 @@ describe('applyTableBorderFormat', () => {
                 dataset: {},
             },
             testBorder,
-            'BottomBorders'
+            'bottomBorders'
         );
     });
     it('Left Borders', () => {
@@ -994,7 +994,7 @@ describe('applyTableBorderFormat', () => {
                 dataset: {},
             },
             testBorder,
-            'LeftBorders'
+            'leftBorders'
         );
     });
     it('Right Borders', () => {
@@ -1117,7 +1117,7 @@ describe('applyTableBorderFormat', () => {
                 dataset: {},
             },
             testBorder,
-            'RightBorders'
+            'rightBorders'
         );
     });
     it('Outside Borders', () => {
@@ -1356,7 +1356,7 @@ describe('applyTableBorderFormat', () => {
                 dataset: {},
             },
             testBorder,
-            'OutsideBorders'
+            'outsideBorders'
         );
     });
     it('Inside Borders', () => {
@@ -1563,7 +1563,7 @@ describe('applyTableBorderFormat', () => {
                 dataset: {},
             },
             testBorder,
-            'InsideBorders'
+            'insideBorders'
         );
     });
 });

--- a/packages-content-model/roosterjs-content-model-editor/test/publicApi/table/applyTableBorderFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/publicApi/table/applyTableBorderFormatTest.ts
@@ -1,0 +1,1570 @@
+import * as normalizeTable from '../../../lib/modelApi/table/normalizeTable';
+import applyTableBorderFormat from '../../../lib/publicApi/table/applyTableBorderFormat';
+import { Border } from '../../../lib/publicTypes/interface/Border';
+import { BorderOperations } from '../../../lib/publicTypes/enum/BorderOperations';
+import { ContentModelTable, ContentModelTableCell } from 'roosterjs-content-model-types';
+import { createContentModelDocument } from 'roosterjs-content-model-dom';
+import { createTable, createTableCell } from 'roosterjs-content-model-dom';
+import { IContentModelEditor } from '../../../lib/publicTypes/IContentModelEditor';
+
+describe('applyTableBorderFormat', () => {
+    let editor: IContentModelEditor;
+    let setContentModel: jasmine.Spy<IContentModelEditor['setContentModel']>;
+    let createContentModel: jasmine.Spy<IContentModelEditor['createContentModel']>;
+    let triggerPluginEvent: jasmine.Spy;
+    let getVisibleViewport: jasmine.Spy;
+    const width = '3px';
+    const style = 'double';
+    const color = '#AABBCC';
+    const testBorder: Border = { width: width, style: style, color: color };
+    const testBorderString = `${width} ${style} ${color}`;
+
+    function createTestTable(
+        rows: number,
+        columns: number,
+        format?: ContentModelTableCell['format']
+    ) {
+        // Create a table with all cells selected except the first and last row and column
+        const table = createTable(rows);
+        for (let i = 0; i < rows; i++) {
+            const row = table.rows[i];
+            for (let j = 0; j < columns; j++) {
+                const cell = createTableCell(false, false, false, format);
+                if (i != 0 && j != 0 && i != rows - 1 && j != columns - 1) {
+                    cell.isSelected = true;
+                }
+                row.cells.push(cell);
+            }
+        }
+        return table;
+    }
+
+    beforeEach(() => {
+        setContentModel = jasmine.createSpy('setContentModel');
+        createContentModel = jasmine.createSpy('createContentModel');
+        triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getVisibleViewport = jasmine.createSpy('getVisibleViewport');
+
+        spyOn(normalizeTable, 'normalizeTable');
+
+        editor = ({
+            focus: () => {},
+            addUndoSnapshot: (callback: Function) => callback(),
+            setContentModel,
+            createContentModel,
+            isDarkMode: () => false,
+            triggerPluginEvent,
+            getVisibleViewport,
+        } as any) as IContentModelEditor;
+    });
+
+    function runTest(
+        table: ContentModelTable,
+        expectedTable: ContentModelTable | null,
+        border: Border,
+        operation: BorderOperations
+    ) {
+        const model = createContentModelDocument();
+        model.blocks.push(table);
+
+        createContentModel.and.returnValue(model);
+
+        applyTableBorderFormat(editor, border, operation);
+
+        console.log('>>', operation, table);
+        if (expectedTable) {
+            expect(setContentModel).toHaveBeenCalledTimes(1);
+            expect(setContentModel).toHaveBeenCalledWith(
+                {
+                    blockGroupType: 'Document',
+                    blocks: [expectedTable],
+                },
+                undefined,
+                undefined
+            );
+        } else {
+            expect(setContentModel).not.toHaveBeenCalled();
+        }
+    }
+    it('All Borders', () => {
+        runTest(
+            createTestTable(4, 4),
+            {
+                blockType: 'Table',
+                dataset: {},
+                format: {},
+                rows: [
+                    {
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {},
+                                format: {},
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderBottom: testBorderString,
+                                },
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderBottom: testBorderString,
+                                },
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {},
+                                format: {},
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                        ],
+                        format: {},
+                        height: 0,
+                    },
+                    {
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderRight: testBorderString,
+                                },
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                    borderTop: testBorderString,
+                                },
+                                isHeader: false,
+                                isSelected: true,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                    borderTop: testBorderString,
+                                },
+                                isHeader: false,
+                                isSelected: true,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderLeft: testBorderString,
+                                },
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                        ],
+                        format: {},
+                        height: 0,
+                    },
+                    {
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderRight: testBorderString,
+                                },
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                    borderTop: testBorderString,
+                                },
+                                isHeader: false,
+                                isSelected: true,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                    borderTop: testBorderString,
+                                },
+                                isHeader: false,
+                                isSelected: true,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderLeft: testBorderString,
+                                },
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                        ],
+                        format: {},
+                        height: 0,
+                    },
+                    {
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {},
+                                format: {},
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderTop: testBorderString,
+                                },
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                format: {
+                                    borderTop: testBorderString,
+                                },
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                dataset: {},
+                                format: {},
+                                isHeader: false,
+                                spanAbove: false,
+                                spanLeft: false,
+                            },
+                        ],
+                        format: {},
+                        height: 0,
+                    },
+                ],
+                widths: [],
+            },
+            testBorder,
+            'AllBorders'
+        );
+    });
+    it('No Borders', () => {
+        runTest(
+            createTestTable(4, 4, {
+                borderTop: testBorderString,
+                borderBottom: testBorderString,
+                borderLeft: testBorderString,
+                borderRight: testBorderString,
+            }),
+            {
+                blockType: 'Table',
+                rows: [
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderBottom: '',
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderBottom: '',
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: '',
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: '',
+                                    borderBottom: '',
+                                    borderLeft: '',
+                                    borderRight: '',
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: '',
+                                    borderBottom: '',
+                                    borderLeft: '',
+                                    borderRight: '',
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderBottom: testBorderString,
+                                    borderLeft: '',
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: '',
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: '',
+                                    borderBottom: '',
+                                    borderLeft: '',
+                                    borderRight: '',
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: '',
+                                    borderBottom: '',
+                                    borderLeft: '',
+                                    borderRight: '',
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderBottom: testBorderString,
+                                    borderLeft: '',
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: '',
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: '',
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                ],
+                format: {},
+                widths: [],
+                dataset: {},
+            },
+            testBorder,
+            'NoBorders'
+        );
+    });
+    it('Top Borders', () => {
+        runTest(
+            createTestTable(3, 3),
+            {
+                blockType: 'Table',
+                rows: [
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderBottom: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                ],
+                format: {},
+                widths: [],
+                dataset: {},
+            },
+            testBorder,
+            'TopBorders'
+        );
+    });
+    it('Bottom Borders', () => {
+        runTest(
+            createTestTable(3, 3),
+            {
+                blockType: 'Table',
+                rows: [
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderBottom: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                ],
+                format: {},
+                widths: [],
+                dataset: {},
+            },
+            testBorder,
+            'BottomBorders'
+        );
+    });
+    it('Left Borders', () => {
+        runTest(
+            createTestTable(3, 3),
+            {
+                blockType: 'Table',
+                rows: [
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderLeft: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                ],
+                format: {},
+                widths: [],
+                dataset: {},
+            },
+            testBorder,
+            'LeftBorders'
+        );
+    });
+    it('Right Borders', () => {
+        runTest(
+            createTestTable(3, 3),
+            {
+                blockType: 'Table',
+                rows: [
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderLeft: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                ],
+                format: {},
+                widths: [],
+                dataset: {},
+            },
+            testBorder,
+            'RightBorders'
+        );
+    });
+    it('Outside Borders', () => {
+        runTest(
+            createTestTable(4, 4),
+            {
+                blockType: 'Table',
+                rows: [
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderBottom: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderBottom: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderLeft: testBorderString,
+                                    borderTop: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderRight: testBorderString,
+                                    borderTop: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderLeft: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderLeft: testBorderString,
+                                    borderBottom: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderRight: testBorderString,
+                                    borderBottom: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderLeft: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                ],
+                format: {},
+                widths: [],
+                dataset: {},
+            },
+            testBorder,
+            'OutsideBorders'
+        );
+    });
+    it('Inside Borders', () => {
+        runTest(
+            createTestTable(4, 4),
+            {
+                blockType: 'Table',
+                rows: [
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderBottom: testBorderString,
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderBottom: testBorderString,
+                                    borderLeft: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderRight: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {
+                                    borderTop: testBorderString,
+                                    borderLeft: testBorderString,
+                                },
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {
+                                    editingInfo: '{"borderOverride":true}',
+                                },
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                            },
+                        ],
+                    },
+                ],
+                format: {},
+                widths: [],
+                dataset: {},
+            },
+            testBorder,
+            'InsideBorders'
+        );
+    });
+});


### PR DESCRIPTION
### Description:

Improve the ability to modify table borders with more operations.

### Fix

* Add more Table border functions to modify and apply changes to table borders to selected cells.

Simplified the operations by having only one function to apply borders to cells. It receives an array of the borders to set, the border format, and the cell. In the case of no border, it is set to '', the attribute is eventually deleted. The functionality to modify the perimeter of the selection has also been implemented as its own function.

* Modified Demo site to Include Table Borders functionality: Left, Right, Top, Bottom, Inside, Outside, and No borders operations added.

* Added tests for Table Border related changes and new functionality.

### Warnings and implications

- None