### PR TITLE
Standalone Editor: Selection API step 1: Add a SelectionPlugin

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/setContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/setContentModel.ts
@@ -33,7 +33,7 @@ export const setContentModel: SetContentModel = (core, model, option, onNodeCrea
             if (!option?.ignoreSelection) {
                 core.api.setDOMSelection(core, selection);
             } else if (selection.type == 'range') {
-                core.domEvent.selectionRange = selection.range;
+                core.selection.selectionRange = selection.range;
             }
         }
 

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/SelectionPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/SelectionPlugin.ts
@@ -1,0 +1,127 @@
+import type { IEditor, PluginWithState } from 'roosterjs-editor-types';
+import type {
+    IStandaloneEditor,
+    SelectionPluginState,
+    StandaloneEditorOptions,
+} from 'roosterjs-content-model-types';
+
+class SelectionPlugin implements PluginWithState<SelectionPluginState> {
+    private editor: (IStandaloneEditor & IEditor) | null = null;
+    private state: SelectionPluginState;
+    private disposer: (() => void) | null = null;
+
+    constructor(options: StandaloneEditorOptions) {
+        this.state = {
+            selectionRange: null,
+            tableSelectionRange: null,
+            imageSelectionRange: null,
+            selectionStyleNode: null,
+            imageSelectionBorderColor: options.imageSelectionBorderColor, // TODO: Move to Selection core plugin
+        };
+    }
+
+    getName() {
+        return 'Selection';
+    }
+
+    initialize(editor: IEditor) {
+        this.editor = editor as IEditor & IStandaloneEditor;
+
+        const doc = this.editor.getDocument();
+        const styleNode = doc.createElement('style');
+
+        doc.head.appendChild(styleNode);
+        this.state.selectionStyleNode = styleNode;
+
+        const env = this.editor.getEnvironment();
+        const document = this.editor.getDocument();
+
+        if (env.isSafari) {
+            document.addEventListener('mousedown', this.onMouseDownDocument, true /*useCapture*/);
+            document.addEventListener('keydown', this.onKeyDownDocument);
+            document.defaultView?.addEventListener('blur', this.onBlur);
+            this.disposer = this.editor.addDomEventHandler('focus', this.onFocus);
+        } else {
+            this.disposer = this.editor.addDomEventHandler({
+                focus: this.onFocus,
+                blur: this.onBlur,
+            });
+        }
+    }
+
+    dispose() {
+        if (this.state.selectionStyleNode) {
+            this.state.selectionStyleNode.parentNode?.removeChild(this.state.selectionStyleNode);
+            this.state.selectionStyleNode = null;
+        }
+
+        if (this.disposer) {
+            this.disposer();
+            this.disposer = null;
+        }
+
+        if (this.editor) {
+            const document = this.editor.getDocument();
+
+            document.removeEventListener(
+                'mousedown',
+                this.onMouseDownDocument,
+                true /*useCapture*/
+            );
+            document.removeEventListener('keydown', this.onKeyDownDocument);
+            document.defaultView?.removeEventListener('blur', this.onBlur);
+
+            this.editor = null;
+        }
+    }
+
+    getState(): SelectionPluginState {
+        return this.state;
+    }
+
+    private onFocus = () => {
+        if (!this.state.skipReselectOnFocus && this.editor) {
+            const { table, coordinates } = this.state.tableSelectionRange || {};
+            const { image } = this.state.imageSelectionRange || {};
+
+            if (table && coordinates) {
+                this.editor.select(table, coordinates);
+            } else if (image) {
+                this.editor.select(image);
+            } else if (this.state.selectionRange) {
+                this.editor.select(this.state.selectionRange);
+            }
+        }
+
+        this.state.selectionRange = null;
+    };
+
+    private onBlur = () => {
+        if (!this.state.selectionRange && this.editor) {
+            this.state.selectionRange = this.editor.getSelectionRange(false /*tryGetFromCache*/);
+        }
+    };
+
+    private onKeyDownDocument = (event: KeyboardEvent) => {
+        if (event.key == 'Tab' && !event.defaultPrevented) {
+            this.onBlur();
+        }
+    };
+
+    private onMouseDownDocument = (event: MouseEvent) => {
+        if (this.editor && !this.editor.contains(event.target as Node)) {
+            this.onBlur();
+        }
+    };
+}
+
+/**
+ * @internal
+ * Create a new instance of SelectionPlugin.
+ * @param option The editor option
+ */
+export function createSelectionPlugin(
+    options: StandaloneEditorOptions
+): PluginWithState<SelectionPluginState> {
+    return new SelectionPlugin(options);
+}

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/createStandaloneEditorCorePlugins.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/createStandaloneEditorCorePlugins.ts
@@ -4,6 +4,7 @@ import { createContentModelFormatPlugin } from './ContentModelFormatPlugin';
 import { createDOMEventPlugin } from './DOMEventPlugin';
 import { createEntityPlugin } from './EntityPlugin';
 import { createLifecyclePlugin } from './LifecyclePlugin';
+import { createSelectionPlugin } from './SelectionPlugin';
 import type {
     StandaloneEditorCorePlugins,
     StandaloneEditorOptions,
@@ -25,5 +26,6 @@ export function createStandaloneEditorCorePlugins(
         domEvent: createDOMEventPlugin(options, contentDiv),
         lifecycle: createLifecyclePlugin(options, contentDiv),
         entity: createEntityPlugin(),
+        selection: createSelectionPlugin(options),
     };
 }

--- a/packages-content-model/roosterjs-content-model-core/lib/editor/createStandaloneEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/editor/createStandaloneEditorCore.ts
@@ -36,13 +36,13 @@ export function createStandaloneEditorCore(
             corePlugins.format,
             corePlugins.copyPaste,
             corePlugins.domEvent,
+            corePlugins.selection,
             corePlugins.entity,
             ...tempPlugins,
             corePlugins.lifecycle,
         ],
         environment: createEditorEnvironment(),
         darkColorHandler: new DarkColorHandlerImpl(contentDiv, options.baseDarkColor),
-        imageSelectionBorderColor: options.imageSelectionBorderColor, // TODO: Move to Selection core plugin
         trustedHTMLHandler: options.trustedHTMLHandler || defaultTrustHtmlHandler,
         ...createStandaloneEditorDefaultSettings(options),
         ...getPluginState(corePlugins),
@@ -79,5 +79,6 @@ function getPluginState(corePlugins: StandaloneEditorCorePlugins): StandaloneEdi
         format: corePlugins.format.getState(),
         lifecycle: corePlugins.lifecycle.getState(),
         entity: corePlugins.entity.getState(),
+        selection: corePlugins.selection.getState(),
     };
 }

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/DomEventPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/DomEventPluginTest.ts
@@ -33,10 +33,7 @@ describe('DOMEventPlugin', () => {
         expect(state).toEqual({
             isInIME: false,
             scrollContainer: div,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: null,
             mouseDownY: null,
             mouseUpEventListerAdded: false,
@@ -85,10 +82,7 @@ describe('DOMEventPlugin', () => {
         expect(state).toEqual({
             isInIME: false,
             scrollContainer: divScrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: null,
             mouseDownY: null,
             mouseUpEventListerAdded: false,
@@ -142,7 +136,6 @@ describe('DOMEventPlugin verify event handlers while disallow keyboard event pro
         expect(eventMap.compositionend).toBeDefined();
         expect(eventMap.dragstart).toBeDefined();
         expect(eventMap.drop).toBeDefined();
-        expect(eventMap.focus).toBeDefined();
         expect(eventMap.mouseup).not.toBeDefined();
     });
 
@@ -243,10 +236,7 @@ describe('DOMEventPlugin handle mouse down and mouse up event', () => {
         expect(plugin.getState()).toEqual({
             isInIME: false,
             scrollContainer: scrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: 100,
             mouseDownY: 200,
             mouseUpEventListerAdded: true,
@@ -265,10 +255,7 @@ describe('DOMEventPlugin handle mouse down and mouse up event', () => {
         expect(plugin.getState()).toEqual({
             isInIME: false,
             scrollContainer: scrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: 100,
             mouseDownY: 200,
             mouseUpEventListerAdded: true,
@@ -285,10 +272,7 @@ describe('DOMEventPlugin handle mouse down and mouse up event', () => {
         expect(plugin.getState()).toEqual({
             isInIME: false,
             scrollContainer: scrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: 100,
             mouseDownY: 200,
             mouseUpEventListerAdded: false,
@@ -311,10 +295,7 @@ describe('DOMEventPlugin handle mouse down and mouse up event', () => {
         expect(plugin.getState()).toEqual({
             isInIME: false,
             scrollContainer: scrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: 100,
             mouseDownY: 200,
             mouseUpEventListerAdded: true,
@@ -331,10 +312,7 @@ describe('DOMEventPlugin handle mouse down and mouse up event', () => {
         expect(plugin.getState()).toEqual({
             isInIME: false,
             scrollContainer: scrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: 100,
             mouseDownY: 200,
             mouseUpEventListerAdded: false,
@@ -394,10 +372,7 @@ describe('DOMEventPlugin handle other event', () => {
         expect(plugin.getState()).toEqual({
             isInIME: true,
             scrollContainer: scrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: null,
             mouseDownY: null,
             mouseUpEventListerAdded: false,
@@ -410,10 +385,7 @@ describe('DOMEventPlugin handle other event', () => {
         expect(plugin.getState()).toEqual({
             isInIME: false,
             scrollContainer: scrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: null,
             mouseDownY: null,
             mouseUpEventListerAdded: false,
@@ -436,10 +408,7 @@ describe('DOMEventPlugin handle other event', () => {
         expect(plugin.getState()).toEqual({
             isInIME: false,
             scrollContainer: scrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: null,
             mouseDownY: null,
             mouseUpEventListerAdded: false,
@@ -462,10 +431,7 @@ describe('DOMEventPlugin handle other event', () => {
         expect(plugin.getState()).toEqual({
             isInIME: false,
             scrollContainer: scrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: null,
             mouseDownY: null,
             mouseUpEventListerAdded: false,
@@ -484,67 +450,12 @@ describe('DOMEventPlugin handle other event', () => {
         expect(plugin.getState()).toEqual({
             isInIME: false,
             scrollContainer: scrollContainer,
-            selectionRange: null,
             contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
             mouseDownX: null,
             mouseDownY: null,
             mouseUpEventListerAdded: false,
         });
         expect(addUndoSnapshotSpy).toHaveBeenCalledWith(jasmine.anything(), ChangeSource.Drop);
-    });
-
-    it('Trigger onFocus event', () => {
-        const selectSpy = jasmine.createSpy('select');
-        editor.select = selectSpy;
-
-        const state = plugin.getState();
-        const mockedRange = 'RANGE' as any;
-
-        state.skipReselectOnFocus = false;
-        state.selectionRange = mockedRange;
-
-        eventMap.focus();
-        expect(plugin.getState()).toEqual({
-            isInIME: false,
-            scrollContainer: scrollContainer,
-            selectionRange: null,
-            contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
-            mouseDownX: null,
-            mouseDownY: null,
-            mouseUpEventListerAdded: false,
-            skipReselectOnFocus: false,
-        });
-        expect(selectSpy).toHaveBeenCalledWith(mockedRange);
-    });
-
-    it('Trigger onFocus event, skip reselect', () => {
-        const selectSpy = jasmine.createSpy('select');
-        editor.select = selectSpy;
-
-        const state = plugin.getState();
-        const mockedRange = 'RANGE' as any;
-
-        state.skipReselectOnFocus = true;
-        state.selectionRange = mockedRange;
-
-        eventMap.focus();
-        expect(plugin.getState()).toEqual({
-            isInIME: false,
-            scrollContainer: scrollContainer,
-            selectionRange: null,
-            contextMenuProviders: [],
-            tableSelectionRange: null,
-            imageSelectionRange: null,
-            mouseDownX: null,
-            mouseDownY: null,
-            mouseUpEventListerAdded: false,
-            skipReselectOnFocus: true,
-        });
-        expect(selectSpy).not.toHaveBeenCalled();
     });
 
     it('Trigger contextmenu event, skip reselect', () => {

--- a/packages-content-model/roosterjs-content-model-editor/lib/coreApi/focus.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/coreApi/focus.ts
@@ -21,8 +21,8 @@ export const focus: Focus = core => {
             // to very begin to of editor since we don't really have last saved selection (created on blur which does not fire in this case).
             // It should be better than the case you cannot type
             if (
-                !core.domEvent.selectionRange ||
-                !core.api.selectRange(core, core.domEvent.selectionRange, true /*skipSameRange*/)
+                !core.selection.selectionRange ||
+                !core.api.selectRange(core, core.selection.selectionRange, true /*skipSameRange*/)
             ) {
                 const node = getFirstLeafNode(core.contentDiv) || core.contentDiv;
                 core.api.selectRange(
@@ -34,7 +34,7 @@ export const focus: Focus = core => {
         }
 
         // remember to clear cached selection range
-        core.domEvent.selectionRange = null;
+        core.selection.selectionRange = null;
 
         // This is more a fallback to ensure editor gets focus if it didn't manage to move focus to editor
         if (!core.api.hasFocus(core)) {

--- a/packages-content-model/roosterjs-content-model-editor/lib/coreApi/getSelectionRange.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/coreApi/getSelectionRange.ts
@@ -25,7 +25,7 @@ export const getSelectionRange: GetSelectionRange = (core, tryGetFromCache: bool
         }
 
         if (!result && tryGetFromCache) {
-            result = core.domEvent.selectionRange;
+            result = core.selection.selectionRange;
         }
 
         return result;

--- a/packages-content-model/roosterjs-content-model-editor/lib/coreApi/getSelectionRangeEx.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/coreApi/getSelectionRangeEx.ts
@@ -15,12 +15,12 @@ export const getSelectionRangeEx: GetSelectionRangeEx = core => {
         return createNormalSelectionEx([]);
     } else {
         if (core.api.hasFocus(core)) {
-            if (core.domEvent.tableSelectionRange) {
-                return core.domEvent.tableSelectionRange;
+            if (core.selection.tableSelectionRange) {
+                return core.selection.tableSelectionRange;
             }
 
-            if (core.domEvent.imageSelectionRange) {
-                return core.domEvent.imageSelectionRange;
+            if (core.selection.imageSelectionRange) {
+                return core.selection.imageSelectionRange;
             }
 
             const selection = core.contentDiv.ownerDocument.defaultView?.getSelection();
@@ -33,10 +33,10 @@ export const getSelectionRangeEx: GetSelectionRangeEx = core => {
         }
 
         return (
-            core.domEvent.tableSelectionRange ??
-            core.domEvent.imageSelectionRange ??
+            core.selection.tableSelectionRange ??
+            core.selection.imageSelectionRange ??
             createNormalSelectionEx(
-                core.domEvent.selectionRange ? [core.domEvent.selectionRange] : []
+                core.selection.selectionRange ? [core.selection.selectionRange] : []
             )
         );
     }

--- a/packages-content-model/roosterjs-content-model-editor/lib/coreApi/select.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/coreApi/select.ts
@@ -23,20 +23,20 @@ export const select: Select = (core, arg1, arg2, arg3, arg4) => {
     const rangeEx = buildRangeEx(core, arg1, arg2, arg3, arg4);
 
     if (rangeEx) {
-        const skipReselectOnFocus = core.domEvent.skipReselectOnFocus;
+        const skipReselectOnFocus = core.selection.skipReselectOnFocus;
 
         // We are applying a new selection, so we don't need to apply cached selection in DOMEventPlugin.
         // Set skipReselectOnFocus to skip this behavior
-        core.domEvent.skipReselectOnFocus = true;
+        core.selection.skipReselectOnFocus = true;
 
         try {
             applyRangeEx(core, rangeEx);
         } finally {
-            core.domEvent.skipReselectOnFocus = skipReselectOnFocus;
+            core.selection.skipReselectOnFocus = skipReselectOnFocus;
         }
     } else {
-        core.domEvent.tableSelectionRange = core.api.selectTable(core, null);
-        core.domEvent.imageSelectionRange = core.api.selectImage(core, null);
+        core.selection.tableSelectionRange = core.api.selectTable(core, null);
+        core.selection.imageSelectionRange = core.api.selectImage(core, null);
     }
 
     return !!rangeEx;
@@ -100,25 +100,25 @@ function applyRangeEx(core: StandaloneEditorCore, rangeEx: SelectionRangeEx | nu
     switch (rangeEx?.type) {
         case SelectionRangeTypes.TableSelection:
             if (contains(core.contentDiv, rangeEx.table)) {
-                core.domEvent.imageSelectionRange = core.api.selectImage(core, null);
-                core.domEvent.tableSelectionRange = core.api.selectTable(
+                core.selection.imageSelectionRange = core.api.selectImage(core, null);
+                core.selection.tableSelectionRange = core.api.selectTable(
                     core,
                     rangeEx.table,
                     rangeEx.coordinates
                 );
-                rangeEx = core.domEvent.tableSelectionRange;
+                rangeEx = core.selection.tableSelectionRange;
             }
             break;
         case SelectionRangeTypes.ImageSelection:
             if (contains(core.contentDiv, rangeEx.image)) {
-                core.domEvent.tableSelectionRange = core.api.selectTable(core, null);
-                core.domEvent.imageSelectionRange = core.api.selectImage(core, rangeEx.image);
-                rangeEx = core.domEvent.imageSelectionRange;
+                core.selection.tableSelectionRange = core.api.selectTable(core, null);
+                core.selection.imageSelectionRange = core.api.selectImage(core, rangeEx.image);
+                rangeEx = core.selection.imageSelectionRange;
             }
             break;
         case SelectionRangeTypes.Normal:
-            core.domEvent.tableSelectionRange = core.api.selectTable(core, null);
-            core.domEvent.imageSelectionRange = core.api.selectImage(core, null);
+            core.selection.tableSelectionRange = core.api.selectTable(core, null);
+            core.selection.imageSelectionRange = core.api.selectImage(core, null);
 
             if (contains(core.contentDiv, rangeEx.ranges[0])) {
                 core.api.selectRange(core, rangeEx.ranges[0]);

--- a/packages-content-model/roosterjs-content-model-editor/lib/coreApi/selectImage.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/coreApi/selectImage.ts
@@ -55,7 +55,7 @@ const select = (core: StandaloneEditorCore, image: HTMLImageElement) => {
 
 const buildBorderCSS = (core: StandaloneEditorCore, imageId: string): string => {
     const divId = core.contentDiv.id;
-    const color = core.imageSelectionBorderColor || DEFAULT_SELECTION_BORDER_COLOR;
+    const color = core.selection.imageSelectionBorderColor || DEFAULT_SELECTION_BORDER_COLOR;
 
     return `#${divId} #${imageId} {outline-style: auto!important;outline-color: ${color}!important;caret-color: transparent!important;}`;
 };

--- a/packages-content-model/roosterjs-content-model-editor/lib/coreApi/selectRange.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/coreApi/selectRange.ts
@@ -15,7 +15,7 @@ export const selectRange: SelectRange = (core, range, skipSameRange) => {
         addRangeToSelection(range, skipSameRange);
 
         if (!core.api.hasFocus(core)) {
-            core.domEvent.selectionRange = range;
+            core.selection.selectionRange = range;
         }
 
         return true;

--- a/packages-content-model/roosterjs-content-model-editor/lib/coreApi/setContent.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/coreApi/setContent.ts
@@ -79,9 +79,9 @@ export const setContent: SetContent = (core, content, triggerContentChangedEvent
 
 function selectContentMetadata(core: StandaloneEditorCore, metadata: ContentMetadata | undefined) {
     if (!core.lifecycle.shadowEditFragment && metadata) {
-        core.domEvent.tableSelectionRange = null;
-        core.domEvent.imageSelectionRange = null;
-        core.domEvent.selectionRange = null;
+        core.selection.tableSelectionRange = null;
+        core.selection.imageSelectionRange = null;
+        core.selection.selectionRange = null;
 
         switch (metadata.type) {
             case SelectionRangeTypes.Normal:
@@ -98,7 +98,11 @@ function selectContentMetadata(core: StandaloneEditorCore, metadata: ContentMeta
                 )[0] as HTMLTableElement;
 
                 if (table) {
-                    core.domEvent.tableSelectionRange = core.api.selectTable(core, table, metadata);
+                    core.selection.tableSelectionRange = core.api.selectTable(
+                        core,
+                        table,
+                        metadata
+                    );
                 }
                 break;
             case SelectionRangeTypes.ImageSelection:
@@ -108,7 +112,7 @@ function selectContentMetadata(core: StandaloneEditorCore, metadata: ContentMeta
                 )[0] as HTMLImageElement;
 
                 if (image) {
-                    core.domEvent.imageSelectionRange = core.api.selectImage(core, image);
+                    core.selection.imageSelectionRange = core.api.selectImage(core, image);
                 }
                 break;
         }

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/createEditorCoreTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/createEditorCoreTest.ts
@@ -8,6 +8,7 @@ import * as EntityPlugin from 'roosterjs-content-model-core/lib/corePlugin/Entit
 import * as ImageSelection from '../../lib/corePlugins/ImageSelection';
 import * as LifecyclePlugin from 'roosterjs-content-model-core/lib/corePlugin/LifecyclePlugin';
 import * as NormalizeTablePlugin from '../../lib/corePlugins/NormalizeTablePlugin';
+import * as SelectionPlugin from 'roosterjs-content-model-core/lib/corePlugin/SelectionPlugin';
 import * as UndoPlugin from '../../lib/corePlugins/UndoPlugin';
 import { coreApiMap } from '../../lib/coreApi/coreApiMap';
 import { createEditorCore } from '../../lib/editor/createEditorCore';
@@ -22,6 +23,7 @@ const mockedEntityState = 'ENTITYSTATE' as any;
 const mockedCopyPasteState = 'COPYPASTESTATE' as any;
 const mockedCacheState = 'CACHESTATE' as any;
 const mockedFormatState = 'FORMATSTATE' as any;
+const mockedSelectionState = 'SELECTION' as any;
 
 const mockedFormatPlugin = {
     getState: () => mockedFormatState,
@@ -43,6 +45,9 @@ const mockedDOMEventPlugin = {
 } as any;
 const mockedEntityPlugin = {
     getState: () => mockedEntityState,
+} as any;
+const mockedSelectionPlugin = {
+    getState: () => mockedSelectionState,
 } as any;
 const mockedImageSelection = 'ImageSelection' as any;
 const mockedNormalizeTablePlugin = 'NormalizeTablePlugin' as any;
@@ -73,6 +78,7 @@ describe('createEditorCore', () => {
         spyOn(EditPlugin, 'createEditPlugin').and.returnValue(mockedEditPlugin);
         spyOn(UndoPlugin, 'createUndoPlugin').and.returnValue(mockedUndoPlugin);
         spyOn(DOMEventPlugin, 'createDOMEventPlugin').and.returnValue(mockedDOMEventPlugin);
+        spyOn(SelectionPlugin, 'createSelectionPlugin').and.returnValue(mockedSelectionPlugin);
         spyOn(EntityPlugin, 'createEntityPlugin').and.returnValue(mockedEntityPlugin);
         spyOn(ImageSelection, 'createImageSelection').and.returnValue(mockedImageSelection);
         spyOn(NormalizeTablePlugin, 'createNormalizeTablePlugin').and.returnValue(
@@ -96,6 +102,7 @@ describe('createEditorCore', () => {
                 mockedFormatPlugin,
                 mockedCopyPastePlugin,
                 mockedDOMEventPlugin,
+                mockedSelectionPlugin,
                 mockedEntityPlugin,
                 mockedEditPlugin,
                 mockedUndoPlugin,
@@ -111,10 +118,10 @@ describe('createEditorCore', () => {
             copyPaste: mockedCopyPasteState,
             cache: mockedCacheState,
             format: mockedFormatState,
+            selection: mockedSelectionState,
             trustedHTMLHandler: defaultTrustHtmlHandler,
             zoomScale: 1,
             sizeTransformer: jasmine.anything(),
-            imageSelectionBorderColor: undefined,
             darkColorHandler: jasmine.anything(),
             disposeErrorHandler: undefined,
             ...mockedDefaultSettings,
@@ -151,6 +158,7 @@ describe('createEditorCore', () => {
                 mockedFormatPlugin,
                 mockedCopyPastePlugin,
                 mockedDOMEventPlugin,
+                mockedSelectionPlugin,
                 mockedEntityPlugin,
                 mockedEditPlugin,
                 mockedUndoPlugin,
@@ -166,10 +174,10 @@ describe('createEditorCore', () => {
             copyPaste: mockedCopyPasteState,
             cache: mockedCacheState,
             format: mockedFormatState,
+            selection: mockedSelectionState,
             trustedHTMLHandler: defaultTrustHtmlHandler,
             zoomScale: 1,
             sizeTransformer: jasmine.anything(),
-            imageSelectionBorderColor: undefined,
             darkColorHandler: jasmine.anything(),
             disposeErrorHandler: undefined,
             ...mockedDefaultSettings,

--- a/packages-content-model/roosterjs-content-model-types/lib/editor/StandaloneEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/editor/StandaloneEditorCore.ts
@@ -600,11 +600,6 @@ export interface StandaloneEditorCore
     readonly darkColorHandler: DarkColorHandler;
 
     /**
-     * Color of the border of a selectedImage. Default color: '#DB626C'
-     */
-    readonly imageSelectionBorderColor?: string;
-
-    /**
      * A handler to convert HTML string to a trust HTML string.
      * By default it will just return the original HTML string directly.
      * To override, pass your own trusted HTML handler to EditorOptions.trustedHTMLHandler

--- a/packages-content-model/roosterjs-content-model-types/lib/editor/StandaloneEditorCorePlugins.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/editor/StandaloneEditorCorePlugins.ts
@@ -1,3 +1,4 @@
+import type { SelectionPluginState } from '../pluginState/SelectionPluginState';
 import type { EntityPluginState } from '../pluginState/EntityPluginState';
 import type { LifecyclePluginState } from '../pluginState/LifecyclePluginState';
 import type { DOMEventPluginState } from '../pluginState/DOMEventPluginState';
@@ -28,6 +29,11 @@ export interface StandaloneEditorCorePlugins {
      * DomEvent plugin helps handle additional DOM events such as IME composition, cut, drop.
      */
     readonly domEvent: PluginWithState<DOMEventPluginState>;
+
+    /**
+     * Selection plugin handles selection, including range selection, table selection, and image selection
+     */
+    readonly selection: PluginWithState<SelectionPluginState>;
 
     /**
      * Entity Plugin handles all operations related to an entity and generate entity specified events

--- a/packages-content-model/roosterjs-content-model-types/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/index.ts
@@ -242,6 +242,7 @@ export {
 export { DOMEventPluginState } from './pluginState/DOMEventPluginState';
 export { LifecyclePluginState } from './pluginState/LifecyclePluginState';
 export { EntityPluginState, KnownEntityItem } from './pluginState/EntityPluginState';
+export { SelectionPluginState } from './pluginState/SelectionPluginState';
 
 export { EditorEnvironment } from './parameter/EditorEnvironment';
 export {

--- a/packages-content-model/roosterjs-content-model-types/lib/pluginState/DOMEventPluginState.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/pluginState/DOMEventPluginState.ts
@@ -1,8 +1,4 @@
-import type {
-    ContextMenuProvider,
-    ImageSelectionRange,
-    TableSelectionRange,
-} from 'roosterjs-editor-types';
+import type { ContextMenuProvider } from 'roosterjs-editor-types';
 
 /**
  * The state object for DOMEventPlugin
@@ -19,29 +15,9 @@ export interface DOMEventPluginState {
     scrollContainer: HTMLElement;
 
     /**
-     * Cached selection range
-     */
-    selectionRange: Range | null;
-
-    /**
-     * Table selection range
-     */
-    tableSelectionRange: TableSelectionRange | null;
-
-    /**
      * Context menu providers, that can provide context menu items
      */
     contextMenuProviders: ContextMenuProvider<any>[];
-
-    /**
-     * Image selection range
-     */
-    imageSelectionRange: ImageSelectionRange | null;
-
-    /**
-     * When set to true, onFocus event will not trigger reselect cached range
-     */
-    skipReselectOnFocus?: boolean;
 
     /**
      * Whether mouse up event handler is added

--- a/packages-content-model/roosterjs-content-model-types/lib/pluginState/SelectionPluginState.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/pluginState/SelectionPluginState.ts
@@ -1,0 +1,36 @@
+import type { ImageSelectionRange, TableSelectionRange } from 'roosterjs-editor-types';
+
+/**
+ * The state object for SelectionPlugin
+ */
+export interface SelectionPluginState {
+    /**
+     * Cached selection range
+     */
+    selectionRange: Range | null;
+
+    /**
+     * Table selection range
+     */
+    tableSelectionRange: TableSelectionRange | null;
+
+    /**
+     * Image selection range
+     */
+    imageSelectionRange: ImageSelectionRange | null;
+
+    /**
+     * A style node in current document to help implement image and table selection
+     */
+    selectionStyleNode: HTMLStyleElement | null;
+
+    /**
+     * When set to true, onFocus event will not trigger reselect cached range
+     */
+    skipReselectOnFocus?: boolean;
+
+    /**
+     * Color of the border of a selectedImage. Default color: '#DB626C'
+     */
+    imageSelectionBorderColor?: string;
+}

--- a/packages-content-model/roosterjs-content-model-types/lib/pluginState/StandaloneEditorPluginState.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/pluginState/StandaloneEditorPluginState.ts
@@ -1,3 +1,4 @@
+import type { SelectionPluginState } from './SelectionPluginState';
 import type {
     CopyPastePluginState,
     EditPluginState,
@@ -43,6 +44,11 @@ export interface StandaloneEditorCorePluginState {
      * Plugin state for EntityPlugin
      */
     entity: EntityPluginState;
+
+    /**
+     * Plugin state for SelectionPlugin
+     */
+    selection: SelectionPluginState;
 }
 
 /**


### PR DESCRIPTION
The general goal is to remove the old selection related core API (`select`, `selectRange`, `selectImage`, `selectTable`, `getSelectionRange`, `getSelectionRangeEx`), and use the selection API (`setDOMSelection`, `getDOMSelection`) instead, and use a new core Plugin `SelectionPlugin` to handle all selection related events.

This is the first step of porting selection API. It creates a new `SelectionPlugin`, and move selection related things into `SelectionPluginState`.