### PR TITLE
Adding module entry to package.json

### DIFF
--- a/tools/buildTools/normalize.js
+++ b/tools/buildTools/normalize.js
@@ -46,6 +46,7 @@ function normalize() {
 
         packageJson.typings = './lib/index.d.ts';
         packageJson.main = './lib/index.js';
+        packageJson.module = './lib-mjs/index.js';
         packageJson.license = 'MIT';
         packageJson.repository = {
             type: 'git',


### PR DESCRIPTION
Adding a module entry to roosterjs' package.json files. Having a module entry helps bundlers such as esbuild know the package is an ES module and find the right entry to the package, while avoid breaking changes for other consumers.

Fixes: #2190 
