### PR TITLE
Allow each package has its own version when publish

### DIFF
--- a/tools/buildTools/normalize.js
+++ b/tools/buildTools/normalize.js
@@ -19,7 +19,7 @@ function normalize() {
 
     allPackages.forEach(packageName => {
         const versionKey = findPackageRoot(packageName);
-        const version = versions[versionKey];
+        const version = versions.overrides?.[packageName] ?? versions[versionKey];
         const packageJson = readPackageJson(packageName, true /*readFromSourceFolder*/);
 
         Object.keys(packageJson.dependencies).forEach(dep => {
@@ -38,11 +38,11 @@ function normalize() {
             }
         });
 
-        if (packageJson.version && packageJson.version != '0.0.0') {
-            knownCustomizedPackages[packageName] = packageJson.version;
-        } else {
+        if (!packageJson.version || packageJson.version == '0.0.0') {
             packageJson.version = version;
         }
+
+        knownCustomizedPackages[packageName] = packageJson.version;
 
         packageJson.typings = './lib/index.d.ts';
         packageJson.main = './lib/index.js';

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,6 @@
 {
-    "packages": "0.0.0",
+    "packages": "0.0.1",
     "packages-ui": "0.0.0",
-    "packages-content-model": "0.0.0"
+    "packages-content-model": "0.0.0",
+    "overrides": {}
 }

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-    "packages": "0.0.1",
+    "packages": "0.0.0",
     "packages-ui": "0.0.0",
     "packages-content-model": "0.0.0",
     "overrides": {}


### PR DESCRIPTION
This change allows us add a version override in versions.json to each package so when we do version bump, no need to bump up those packages that is not changed.

For example
```js
{
    "packages": "8.59.0",
    "packages-ui": "8.54.0",
    "packages-content-model": "0.20.0",
    "overrides": {
        "roosterjs-editor-plugins": "8.59.1"
    }
}
```

With this config, all other roosterjs packages are still in 8.59.0, only `roosterjs-editor-plugins` will be bumped to 8.59.1.