### PR TITLE
Fix #237735

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/editTable.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/table/editTable.ts
@@ -114,7 +114,7 @@ export default function editTable(editor: IContentModelEditor, operation: TableO
                 }
             }
 
-            normalizeTable(tableModel);
+            normalizeTable(tableModel, model.format);
 
             if (hasMetadata(tableModel)) {
                 applyTableFormat(tableModel, undefined /*newFormat*/, true /*keepCellShade*/);


### PR DESCRIPTION
https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/237735/?triage=true

After edit table, we already have code to normalize the table to make sure every cell has at least one paragraph. The problem is we need to pass in default segment format so that the segment under new paragraph can be properly formatted.