### PR TITLE
Correctly stop shadow edit

### DIFF
--- a/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
@@ -161,7 +161,9 @@ export default class DOMEventPlugin implements PluginWithState<DOMEventPluginSta
 
     private onFocus = () => {
         // Always quit shadow edit once editor got focus, to fix the problem when editor.stopShadowEdit() didn't get called correctly
-        this.editor?.stopShadowEdit();
+        if (this.editor?.isInShadowEdit()) {
+            this.editor.stopShadowEdit();
+        }
 
         if (!this.state.skipReselectOnFocus) {
             const { table, coordinates } = this.state.tableSelectionRange || {};

--- a/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
+++ b/packages/roosterjs-editor-core/lib/corePlugins/DOMEventPlugin.ts
@@ -160,6 +160,9 @@ export default class DOMEventPlugin implements PluginWithState<DOMEventPluginSta
     };
 
     private onFocus = () => {
+        // Always quit shadow edit once editor got focus, to fix the problem when editor.stopShadowEdit() didn't get called correctly
+        this.editor?.stopShadowEdit();
+
         if (!this.state.skipReselectOnFocus) {
             const { table, coordinates } = this.state.tableSelectionRange || {};
             const { image } = this.state.imageSelectionRange || {};


### PR DESCRIPTION
If for any reason we entered shadow edit state but didn't exit (by calling editor.stopShadowEdit), this change makes sure editor always quit shadow edit state when it got focused