### PR TITLE
Fix #236416

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/delimiterProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/delimiterProcessor.ts
@@ -1,23 +1,28 @@
-import { getRegularSelectionOffsets } from '../utils/getRegularSelectionOffsets';
-import { handleRegularSelection } from './childProcessor';
+import { addSelectionMarker } from '../utils/addSelectionMarker';
 import type { ElementProcessor } from 'roosterjs-content-model-types';
 
 /**
  * @internal
  * @param group
- * @param element
+ * @param node
  * @param context
  */
-export const delimiterProcessor: ElementProcessor<Node> = (group, element, context) => {
-    let index = 0;
-    const [nodeStartOffset, nodeEndOffset] = getRegularSelectionOffsets(context, element);
+export const delimiterProcessor: ElementProcessor<Node> = (group, node, context) => {
+    const range = context.selection?.type == 'range' ? context.selection.range : null;
 
-    for (let child = element.firstChild; child; child = child.nextSibling) {
-        handleRegularSelection(index, context, group, nodeStartOffset, nodeEndOffset);
+    if (range) {
+        if (node.contains(range.startContainer)) {
+            context.isInSelection = true;
 
-        delimiterProcessor(group, child, context);
-        index++;
+            addSelectionMarker(group, context);
+        }
+
+        if (context.selection?.type == 'range' && node.contains(range.endContainer)) {
+            if (!context.selection.range.collapsed) {
+                addSelectionMarker(group, context);
+            }
+
+            context.isInSelection = false;
+        }
     }
-
-    handleRegularSelection(index, context, group, nodeStartOffset, nodeEndOffset);
 };

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/delimiterProcessorTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/delimiterProcessorTest.ts
@@ -24,7 +24,6 @@ describe('delimiterProcessor', () => {
             blockGroupType: 'Document',
             blocks: [],
         });
-        expect(delimiterProcessorFile.handleRegularSelection).toHaveBeenCalledTimes(3);
     });
 
     it('Delimiter with selection', () => {
@@ -64,5 +63,46 @@ describe('delimiterProcessor', () => {
             ],
         });
         expect(context.isInSelection).toBeTrue();
+    });
+
+    it('Delimiter with selection end', () => {
+        const doc = createContentModelDocument();
+        const text1 = document.createTextNode('test1');
+        const text2 = document.createTextNode('test2');
+        const span = document.createElement('span');
+        const span2 = document.createElement('span');
+        const div = document.createElement('div');
+
+        span.appendChild(text2);
+
+        div.appendChild(text1);
+        div.appendChild(span);
+        div.appendChild(span2);
+
+        context.selection = {
+            type: 'range',
+            range: createRange(text1, 2, text2, 3),
+        };
+
+        delimiterProcessor(doc, span, context);
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    isImplicit: true,
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(context.isInSelection).toBeFalse();
     });
 });


### PR DESCRIPTION
https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/236416/?triage=true

The root cause is delimiterProcessor didn't handle selection well if the start/endContainer is set to text under delimiter, then the offset won't match. And now emoji is wrapped with entity, so that if a selection range is ended right before an entity, it is not treated as end so everything after are still treated as selected.

For an entity delimiter, we actually don't need to care if selection offset matches, but just check if the selection container is contained by the delimiter element, then we can treat it as the right place, and do proper handling.

Fix by using Node.contains() to check if we should start/end the selection in a delimiter.