### PR TITLE
Table Fidelity improvement: Width Attribute and Cellpadding attribute

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
@@ -62,7 +62,7 @@ function tryParseSize(element: HTMLElement, attrName: 'width' | 'height'): strin
 
     return attrValue && PercentageRegex.test(attrValue)
         ? attrValue
-        : Number.isNaN(value)
+        : Number.isNaN(value) || value == 0
         ? undefined
         : value + 'px';
 }

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/table/tableSpacingFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/table/tableSpacingFormatHandler.ts
@@ -2,6 +2,7 @@ import type { FormatHandler } from '../FormatHandler';
 import type { SpacingFormat } from 'roosterjs-content-model-types';
 
 const BorderCollapsed = 'collapse';
+const CellPadding = 'cellPadding';
 
 /**
  * @internal
@@ -10,6 +11,11 @@ export const tableSpacingFormatHandler: FormatHandler<SpacingFormat> = {
     parse: (format, element) => {
         if (element.style.borderCollapse == BorderCollapsed) {
             format.borderCollapse = true;
+        } else {
+            const cellPadding = element.getAttribute(CellPadding);
+            if (cellPadding) {
+                format.borderCollapse = true;
+            }
         }
     },
     apply: (format, element) => {

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/common/sizeFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/common/sizeFormatHandlerTest.ts
@@ -56,6 +56,17 @@ describe('sizeFormatHandler.parse', () => {
         expect(format).toEqual({ width: '10px', height: '20px' });
     });
 
+    it('Element with width and height attributes equal to 0', () => {
+        const element = document.createElement('div');
+
+        element.setAttribute('width', '0');
+        element.setAttribute('height', '0');
+
+        sizeFormatHandler.parse(format, element, context, {});
+
+        expect(format).toEqual({});
+    });
+
     it('Element with width and height in attribute in percentage', () => {
         const element = document.createElement('div');
 

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/table/tableSpacingFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/table/tableSpacingFormatHandlerTest.ts
@@ -30,6 +30,12 @@ describe('tableSpacingFormatHandler.parse', () => {
         tableSpacingFormatHandler.parse(format, div, context, {});
         expect(format).toEqual({});
     });
+
+    it('Non-collapsed border', () => {
+        div.setAttribute('cellPadding', '0');
+        tableSpacingFormatHandler.parse(format, div, context, {});
+        expect(format).toEqual({ borderCollapse: true });
+    });
 });
 
 describe('tableSpacingFormatHandler.apply', () => {

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/table/tableSpacingFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/table/tableSpacingFormatHandlerTest.ts
@@ -31,7 +31,7 @@ describe('tableSpacingFormatHandler.parse', () => {
         expect(format).toEqual({});
     });
 
-    it('Non-collapsed border', () => {
+    it('Set border collapsed if element contains cellpadding attribute', () => {
         div.setAttribute('cellPadding', '0');
         tableSpacingFormatHandler.parse(format, div, context, {});
         expect(format).toEqual({ borderCollapse: true });


### PR DESCRIPTION
Couple of improvements for table fidelity.

1. If the Width & Height attribute of the table is set to 0, it is not needed update the format, as width = 0 does not change the styling of the table
2. If the element has CellPadding attribute set the bordercollpase style to true, CellPadding attribute is deprecated, but to have a similar treatment use `bordercollapse: collapse` according to this link: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table#cellpadding

![image](https://github.com/microsoft/roosterjs/assets/8291124/61e71f04-db4f-489f-9da2-2e328afeddf7)


Before and After here:
https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/245219/