### PR TITLE
Use Content Model to handle Delete/Backspace key in more cases

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/editing/keyboardDelete.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/editing/keyboardDelete.ts
@@ -89,16 +89,12 @@ function shouldDeleteWithContentModel(range: Range | null, rawEvent: KeyboardEve
 }
 
 function canDeleteBefore(rawEvent: KeyboardEvent, range: Range) {
-    return (
-        rawEvent.key == 'Backspace' &&
-        (range.startOffset > 1 || range.startContainer.previousSibling)
-    );
+    return rawEvent.key == 'Backspace' && range.startOffset > 1;
 }
 
 function canDeleteAfter(rawEvent: KeyboardEvent, range: Range) {
     return (
         rawEvent.key == 'Delete' &&
-        (range.startOffset < (range.startContainer.nodeValue?.length ?? 0) - 1 ||
-            range.startContainer.nextSibling)
+        range.startOffset < (range.startContainer.nodeValue?.length ?? 0) - 1
     );
 }


### PR DESCRIPTION
Today when user press Backspace/Delete key, we check if we should handle it using Content Model. One if the check is if there is charactor before/after the cursor, or there is other element before/after current element, we will let browser to handle it.

But there is one case, if there is an empty text node before current cursor and user press Backspace key, browser may not handle it well and may lose format. So in that case we should still let Content Model to handle the event.

e.g.
```html
<span>[] <Focus> text</span>
```
([] means an empty text node)
Here we should let Content Model to handle the backspace event since the empty text node should be ignored.