### PR TITLE
Content Model: Fix overwrite table cell bug

### DIFF
--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -1,4 +1,5 @@
 import { deleteSelection, isModifierKey } from 'roosterjs-content-model-core';
+import { normalizeContentModel } from 'roosterjs-content-model-dom';
 import type { IContentModelEditor } from 'roosterjs-content-model-editor';
 import type { DOMSelection } from 'roosterjs-content-model-types';
 
@@ -25,6 +26,8 @@ export function keyboardInput(editor: IContentModelEditor, rawEvent: KeyboardEve
                 if (result.deleteResult == 'range') {
                     // We have deleted something, next input should inherit the segment format from deleted content, so set pending format here
                     context.newPendingFormat = result.insertPoint?.marker.format;
+
+                    normalizeContentModel(model);
 
                     // Do not preventDefault since we still want browser to handle the final input for now
                     return true;

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
@@ -1,4 +1,5 @@
 import * as deleteSelection from 'roosterjs-content-model-core/lib/publicApi/selection/deleteSelection';
+import * as normalizeContentModel from 'roosterjs-content-model-dom/lib/modelApi/common/normalizeContentModel';
 import { IContentModelEditor } from 'roosterjs-content-model-editor';
 import { keyboardInput } from '../../lib/edit/keyboardInput';
 import {
@@ -13,6 +14,7 @@ describe('keyboardInput', () => {
     let formatContentModelSpy: jasmine.Spy;
     let getDOMSelectionSpy: jasmine.Spy;
     let deleteSelectionSpy: jasmine.Spy;
+    let normalizeContentModelSpy: jasmine.Spy;
     let mockedModel: ContentModelDocument;
     let mockedContext: FormatWithContentModelContext;
     let formatResult: boolean | undefined;
@@ -34,6 +36,7 @@ describe('keyboardInput', () => {
             });
         getDOMSelectionSpy = jasmine.createSpy('getDOMSelection');
         deleteSelectionSpy = spyOn(deleteSelection, 'deleteSelection');
+        normalizeContentModelSpy = spyOn(normalizeContentModel, 'normalizeContentModel');
 
         editor = {
             getDOMSelection: getDOMSelectionSpy,
@@ -69,6 +72,7 @@ describe('keyboardInput', () => {
             newEntities: [],
             newImages: [],
         });
+        expect(normalizeContentModelSpy).not.toHaveBeenCalled();
     });
 
     it('Letter input, expanded selection, no modifier key, deleteSelection returns not deleted', () => {
@@ -100,6 +104,7 @@ describe('keyboardInput', () => {
             clearModelCache: true,
             skipUndoSnapshot: true,
         });
+        expect(normalizeContentModelSpy).not.toHaveBeenCalled();
     });
 
     it('Letter input, expanded selection, no modifier key, deleteSelection returns range', () => {
@@ -132,6 +137,7 @@ describe('keyboardInput', () => {
             skipUndoSnapshot: true,
             newPendingFormat: undefined,
         });
+        expect(normalizeContentModelSpy).toHaveBeenCalledWith(mockedModel);
     });
 
     it('Letter input, table selection, no modifier key, deleteSelection returns range', () => {
@@ -161,6 +167,7 @@ describe('keyboardInput', () => {
             skipUndoSnapshot: true,
             newPendingFormat: undefined,
         });
+        expect(normalizeContentModelSpy).toHaveBeenCalledWith(mockedModel);
     });
 
     it('Letter input, image selection, no modifier key, deleteSelection returns range', () => {
@@ -190,6 +197,7 @@ describe('keyboardInput', () => {
             skipUndoSnapshot: true,
             newPendingFormat: undefined,
         });
+        expect(normalizeContentModelSpy).toHaveBeenCalledWith(mockedModel);
     });
 
     it('Letter input, no selection, no modifier key, deleteSelection returns range', () => {
@@ -214,6 +222,7 @@ describe('keyboardInput', () => {
             newEntities: [],
             newImages: [],
         });
+        expect(normalizeContentModelSpy).not.toHaveBeenCalled();
     });
 
     it('Letter input, expanded selection, has modifier key, deleteSelection returns range', () => {
@@ -244,6 +253,7 @@ describe('keyboardInput', () => {
             newEntities: [],
             newImages: [],
         });
+        expect(normalizeContentModelSpy).not.toHaveBeenCalled();
     });
 
     it('Space input, table selection, no modifier key, deleteSelection returns range', () => {
@@ -273,6 +283,7 @@ describe('keyboardInput', () => {
             skipUndoSnapshot: true,
             newPendingFormat: undefined,
         });
+        expect(normalizeContentModelSpy).toHaveBeenCalledWith(mockedModel);
     });
 
     it('Backspace input, table selection, no modifier key, deleteSelection returns range', () => {
@@ -299,6 +310,7 @@ describe('keyboardInput', () => {
             newEntities: [],
             newImages: [],
         });
+        expect(normalizeContentModelSpy).not.toHaveBeenCalled();
     });
 
     it('Enter input, table selection, no modifier key, deleteSelection returns range', () => {
@@ -328,6 +340,7 @@ describe('keyboardInput', () => {
             skipUndoSnapshot: true,
             newPendingFormat: undefined,
         });
+        expect(normalizeContentModelSpy).toHaveBeenCalledWith(mockedModel);
     });
 
     it('Letter input, expanded selection, no modifier key, deleteSelection returns range, has segment format', () => {
@@ -366,5 +379,6 @@ describe('keyboardInput', () => {
             skipUndoSnapshot: true,
             newPendingFormat: mockedFormat,
         });
+        expect(normalizeContentModelSpy).toHaveBeenCalledWith(mockedModel);
     });
 });

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyDownEvent.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/keyUtils/handleKeyDownEvent.ts
@@ -10,7 +10,6 @@ import { updateSelection } from '../utils/updateSelection';
 import type { TableCellSelectionState } from '../TableCellSelectionState';
 import {
     contains,
-    createRange,
     isCtrlOrMetaPressed,
     Position,
     safeInstanceOf,
@@ -72,9 +71,9 @@ export function handleKeyDownEvent(
         // Select all content in the first cell
         const row = range.ranges[0];
         const firstCell = row.startContainer.childNodes[row.startOffset];
-        const children = firstCell.childNodes;
-        const contentRange = createRange(children[0], children[children.length - 1]);
-        editor.select(contentRange);
+        const startPos = new Position(firstCell, PositionType.Begin).normalize();
+        const endPos = new Position(firstCell, PositionType.End).normalize();
+        editor.select(startPos, endPos);
     }
 }
 


### PR DESCRIPTION
Repro step:
1. Use Content Model editor
2. Set a default font
3. Insert a table
4. Type something in the table, it should be in the default font
5. Select the cell and another cell to make a table selection
6. Type something

Expect: The new typed text overwrites the first cell, and is in default format
Actual: The new typed text overwrites the first cell, but it loses font

This is because with a recent change, we now use Content Model to delete the selected text. However, in TableCellSelection plugin we will select the whole TD then in Content Model we will create two implicit paragraphs before and after the real paragraph. Those implicit paragraphs do not have font, that causes after delete the selection marker also does not have font.

To fix it, normalize the selection before select it in TableCellSelection plugin. Also in keyboardInput.ts, we need to normalize the Content Model after we delete the selected content so that an empty paragraph will have a BR tag to receive input.