### PR TITLE
Bump roosterjs-content-model-plugins to 0.21.3 to fix entity delimiter issue

### DIFF
--- a/packages-content-model/roosterjs-content-model-plugins/lib/entityDelimiter/EntityDelimiterPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/entityDelimiter/EntityDelimiterPlugin.ts
@@ -147,7 +147,11 @@ export function normalizeDelimitersInEditor(editor: IEditor) {
 
 function addDelimitersIfNeeded(nodes: Element[] | NodeListOf<Element>) {
     nodes.forEach(node => {
-        if (isEntityElement(node)) {
+        if (
+            isNodeOfType(node, 'ELEMENT_NODE') &&
+            isEntityElement(node) &&
+            !node.isContentEditable
+        ) {
             addDelimiters(node.ownerDocument, node as HTMLElement);
         }
     });

--- a/versions.json
+++ b/versions.json
@@ -4,6 +4,7 @@
     "packages-content-model": "0.21.2",
     "overrides": {
         "roosterjs-editor-core": "8.59.1",
-        "roosterjs-editor-plugins": "8.59.1"
+        "roosterjs-editor-plugins": "8.59.1",
+        "roosterjs-content-model-plugins": "0.21.3"
     }
 }


### PR DESCRIPTION
See https://github.com/microsoft/roosterjs/pull/2252 for more details.