### PR TITLE
Content Model: Do not add entity delimiter to editable entity

### DIFF
--- a/packages-content-model/roosterjs-content-model-plugins/lib/entityDelimiter/EntityDelimiterPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/entityDelimiter/EntityDelimiterPlugin.ts
@@ -147,7 +147,11 @@ export function normalizeDelimitersInEditor(editor: IEditor) {
 
 function addDelimitersIfNeeded(nodes: Element[] | NodeListOf<Element>) {
     nodes.forEach(node => {
-        if (isEntityElement(node)) {
+        if (
+            isNodeOfType(node, 'ELEMENT_NODE') &&
+            isEntityElement(node) &&
+            !node.isContentEditable
+        ) {
             addDelimiters(node.ownerDocument, node as HTMLElement);
         }
     });


### PR DESCRIPTION
After porting EntityPlugin, the logic to check if we need to add entity delimiter is modified. Now it is always called after content change. So we need to skip those editable entities when we add entity delimiters.