### PR TITLE
Update selection 

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/setContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/setContentModel.ts
@@ -31,6 +31,8 @@ export const setContentModel: SetContentModel = (core, model, option, onNodeCrea
 
         if (!option?.ignoreSelection && selection) {
             core.api.setDOMSelection(core, selection);
+        } else if (!selection || selection.type !== 'range') {
+            core.selection.selection = selection;
         }
 
         core.cache.cachedModel = model;

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/setContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/setContentModelTest.ts
@@ -132,7 +132,7 @@ describe('setContentModel', () => {
         expect(setDOMSelectionSpy).not.toHaveBeenCalled();
     });
 
-    it('option ignore selection ', () => {
+    it('restore selection ', () => {
         core.selection = {
             selection: null,
             selectionStyleNode: null,

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/setContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/setContentModelTest.ts
@@ -4,7 +4,9 @@ import { EditorCore } from 'roosterjs-editor-types';
 import { setContentModel } from '../../lib/coreApi/setContentModel';
 import { StandaloneEditorCore } from 'roosterjs-content-model-types';
 
-const mockedRange = 'RANGE' as any;
+const mockedRange = {
+    type: 'image',
+} as any;
 const mockedDoc = 'DOCUMENT' as any;
 const mockedModel = 'MODEL' as any;
 const mockedEditorContext = 'EDITORCONTEXT' as any;
@@ -128,5 +130,28 @@ describe('setContentModel', () => {
             undefined
         );
         expect(setDOMSelectionSpy).not.toHaveBeenCalled();
+    });
+
+    it('option ignore selection ', () => {
+        core.selection = {
+            selection: null,
+            selectionStyleNode: null,
+        };
+        setContentModel(core, mockedModel, {
+            ignoreSelection: true,
+        });
+
+        expect(createModelToDomContextSpy).toHaveBeenCalledWith(mockedEditorContext, {
+            ignoreSelection: true,
+        });
+        expect(contentModelToDomSpy).toHaveBeenCalledWith(
+            mockedDoc,
+            mockedDiv,
+            mockedModel,
+            mockedContext,
+            undefined
+        );
+        expect(setDOMSelectionSpy).not.toHaveBeenCalled();
+        expect(core.selection.selection).toBe(mockedRange);
     });
 });


### PR DESCRIPTION
When use setContentModel to rewrite content, we must reset the selection if it is not a range. Otherwise, the editor will keep a selection of an element that is no longer part of the document, resulting in a loss of selection.