### PR TITLE
Content Model: Go back to getDarkColor

### DIFF
--- a/demo/scripts/controls/ContentModelEditorMainPane.tsx
+++ b/demo/scripts/controls/ContentModelEditorMainPane.tsx
@@ -20,6 +20,7 @@ import { ContentModelRibbonPlugin } from './ribbonButtons/contentModel/ContentMo
 import { ContentModelSegmentFormat } from 'roosterjs-content-model-types';
 import { createEmojiPlugin, createPasteOptionPlugin, RibbonPlugin } from 'roosterjs-react';
 import { EditorPlugin } from 'roosterjs-editor-types';
+import { getDarkColor } from 'roosterjs-color-utils';
 import { PartialTheme } from '@fluentui/react/lib/Theme';
 import { trustedHTMLHandler } from '../utils/trustedHTMLHandler';
 import {
@@ -236,6 +237,7 @@ class ContentModelEditorMainPane extends MainPaneBase<ContentModelMainPaneState>
                             plugins={allPlugins}
                             defaultSegmentFormat={defaultFormat}
                             inDarkMode={this.state.isDarkMode}
+                            getDarkColor={getDarkColor}
                             experimentalFeatures={this.state.initState.experimentalFeatures}
                             undoMetadataSnapshotService={this.snapshotPlugin.getSnapshotService()}
                             trustedHTMLHandler={trustedHTMLHandler}

--- a/packages-content-model/roosterjs-content-model-core/lib/editor/createStandaloneEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/editor/createStandaloneEditorCore.ts
@@ -42,7 +42,10 @@ export function createStandaloneEditorCore(
             corePlugins.lifecycle,
         ],
         environment: createEditorEnvironment(),
-        darkColorHandler: new DarkColorHandlerImpl(contentDiv, options.baseDarkColor),
+        darkColorHandler: new DarkColorHandlerImpl(
+            contentDiv,
+            options.getDarkColor ?? getDarkColorFallback
+        ),
         trustedHTMLHandler: options.trustedHTMLHandler || defaultTrustHtmlHandler,
         ...createStandaloneEditorDefaultSettings(options),
         ...getPluginState(corePlugins),
@@ -81,4 +84,9 @@ function getPluginState(corePlugins: StandaloneEditorCorePlugins): StandaloneEdi
         entity: corePlugins.entity.getState(),
         selection: corePlugins.selection.getState(),
     };
+}
+
+// A fallback function, always return original color
+function getDarkColorFallback(color: string) {
+    return color;
 }

--- a/packages-content-model/roosterjs-content-model-core/package.json
+++ b/packages-content-model/roosterjs-content-model-core/package.json
@@ -3,7 +3,6 @@
     "description": "Content Model for roosterjs (Under development)",
     "dependencies": {
         "tslib": "^2.3.1",
-        "color": "^3.0.0",
         "roosterjs-editor-types": "",
         "roosterjs-editor-dom": "",
         "roosterjs-content-model-dom": "",

--- a/packages-content-model/roosterjs-content-model-core/test/editor/DarkColorHandlerImplTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/editor/DarkColorHandlerImplTest.ts
@@ -1,26 +1,21 @@
 import { ColorKeyAndValue } from 'roosterjs-editor-types';
 import { DarkColorHandlerImpl } from '../../lib/editor/DarkColorHandlerImpl';
 
+function getDarkColor(color: string) {
+    return 'Dark_' + color;
+}
+
 describe('DarkColorHandlerImpl.ctor', () => {
     it('No additional param', () => {
         const div = document.createElement('div');
-        const handler = new DarkColorHandlerImpl(div);
+        const handler = new DarkColorHandlerImpl(div, getDarkColor);
 
         expect(handler).toBeDefined();
-        expect(handler.baseLightness).toBe(21.25);
-    });
-
-    it('With customized base color', () => {
-        const div = document.createElement('div');
-        const handler = new DarkColorHandlerImpl(div, '#555555');
-
-        expect(handler).toBeDefined();
-        expect(Math.round(handler.baseLightness)).toBe(36);
     });
 
     it('Calculate color using customized base color', () => {
         const div = document.createElement('div');
-        const handler = new DarkColorHandlerImpl(div, '#555555');
+        const handler = new DarkColorHandlerImpl(div, getDarkColor);
 
         const darkColor = handler.registerColor('red', true);
         const parsedColor = handler.parseColorValue(darkColor);
@@ -29,7 +24,7 @@ describe('DarkColorHandlerImpl.ctor', () => {
         expect(parsedColor).toEqual({
             key: '--darkColor_red',
             lightModeColor: 'red',
-            darkModeColor: 'rgb(255, 72, 40)',
+            darkModeColor: 'Dark_red',
         });
     });
 });
@@ -40,7 +35,7 @@ describe('DarkColorHandlerImpl.parseColorValue', () => {
 
     beforeEach(() => {
         div = document.createElement('div');
-        handler = new DarkColorHandlerImpl(div);
+        handler = new DarkColorHandlerImpl(div, getDarkColor);
     });
 
     function runTest(input: string, expectedOutput: ColorKeyAndValue) {
@@ -143,7 +138,7 @@ describe('DarkColorHandlerImpl.registerColor', () => {
                 setProperty,
             },
         } as any) as HTMLElement;
-        handler = new DarkColorHandlerImpl(div);
+        handler = new DarkColorHandlerImpl(div, getDarkColor);
     });
 
     function runTest(
@@ -186,10 +181,10 @@ describe('DarkColorHandlerImpl.registerColor', () => {
             {
                 '--darkColor_red': {
                     lightModeColor: 'red',
-                    darkModeColor: 'rgb(255, 39, 17)',
+                    darkModeColor: 'Dark_red',
                 },
             },
-            [['--darkColor_red', 'rgb(255, 39, 17)']]
+            [['--darkColor_red', 'Dark_red']]
         );
     });
 
@@ -222,10 +217,10 @@ describe('DarkColorHandlerImpl.registerColor', () => {
             {
                 '--aa': {
                     lightModeColor: 'red',
-                    darkModeColor: 'rgb(255, 39, 17)',
+                    darkModeColor: 'Dark_red',
                 },
             },
-            [['--aa', 'rgb(255, 39, 17)']]
+            [['--aa', 'Dark_red']]
         );
     });
 
@@ -395,7 +390,7 @@ describe('DarkColorHandlerImpl.transformElementColor', () => {
 
     beforeEach(() => {
         contentDiv = document.createElement('div');
-        handler = new DarkColorHandlerImpl(contentDiv);
+        handler = new DarkColorHandlerImpl(contentDiv, getDarkColor);
 
         parseColorSpy = spyOn(handler, 'parseColorValue').and.callThrough();
         registerColorSpy = spyOn(handler, 'registerColor').and.callThrough();

--- a/packages-content-model/roosterjs-content-model-types/lib/editor/StandaloneEditorOptions.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/editor/StandaloneEditorOptions.ts
@@ -52,10 +52,10 @@ export interface StandaloneEditorOptions {
     scrollContainer?: HTMLElement;
 
     /**
-     * Base dark mode color. We will use this color to calculate the dark mode color from a given light mode color
-     * @default #333333
+     * A util function to transform light mode color to dark mode color
+     * Default value is to return the original light color
      */
-    baseDarkColor?: string;
+    getDarkColor?: (lightColor: string) => string;
 
     /**
      * Customized trusted type handler used for sanitizing HTML string before assign to DOM tree


### PR DESCRIPTION
In my earlier change I removed `getDarkColor` from `StandaloneEditorOptions` and directly import `color` library to calculate dark color. It generally works well. But when I integrate the code into OWA I hit some issue.

So for now let's go back to use the `getDarkColor` parameter from options, and pass a callback function into editor to calculate dark color. Later we can revisit this part.