### PR TITLE
Fix demo site broken

### DIFF
--- a/demo/scripts/controls/sidePane/snapshot/ContentModelSnapshotPlugin.tsx
+++ b/demo/scripts/controls/sidePane/snapshot/ContentModelSnapshotPlugin.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import ContentModelSnapshotPane from './ContentModelSnapshotPane';
 import SidePanePlugin from '../../SidePanePlugin';
-import { createSnapshotsManager } from 'roosterjs-content-model-core/lib/editor/SnapshotsManagerImpl';
+import { createSnapshotsManager } from 'roosterjs-content-model-core';
 import { IEditor, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import {
     IStandaloneEditor,

--- a/packages-content-model/roosterjs-content-model-core/lib/editor/SnapshotsManagerImpl.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/editor/SnapshotsManagerImpl.ts
@@ -114,7 +114,8 @@ class SnapshotsManagerImpl implements SnapshotsManager {
 }
 
 /**
- * @internal
+ * Create a new instance of Undo Snapshots Manager
+ * @param snapshots @optional Snapshots object for storing undo snapshots. If not passed, default implementation will be used
  */
 export function createSnapshotsManager(snapshots?: Snapshots): SnapshotsManager {
     return new SnapshotsManagerImpl(snapshots);

--- a/packages-content-model/roosterjs-content-model-core/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/index.ts
@@ -51,3 +51,4 @@ export { NumberingListType } from './constants/NumberingListType';
 export { TableBorderFormat } from './constants/TableBorderFormat';
 
 export { createStandaloneEditorCore } from './editor/createStandaloneEditorCore';
+export { createSnapshotsManager } from './editor/SnapshotsManagerImpl';


### PR DESCRIPTION
Demo site is broken because we are directly importing function `createSnapshotsManager` which is not officially exported so its function name is changed when pack.

Fix by exporting this function.