### PR TITLE
Content Model: Fix #2230

### DIFF
--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -13,7 +13,7 @@ export function keyboardInput(editor: IContentModelEditor, rawEvent: KeyboardEve
 
         editor.formatContentModel(
             (model, context) => {
-                const result = deleteSelection(model, [], context).deleteResult;
+                const result = deleteSelection(model, [], context);
 
                 // We have deleted selection then we will let browser to handle the input.
                 // With this combined operation, we don't wan to mass up the cached model so clear it
@@ -22,8 +22,15 @@ export function keyboardInput(editor: IContentModelEditor, rawEvent: KeyboardEve
                 // Skip undo snapshot here and add undo snapshot before the operation so that we don't add another undo snapshot in middle of this replace operation
                 context.skipUndoSnapshot = true;
 
-                // Do not preventDefault since we still want browser to handle the final input for now
-                return result == 'range';
+                if (result.deleteResult == 'range') {
+                    // We have deleted something, next input should inherit the segment format from deleted content, so set pending format here
+                    context.newPendingFormat = result.insertPoint?.marker.format;
+
+                    // Do not preventDefault since we still want browser to handle the final input for now
+                    return true;
+                } else {
+                    return false;
+                }
             },
             {
                 rawEvent,

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
@@ -130,6 +130,7 @@ describe('keyboardInput', () => {
             newImages: [],
             clearModelCache: true,
             skipUndoSnapshot: true,
+            newPendingFormat: undefined,
         });
     });
 
@@ -158,6 +159,7 @@ describe('keyboardInput', () => {
             newImages: [],
             clearModelCache: true,
             skipUndoSnapshot: true,
+            newPendingFormat: undefined,
         });
     });
 
@@ -186,6 +188,7 @@ describe('keyboardInput', () => {
             newImages: [],
             clearModelCache: true,
             skipUndoSnapshot: true,
+            newPendingFormat: undefined,
         });
     });
 
@@ -268,6 +271,7 @@ describe('keyboardInput', () => {
             newImages: [],
             clearModelCache: true,
             skipUndoSnapshot: true,
+            newPendingFormat: undefined,
         });
     });
 
@@ -322,6 +326,45 @@ describe('keyboardInput', () => {
             newImages: [],
             clearModelCache: true,
             skipUndoSnapshot: true,
+            newPendingFormat: undefined,
+        });
+    });
+
+    it('Letter input, expanded selection, no modifier key, deleteSelection returns range, has segment format', () => {
+        const mockedFormat = 'FORMAT' as any;
+        getDOMSelectionSpy.and.returnValue({
+            type: 'range',
+            range: {
+                collapsed: false,
+            },
+        });
+        deleteSelectionSpy.and.returnValue({
+            deleteResult: 'range',
+            insertPoint: {
+                marker: {
+                    format: mockedFormat,
+                },
+            },
+        });
+
+        const rawEvent = {
+            key: 'A',
+        } as any;
+
+        keyboardInput(editor, rawEvent);
+
+        expect(getDOMSelectionSpy).toHaveBeenCalled();
+        expect(addUndoSnapshotSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(deleteSelectionSpy).toHaveBeenCalledWith(mockedModel, [], mockedContext);
+        expect(formatResult).toBeTrue();
+        expect(mockedContext).toEqual({
+            deletedEntities: [],
+            newEntities: [],
+            newImages: [],
+            clearModelCache: true,
+            skipUndoSnapshot: true,
+            newPendingFormat: mockedFormat,
         });
     });
 });


### PR DESCRIPTION
#2230 when input on top of an expanded selection, we first use content model to delete the selection, then let browser handle the input. The problem here is if the selected content is in a different format, the format is lost after delete.

Fix: set pending format after delete, so it will be applied when input.