### PR TITLE
Standalone Editor: Port paste API step 1

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/pasteTest.ts
@@ -1,16 +1,16 @@
-import * as addParserF from '../../../roosterjs-content-model-plugins/lib/paste/utils/addParser';
+import * as addParserF from 'roosterjs-content-model-plugins/lib/paste/utils/addParser';
 import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
-import * as ExcelF from '../../../roosterjs-content-model-plugins/lib/paste/Excel/processPastedContentFromExcel';
-import * as getPasteSourceF from '../../../roosterjs-content-model-plugins/lib/paste/pasteSourceValidations/getPasteSource';
+import * as ExcelF from 'roosterjs-content-model-plugins/lib/paste/Excel/processPastedContentFromExcel';
+import * as getPasteSourceF from 'roosterjs-content-model-plugins/lib/paste/pasteSourceValidations/getPasteSource';
 import * as getSelectedSegmentsF from '../../lib/publicApi/selection/collectSelections';
 import * as mergeModelFile from '../../lib/publicApi/model/mergeModel';
-import * as PPT from '../../../roosterjs-content-model-plugins/lib/paste/PowerPoint/processPastedContentFromPowerPoint';
-import * as setProcessorF from '../../../roosterjs-content-model-plugins/lib/paste/utils/setProcessor';
-import * as WacComponents from '../../../roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents';
-import * as WordDesktopFile from '../../../roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop';
+import * as PPT from 'roosterjs-content-model-plugins/lib/paste/PowerPoint/processPastedContentFromPowerPoint';
+import * as setProcessorF from 'roosterjs-content-model-plugins/lib/paste/utils/setProcessor';
+import * as WacComponents from 'roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents';
+import * as WordDesktopFile from 'roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop';
 import { BeforePasteEvent, IEditor, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import { ContentModelEditor } from 'roosterjs-content-model-editor';
-import { ContentModelPastePlugin } from '../../../roosterjs-content-model-plugins/lib/paste/ContentModelPastePlugin';
+import { ContentModelPastePlugin } from 'roosterjs-content-model-plugins/lib/paste/ContentModelPastePlugin';
 import { createContentModelDocument, tableProcessor } from 'roosterjs-content-model-dom';
 import { mergePasteContent } from '../../lib/coreApi/paste';
 import {
@@ -22,10 +22,7 @@ import {
     FormatWithContentModelOptions,
     IStandaloneEditor,
 } from 'roosterjs-content-model-types';
-import {
-    expectEqual,
-    initEditor,
-} from '../../../roosterjs-content-model-plugins/test/paste/e2e/testUtils';
+import { expectEqual, initEditor } from 'roosterjs-content-model-plugins/test/paste/e2e/testUtils';
 
 let clipboardData: ClipboardData;
 

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/block/paddingFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/block/paddingFormatHandler.ts
@@ -12,11 +12,16 @@ const PaddingKeys: (keyof PaddingFormat & keyof CSSStyleDeclaration)[] = [
  * @internal
  */
 export const paddingFormatHandler: FormatHandler<PaddingFormat> = {
-    parse: (format, element) => {
+    parse: (format, element, _, defaultStyle) => {
         PaddingKeys.forEach(key => {
-            const value = element.style[key];
+            let value = element.style[key];
+            const defaultValue = defaultStyle[key] ?? '0px';
 
-            if (value) {
+            if (value == '0') {
+                value = '0px';
+            }
+
+            if (value && value != defaultValue) {
                 format[key] = value;
             }
         });

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/block/whiteSpaceFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/block/whiteSpaceFormatHandler.ts
@@ -1,3 +1,4 @@
+import { shouldSetValue } from '../utils/shouldSetValue';
 import type { FormatHandler } from '../FormatHandler';
 import type { WhiteSpaceFormat } from 'roosterjs-content-model-types';
 
@@ -8,7 +9,7 @@ export const whiteSpaceFormatHandler: FormatHandler<WhiteSpaceFormat> = {
     parse: (format, element, _, defaultStyle) => {
         const whiteSpace = element.style.whiteSpace || defaultStyle.whiteSpace;
 
-        if (whiteSpace) {
+        if (shouldSetValue(whiteSpace, 'normal', format.whiteSpace, defaultStyle.whiteSpace)) {
             format.whiteSpace = whiteSpace;
         }
     },

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/common/backgroundColorFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/common/backgroundColorFormatHandler.ts
@@ -1,4 +1,5 @@
 import { getColor, setColor } from '../utils/color';
+import { shouldSetValue } from '../utils/shouldSetValue';
 import type { BackgroundColorFormat } from 'roosterjs-content-model-types';
 import type { FormatHandler } from '../FormatHandler';
 
@@ -15,7 +16,14 @@ export const backgroundColorFormatHandler: FormatHandler<BackgroundColorFormat> 
                 !!context.isDarkMode
             ) || defaultStyle.backgroundColor;
 
-        if (backgroundColor) {
+        if (
+            shouldSetValue(
+                backgroundColor,
+                'transparent',
+                undefined /*existingValue*/,
+                defaultStyle.backgroundColor
+            )
+        ) {
             format.backgroundColor = backgroundColor;
         }
     },

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/common/borderFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/common/borderFormatHandler.ts
@@ -9,21 +9,40 @@ export const BorderKeys: (keyof BorderFormat & keyof CSSStyleDeclaration)[] = [
     'borderRight',
     'borderBottom',
     'borderLeft',
-    'borderRadius',
+];
+
+// This array needs to match BorderKeys array
+const BorderWidthKeys: (keyof CSSStyleDeclaration)[] = [
+    'borderTopWidth',
+    'borderRightWidth',
+    'borderBottomWidth',
+    'borderLeftWidth',
 ];
 
 /**
  * @internal
  */
 export const borderFormatHandler: FormatHandler<BorderFormat> = {
-    parse: (format, element) => {
-        BorderKeys.forEach(key => {
+    parse: (format, element, _, defaultStyle) => {
+        BorderKeys.forEach((key, i) => {
             const value = element.style[key];
+            const defaultWidth = defaultStyle[BorderWidthKeys[i]] ?? '0px';
+            let width = element.style[BorderWidthKeys[i]];
 
-            if (value) {
+            if (width == '0') {
+                width = '0px';
+            }
+
+            if (value && width != defaultWidth) {
                 format[key] = value == 'none' ? '' : value;
             }
         });
+
+        const borderRadius = element.style.borderRadius;
+
+        if (borderRadius) {
+            format.borderRadius = borderRadius;
+        }
     },
     apply: (format, element) => {
         BorderKeys.forEach(key => {

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/segment/boldFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/segment/boldFormatHandler.ts
@@ -1,3 +1,4 @@
+import { shouldSetValue } from '../utils/shouldSetValue';
 import { wrapAllChildNodes } from '../../domUtils/moveChildNodes';
 import type { BoldFormat } from 'roosterjs-content-model-types';
 import type { FormatHandler } from '../FormatHandler';
@@ -9,7 +10,7 @@ export const boldFormatHandler: FormatHandler<BoldFormat> = {
     parse: (format, element, context, defaultStyle) => {
         const fontWeight = element.style.fontWeight || defaultStyle.fontWeight;
 
-        if (fontWeight) {
+        if (shouldSetValue(fontWeight, '400', format.fontWeight, defaultStyle.fontWeight)) {
             format.fontWeight = fontWeight;
         }
     },

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/segment/letterSpacingFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/segment/letterSpacingFormatHandler.ts
@@ -1,3 +1,4 @@
+import { shouldSetValue } from '../utils/shouldSetValue';
 import type { FormatHandler } from '../FormatHandler';
 import type { LetterSpacingFormat } from 'roosterjs-content-model-types';
 
@@ -5,14 +6,21 @@ import type { LetterSpacingFormat } from 'roosterjs-content-model-types';
  * @internal
  */
 export const letterSpacingFormatHandler: FormatHandler<LetterSpacingFormat> = {
-    parse: (format, element, context, defaultStyle) => {
+    parse: (format, element, _, defaultStyle) => {
         const letterSpacing = element.style.letterSpacing || defaultStyle.letterSpacing;
 
-        if (letterSpacing) {
+        if (
+            shouldSetValue(
+                letterSpacing,
+                'normal',
+                format.letterSpacing,
+                defaultStyle.letterSpacing
+            )
+        ) {
             format.letterSpacing = letterSpacing;
         }
     },
-    apply: (format, element, context) => {
+    apply: (format, element) => {
         if (format.letterSpacing) {
             element.style.letterSpacing = format.letterSpacing;
         }

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/shouldSetValue.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/shouldSetValue.ts
@@ -1,0 +1,15 @@
+/**
+ * @internal
+ */
+export function shouldSetValue(
+    value: string | undefined,
+    normalValue: string,
+    existingValue: string | undefined,
+    defaultValue: string | undefined
+): boolean {
+    return (
+        !!value &&
+        value != 'inherit' &&
+        !!(value != normalValue || existingValue || (defaultValue && value != defaultValue))
+    );
+}

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/knownElementProcessorTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/knownElementProcessorTest.ts
@@ -313,8 +313,6 @@ describe('knownElementProcessor', () => {
                     blockType: 'BlockGroup',
                     blockGroupType: 'FormatContainer',
                     format: {
-                        paddingLeft: '0px',
-                        paddingRight: '0px',
                         paddingTop: '20px',
                         paddingBottom: '40px',
                     },

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/block/paddingFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/block/paddingFormatHandlerTest.ts
@@ -1,0 +1,78 @@
+import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
+import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { DomToModelContext, ModelToDomContext, PaddingFormat } from 'roosterjs-content-model-types';
+import { paddingFormatHandler } from '../../../lib/formatHandlers/block/paddingFormatHandler';
+
+describe('paddingFormatHandler.parse', () => {
+    let div: HTMLElement;
+    let format: PaddingFormat;
+    let context: DomToModelContext;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+        format = {};
+        context = createDomToModelContext();
+    });
+
+    it('No padding', () => {
+        paddingFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({});
+    });
+
+    it('Has padding in CSS', () => {
+        div.style.padding = '1px 2px 3px 4px';
+        paddingFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({
+            paddingTop: '1px',
+            paddingRight: '2px',
+            paddingBottom: '3px',
+            paddingLeft: '4px',
+        });
+    });
+
+    it('Overwrite padding values', () => {
+        div.style.paddingLeft = '15pt';
+        format.paddingLeft = '30px';
+        paddingFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({
+            paddingLeft: '15pt',
+        });
+    });
+
+    it('0 padding', () => {
+        div.style.padding = '0 10px 20px 0';
+        paddingFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({
+            paddingRight: '10px',
+            paddingBottom: '20px',
+        });
+    });
+});
+
+describe('paddingFormatHandler.apply', () => {
+    let div: HTMLElement;
+    let format: PaddingFormat;
+    let context: ModelToDomContext;
+
+    beforeEach(() => {
+        div = document.createElement('div');
+        format = {};
+        context = createModelToDomContext();
+    });
+
+    it('No padding', () => {
+        paddingFormatHandler.apply(format, div, context);
+        expect(div.outerHTML).toBe('<div></div>');
+    });
+
+    it('Has padding', () => {
+        format.paddingTop = '1px';
+        format.paddingRight = '2px';
+        format.paddingBottom = '3px';
+        format.paddingLeft = '4px';
+
+        paddingFormatHandler.apply(format, div, context);
+
+        expect(div.outerHTML).toBe('<div style="padding: 1px 2px 3px 4px;"></div>');
+    });
+});

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/block/whiteSpaceFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/block/whiteSpaceFormatHandlerTest.ts
@@ -49,6 +49,12 @@ describe('whiteSpaceFormatHandler.parse', () => {
             whiteSpace: 'pre',
         });
     });
+
+    it('White space = normal', () => {
+        div.style.whiteSpace = 'normal';
+        whiteSpaceFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({});
+    });
 });
 
 describe('whiteSpaceFormatHandler.apply', () => {

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/common/backgroundColorFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/common/backgroundColorFormatHandlerTest.ts
@@ -37,6 +37,13 @@ describe('backgroundColorFormatHandler.parse', () => {
         div.style.backgroundColor = 'transparent';
         backgroundColorFormatHandler.parse(format, div, context, {});
 
+        expect(format.backgroundColor).toBeUndefined();
+    });
+
+    it('Transparent, different with default value', () => {
+        div.style.backgroundColor = 'transparent';
+        backgroundColorFormatHandler.parse(format, div, context, { backgroundColor: 'red' });
+
         expect(format.backgroundColor).toBe('transparent');
     });
 

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/common/borderFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/common/borderFormatHandlerTest.ts
@@ -73,6 +73,24 @@ describe('borderFormatHandler.parse', () => {
 
         expect(format).toEqual({});
     });
+
+    it('Has 0 width border', () => {
+        div.style.border = '0px sold black';
+
+        borderFormatHandler.parse(format, div, context, {});
+
+        expect(format).toEqual({});
+    });
+
+    it('Has border radius', () => {
+        div.style.borderRadius = '10px';
+
+        borderFormatHandler.parse(format, div, context, {});
+
+        expect(format).toEqual({
+            borderRadius: '10px',
+        });
+    });
 });
 
 describe('borderFormatHandler.apply', () => {

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/segment/boldFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/segment/boldFormatHandlerTest.ts
@@ -45,6 +45,21 @@ describe('boldFormatHandler.parse', () => {
         expect(format.fontWeight).toBe('600');
     });
 
+    it('bold 400', () => {
+        div.style.fontWeight = '400';
+        boldFormatHandler.parse(format, div, context, {});
+
+        expect(format.fontWeight).toBeUndefined();
+    });
+
+    it('bold 400 when it is already in 600', () => {
+        div.style.fontWeight = '400';
+        format.fontWeight = '600';
+        boldFormatHandler.parse(format, div, context, {});
+
+        expect(format.fontWeight).toBe('400');
+    });
+
     it('default style to bold', () => {
         ['bold', 'bolder', '600', '700'].forEach(value => {
             boldFormatHandler.parse(format, div, context, { fontWeight: value });

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/segment/letterSpacingFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/segment/letterSpacingFormatHandlerTest.ts
@@ -30,6 +30,13 @@ describe('letterSpacingFormatHandler.parse', () => {
 
         expect(format.letterSpacing).toBe('1em');
     });
+
+    it('Normal', () => {
+        div.style.letterSpacing = 'normal';
+        letterSpacingFormatHandler.parse(format, div, context, {});
+
+        expect(format.letterSpacing).toBeUndefined();
+    });
 });
 
 describe('letterSpacingFormatHandler.apply', () => {

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/utils/shouldSetValueTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/utils/shouldSetValueTest.ts
@@ -1,0 +1,45 @@
+import { shouldSetValue } from '../../../lib/formatHandlers/utils/shouldSetValue';
+
+describe('shouldSetValue', () => {
+    it('no value', () => {
+        const result = shouldSetValue(undefined, '', 'existing', '');
+
+        expect(result).toBeFalsy();
+    });
+
+    it('Empty string value', () => {
+        const result = shouldSetValue('', '', 'existing', '');
+
+        expect(result).toBeFalsy();
+    });
+
+    it('Has value, is inherit', () => {
+        const result = shouldSetValue('inherit', '', 'existing', '');
+
+        expect(result).toBeFalsy();
+    });
+
+    it('value equals normal value', () => {
+        const result = shouldSetValue('test', 'test', '', '');
+
+        expect(result).toBeFalsy();
+    });
+
+    it('Has value, no existing value', () => {
+        const result = shouldSetValue('test', 'test2', '', '');
+
+        expect(result).toBeTruthy();
+    });
+
+    it('Has value, value equal to default value', () => {
+        const result = shouldSetValue('test', 'test2', '', 'test');
+
+        expect(result).toBeTruthy();
+    });
+
+    it('Has value, no normal value, no existing value, no default value', () => {
+        const result = shouldSetValue('test', '', '', '');
+
+        expect(result).toBeTruthy();
+    });
+});

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelOnlineTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelOnlineTest.ts
@@ -182,13 +182,11 @@ describe(ID, () => {
                                             blockType: 'Paragraph',
                                             format: {
                                                 textAlign: 'center',
-                                                whiteSpace: 'normal',
                                             },
                                         },
                                     ],
                                     format: {
                                         textAlign: 'center',
-                                        whiteSpace: 'normal',
                                         borderTop: '0.5pt solid',
                                         borderRight: '0.5pt solid',
                                         borderBottom: '0.5pt solid',
@@ -222,7 +220,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -264,7 +261,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -313,7 +309,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -360,7 +355,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -402,7 +396,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -451,7 +444,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -498,7 +490,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -540,7 +531,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -589,7 +579,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -636,7 +625,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -678,7 +666,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -727,7 +714,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -774,7 +760,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -816,7 +801,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -865,7 +849,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -912,7 +895,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -954,7 +936,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -1003,7 +984,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -1050,7 +1030,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -1092,7 +1071,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -1141,7 +1119,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelTest.ts
@@ -224,13 +224,11 @@ describe(ID, () => {
                                             blockType: 'Paragraph',
                                             format: {
                                                 textAlign: 'center',
-                                                whiteSpace: 'normal',
                                             },
                                         },
                                     ],
                                     format: {
                                         textAlign: 'center',
-                                        whiteSpace: 'normal',
                                         borderTop: '0.5pt solid',
                                         borderRight: '0.5pt solid',
                                         borderBottom: '0.5pt solid',
@@ -263,7 +261,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -304,7 +301,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -351,7 +347,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -396,7 +391,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -437,7 +431,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -484,7 +477,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -529,7 +521,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -570,7 +561,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -617,7 +607,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -662,7 +651,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -703,7 +691,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -750,7 +737,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -795,7 +781,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -836,7 +821,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -883,7 +867,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -928,7 +911,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -969,7 +951,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -1016,7 +997,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },
@@ -1061,7 +1041,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'black',
                                                     },
                                                 },
@@ -1102,7 +1081,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(5, 99, 193)',
                                                         underline: true,
                                                     },
@@ -1149,7 +1127,6 @@ describe(ID, () => {
                                                     format: {
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
-                                                        fontWeight: '400',
                                                         textColor: 'rgb(219, 219, 219)',
                                                     },
                                                 },

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromWacTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromWacTest.ts
@@ -5,23 +5,25 @@ import { IContentModelEditor } from 'roosterjs-content-model-editor';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 
 const ID = 'CM_Paste_From_WORD_Online_E2E';
-const clipboardData = <ClipboardData>(<any>{
-    types: ['text/plain', 'text/html'],
-    text: 'asd\r\n\r\nTest ',
-    image: null,
-    files: [],
-    customValues: {},
-    snapshotBeforePaste: '<div><br></div><!--{"start":[0,0],"end":[0,0]}-->',
-    htmlFirstLevelChildTags: ['DIV', 'DIV'],
-    html:
-        '<div class="OutlineElement Ltr SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow: visible; cursor: text; clear: both; position: relative; direction: ltr; color: rgb(0, 0, 0); font-family: Calibri, Calibri_MSFontService, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><p class="Paragraph SCXW119048576 BCX8" xml:lang="EN-US" lang="EN-US" paraid="1445671679" paraeid="{56ca519d-7e7d-41fd-839e-df3f4a7a8277}{82}" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow-wrap: break-word; white-space: pre-wrap; font-weight: normal; font-style: normal; vertical-align: baseline; font-kerning: none; background-color: transparent; color: windowtext; text-align: left; text-indent: 0px;"><span data-contrast="auto" xml:lang="EN-US" lang="EN-US" class="TextRun SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; font-variant-ligatures: none !important; font-size: 12pt; line-height: 21.5833px; font-family: Calibri, Calibri_EmbeddedFont, Calibri_MSFontService, sans-serif;"><span class="NormalTextRun SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent;">asd</span></span><span class="EOP SCXW119048576 BCX8" data-ccp-props="{&quot;201341983&quot;:0,&quot;335559685&quot;:0,&quot;335559739&quot;:160,&quot;335559740&quot;:259}" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; font-size: 12pt; line-height: 21.5833px; font-family: Calibri, Calibri_EmbeddedFont, Calibri_MSFontService, sans-serif;"> </span></p></div><div class="ListContainerWrapper SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; position: relative; color: rgb(0, 0, 0); font-family: Calibri, Calibri_MSFontService, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><ul class="BulletListStyle1 SCXW119048576 BCX8" role="list" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow: visible; cursor: text; list-style-type: disc; font-family: verdana;"><li data-leveltext="" data-font="Symbol" data-listid="10" data-list-defn-props="{&quot;335552541&quot;:1,&quot;335559683&quot;:0,&quot;335559684&quot;:-2,&quot;335559685&quot;:720,&quot;335559991&quot;:360,&quot;469769226&quot;:&quot;Symbol&quot;,&quot;469769242&quot;:[8226],&quot;469777803&quot;:&quot;left&quot;,&quot;469777804&quot;:&quot;&quot;,&quot;469777815&quot;:&quot;hybridMultilevel&quot;}" aria-setsize="-1" data-aria-posinset="1" data-aria-level="1" role="listitem" class="OutlineElement Ltr SCXW119048576 BCX8" style="margin: 0px 0px 0px 24px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow: visible; cursor: text; clear: both; position: relative; direction: ltr; display: block; font-size: 12pt; font-family: Calibri, Calibri_MSFontService, sans-serif; vertical-align: baseline;"><p class="Paragraph SCXW119048576 BCX8" xml:lang="EN-US" lang="EN-US" paraid="797108091" paraeid="{56ca519d-7e7d-41fd-839e-df3f4a7a8277}{26}" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow-wrap: break-word; white-space: pre-wrap; font-weight: normal; font-style: normal; vertical-align: baseline; font-kerning: none; background-color: transparent; color: windowtext; text-align: left; text-indent: 0px;"><span data-contrast="auto" xml:lang="EN-US" lang="EN-US" class="TextRun SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; font-variant-ligatures: none !important; font-size: 12pt; line-height: 20px; font-family: Calibri, Calibri_EmbeddedFont, Calibri_MSFontService, sans-serif;"><span class="NormalTextRun SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent;">Test</span></span><span class="EOP SCXW119048576 BCX8" data-ccp-props="{&quot;201341983&quot;:0,&quot;335559739&quot;:0,&quot;335559740&quot;:240}" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; font-size: 12pt; line-height: 20px; font-family: Calibri, Calibri_EmbeddedFont, Calibri_MSFontService, sans-serif;"> </span></p></li></ul></div>',
-});
 
 describe(ID, () => {
     let editor: IContentModelEditor = undefined!;
+    let clipboardData: ClipboardData;
 
     beforeEach(() => {
         editor = initEditor(ID);
+
+        clipboardData = <ClipboardData>(<any>{
+            types: ['text/plain', 'text/html'],
+            text: 'asd\r\n\r\nTest ',
+            image: null,
+            files: [],
+            customValues: {},
+            snapshotBeforePaste: '<div><br></div><!--{"start":[0,0],"end":[0,0]}-->',
+            htmlFirstLevelChildTags: ['DIV', 'DIV'],
+            html:
+                '<div class="OutlineElement Ltr SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow: visible; cursor: text; clear: both; position: relative; direction: ltr; color: rgb(0, 0, 0); font-family: Calibri, Calibri_MSFontService, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><p class="Paragraph SCXW119048576 BCX8" xml:lang="EN-US" lang="EN-US" paraid="1445671679" paraeid="{56ca519d-7e7d-41fd-839e-df3f4a7a8277}{82}" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow-wrap: break-word; white-space: pre-wrap; font-weight: normal; font-style: normal; vertical-align: baseline; font-kerning: none; background-color: transparent; color: windowtext; text-align: left; text-indent: 0px;"><span data-contrast="auto" xml:lang="EN-US" lang="EN-US" class="TextRun SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; font-variant-ligatures: none !important; font-size: 12pt; line-height: 21.5833px; font-family: Calibri, Calibri_EmbeddedFont, Calibri_MSFontService, sans-serif;"><span class="NormalTextRun SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent;">asd</span></span><span class="EOP SCXW119048576 BCX8" data-ccp-props="{&quot;201341983&quot;:0,&quot;335559685&quot;:0,&quot;335559739&quot;:160,&quot;335559740&quot;:259}" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; font-size: 12pt; line-height: 21.5833px; font-family: Calibri, Calibri_EmbeddedFont, Calibri_MSFontService, sans-serif;"> </span></p></div><div class="ListContainerWrapper SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; position: relative; color: rgb(0, 0, 0); font-family: Calibri, Calibri_MSFontService, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><ul class="BulletListStyle1 SCXW119048576 BCX8" role="list" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow: visible; cursor: text; list-style-type: disc; font-family: verdana;"><li data-leveltext="" data-font="Symbol" data-listid="10" data-list-defn-props="{&quot;335552541&quot;:1,&quot;335559683&quot;:0,&quot;335559684&quot;:-2,&quot;335559685&quot;:720,&quot;335559991&quot;:360,&quot;469769226&quot;:&quot;Symbol&quot;,&quot;469769242&quot;:[8226],&quot;469777803&quot;:&quot;left&quot;,&quot;469777804&quot;:&quot;&quot;,&quot;469777815&quot;:&quot;hybridMultilevel&quot;}" aria-setsize="-1" data-aria-posinset="1" data-aria-level="1" role="listitem" class="OutlineElement Ltr SCXW119048576 BCX8" style="margin: 0px 0px 0px 24px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow: visible; cursor: text; clear: both; position: relative; direction: ltr; display: block; font-size: 12pt; font-family: Calibri, Calibri_MSFontService, sans-serif; vertical-align: baseline;"><p class="Paragraph SCXW119048576 BCX8" xml:lang="EN-US" lang="EN-US" paraid="797108091" paraeid="{56ca519d-7e7d-41fd-839e-df3f4a7a8277}{26}" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow-wrap: break-word; white-space: pre-wrap; font-weight: normal; font-style: normal; vertical-align: baseline; font-kerning: none; background-color: transparent; color: windowtext; text-align: left; text-indent: 0px;"><span data-contrast="auto" xml:lang="EN-US" lang="EN-US" class="TextRun SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; font-variant-ligatures: none !important; font-size: 12pt; line-height: 20px; font-family: Calibri, Calibri_EmbeddedFont, Calibri_MSFontService, sans-serif;"><span class="NormalTextRun SCXW119048576 BCX8" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent;">Test</span></span><span class="EOP SCXW119048576 BCX8" data-ccp-props="{&quot;201341983&quot;:0,&quot;335559739&quot;:0,&quot;335559740&quot;:240}" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; font-size: 12pt; line-height: 20px; font-family: Calibri, Calibri_EmbeddedFont, Calibri_MSFontService, sans-serif;"> </span></p></li></ul></div>',
+        });
     });
 
     afterEach(() => {
@@ -95,8 +97,6 @@ describe(ID, () => {
                                                                             segmentType: 'Text',
                                                                             text: 'Test TableÂ ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, sans-serif',
                                                                                 fontSize: '11pt',
@@ -125,14 +125,11 @@ describe(ID, () => {
                                                             format: {
                                                                 direction: 'ltr',
                                                                 textAlign: 'start',
-                                                                whiteSpace: 'normal',
                                                                 marginTop: '0px',
                                                                 marginRight: '0px',
                                                                 marginBottom: '0px',
                                                                 marginLeft: '0px',
-                                                                paddingTop: '0px',
                                                                 paddingRight: '7px',
-                                                                paddingBottom: '0px',
                                                                 paddingLeft: '7px',
                                                             },
                                                         },
@@ -140,7 +137,6 @@ describe(ID, () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        whiteSpace: 'normal',
                                                         borderTop: '1px solid',
                                                         borderRight: '1px solid',
                                                         borderBottom: '1px solid',
@@ -170,8 +166,6 @@ describe(ID, () => {
                                                                             segmentType: 'Text',
                                                                             text: 'Test TableÂ ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, sans-serif',
                                                                                 fontSize: '11pt',
@@ -200,14 +194,11 @@ describe(ID, () => {
                                                             format: {
                                                                 direction: 'ltr',
                                                                 textAlign: 'start',
-                                                                whiteSpace: 'normal',
                                                                 marginTop: '0px',
                                                                 marginRight: '0px',
                                                                 marginBottom: '0px',
                                                                 marginLeft: '0px',
-                                                                paddingTop: '0px',
                                                                 paddingRight: '7px',
-                                                                paddingBottom: '0px',
                                                                 paddingLeft: '7px',
                                                             },
                                                         },
@@ -215,7 +206,6 @@ describe(ID, () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        whiteSpace: 'normal',
                                                         borderTop: '1px solid',
                                                         borderRight: '1px solid',
                                                         borderBottom: '1px solid',
@@ -237,8 +227,6 @@ describe(ID, () => {
                                         useBorderBox: true,
                                         direction: 'ltr',
                                         textAlign: 'start',
-                                        whiteSpace: 'normal',
-                                        backgroundColor: 'transparent',
                                         marginTop: '0px',
                                         marginRight: '0px',
                                         marginBottom: '0px',
@@ -281,7 +269,6 @@ describe(ID, () => {
                                     segmentType: 'Text',
                                     text: 'Â ',
                                     format: {
-                                        letterSpacing: 'normal',
                                         fontFamily:
                                             'Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, sans-serif',
                                         fontSize: '12pt',

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteTest.ts
@@ -63,7 +63,6 @@ describe(ID, () => {
                                                     segmentType: 'Text',
                                                     text: 'No.',
                                                     format: {
-                                                        letterSpacing: 'normal',
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
                                                         fontWeight: '700',
@@ -113,7 +112,6 @@ describe(ID, () => {
                                                     segmentType: 'Text',
                                                     text: 'ID',
                                                     format: {
-                                                        letterSpacing: 'normal',
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
                                                         fontWeight: '700',
@@ -161,7 +159,6 @@ describe(ID, () => {
                                                     segmentType: 'Text',
                                                     text: 'Work Item Type',
                                                     format: {
-                                                        letterSpacing: 'normal',
                                                         fontFamily: 'Calibri, sans-serif',
                                                         fontSize: '11pt',
                                                         fontWeight: '700',
@@ -171,7 +168,6 @@ describe(ID, () => {
                                             ],
                                             format: {
                                                 textAlign: 'center',
-                                                whiteSpace: 'normal',
                                                 marginTop: '0px',
                                                 marginRight: '0px',
                                                 marginBottom: '0px',
@@ -181,7 +177,6 @@ describe(ID, () => {
                                     ],
                                     format: {
                                         textAlign: 'center',
-                                        whiteSpace: 'normal',
                                         borderTop: '0.5pt solid',
                                         borderRight: '0.5pt solid',
                                         borderBottom: '0.5pt solid',
@@ -204,7 +199,6 @@ describe(ID, () => {
                     ],
                     format: <any>{
                         textAlign: 'start',
-                        whiteSpace: 'normal',
                         backgroundColor: 'rgb(255, 255, 255)',
                         width: '170pt',
                         useBorderBox: true,

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/processPastedContentFromWacTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/processPastedContentFromWacTest.ts
@@ -1357,12 +1357,10 @@ describe('wordOnlineHandler', () => {
                                         segmentType: 'Image',
                                         src: 'http://www.microsoft.com',
                                         format: {
-                                            letterSpacing: 'normal',
                                             fontFamily:
                                                 '"Segoe UI", "Segoe UI Web", Arial, Verdana, sans-serif',
                                             fontSize: '12px',
                                             italic: false,
-                                            fontWeight: '400',
                                             textColor: 'rgb(0, 0, 0)',
                                             backgroundColor: 'rgb(255, 255, 255)',
                                             width: '264px',
@@ -1371,10 +1369,6 @@ describe('wordOnlineHandler', () => {
                                             marginRight: '0px',
                                             marginBottom: '0px',
                                             marginLeft: '0px',
-                                            paddingTop: '0px',
-                                            paddingRight: '0px',
-                                            paddingBottom: '0px',
-                                            paddingLeft: '0px',
                                             borderTop: Browser.isFirefox ? 'medium none' : '',
                                             borderRight: Browser.isFirefox ? 'medium none' : '',
                                             borderBottom: Browser.isFirefox ? 'medium none' : '',
@@ -1662,8 +1656,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: 'ODSP',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '20pt',
@@ -1679,8 +1671,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '20pt',
@@ -1696,8 +1686,6 @@ describe('wordOnlineHandler', () => {
                                                                         {
                                                                             segmentType: 'Br',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '20pt',
@@ -1714,8 +1702,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: 'xFun',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '20pt',
@@ -1731,8 +1717,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '20pt',
@@ -1754,12 +1738,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -1774,14 +1752,11 @@ describe('wordOnlineHandler', () => {
                                                             format: {
                                                                 direction: 'ltr',
                                                                 textAlign: 'start',
-                                                                whiteSpace: 'normal',
                                                                 marginTop: '0px',
                                                                 marginRight: '0px',
                                                                 marginBottom: '0px',
                                                                 marginLeft: '0px',
-                                                                paddingTop: '0px',
                                                                 paddingRight: '6px',
-                                                                paddingBottom: '0px',
                                                                 paddingLeft: '6px',
                                                             },
                                                         },
@@ -1789,17 +1764,11 @@ describe('wordOnlineHandler', () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        whiteSpace: 'normal',
                                                         backgroundColor: 'rgb(21, 96, 130)',
                                                         width: '312px',
                                                         borderTop: '1px solid',
-                                                        borderRight: '0px none',
                                                         borderBottom: '1px solid rgb(0, 0, 0)',
                                                         borderLeft: '1px solid',
-                                                        paddingTop: '0px',
-                                                        paddingRight: '0px',
-                                                        paddingBottom: '0px',
-                                                        paddingLeft: '0px',
                                                         verticalAlign: 'middle',
                                                     },
                                                     spanLeft: false,
@@ -1825,8 +1794,6 @@ describe('wordOnlineHandler', () => {
                                                                             text:
                                                                                 'Title of Announcement',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '21.5pt',
@@ -1842,8 +1809,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '21.5pt',
@@ -1865,12 +1830,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -1885,14 +1844,11 @@ describe('wordOnlineHandler', () => {
                                                             format: {
                                                                 direction: 'ltr',
                                                                 textAlign: 'start',
-                                                                whiteSpace: 'normal',
                                                                 marginTop: '0px',
                                                                 marginRight: '0px',
                                                                 marginBottom: '0px',
                                                                 marginLeft: '0px',
-                                                                paddingTop: '0px',
                                                                 paddingRight: '6px',
-                                                                paddingBottom: '0px',
                                                                 paddingLeft: '6px',
                                                             },
                                                         },
@@ -1900,17 +1856,11 @@ describe('wordOnlineHandler', () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        whiteSpace: 'normal',
                                                         backgroundColor: 'rgb(21, 96, 130)',
                                                         width: '312px',
                                                         borderTop: '1px solid',
                                                         borderRight: '1px solid',
                                                         borderBottom: '1px solid rgb(0, 0, 0)',
-                                                        borderLeft: '0px none',
-                                                        paddingTop: '0px',
-                                                        paddingRight: '0px',
-                                                        paddingBottom: '0px',
-                                                        paddingLeft: '0px',
                                                         verticalAlign: 'middle',
                                                     },
                                                     spanLeft: false,
@@ -1941,8 +1891,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: 'Announcement ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'Aptos_MSFontService, Aptos_MSFontService_EmbeddedFont, Aptos_MSFontService_MSFontService, sans-serif',
                                                                                 fontSize: '14pt',
@@ -1958,8 +1906,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'Aptos_MSFontService, Aptos_MSFontService_EmbeddedFont, Aptos_MSFontService_MSFontService, sans-serif',
                                                                                 fontSize: '14pt',
@@ -1981,12 +1927,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -2001,14 +1941,11 @@ describe('wordOnlineHandler', () => {
                                                             format: {
                                                                 direction: 'ltr',
                                                                 textAlign: 'start',
-                                                                whiteSpace: 'normal',
                                                                 marginTop: '0px',
                                                                 marginRight: '0px',
                                                                 marginBottom: '0px',
                                                                 marginLeft: '0px',
-                                                                paddingTop: '0px',
                                                                 paddingRight: '6px',
-                                                                paddingBottom: '0px',
                                                                 paddingLeft: '6px',
                                                             },
                                                         },
@@ -2016,17 +1953,12 @@ describe('wordOnlineHandler', () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        whiteSpace: 'normal',
                                                         backgroundColor: 'rgb(0, 0, 0)',
                                                         width: '624px',
                                                         borderTop: '1px solid rgb(0, 0, 0)',
                                                         borderRight: '1px solid',
                                                         borderBottom: '1px solid rgb(0, 0, 0)',
                                                         borderLeft: '1px solid',
-                                                        paddingTop: '0px',
-                                                        paddingRight: '0px',
-                                                        paddingBottom: '0px',
-                                                        paddingLeft: '0px',
                                                         verticalAlign: 'middle',
                                                     },
                                                     spanLeft: false,
@@ -2042,17 +1974,12 @@ describe('wordOnlineHandler', () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        whiteSpace: 'normal',
                                                         backgroundColor: 'rgb(0, 0, 0)',
                                                         width: '624px',
                                                         borderTop: '1px solid rgb(0, 0, 0)',
                                                         borderRight: '1px solid',
                                                         borderBottom: '1px solid rgb(0, 0, 0)',
                                                         borderLeft: '1px solid',
-                                                        paddingTop: '0px',
-                                                        paddingRight: '0px',
-                                                        paddingBottom: '0px',
-                                                        paddingLeft: '0px',
                                                         verticalAlign: 'middle',
                                                     },
                                                     spanLeft: true,
@@ -2083,8 +2010,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: 'Hello ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2101,8 +2026,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2124,12 +2047,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -2147,8 +2064,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2170,12 +2085,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -2194,8 +2103,6 @@ describe('wordOnlineHandler', () => {
                                                                             text:
                                                                                 '[Brief description of change]',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2212,8 +2119,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2229,8 +2134,6 @@ describe('wordOnlineHandler', () => {
                                                                         {
                                                                             segmentType: 'Br',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2247,8 +2150,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2270,12 +2171,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -2294,8 +2189,6 @@ describe('wordOnlineHandler', () => {
                                                                             text:
                                                                                 '[What changed and how it ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2313,8 +2206,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: 'benefits',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2331,8 +2222,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2349,8 +2238,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: 'devs',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2367,8 +2254,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ']',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2385,8 +2270,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2408,12 +2291,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -2431,8 +2308,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2453,12 +2328,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -2477,8 +2346,6 @@ describe('wordOnlineHandler', () => {
                                                                             text:
                                                                                 '[Any action needed by devs]',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2494,8 +2361,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2516,12 +2381,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -2539,8 +2398,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2561,12 +2418,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -2585,8 +2436,6 @@ describe('wordOnlineHandler', () => {
                                                                             text:
                                                                                 '[Link to Documentation ]',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2602,8 +2451,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2618,8 +2465,6 @@ describe('wordOnlineHandler', () => {
                                                                         {
                                                                             segmentType: 'Br',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2635,8 +2480,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2652,8 +2495,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2674,12 +2515,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -2698,8 +2533,6 @@ describe('wordOnlineHandler', () => {
                                                                             text:
                                                                                 '[What comes next if something comes next]',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2716,8 +2549,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2733,8 +2564,6 @@ describe('wordOnlineHandler', () => {
                                                                         {
                                                                             segmentType: 'Br',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2751,8 +2580,6 @@ describe('wordOnlineHandler', () => {
                                                                             segmentType: 'Text',
                                                                             text: ' ',
                                                                             format: {
-                                                                                letterSpacing:
-                                                                                    'normal',
                                                                                 fontFamily:
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
@@ -2774,12 +2601,6 @@ describe('wordOnlineHandler', () => {
                                                                         marginRight: '0px',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
-                                                                        paddingLeft: '0px',
-                                                                        paddingRight: '0px',
-                                                                        backgroundColor:
-                                                                            'transparent',
-                                                                        paddingTop: '0px',
-                                                                        paddingBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
                                                                         fontWeight: 'normal',
@@ -2794,14 +2615,11 @@ describe('wordOnlineHandler', () => {
                                                             format: {
                                                                 direction: 'ltr',
                                                                 textAlign: 'start',
-                                                                whiteSpace: 'normal',
                                                                 marginTop: '0px',
                                                                 marginRight: '0px',
                                                                 marginBottom: '0px',
                                                                 marginLeft: '0px',
-                                                                paddingTop: '0px',
                                                                 paddingRight: '6px',
-                                                                paddingBottom: '0px',
                                                                 paddingLeft: '6px',
                                                             },
                                                         },
@@ -2809,18 +2627,12 @@ describe('wordOnlineHandler', () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        whiteSpace: 'normal',
                                                         borderTop: '1px solid rgb(0, 0, 0)',
                                                         borderRight: '1px solid rgb(0, 0, 0)',
                                                         borderBottom: '1px solid rgb(0, 0, 0)',
                                                         borderLeft: '1px solid rgb(0, 0, 0)',
                                                         verticalAlign: 'top',
                                                         width: '624px',
-                                                        backgroundColor: 'transparent',
-                                                        paddingTop: '0px',
-                                                        paddingRight: '0px',
-                                                        paddingBottom: '0px',
-                                                        paddingLeft: '0px',
                                                     },
                                                     spanLeft: false,
                                                     spanAbove: false,
@@ -2835,18 +2647,12 @@ describe('wordOnlineHandler', () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        whiteSpace: 'normal',
                                                         borderTop: '1px solid rgb(0, 0, 0)',
                                                         borderRight: '1px solid rgb(0, 0, 0)',
                                                         borderBottom: '1px solid rgb(0, 0, 0)',
                                                         borderLeft: '1px solid rgb(0, 0, 0)',
                                                         verticalAlign: 'top',
                                                         width: '624px',
-                                                        backgroundColor: 'transparent',
-                                                        paddingTop: '0px',
-                                                        paddingRight: '0px',
-                                                        paddingBottom: '0px',
-                                                        paddingLeft: '0px',
                                                     },
                                                     spanLeft: true,
                                                     spanAbove: false,
@@ -2861,8 +2667,6 @@ describe('wordOnlineHandler', () => {
                                     format: {
                                         direction: 'ltr',
                                         textAlign: 'start',
-                                        whiteSpace: 'normal',
-                                        backgroundColor: 'transparent',
                                         marginTop: '0px',
                                         marginRight: '0px',
                                         marginBottom: '0px',
@@ -2881,31 +2685,21 @@ describe('wordOnlineHandler', () => {
                             format: {
                                 direction: 'ltr',
                                 textAlign: 'start',
-                                whiteSpace: 'normal',
                                 marginTop: '2px',
                                 marginRight: '0px',
                                 marginBottom: '2px',
                                 display: 'flex',
-                                paddingTop: '0px',
-                                paddingRight: '0px',
-                                paddingBottom: '0px',
-                                paddingLeft: '0px',
                             },
                         },
                     ],
                     format: {
                         direction: 'ltr',
                         textAlign: 'start',
-                        whiteSpace: 'normal',
                         backgroundColor: 'rgb(255, 255, 255)',
                         marginTop: '0px',
                         marginRight: '0px',
                         marginBottom: '0px',
                         marginLeft: '0px',
-                        paddingTop: '0px',
-                        paddingRight: '0px',
-                        paddingBottom: '0px',
-                        paddingLeft: '0px',
                     },
                 },
             ],


### PR DESCRIPTION
Today the paste API is still using a bunch of old API from `roosterjs-editor-dom` package. Now I'm porting it to use Content Model API only. 

This is the first step.

We have a HtmlSanitizer class used for sanitizing pasted content. Actually, Content Model is also going through the tree and pick up supported elements and attributes, so Content Model itself can also be used as Html Sanitizer. There are two places that we still directly pull in DOM element without sanitizing:
- General element: It handles all unrecognized HTML tags and hold a reference of those element directly.
- Entity: We hold the whole entity DOM tree without any sanitization

For all others, we are using `ElementProcessor` and `FormatHandler` to parse and sanitize them.

This change is a preparation step to do sanitization of DOM tree using Content Model, we first add some checks to existing format handlers to let them working in a same with with HtmlSanitizer. So that when we remove HtmlSanitizer, those unsupported HTML attributes/styles. This includes:

- padding: Ignore "0" padding
- white-space: Ignore "normal" white-space
- background-color: Ignore "transparent" background color
- border: Ignore "0" border
- bold: Ignore "400" font weight (default value)
- letter-spacing: ignore "normal" letter spacing

Also add related test cases and fix existing test cases