### PR TITLE
Fix 237733: [Table] The size of the pasted table becomes larger

### DIFF
--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/selection/collapseTableSelection.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/selection/collapseTableSelection.ts
@@ -1,6 +1,8 @@
 import { addSegment, createSelectionMarker } from 'roosterjs-content-model-dom';
-import type { ContentModelTableRow } from 'roosterjs-content-model-types';
-import type { TableSelectionCoordinates } from '../table/getSelectedCells';
+import type {
+    ContentModelTableRow,
+    TableSelectionCoordinates,
+} from 'roosterjs-content-model-types';
 
 /**
  * @internal
@@ -9,8 +11,8 @@ export function collapseTableSelection(
     rows: ContentModelTableRow[],
     selection: TableSelectionCoordinates
 ) {
-    const { firstCol, firstRow } = selection;
-    const cell = rows[firstRow]?.cells[firstCol];
+    const { firstColumn, firstRow } = selection;
+    const cell = rows[firstRow]?.cells[firstColumn];
     if (cell) {
         addSegment(cell, createSelectionMarker());
     }

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/alignTableCell.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/alignTableCell.ts
@@ -1,5 +1,4 @@
-import { getSelectedCells } from './getSelectedCells';
-import { updateTableCellMetadata } from 'roosterjs-content-model-core';
+import { getSelectedCells, updateTableCellMetadata } from 'roosterjs-content-model-core';
 import type {
     ContentModelTable,
     ContentModelTableCell,
@@ -63,7 +62,7 @@ function alignTableCellInternal(
 
     if (sel) {
         for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
-            for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
+            for (let colIndex = sel.firstColumn; colIndex <= sel.lastColumn; colIndex++) {
                 const cell = table.rows[rowIndex]?.cells[colIndex];
                 const format = cell?.format;
 

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/deleteTableColumn.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/deleteTableColumn.ts
@@ -1,5 +1,5 @@
 import { collapseTableSelection } from '../selection/collapseTableSelection';
-import { getSelectedCells } from './getSelectedCells';
+import { getSelectedCells } from 'roosterjs-content-model-core';
 import type { ContentModelTable } from 'roosterjs-content-model-types';
 
 /**
@@ -10,17 +10,20 @@ export function deleteTableColumn(table: ContentModelTable) {
 
     if (sel) {
         for (let rowIndex = 0; rowIndex < table.rows.length; rowIndex++) {
-            const cellInNextCol = table.rows[rowIndex].cells[sel.lastCol + 1];
+            const cellInNextCol = table.rows[rowIndex].cells[sel.lastColumn + 1];
 
             if (cellInNextCol) {
                 cellInNextCol.spanLeft =
-                    cellInNextCol.spanLeft && table.rows[rowIndex].cells[sel.firstCol].spanLeft;
+                    cellInNextCol.spanLeft && table.rows[rowIndex].cells[sel.firstColumn].spanLeft;
             }
 
-            table.rows[rowIndex].cells.splice(sel.firstCol, sel.lastCol - sel.firstCol + 1);
+            table.rows[rowIndex].cells.splice(
+                sel.firstColumn,
+                sel.lastColumn - sel.firstColumn + 1
+            );
         }
 
-        table.widths.splice(sel.firstCol, sel.lastCol - sel.firstCol + 1);
+        table.widths.splice(sel.firstColumn, sel.lastColumn - sel.firstColumn + 1);
         collapseTableSelection(table.rows, sel);
     }
 }

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/deleteTableRow.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/deleteTableRow.ts
@@ -1,5 +1,5 @@
 import { collapseTableSelection } from '../selection/collapseTableSelection';
-import { getSelectedCells } from './getSelectedCells';
+import { getSelectedCells } from 'roosterjs-content-model-core';
 import type { ContentModelTable } from 'roosterjs-content-model-types';
 
 /**

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/insertTableColumn.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/insertTableColumn.ts
@@ -1,5 +1,5 @@
 import { createTableCell } from 'roosterjs-content-model-dom';
-import { getSelectedCells } from './getSelectedCells';
+import { getSelectedCells } from 'roosterjs-content-model-core';
 import type {
     ContentModelTable,
     TableHorizontalInsertOperation,
@@ -16,12 +16,12 @@ export function insertTableColumn(
     const insertLeft = operation == 'insertLeft';
 
     if (sel) {
-        for (let i = sel?.firstCol; i <= sel.lastCol; i++) {
+        for (let i = sel?.firstColumn; i <= sel.lastColumn; i++) {
             table.rows.forEach(row => {
-                const cell = row.cells[insertLeft ? sel.firstCol : sel.lastCol];
+                const cell = row.cells[insertLeft ? sel.firstColumn : sel.lastColumn];
 
                 row.cells.splice(
-                    insertLeft ? sel.firstCol : sel.lastCol + 1,
+                    insertLeft ? sel.firstColumn : sel.lastColumn + 1,
                     0,
                     createTableCell(
                         cell.spanLeft,
@@ -33,9 +33,9 @@ export function insertTableColumn(
                 );
             });
             table.widths.splice(
-                insertLeft ? sel.firstCol : sel.lastCol + 1,
+                insertLeft ? sel.firstColumn : sel.lastColumn + 1,
                 0,
-                table.widths[insertLeft ? sel.firstCol : sel.lastCol]
+                table.widths[insertLeft ? sel.firstColumn : sel.lastColumn]
             );
         }
     }

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/insertTableRow.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/insertTableRow.ts
@@ -1,5 +1,5 @@
 import { createTableCell } from 'roosterjs-content-model-dom';
-import { getSelectedCells } from './getSelectedCells';
+import { getSelectedCells } from 'roosterjs-content-model-core';
 import type {
     ContentModelTable,
     TableVerticalInsertOperation,

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/mergeTableCells.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/mergeTableCells.ts
@@ -1,5 +1,5 @@
 import { canMergeCells } from './canMergeCells';
-import { getSelectedCells } from './getSelectedCells';
+import { getSelectedCells } from 'roosterjs-content-model-core';
 import type { ContentModelTable } from 'roosterjs-content-model-types';
 
 /**
@@ -8,13 +8,16 @@ import type { ContentModelTable } from 'roosterjs-content-model-types';
 export function mergeTableCells(table: ContentModelTable) {
     const sel = getSelectedCells(table);
 
-    if (sel && canMergeCells(table.rows, sel.firstRow, sel.firstCol, sel.lastRow, sel.lastCol)) {
+    if (
+        sel &&
+        canMergeCells(table.rows, sel.firstRow, sel.firstColumn, sel.lastRow, sel.lastColumn)
+    ) {
         for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
-            for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
+            for (let colIndex = sel.firstColumn; colIndex <= sel.lastColumn; colIndex++) {
                 const cell = table.rows[rowIndex].cells[colIndex];
 
                 if (cell) {
-                    cell.spanLeft = colIndex > sel.firstCol;
+                    cell.spanLeft = colIndex > sel.firstColumn;
                     cell.spanAbove = rowIndex > sel.firstRow;
 
                     delete cell.cachedElement;

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/mergeTableColumn.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/mergeTableColumn.ts
@@ -1,5 +1,5 @@
 import { canMergeCells } from './canMergeCells';
-import { getSelectedCells } from './getSelectedCells';
+import { getSelectedCells } from 'roosterjs-content-model-core';
 import type {
     ContentModelTable,
     TableHorizontalMergeOperation,
@@ -16,7 +16,7 @@ export function mergeTableColumn(
     const mergeLeft = operation == 'mergeLeft';
 
     if (sel) {
-        const mergingColIndex = mergeLeft ? sel.firstCol : sel.lastCol + 1;
+        const mergingColIndex = mergeLeft ? sel.firstColumn : sel.lastColumn + 1;
 
         if (mergingColIndex > 0 && mergingColIndex < table.rows[0].cells.length) {
             for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/mergeTableRow.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/mergeTableRow.ts
@@ -1,5 +1,5 @@
 import { canMergeCells } from './canMergeCells';
-import { getSelectedCells } from './getSelectedCells';
+import { getSelectedCells } from 'roosterjs-content-model-core';
 import type { ContentModelTable, TableVerticalMergeOperation } from 'roosterjs-content-model-types';
 
 /**
@@ -13,7 +13,7 @@ export function mergeTableRow(table: ContentModelTable, operation: TableVertical
         const mergingRowIndex = mergeAbove ? sel.firstRow : sel.lastRow + 1;
 
         if (mergingRowIndex > 0 && mergingRowIndex < table.rows.length) {
-            for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
+            for (let colIndex = sel.firstColumn; colIndex <= sel.lastColumn; colIndex++) {
                 const cell = table.rows[mergingRowIndex].cells[colIndex];
 
                 if (

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/splitTableCellHorizontally.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/splitTableCellHorizontally.ts
@@ -1,5 +1,5 @@
 import { createTableCell } from 'roosterjs-content-model-dom';
-import { getSelectedCells } from './getSelectedCells';
+import { getSelectedCells } from 'roosterjs-content-model-core';
 import type { ContentModelTable } from 'roosterjs-content-model-types';
 
 const MIN_WIDTH = 30;
@@ -11,7 +11,7 @@ export function splitTableCellHorizontally(table: ContentModelTable) {
     const sel = getSelectedCells(table);
 
     if (sel) {
-        for (let colIndex = sel.lastCol; colIndex >= sel.firstCol; colIndex--) {
+        for (let colIndex = sel.lastColumn; colIndex >= sel.firstColumn; colIndex--) {
             if (
                 table.rows.every(
                     (row, rowIndex) =>

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/splitTableCellVertically.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/table/splitTableCellVertically.ts
@@ -1,5 +1,5 @@
 import { createTableCell } from 'roosterjs-content-model-dom';
-import { getSelectedCells } from './getSelectedCells';
+import { getSelectedCells } from 'roosterjs-content-model-core';
 import type { ContentModelTable, ContentModelTableRow } from 'roosterjs-content-model-types';
 
 const MIN_HEIGHT = 22;
@@ -24,11 +24,13 @@ export function splitTableCellVertically(table: ContentModelTable) {
             if (
                 belowRow?.cells.every(
                     (belowCell, colIndex) =>
-                        colIndex < sel.firstCol || colIndex > sel.lastCol || belowCell.spanAbove
+                        colIndex < sel.firstColumn ||
+                        colIndex > sel.lastColumn ||
+                        belowCell.spanAbove
                 )
             ) {
                 belowRow.cells.forEach((belowCell, colIndex) => {
-                    if (colIndex >= sel.firstCol && colIndex <= sel.lastCol) {
+                    if (colIndex >= sel.firstColumn && colIndex <= sel.lastColumn) {
                         belowCell.spanAbove = false;
                         delete belowCell.cachedElement;
                     }
@@ -50,7 +52,7 @@ export function splitTableCellVertically(table: ContentModelTable) {
 
                         newCell.dataset = { ...cell.dataset };
 
-                        if (colIndex < sel.firstCol || colIndex > sel.lastCol) {
+                        if (colIndex < sel.firstColumn || colIndex > sel.lastColumn) {
                             newCell.spanAbove = true;
                         } else {
                             newCell.isSelected = cell.isSelected;

--- a/packages-content-model/roosterjs-content-model-api/lib/publicApi/table/applyTableBorderFormat.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/publicApi/table/applyTableBorderFormat.ts
@@ -1,8 +1,8 @@
-import { getSelectedCells } from '../../modelApi/table/getSelectedCells';
 import { parseValueWithUnit } from 'roosterjs-content-model-dom';
 import {
     extractBorderValues,
     getFirstSelectedTable,
+    getSelectedCells,
     updateTableCellMetadata,
 } from 'roosterjs-content-model-core';
 import type {
@@ -11,8 +11,8 @@ import type {
     ContentModelTable,
     ContentModelTableCell,
     BorderOperations,
+    TableSelectionCoordinates,
 } from 'roosterjs-content-model-types';
-import type { TableSelectionCoordinates } from '../../modelApi/table/getSelectedCells';
 
 /**
  * @internal
@@ -109,8 +109,8 @@ export default function applyTableBorderFormat(
                                     rowIndex++
                                 ) {
                                     for (
-                                        let colIndex = sel.firstCol;
-                                        colIndex <= sel.lastCol;
+                                        let colIndex = sel.firstColumn;
+                                        colIndex <= sel.lastColumn;
                                         colIndex++
                                     ) {
                                         const cell = tableModel.rows[rowIndex].cells[colIndex];
@@ -132,7 +132,7 @@ export default function applyTableBorderFormat(
                                     rowIndex <= sel.lastRow;
                                     rowIndex++
                                 ) {
-                                    const cell = tableModel.rows[rowIndex].cells[sel.firstCol];
+                                    const cell = tableModel.rows[rowIndex].cells[sel.firstColumn];
                                     // Format cells - Left border
                                     applyBorderFormat(cell, borderFormat, leftBorder);
                                 }
@@ -147,7 +147,7 @@ export default function applyTableBorderFormat(
                                     rowIndex <= sel.lastRow;
                                     rowIndex++
                                 ) {
-                                    const cell = tableModel.rows[rowIndex].cells[sel.lastCol];
+                                    const cell = tableModel.rows[rowIndex].cells[sel.lastColumn];
                                     // Format cells - Right border
                                     applyBorderFormat(cell, borderFormat, rightBorder);
                                 }
@@ -158,8 +158,8 @@ export default function applyTableBorderFormat(
                             case 'topBorders':
                                 const topBorder: BorderPositions[] = ['borderTop'];
                                 for (
-                                    let colIndex = sel.firstCol;
-                                    colIndex <= sel.lastCol;
+                                    let colIndex = sel.firstColumn;
+                                    colIndex <= sel.lastColumn;
                                     colIndex++
                                 ) {
                                     const cell = tableModel.rows[sel.firstRow].cells[colIndex];
@@ -173,8 +173,8 @@ export default function applyTableBorderFormat(
                             case 'bottomBorders':
                                 const bottomBorder: BorderPositions[] = ['borderBottom'];
                                 for (
-                                    let colIndex = sel.firstCol;
-                                    colIndex <= sel.lastCol;
+                                    let colIndex = sel.firstColumn;
+                                    colIndex <= sel.lastColumn;
                                     colIndex++
                                 ) {
                                     const cell = tableModel.rows[sel.lastRow].cells[colIndex];
@@ -187,7 +187,7 @@ export default function applyTableBorderFormat(
                                 break;
                             case 'insideBorders':
                                 // Format cells - Inside borders
-                                const singleCol = sel.lastCol == sel.firstCol;
+                                const singleCol = sel.lastColumn == sel.firstColumn;
                                 const singleRow = sel.lastRow == sel.firstRow;
                                 // Single cell selection
                                 if (singleCol && singleRow) {
@@ -196,7 +196,7 @@ export default function applyTableBorderFormat(
                                 // Single column selection
                                 if (singleCol) {
                                     applyBorderFormat(
-                                        tableModel.rows[sel.firstRow].cells[sel.firstCol],
+                                        tableModel.rows[sel.firstRow].cells[sel.firstColumn],
                                         borderFormat,
                                         ['borderBottom']
                                     );
@@ -205,14 +205,15 @@ export default function applyTableBorderFormat(
                                         rowIndex <= sel.lastRow - 1;
                                         rowIndex++
                                     ) {
-                                        const cell = tableModel.rows[rowIndex].cells[sel.firstCol];
+                                        const cell =
+                                            tableModel.rows[rowIndex].cells[sel.firstColumn];
                                         applyBorderFormat(cell, borderFormat, [
                                             'borderTop',
                                             'borderBottom',
                                         ]);
                                     }
                                     applyBorderFormat(
-                                        tableModel.rows[sel.lastRow].cells[sel.firstCol],
+                                        tableModel.rows[sel.lastRow].cells[sel.firstColumn],
                                         borderFormat,
                                         ['borderTop']
                                     );
@@ -221,13 +222,13 @@ export default function applyTableBorderFormat(
                                 // Single row selection
                                 if (singleRow) {
                                     applyBorderFormat(
-                                        tableModel.rows[sel.firstRow].cells[sel.firstCol],
+                                        tableModel.rows[sel.firstRow].cells[sel.firstColumn],
                                         borderFormat,
                                         ['borderRight']
                                     );
                                     for (
-                                        let colIndex = sel.firstCol + 1;
-                                        colIndex <= sel.lastCol - 1;
+                                        let colIndex = sel.firstColumn + 1;
+                                        colIndex <= sel.lastColumn - 1;
                                         colIndex++
                                     ) {
                                         const cell = tableModel.rows[sel.firstRow].cells[colIndex];
@@ -237,7 +238,7 @@ export default function applyTableBorderFormat(
                                         ]);
                                     }
                                     applyBorderFormat(
-                                        tableModel.rows[sel.firstRow].cells[sel.lastCol],
+                                        tableModel.rows[sel.firstRow].cells[sel.lastColumn],
                                         borderFormat,
                                         ['borderLeft']
                                     );
@@ -247,32 +248,32 @@ export default function applyTableBorderFormat(
                                 // For multiple rows and columns selections
                                 // Top left cell
                                 applyBorderFormat(
-                                    tableModel.rows[sel.firstRow].cells[sel.firstCol],
+                                    tableModel.rows[sel.firstRow].cells[sel.firstColumn],
                                     borderFormat,
                                     ['borderBottom', 'borderRight']
                                 );
                                 // Top right cell
                                 applyBorderFormat(
-                                    tableModel.rows[sel.firstRow].cells[sel.lastCol],
+                                    tableModel.rows[sel.firstRow].cells[sel.lastColumn],
                                     borderFormat,
                                     ['borderBottom', 'borderLeft']
                                 );
                                 // Bottom left cell
                                 applyBorderFormat(
-                                    tableModel.rows[sel.lastRow].cells[sel.firstCol],
+                                    tableModel.rows[sel.lastRow].cells[sel.firstColumn],
                                     borderFormat,
                                     ['borderTop', 'borderRight']
                                 );
                                 // Bottom right cell
                                 applyBorderFormat(
-                                    tableModel.rows[sel.lastRow].cells[sel.lastCol],
+                                    tableModel.rows[sel.lastRow].cells[sel.lastColumn],
                                     borderFormat,
                                     ['borderTop', 'borderLeft']
                                 );
                                 // First row
                                 for (
-                                    let colIndex = sel.firstCol + 1;
-                                    colIndex < sel.lastCol;
+                                    let colIndex = sel.firstColumn + 1;
+                                    colIndex < sel.lastColumn;
                                     colIndex++
                                 ) {
                                     const cell = tableModel.rows[sel.firstRow].cells[colIndex];
@@ -284,8 +285,8 @@ export default function applyTableBorderFormat(
                                 }
                                 // Last row
                                 for (
-                                    let colIndex = sel.firstCol + 1;
-                                    colIndex < sel.lastCol;
+                                    let colIndex = sel.firstColumn + 1;
+                                    colIndex < sel.lastColumn;
                                     colIndex++
                                 ) {
                                     const cell = tableModel.rows[sel.lastRow].cells[colIndex];
@@ -301,7 +302,7 @@ export default function applyTableBorderFormat(
                                     rowIndex < sel.lastRow;
                                     rowIndex++
                                 ) {
-                                    const cell = tableModel.rows[rowIndex].cells[sel.firstCol];
+                                    const cell = tableModel.rows[rowIndex].cells[sel.firstColumn];
                                     applyBorderFormat(cell, borderFormat, [
                                         'borderTop',
                                         'borderBottom',
@@ -314,7 +315,7 @@ export default function applyTableBorderFormat(
                                     rowIndex < sel.lastRow;
                                     rowIndex++
                                 ) {
-                                    const cell = tableModel.rows[rowIndex].cells[sel.lastCol];
+                                    const cell = tableModel.rows[rowIndex].cells[sel.lastColumn];
                                     applyBorderFormat(cell, borderFormat, [
                                         'borderTop',
                                         'borderBottom',
@@ -322,9 +323,9 @@ export default function applyTableBorderFormat(
                                     ]);
                                 }
                                 // Inner cells
-                                sel.firstCol++;
+                                sel.firstColumn++;
                                 sel.firstRow++;
-                                sel.lastCol--;
+                                sel.lastColumn--;
                                 sel.lastRow--;
                                 operations.push('allBorders');
                                 break;
@@ -398,29 +399,29 @@ function modifyPerimeter(
 ) {
     // Top of selection
     if (perimeter.Top && sel.firstRow - 1 >= 0) {
-        for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
+        for (let colIndex = sel.firstColumn; colIndex <= sel.lastColumn; colIndex++) {
             const cell = tableModel.rows[sel.firstRow - 1].cells[colIndex];
             applyBorderFormat(cell, borderFormat, ['borderBottom']);
         }
     }
     // Bottom of selection
     if (perimeter.Bottom && sel.lastRow + 1 < tableModel.rows.length) {
-        for (let colIndex = sel.firstCol; colIndex <= sel.lastCol; colIndex++) {
+        for (let colIndex = sel.firstColumn; colIndex <= sel.lastColumn; colIndex++) {
             const cell = tableModel.rows[sel.lastRow + 1].cells[colIndex];
             applyBorderFormat(cell, borderFormat, ['borderTop']);
         }
     }
     // Left of selection
-    if (perimeter.Left && sel.firstCol - 1 >= 0) {
+    if (perimeter.Left && sel.firstColumn - 1 >= 0) {
         for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
-            const cell = tableModel.rows[rowIndex].cells[sel.firstCol - 1];
+            const cell = tableModel.rows[rowIndex].cells[sel.firstColumn - 1];
             applyBorderFormat(cell, borderFormat, ['borderRight']);
         }
     }
     // Right of selection
-    if (perimeter.Right && sel.lastCol + 1 < tableModel.rows[0].cells.length) {
+    if (perimeter.Right && sel.lastColumn + 1 < tableModel.rows[0].cells.length) {
         for (let rowIndex = sel.firstRow; rowIndex <= sel.lastRow; rowIndex++) {
-            const cell = tableModel.rows[rowIndex].cells[sel.lastCol + 1];
+            const cell = tableModel.rows[rowIndex].cells[sel.lastColumn + 1];
             applyBorderFormat(cell, borderFormat, ['borderLeft']);
         }
     }

--- a/packages-content-model/roosterjs-content-model-api/test/modelApi/selection/collapseTableSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/modelApi/selection/collapseTableSelectionTest.ts
@@ -15,7 +15,12 @@ describe('collapseTableSelection', () => {
         const cell2 = createTableCell();
         table.rows[0].cells.push(cell1, cell2);
 
-        collapseTableSelection(table.rows, { firstCol: 0, firstRow: 0, lastCol: 0, lastRow: 0 });
+        collapseTableSelection(table.rows, {
+            firstColumn: 0,
+            firstRow: 0,
+            lastColumn: 0,
+            lastRow: 0,
+        });
 
         expect(addSegment.addSegment).toHaveBeenCalledWith(table.rows[0].cells[0], selectionMarker);
     });
@@ -30,7 +35,12 @@ describe('collapseTableSelection', () => {
         const cell2 = createTableCell();
         table.rows[0].cells.push(cell1, cell2);
 
-        collapseTableSelection(table.rows, { firstCol: 1, firstRow: 1, lastCol: 0, lastRow: 0 });
+        collapseTableSelection(table.rows, {
+            firstColumn: 1,
+            firstRow: 1,
+            lastColumn: 0,
+            lastRow: 0,
+        });
 
         expect(createSelectionMarker.createSelectionMarker).not.toHaveBeenCalled();
         expect(addSegment.addSegment).not.toHaveBeenCalled();

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCopyPastePlugin.ts
@@ -5,6 +5,7 @@ import { ColorTransformDirection, PluginEventType } from 'roosterjs-editor-types
 import { deleteEmptyList } from './utils/deleteEmptyList';
 import { deleteSelection } from '../publicApi/selection/deleteSelection';
 import { extractClipboardItems } from 'roosterjs-editor-dom';
+import { getSelectedCells } from '../publicApi/table/getSelectedCells';
 import { iterateSelections } from '../publicApi/selection/iterateSelections';
 import { paste } from '../publicApi/model/paste';
 import {
@@ -18,6 +19,7 @@ import {
     wrap,
 } from 'roosterjs-content-model-dom';
 import type {
+    ContentModelTable,
     DOMSelection,
     IStandaloneEditor,
     OnNodeCreated,
@@ -122,15 +124,8 @@ class ContentModelCopyPastePlugin implements PluginWithState<CopyPastePluginStat
             if (selection.type === 'table') {
                 iterateSelections(pasteModel, (_, tableContext) => {
                     if (tableContext?.table) {
-                        const table = tableContext?.table;
-                        table.rows = table.rows
-                            .map(row => {
-                                return {
-                                    ...row,
-                                    cells: row.cells.filter(cell => cell.isSelected),
-                                };
-                            })
-                            .filter(row => row.cells.length > 0);
+                        preprocessTable(tableContext.table);
+
                         return true;
                     }
                     return false;
@@ -299,6 +294,28 @@ export const onNodeCreated: OnNodeCreated = (_, node): void => {
         node.removeAttribute('contenteditable');
     }
 };
+
+/**
+ * @internal
+ * Exported only for unit testing
+ */
+export function preprocessTable(table: ContentModelTable) {
+    const sel = getSelectedCells(table);
+    table.rows = table.rows
+        .map(row => {
+            return {
+                ...row,
+                cells: row.cells.filter(cell => cell.isSelected),
+            };
+        })
+        .filter(row => row.cells.length > 0);
+
+    delete table.format.width;
+
+    table.widths = sel
+        ? table.widths.filter((_, index) => index >= sel?.firstColumn && index <= sel?.lastColumn)
+        : [];
+}
 
 /**
  * @internal

--- a/packages-content-model/roosterjs-content-model-core/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/index.ts
@@ -35,6 +35,7 @@ export { setSelection } from './publicApi/selection/setSelection';
 export { applyTableFormat } from './publicApi/table/applyTableFormat';
 export { normalizeTable } from './publicApi/table/normalizeTable';
 export { setTableCellBackgroundColor } from './publicApi/table/setTableCellBackgroundColor';
+export { getSelectedCells } from './publicApi/table/getSelectedCells';
 
 export { isCharacterValue, isModifierKey } from './publicApi/domUtils/eventUtils';
 export { combineBorderValue, extractBorderValues } from './publicApi/domUtils/borderValues';

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/table/getSelectedCells.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/table/getSelectedCells.ts
@@ -1,4 +1,4 @@
-import { hasSelectionInBlockGroup } from 'roosterjs-content-model-core';
+import hasSelectionInBlockGroup from '../selection/hasSelectionInBlockGroup';
 import type { ContentModelTable, TableSelectionCoordinates } from 'roosterjs-content-model-types';
 
 /**

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/table/getSelectedCells.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/table/getSelectedCells.ts
@@ -1,24 +1,15 @@
 import { hasSelectionInBlockGroup } from 'roosterjs-content-model-core';
-import type { ContentModelTable } from 'roosterjs-content-model-types';
+import type { ContentModelTable, TableSelectionCoordinates } from 'roosterjs-content-model-types';
 
 /**
- * @internal
- */
-export interface TableSelectionCoordinates {
-    firstRow: number;
-    firstCol: number;
-    lastRow: number;
-    lastCol: number;
-}
-
-/**
- * @internal
+ * Get selection coordinates of a table. If there is no selection, return null
+ * @param table The table model to get selection from
  */
 export function getSelectedCells(table: ContentModelTable): TableSelectionCoordinates | null {
     let firstRow = -1;
-    let firstCol = -1;
+    let firstColumn = -1;
     let lastRow = -1;
-    let lastCol = -1;
+    let lastColumn = -1;
     let hasSelection = false;
 
     table.rows.forEach((row, rowIndex) =>
@@ -30,15 +21,15 @@ export function getSelectedCells(table: ContentModelTable): TableSelectionCoordi
                     firstRow = rowIndex;
                 }
 
-                if (firstCol < 0) {
-                    firstCol = colIndex;
+                if (firstColumn < 0) {
+                    firstColumn = colIndex;
                 }
 
                 lastRow = Math.max(lastRow, rowIndex);
-                lastCol = Math.max(lastCol, colIndex);
+                lastColumn = Math.max(lastColumn, colIndex);
             }
         })
     );
 
-    return hasSelection ? { firstRow, firstCol, lastRow, lastCol } : null;
+    return hasSelection ? { firstRow, firstColumn, lastRow, lastColumn } : null;
 }

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelCopyPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelCopyPastePluginTest.ts
@@ -6,7 +6,7 @@ import * as extractClipboardItemsFile from 'roosterjs-editor-dom/lib/clipboard/e
 import * as iterateSelectionsFile from '../../lib/publicApi/selection/iterateSelections';
 import * as normalizeContentModel from 'roosterjs-content-model-dom/lib/modelApi/common/normalizeContentModel';
 import * as PasteFile from '../../lib/publicApi/model/paste';
-import { createModelToDomContext } from 'roosterjs-content-model-dom';
+import { createModelToDomContext, createTable, createTableCell } from 'roosterjs-content-model-dom';
 import { createRange } from 'roosterjs-editor-dom';
 import { setEntityElementClasses } from 'roosterjs-content-model-dom/test/domUtils/entityUtilTest';
 import {
@@ -19,6 +19,7 @@ import {
 import {
     createContentModelCopyPastePlugin,
     onNodeCreated,
+    preprocessTable,
 } from '../../lib/corePlugin/ContentModelCopyPastePlugin';
 import {
     ClipboardData,
@@ -632,5 +633,78 @@ describe('ContentModelCopyPastePlugin |', () => {
         onNodeCreated(null!, span);
 
         expect(div.innerHTML).toBe('<span></span>');
+    });
+
+    describe('preprocessTable', () => {
+        it('Preprocess table without selection', () => {
+            const cell1 = createTableCell();
+            const cell2 = createTableCell();
+            const cell3 = createTableCell();
+            const cell4 = createTableCell();
+            const table = createTable(1);
+
+            table.rows[0].cells.push(cell1, cell2, cell3, cell4);
+            table.widths = [100, 20, 30, 80];
+
+            preprocessTable(table);
+
+            expect(table).toEqual({
+                blockType: 'Table',
+                rows: [],
+                format: {},
+                widths: [],
+                dataset: {},
+            });
+        });
+
+        it('Preprocess table with selection', () => {
+            const cell1 = createTableCell();
+            const cell2 = createTableCell();
+            const cell3 = createTableCell();
+            const cell4 = createTableCell();
+            const table = createTable(1);
+
+            table.rows[0].cells.push(cell1, cell2, cell3, cell4);
+            table.widths = [100, 20, 30, 80];
+            cell2.isSelected = true;
+            cell3.isSelected = true;
+
+            preprocessTable(table);
+
+            expect(table).toEqual({
+                blockType: 'Table',
+                rows: [
+                    {
+                        height: 0,
+                        format: {},
+                        cells: [
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                                isSelected: true,
+                            },
+                            {
+                                blockGroupType: 'TableCell',
+                                blocks: [],
+                                format: {},
+                                spanLeft: false,
+                                spanAbove: false,
+                                isHeader: false,
+                                dataset: {},
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+                format: {},
+                widths: [20, 30],
+                dataset: {},
+            });
+        });
     });
 });

--- a/packages-content-model/roosterjs-content-model-core/test/publicApi/table/getSelectedCellsTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/publicApi/table/getSelectedCellsTest.ts
@@ -1,5 +1,5 @@
 import { addSegment, createBr, createTable, createTableCell } from 'roosterjs-content-model-dom';
-import { getSelectedCells } from '../../../lib/modelApi/table/getSelectedCells';
+import { getSelectedCells } from '../../../lib/publicApi/table/getSelectedCells';
 
 describe('getSelectedCells', () => {
     it('empty table', () => {
@@ -30,9 +30,9 @@ describe('getSelectedCells', () => {
 
         expect(selection).toEqual({
             firstRow: 1,
-            firstCol: 1,
+            firstColumn: 1,
             lastRow: 1,
-            lastCol: 1,
+            lastColumn: 1,
         });
     });
 
@@ -46,9 +46,9 @@ describe('getSelectedCells', () => {
 
         expect(selection).toEqual({
             firstRow: 0,
-            firstCol: 1,
+            firstColumn: 1,
             lastRow: 0,
-            lastCol: 1,
+            lastColumn: 1,
         });
     });
 
@@ -63,9 +63,9 @@ describe('getSelectedCells', () => {
 
         expect(selection).toEqual({
             firstRow: 0,
-            firstCol: 0,
+            firstColumn: 0,
             lastRow: 1,
-            lastCol: 1,
+            lastColumn: 1,
         });
     });
 });

--- a/packages-content-model/roosterjs-content-model-types/lib/format/ContentModelTableFormat.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/format/ContentModelTableFormat.ts
@@ -6,6 +6,7 @@ import type { IdFormat } from './formatParts/IdFormat';
 import type { MarginFormat } from './formatParts/MarginFormat';
 import type { SpacingFormat } from './formatParts/SpacingFormat';
 import type { TableLayoutFormat } from './formatParts/TableLayoutFormat';
+import type { SizeFormat } from './formatParts/SizeFormat';
 
 /**
  * Format of Table
@@ -17,4 +18,5 @@ export type ContentModelTableFormat = ContentModelBlockFormat &
     SpacingFormat &
     MarginFormat &
     DisplayFormat &
-    TableLayoutFormat;
+    TableLayoutFormat &
+    SizeFormat;

--- a/packages-content-model/roosterjs-content-model-types/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/index.ts
@@ -129,6 +129,7 @@ export {
 } from './selection/DOMSelection';
 export { InsertPoint } from './selection/InsertPoint';
 export { TableSelectionContext } from './selection/TableSelectionContext';
+export { TableSelectionCoordinates } from './selection/TableSelectionCoordinates';
 
 export {
     ContentModelHandlerMap,

--- a/packages-content-model/roosterjs-content-model-types/lib/parameter/Snapshot.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/parameter/Snapshot.ts
@@ -1,3 +1,4 @@
+import type { TableSelectionCoordinates } from '../selection/TableSelectionCoordinates';
 import type { EntityState } from './FormatWithContentModelContext';
 import type { ModeIndependentColor } from 'roosterjs-editor-types';
 import type { SelectionType } from '../selection/DOMSelection';
@@ -30,31 +31,13 @@ export interface RangeSnapshotSelection extends SnapshotSelectionBase<'range'> {
 /**
  * Undo snapshot selection from table
  */
-export interface TableSnapshotSelection extends SnapshotSelectionBase<'table'> {
+export interface TableSnapshotSelection
+    extends TableSelectionCoordinates,
+        SnapshotSelectionBase<'table'> {
     /**
      * Id of selected table
      */
     tableId: string;
-
-    /**
-     * Number of first selected row
-     */
-    firstRow: number;
-
-    /**
-     * Number of last selected row
-     */
-    lastRow: number;
-
-    /**
-     * Number of first selected column
-     */
-    firstColumn: number;
-
-    /**
-     * Number of last selected column
-     */
-    lastColumn: number;
 }
 
 /**

--- a/packages-content-model/roosterjs-content-model-types/lib/selection/DOMSelection.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/selection/DOMSelection.ts
@@ -1,3 +1,5 @@
+import type { TableSelectionCoordinates } from '../selection/TableSelectionCoordinates';
+
 /**
  * Type of DOM selection, it can be one of the 3 below:
  * range: A regular selection that can be represented by a DOM Range object with start and end container and offset
@@ -43,31 +45,11 @@ export interface ImageSelection extends SelectionBase<'image'> {
  * A table selection that can be defined using the Table element and first/last row and column number. Table selection can
  * cover multiple table cells, it does not need to be continuous, but it should be a rectangle
  */
-export interface TableSelection extends SelectionBase<'table'> {
+export interface TableSelection extends TableSelectionCoordinates, SelectionBase<'table'> {
     /**
      * The table that this selection is representing
      */
     table: HTMLTableElement;
-
-    /**
-     * Number of first selected row
-     */
-    firstRow: number;
-
-    /**
-     * Number of last selected row
-     */
-    lastRow: number;
-
-    /**
-     * Number of first selected column
-     */
-    firstColumn: number;
-
-    /**
-     * Number of last selected column
-     */
-    lastColumn: number;
 }
 
 /**

--- a/packages-content-model/roosterjs-content-model-types/lib/selection/TableSelectionCoordinates.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/selection/TableSelectionCoordinates.ts
@@ -1,0 +1,24 @@
+/**
+ * Coordinates of table selection
+ */
+export interface TableSelectionCoordinates {
+    /**
+     * Index of the first selected row, start from 0
+     */
+    firstRow: number;
+
+    /**
+     * Index of the first selected column, start from 0
+     */
+    firstColumn: number;
+
+    /**
+     * Index of the last selected row, start from 0
+     */
+    lastRow: number;
+
+    /**
+     * Index of the last selected column, start from 0
+     */
+    lastColumn: number;
+}


### PR DESCRIPTION
https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/237733/?triage=true

This is because when cut/copy, if the original table has width, we didn't remove it. The same for column widths.

To fix it, we can delete table width and width for unselected columns when copy.

There is an exisiting interface `TableSelectionCoordinates` for `getSelectedCells` API can be reused in selection types, so reuse it. Also move `getSelectedCells` to `roosterjs-content-model-core` package so we can reuse it in `ContentModelCopyPastePlugin`.