### PR TITLE
Content Model: keep default format when paste into empty editor

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
@@ -1,5 +1,9 @@
 import { createDomToModelContext, domToContentModel } from 'roosterjs-content-model-dom';
-import type { ContentModelDocument, DomToModelOption } from 'roosterjs-content-model-types';
+import type {
+    ContentModelDocument,
+    ContentModelSegmentFormat,
+    DomToModelOption,
+} from 'roosterjs-content-model-types';
 import type { TrustedHTMLHandler } from 'roosterjs-editor-types';
 
 /**
@@ -12,11 +16,20 @@ import type { TrustedHTMLHandler } from 'roosterjs-editor-types';
 export function createModelFromHtml(
     html: string,
     options?: DomToModelOption,
-    trustedHTMLHandler?: TrustedHTMLHandler
+    trustedHTMLHandler?: TrustedHTMLHandler,
+    defaultSegmentFormat?: ContentModelSegmentFormat
 ): ContentModelDocument | undefined {
     const doc = new DOMParser().parseFromString(trustedHTMLHandler?.(html) ?? html, 'text/html');
 
     return doc?.body
-        ? domToContentModel(doc.body, createDomToModelContext(undefined /*editorContext*/, options))
+        ? domToContentModel(
+              doc.body,
+              createDomToModelContext(
+                  {
+                      defaultFormat: defaultSegmentFormat,
+                  },
+                  options
+              )
+          )
         : undefined;
 }

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/paste.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/paste.ts
@@ -107,7 +107,11 @@ export function paste(
             }
 
             if (originalFormat) {
-                context.newPendingFormat = { ...EmptySegmentFormat, ...originalFormat }; // Use empty format as initial value to clear any other format inherits from pasted content
+                context.newPendingFormat = {
+                    ...EmptySegmentFormat,
+                    ...model.format,
+                    ...originalFormat,
+                }; // Use empty format as initial value to clear any other format inherits from pasted content
             }
 
             return true;

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/createEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/createEditorCore.ts
@@ -32,7 +32,8 @@ export function createEditorCore(
         options.initialModel = createModelFromHtml(
             initContent,
             options.defaultDomToModelOptions,
-            options.trustedHTMLHandler
+            options.trustedHTMLHandler,
+            options.defaultSegmentFormat
         );
     }
 


### PR DESCRIPTION
Repro:
1. copy something with format
2. open demo site
3. set a different default format
4. paste
5. keep typing

Expect: the typed text is in default format
Actual: the type text does not have format

This is because when editor is empty, we didn't get original format. To fix, we need to retrieve default format as default value then let "original format" (retrieved from current selection) overwrite it.

We also need to set default format to initial model since we will have a cached model at beginning.