### PR TITLE
Rearrange parameters of iterateSelections

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/switchShadowEdit.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/coreApi/switchShadowEdit.ts
@@ -56,7 +56,7 @@ export const switchShadowEdit: SwitchShadowEdit = (editorCore, isOn): void => {
 
             if (core.cache.cachedModel) {
                 // Force clear cached element from selected block
-                iterateSelections([core.cache.cachedModel], () => {});
+                iterateSelections(core.cache.cachedModel, () => {});
 
                 core.api.setContentModel(core, core.cache.cachedModel, {
                     ignoreSelection: true, // Do not set focus and selection when quit shadow edit, focus may remain in UI control (picker, ...)

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/corePlugins/ContentModelCopyPastePlugin.ts
@@ -112,7 +112,7 @@ export default class ContentModelCopyPastePlugin implements PluginWithState<Copy
                     : false,
             });
             if (selection.type === 'table') {
-                iterateSelections([pasteModel], (path, tableContext) => {
+                iterateSelections(pasteModel, (_, tableContext) => {
                     if (tableContext?.table) {
                         const table = tableContext?.table;
                         table.rows = table.rows

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/clearModelFormat.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/clearModelFormat.ts
@@ -28,7 +28,7 @@ export function clearModelFormat(
     tablesToClear: [ContentModelTable, boolean][]
 ) {
     iterateSelections(
-        [model],
+        model,
         (path, tableContext, block, segments) => {
             if (segments) {
                 segmentsToClear.push(...segments);

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/common/retrieveModelFormatState.ts
@@ -31,7 +31,7 @@ export function retrieveModelFormatState(
     let isFirstSegment = true;
 
     iterateSelections(
-        [model],
+        model,
         (path, tableContext, block, segments) => {
             // Structure formats
             retrieveStructureFormat(formatState, path, isFirst);

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/utils/deleteExpandedSelection.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/edit/utils/deleteExpandedSelection.ts
@@ -36,7 +36,7 @@ export function deleteExpandedSelection(
     };
 
     iterateSelections(
-        [model],
+        model,
         (path, tableContext, block, segments) => {
             // Set paragraph, format and index for default position where we will put cursor to.
             // Later we can overwrite these info when process the selections

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/adjustWordSelection.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/adjustWordSelection.ts
@@ -17,7 +17,7 @@ export function adjustWordSelection(
 ): ContentModelSegment[] {
     let markerBlock: ContentModelParagraph | undefined;
 
-    iterateSelections([model], (path, tableContext, block, segments) => {
+    iterateSelections(model, (_, __, block, segments) => {
         //Find the block with the selection marker
         if (block?.blockType == 'Paragraph' && segments?.length == 1 && segments[0] == marker) {
             markerBlock = block;

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/collectSelections.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/collectSelections.ts
@@ -172,7 +172,7 @@ function collectSelections(
     const selections: SelectionInfo[] = [];
 
     iterateSelections(
-        [model],
+        model,
         (path, tableContext, block, segments) => {
             selections.push({
                 path,

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/iterateSelections.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/iterateSelections.ts
@@ -8,6 +8,7 @@ import type {
 
 /**
  * @internal
+ * Options for iterateSelections API
  */
 export interface IterateSelectionsOption {
     /**
@@ -42,6 +43,11 @@ export interface IterateSelectionsOption {
 
 /**
  * @internal
+ * The callback function type for iterateSelections
+ * @param path The block group path of current selection
+ * @param tableContext Table context of current selection
+ * @param block Block of current selection
+ * @param segments Segments of current selection
  * @returns True to stop iterating, otherwise keep going
  */
 export type IterateSelectionsCallback = (
@@ -53,15 +59,16 @@ export type IterateSelectionsCallback = (
 
 /**
  * @internal
- * @returns True to stop iterating, otherwise keep going
+ * Iterate all selected elements in a given model
+ * @param modelOrPath The given Content Model to iterate from
+ * @param callback The callback function to access the selected element
+ * @param option Option to determine how to iterate
  */
 export function iterateSelections(
-    path: ContentModelBlockGroup[],
+    group: ContentModelBlockGroup,
     callback: IterateSelectionsCallback,
-    option?: IterateSelectionsOption,
-    table?: TableSelectionContext,
-    treatAllAsSelect?: boolean
-) {
+    option?: IterateSelectionsOption
+): void {
     const internalCallback: IterateSelectionsCallback = (path, tableContext, block, segments) => {
         if (!!(block as ContentModelBlockWithCache)?.cachedElement) {
             // TODO: This is a temporary solution. A better solution would be making all results from iterationSelection() to be readonly,
@@ -72,7 +79,7 @@ export function iterateSelections(
         return callback(path, tableContext, block, segments);
     };
 
-    internalIterateSelections(path, internalCallback, option, table, treatAllAsSelect);
+    internalIterateSelections([group], internalCallback, option);
 }
 
 function internalIterateSelections(

--- a/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/iterateSelections.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/modelApi/selection/iterateSelections.ts
@@ -60,7 +60,7 @@ export type IterateSelectionsCallback = (
 /**
  * @internal
  * Iterate all selected elements in a given model
- * @param modelOrPath The given Content Model to iterate from
+ * @param group The given Content Model to iterate selection from
  * @param callback The callback function to access the selected element
  * @param option Option to determine how to iterate
  */

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicApi/format/applyPendingFormat.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicApi/format/applyPendingFormat.ts
@@ -23,7 +23,7 @@ export default function applyPendingFormat(editor: IContentModelEditor, data: st
         let isChanged = false;
 
         formatWithContentModel(editor, 'applyPendingFormat', (model, context) => {
-            iterateSelections([model], (_, __, block, segments) => {
+            iterateSelections(model, (_, __, block, segments) => {
                 if (
                     block?.blockType == 'Paragraph' &&
                     segments?.length == 1 &&

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/retrieveModelFormatStateTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/common/retrieveModelFormatStateTest.ts
@@ -64,7 +64,7 @@ describe('retrieveModelFormatState', () => {
         const marker = createSelectionMarker(segmentFormat);
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [marker]);
+            callback([path], undefined, para, [marker]);
             return false;
         });
 
@@ -82,7 +82,7 @@ describe('retrieveModelFormatState', () => {
         addCode(marker, { format: { fontFamily: 'monospace' } });
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [marker]);
+            callback([path], undefined, para, [marker]);
             return false;
         });
 
@@ -150,7 +150,7 @@ describe('retrieveModelFormatState', () => {
         const marker = createSelectionMarker(segmentFormat);
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [marker]);
+            callback([path], undefined, para, [marker]);
             return false;
         });
 
@@ -175,7 +175,7 @@ describe('retrieveModelFormatState', () => {
         const marker = createSelectionMarker(segmentFormat);
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [marker]);
+            callback([path], undefined, para, [marker]);
             return false;
         });
 
@@ -201,7 +201,7 @@ describe('retrieveModelFormatState', () => {
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
             callback(
-                path,
+                [path],
                 {
                     table: table,
                     colIndex: 0,
@@ -238,7 +238,7 @@ describe('retrieveModelFormatState', () => {
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
             callback(
-                path,
+                [path],
                 {
                     table: table,
                     colIndex: 0,
@@ -287,7 +287,12 @@ describe('retrieveModelFormatState', () => {
         model.blocks.push(table);
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, { table: table, rowIndex: 0, colIndex: 0, isWholeTableSelected: false });
+            callback([path], {
+                table: table,
+                rowIndex: 0,
+                colIndex: 0,
+                isWholeTableSelected: false,
+            });
             return false;
         });
 
@@ -309,8 +314,8 @@ describe('retrieveModelFormatState', () => {
         const marker2 = createSelectionMarker();
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para1, [marker1]);
-            callback(path, undefined, para2, [marker2]);
+            callback([path], undefined, para1, [marker1]);
+            callback([path], undefined, para2, [marker2]);
             return false;
         });
 
@@ -344,7 +349,7 @@ describe('retrieveModelFormatState', () => {
         const result: ContentModelFormatState = {};
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [text1, text2]);
+            callback([path], undefined, para, [text1, text2]);
             return false;
         });
 
@@ -370,7 +375,7 @@ describe('retrieveModelFormatState', () => {
         const result: ContentModelFormatState = {};
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [text1, text2]);
+            callback([path], undefined, para, [text1, text2]);
             return false;
         });
 
@@ -395,7 +400,7 @@ describe('retrieveModelFormatState', () => {
         const result: ContentModelFormatState = {};
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [text, marker]);
+            callback([path], undefined, para, [text, marker]);
             return false;
         });
 
@@ -421,8 +426,8 @@ describe('retrieveModelFormatState', () => {
         const marker1 = createSelectionMarker(segmentFormat);
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para1, [marker1]);
-            callback(path, undefined, divider);
+            callback([path], undefined, para1, [marker1]);
+            callback([path], undefined, divider);
             return false;
         });
 
@@ -444,8 +449,8 @@ describe('retrieveModelFormatState', () => {
         const marker1 = createSelectionMarker(segmentFormat);
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, divider);
-            callback(path, undefined, para1, [marker1]);
+            callback([path], undefined, divider);
+            callback([path], undefined, para1, [marker1]);
             return false;
         });
 
@@ -471,7 +476,7 @@ describe('retrieveModelFormatState', () => {
         };
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para1, [marker1]);
+            callback([path], undefined, para1, [marker1]);
             return false;
         });
 
@@ -622,7 +627,7 @@ describe('retrieveModelFormatState', () => {
         para.segments.push(image);
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [image]);
+            callback([path], undefined, para, [image]);
             return false;
         });
 
@@ -662,7 +667,7 @@ describe('retrieveModelFormatState', () => {
         para.segments.push(image2);
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [image, image2]);
+            callback([path], undefined, para, [image, image2]);
             return false;
         });
 
@@ -691,7 +696,7 @@ describe('retrieveModelFormatState', () => {
         para.segments.push(marker);
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [marker]);
+            callback([path], undefined, para, [marker]);
             return false;
         });
 
@@ -726,7 +731,7 @@ describe('retrieveModelFormatState', () => {
         text1.isSelected = true;
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [text1]);
+            callback([path], undefined, para, [text1]);
             return false;
         });
 
@@ -760,7 +765,7 @@ describe('retrieveModelFormatState', () => {
         text2.isSelected = true;
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
-            callback(path, undefined, para, [text1, text2]);
+            callback([path], undefined, para, [text1, text2]);
             return false;
         });
 

--- a/packages-content-model/roosterjs-content-model-editor/test/modelApi/selection/iterateSelectionsTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/modelApi/selection/iterateSelectionsTest.ts
@@ -28,7 +28,7 @@ describe('iterateSelections', () => {
 
     it('empty group', () => {
         const group = createContentModelDocument();
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).not.toHaveBeenCalled();
     });
@@ -45,7 +45,7 @@ describe('iterateSelections', () => {
         group.blocks.push(para1);
         group.blocks.push(para2);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).not.toHaveBeenCalled();
     });
@@ -64,7 +64,7 @@ describe('iterateSelections', () => {
         group.blocks.push(para1);
         group.blocks.push(para2);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([group], undefined, para1, [text1]);
@@ -85,7 +85,7 @@ describe('iterateSelections', () => {
         group.blocks.push(para1);
         group.blocks.push(para2);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(2);
         expect(callback).toHaveBeenCalledWith([group], undefined, para1, [text1]);
@@ -110,7 +110,7 @@ describe('iterateSelections', () => {
         group.blocks.push(listItem);
         group.blocks.push(para2);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(2);
         expect(callback).toHaveBeenCalledWith([listItem, group], undefined, para1, [text1]);
@@ -137,7 +137,7 @@ describe('iterateSelections', () => {
         group.blocks.push(quote);
         group.blocks.push(para2);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([quote, group], undefined, para1, [text1]);
@@ -163,7 +163,7 @@ describe('iterateSelections', () => {
         group.blocks.push(table);
         group.blocks.push(para2);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith(
@@ -202,7 +202,7 @@ describe('iterateSelections', () => {
         group.blocks.push(table);
         group.blocks.push(para2);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(2);
         expect(callback).toHaveBeenCalledWith(
@@ -250,7 +250,7 @@ describe('iterateSelections', () => {
 
         group.blocks.push(table);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(3);
         expect(callback).toHaveBeenCalledWith(
@@ -309,7 +309,7 @@ describe('iterateSelections', () => {
 
         group.blocks.push(table);
 
-        iterateSelections([group], callback, {
+        iterateSelections(group, callback, {
             contentUnderSelectedTableCell: 'ignoreForTableOrCell',
         });
 
@@ -348,7 +348,7 @@ describe('iterateSelections', () => {
 
         group.blocks.push(table);
 
-        iterateSelections([group], callback, {
+        iterateSelections(group, callback, {
             contentUnderSelectedTableCell: 'ignoreForTable',
         });
 
@@ -410,7 +410,7 @@ describe('iterateSelections', () => {
 
         group.blocks.push(table);
 
-        iterateSelections([group], callback, { contentUnderSelectedTableCell: 'ignoreForTable' });
+        iterateSelections(group, callback, { contentUnderSelectedTableCell: 'ignoreForTable' });
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([group], undefined, table, undefined);
@@ -429,7 +429,7 @@ describe('iterateSelections', () => {
         group.blocks.push(para1);
         group.blocks.push(para2);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(2);
         expect(callback).toHaveBeenCalledWith([group], undefined, para1, [marker]);
@@ -449,7 +449,7 @@ describe('iterateSelections', () => {
         group.blocks.push(para1);
         group.blocks.push(para2);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(2);
         expect(callback).toHaveBeenCalledWith([group], undefined, para1, [text]);
@@ -469,7 +469,7 @@ describe('iterateSelections', () => {
         group.blocks.push(para1);
         group.blocks.push(para2);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(2);
         expect(callback).toHaveBeenCalledWith([group], undefined, para1, [marker]);
@@ -493,7 +493,7 @@ describe('iterateSelections', () => {
         group.blocks.push(para2);
         group.blocks.push(para3);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(3);
         expect(callback).toHaveBeenCalledWith([group], undefined, para1, [marker1]);
@@ -524,7 +524,7 @@ describe('iterateSelections', () => {
         group.blocks.push(para2);
         group.blocks.push(para3);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(3);
         expect(callback).toHaveBeenCalledWith([group], undefined, para1, [marker1, text1]);
@@ -543,7 +543,7 @@ describe('iterateSelections', () => {
         listItem.blocks.push(para);
         group.blocks.push(listItem);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(2);
         expect(callback).toHaveBeenCalledWith([listItem, group], undefined, para, [text]);
@@ -565,7 +565,7 @@ describe('iterateSelections', () => {
         listItem.blocks.push(para);
         group.blocks.push(listItem);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([listItem, group], undefined, para, [text1]);
@@ -584,7 +584,7 @@ describe('iterateSelections', () => {
         generalSpan.blocks.push(para);
         group.blocks.push(generalSpan);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([generalSpan, group], undefined, para, [text1]);
@@ -604,7 +604,7 @@ describe('iterateSelections', () => {
         para2.segments.push(text1, text2);
         group.blocks.push(para1);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([generalSpan, group], undefined, para2, [text1]);
@@ -622,14 +622,14 @@ describe('iterateSelections', () => {
         const callback2 = jasmine.createSpy('callback2');
         const callback3 = jasmine.createSpy('callback3');
 
-        iterateSelections([group], callback);
-        iterateSelections([group], callback1, {
+        iterateSelections(group, callback);
+        iterateSelections(group, callback1, {
             contentUnderSelectedGeneralElement: 'contentOnly',
         });
-        iterateSelections([group], callback2, {
+        iterateSelections(group, callback2, {
             contentUnderSelectedGeneralElement: 'generalElementOnly',
         });
-        iterateSelections([group], callback3, { contentUnderSelectedGeneralElement: 'both' });
+        iterateSelections(group, callback3, { contentUnderSelectedGeneralElement: 'both' });
 
         expect(callback).toHaveBeenCalledTimes(0);
         expect(callback1).toHaveBeenCalledTimes(0);
@@ -656,14 +656,14 @@ describe('iterateSelections', () => {
         const callback2 = jasmine.createSpy('callback2');
         const callback3 = jasmine.createSpy('callback3');
 
-        iterateSelections([group], callback);
-        iterateSelections([group], callback1, {
+        iterateSelections(group, callback);
+        iterateSelections(group, callback1, {
             contentUnderSelectedGeneralElement: 'contentOnly',
         });
-        iterateSelections([group], callback2, {
+        iterateSelections(group, callback2, {
             contentUnderSelectedGeneralElement: 'generalElementOnly',
         });
-        iterateSelections([group], callback3, { contentUnderSelectedGeneralElement: 'both' });
+        iterateSelections(group, callback3, { contentUnderSelectedGeneralElement: 'both' });
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([generalSpan, group], undefined, para2, [text2]);
@@ -688,14 +688,14 @@ describe('iterateSelections', () => {
         const callback2 = jasmine.createSpy('callback2');
         const callback3 = jasmine.createSpy('callback3');
 
-        iterateSelections([group], callback);
-        iterateSelections([group], callback1, {
+        iterateSelections(group, callback);
+        iterateSelections(group, callback1, {
             contentUnderSelectedGeneralElement: 'contentOnly',
         });
-        iterateSelections([group], callback2, {
+        iterateSelections(group, callback2, {
             contentUnderSelectedGeneralElement: 'generalElementOnly',
         });
-        iterateSelections([group], callback3, { contentUnderSelectedGeneralElement: 'both' });
+        iterateSelections(group, callback3, { contentUnderSelectedGeneralElement: 'both' });
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([group], undefined, para1, [generalSpan]);
@@ -728,81 +728,14 @@ describe('iterateSelections', () => {
         const callback2 = jasmine.createSpy('callback2');
         const callback3 = jasmine.createSpy('callback3');
 
-        iterateSelections([group], callback);
-        iterateSelections([group], callback1, {
+        iterateSelections(group, callback);
+        iterateSelections(group, callback1, {
             contentUnderSelectedGeneralElement: 'contentOnly',
         });
-        iterateSelections([group], callback2, {
+        iterateSelections(group, callback2, {
             contentUnderSelectedGeneralElement: 'generalElementOnly',
         });
-        iterateSelections([group], callback3, { contentUnderSelectedGeneralElement: 'both' });
-
-        expect(callback).toHaveBeenCalledTimes(1);
-        expect(callback).toHaveBeenCalledWith([generalSpan, group], undefined, para2, [
-            text1,
-            text2,
-        ]);
-
-        expect(callback1).toHaveBeenCalledTimes(1);
-        expect(callback1).toHaveBeenCalledWith([generalSpan, group], undefined, para2, [
-            text1,
-            text2,
-        ]);
-
-        expect(callback2).toHaveBeenCalledTimes(1);
-        expect(callback2).toHaveBeenCalledWith([group], undefined, para1, [generalSpan]);
-
-        expect(callback3).toHaveBeenCalledTimes(2);
-        expect(callback3).toHaveBeenCalledWith([generalSpan, group], undefined, para2, [
-            text1,
-            text2,
-        ]);
-        expect(callback3).toHaveBeenCalledWith([group], undefined, para1, [generalSpan]);
-    });
-
-    it('Get Selection from model that contains general segment, treat all as selected', () => {
-        const group = createContentModelDocument();
-        const generalSpan = createGeneralSegment(document.createElement('span'));
-        const para1 = createParagraph(true /*implicit*/);
-        const para2 = createParagraph(true /*implicit*/);
-        const text1 = createText('test1');
-        const text2 = createText('test1');
-
-        para1.segments.push(generalSpan);
-        generalSpan.blocks.push(para2);
-        para2.segments.push(text1, text2);
-        group.blocks.push(para1);
-
-        const callback1 = jasmine.createSpy('callback1');
-        const callback2 = jasmine.createSpy('callback2');
-        const callback3 = jasmine.createSpy('callback3');
-
-        iterateSelections([group], callback, undefined, undefined, true);
-        iterateSelections(
-            [group],
-            callback1,
-            {
-                contentUnderSelectedGeneralElement: 'contentOnly',
-            },
-            undefined,
-            true
-        );
-        iterateSelections(
-            [group],
-            callback2,
-            {
-                contentUnderSelectedGeneralElement: 'generalElementOnly',
-            },
-            undefined,
-            true
-        );
-        iterateSelections(
-            [group],
-            callback3,
-            { contentUnderSelectedGeneralElement: 'both' },
-            undefined,
-            true
-        );
+        iterateSelections(group, callback3, { contentUnderSelectedGeneralElement: 'both' });
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([generalSpan, group], undefined, para2, [
@@ -839,7 +772,7 @@ describe('iterateSelections', () => {
         para2.segments.push(text1, text2);
         group.blocks.push(generalDiv);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([generalDiv, group], undefined, para2, [text1]);
@@ -855,14 +788,14 @@ describe('iterateSelections', () => {
         const callback2 = jasmine.createSpy('callback2');
         const callback3 = jasmine.createSpy('callback3');
 
-        iterateSelections([group], callback);
-        iterateSelections([group], callback1, {
+        iterateSelections(group, callback);
+        iterateSelections(group, callback1, {
             contentUnderSelectedGeneralElement: 'contentOnly',
         });
-        iterateSelections([group], callback2, {
+        iterateSelections(group, callback2, {
             contentUnderSelectedGeneralElement: 'generalElementOnly',
         });
-        iterateSelections([group], callback3, { contentUnderSelectedGeneralElement: 'both' });
+        iterateSelections(group, callback3, { contentUnderSelectedGeneralElement: 'both' });
 
         expect(callback).toHaveBeenCalledTimes(0);
         expect(callback1).toHaveBeenCalledTimes(0);
@@ -887,14 +820,14 @@ describe('iterateSelections', () => {
         const callback2 = jasmine.createSpy('callback2');
         const callback3 = jasmine.createSpy('callback3');
 
-        iterateSelections([group], callback);
-        iterateSelections([group], callback1, {
+        iterateSelections(group, callback);
+        iterateSelections(group, callback1, {
             contentUnderSelectedGeneralElement: 'contentOnly',
         });
-        iterateSelections([group], callback2, {
+        iterateSelections(group, callback2, {
             contentUnderSelectedGeneralElement: 'generalElementOnly',
         });
-        iterateSelections([group], callback3, { contentUnderSelectedGeneralElement: 'both' });
+        iterateSelections(group, callback3, { contentUnderSelectedGeneralElement: 'both' });
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([generalDiv, group], undefined, para2, [text2]);
@@ -917,14 +850,14 @@ describe('iterateSelections', () => {
         const callback2 = jasmine.createSpy('callback2');
         const callback3 = jasmine.createSpy('callback3');
 
-        iterateSelections([group], callback);
-        iterateSelections([group], callback1, {
+        iterateSelections(group, callback);
+        iterateSelections(group, callback1, {
             contentUnderSelectedGeneralElement: 'contentOnly',
         });
-        iterateSelections([group], callback2, {
+        iterateSelections(group, callback2, {
             contentUnderSelectedGeneralElement: 'generalElementOnly',
         });
-        iterateSelections([group], callback3, { contentUnderSelectedGeneralElement: 'both' });
+        iterateSelections(group, callback3, { contentUnderSelectedGeneralElement: 'both' });
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([group], undefined, generalDiv, undefined);
@@ -955,79 +888,14 @@ describe('iterateSelections', () => {
         const callback2 = jasmine.createSpy('callback2');
         const callback3 = jasmine.createSpy('callback3');
 
-        iterateSelections([group], callback);
-        iterateSelections([group], callback1, {
+        iterateSelections(group, callback);
+        iterateSelections(group, callback1, {
             contentUnderSelectedGeneralElement: 'contentOnly',
         });
-        iterateSelections([group], callback2, {
+        iterateSelections(group, callback2, {
             contentUnderSelectedGeneralElement: 'generalElementOnly',
         });
-        iterateSelections([group], callback3, { contentUnderSelectedGeneralElement: 'both' });
-
-        expect(callback).toHaveBeenCalledTimes(1);
-        expect(callback).toHaveBeenCalledWith([generalDiv, group], undefined, para2, [
-            text1,
-            text2,
-        ]);
-
-        expect(callback1).toHaveBeenCalledTimes(1);
-        expect(callback1).toHaveBeenCalledWith([generalDiv, group], undefined, para2, [
-            text1,
-            text2,
-        ]);
-
-        expect(callback2).toHaveBeenCalledTimes(1);
-        expect(callback2).toHaveBeenCalledWith([group], undefined, generalDiv, undefined);
-
-        expect(callback3).toHaveBeenCalledTimes(2);
-        expect(callback3).toHaveBeenCalledWith([generalDiv, group], undefined, para2, [
-            text1,
-            text2,
-        ]);
-        expect(callback3).toHaveBeenCalledWith([group], undefined, generalDiv, undefined);
-    });
-
-    it('Get Selection from model that contains general block, treat all as selected', () => {
-        const group = createContentModelDocument();
-        const generalDiv = createGeneralBlock(document.createElement('div'));
-        const para2 = createParagraph(true /*implicit*/);
-        const text1 = createText('test1');
-        const text2 = createText('test1');
-
-        generalDiv.blocks.push(para2);
-        para2.segments.push(text1, text2);
-        group.blocks.push(generalDiv);
-
-        const callback1 = jasmine.createSpy('callback1');
-        const callback2 = jasmine.createSpy('callback2');
-        const callback3 = jasmine.createSpy('callback3');
-
-        iterateSelections([group], callback, undefined, undefined, true);
-        iterateSelections(
-            [group],
-            callback1,
-            {
-                contentUnderSelectedGeneralElement: 'contentOnly',
-            },
-            undefined,
-            true
-        );
-        iterateSelections(
-            [group],
-            callback2,
-            {
-                contentUnderSelectedGeneralElement: 'generalElementOnly',
-            },
-            undefined,
-            true
-        );
-        iterateSelections(
-            [group],
-            callback3,
-            { contentUnderSelectedGeneralElement: 'both' },
-            undefined,
-            true
-        );
+        iterateSelections(group, callback3, { contentUnderSelectedGeneralElement: 'both' });
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([generalDiv, group], undefined, para2, [
@@ -1059,7 +927,7 @@ describe('iterateSelections', () => {
         divider.isSelected = true;
         group.blocks.push(divider);
 
-        iterateSelections([group], callback);
+        iterateSelections(group, callback);
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([group], undefined, divider, undefined);
@@ -1086,7 +954,7 @@ describe('iterateSelections', () => {
                 return block == para1;
             });
 
-        iterateSelections([group], newCallback);
+        iterateSelections(group, newCallback);
 
         expect(newCallback).toHaveBeenCalledTimes(1);
         expect(newCallback).toHaveBeenCalledWith([group], undefined, para1, [text1]);
@@ -1114,7 +982,7 @@ describe('iterateSelections', () => {
                 return block == divider;
             });
 
-        iterateSelections([group], newCallback);
+        iterateSelections(group, newCallback);
 
         expect(newCallback).toHaveBeenCalledTimes(2);
         expect(newCallback).toHaveBeenCalledWith([group], undefined, para1, [text1]);
@@ -1146,7 +1014,7 @@ describe('iterateSelections', () => {
                 return block == para1;
             });
 
-        iterateSelections([group], newCallback);
+        iterateSelections(group, newCallback);
 
         expect(newCallback).toHaveBeenCalledTimes(1);
         expect(newCallback).toHaveBeenCalledWith([quote1, group], undefined, para1, [text1]);
@@ -1173,7 +1041,7 @@ describe('iterateSelections', () => {
                 return block == table;
             });
 
-        iterateSelections([group], newCallback, {
+        iterateSelections(group, newCallback, {
             contentUnderSelectedTableCell: 'ignoreForTable',
         });
 
@@ -1207,7 +1075,7 @@ describe('iterateSelections', () => {
                 }
             });
 
-        iterateSelections([group], newCallback);
+        iterateSelections(group, newCallback);
 
         expect(newCallback).toHaveBeenCalledTimes(2);
         expect(newCallback).toHaveBeenCalledWith(
@@ -1247,7 +1115,7 @@ describe('iterateSelections', () => {
         list.blocks.push(para);
         doc.blocks.push(list);
 
-        iterateSelections([doc], callback, { includeListFormatHolder: 'anySegment' });
+        iterateSelections(doc, callback, { includeListFormatHolder: 'anySegment' });
 
         expect(callback).toHaveBeenCalledTimes(2);
         expect(callback).toHaveBeenCalledWith([list, doc], undefined, para, [text2]);
@@ -1273,7 +1141,7 @@ describe('iterateSelections', () => {
         list.blocks.push(para);
         doc.blocks.push(list);
 
-        iterateSelections([doc], callback, { includeListFormatHolder: 'allSegments' });
+        iterateSelections(doc, callback, { includeListFormatHolder: 'allSegments' });
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([list, doc], undefined, para, [text2]);
@@ -1293,7 +1161,7 @@ describe('iterateSelections', () => {
         list.blocks.push(para);
         doc.blocks.push(list);
 
-        iterateSelections([doc], callback, { includeListFormatHolder: 'allSegments' });
+        iterateSelections(doc, callback, { includeListFormatHolder: 'allSegments' });
 
         expect(callback).toHaveBeenCalledTimes(2);
         expect(callback).toHaveBeenCalledWith([list, doc], undefined, para, [text1, text2]);
@@ -1320,7 +1188,7 @@ describe('iterateSelections', () => {
         list.blocks.push(para);
         doc.blocks.push(list);
 
-        iterateSelections([doc], callback, { includeListFormatHolder: 'never' });
+        iterateSelections(doc, callback, { includeListFormatHolder: 'never' });
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([list, doc], undefined, para, [text1, text2]);
@@ -1336,7 +1204,7 @@ describe('iterateSelections', () => {
         para.segments.push(entity);
         doc.blocks.push(para);
 
-        iterateSelections([doc], callback, { includeListFormatHolder: 'never' });
+        iterateSelections(doc, callback, { includeListFormatHolder: 'never' });
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith([doc], undefined, para, [entity]);
@@ -1368,7 +1236,7 @@ describe('iterateSelections', () => {
 
         doc.blocks.push(quote1, quote2, para1, para2, divider1, divider2);
 
-        iterateSelections([doc], callback);
+        iterateSelections(doc, callback);
 
         expect(doc).toEqual({
             blockGroupType: 'Document',


### PR DESCRIPTION
The Content Model API `iterateSelections` has 5 parameters today:
- path
- callback
- option
- table
- treatAllAsSelect

But actually the 4th and 5th parameters have never been really used, and the first parameter is always used as a single content model group. So do the following change to make this API simpler:
1. Change parameter path to a single `ContentModelGroup`
2. Remove the 4th parameter table
3. Remove the 5th paramter treatAllAsSelect