### PR TITLE
Set Deprecated font color to black instead of undefined

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/pasteTest.ts
@@ -11,6 +11,7 @@ import * as WordDesktopFile from 'roosterjs-content-model-plugins/lib/paste/Word
 import { BeforePasteEvent, IEditor, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import { ContentModelEditor } from 'roosterjs-content-model-editor';
 import { ContentModelPastePlugin } from 'roosterjs-content-model-plugins/lib/paste/ContentModelPastePlugin';
+import { expectEqual, initEditor } from 'roosterjs-content-model-plugins/test/paste/e2e/testUtils';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 import {
     ClipboardData,
@@ -21,7 +22,6 @@ import {
     FormatWithContentModelOptions,
     IStandaloneEditor,
 } from 'roosterjs-content-model-types';
-import { expectEqual, initEditor } from 'roosterjs-content-model-plugins/test/paste/e2e/testUtils';
 
 let clipboardData: ClipboardData;
 
@@ -386,7 +386,7 @@ describe('Paste with clipboardData', () => {
         document.getElementById(ID)?.remove();
     });
 
-    it('Remove windowtext from clipboardContent', () => {
+    it('Replace windowtext with set black font color from clipboardContent', () => {
         clipboardData.rawHtml =
             '<html><head></head><body><p style="color: windowtext;">Test</p></body></html>';
 
@@ -407,12 +407,16 @@ describe('Paste with clipboardData', () => {
                         {
                             segmentType: 'Text',
                             text: 'Test',
-                            format: {},
+                            format: {
+                                textColor: 'rgb(0, 0, 0)',
+                            },
                         },
                         {
                             segmentType: 'SelectionMarker',
                             isSelected: true,
-                            format: {},
+                            format: {
+                                textColor: 'rgb(0, 0, 0)',
+                            },
                         },
                     ],
                     format: {

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/color.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/color.ts
@@ -29,6 +29,8 @@ export const DeprecatedColors: string[] = [
     'window',
 ];
 
+const BlackColor = 'rgb(0, 0, 0)';
+
 /**
  * Get color from given HTML element
  * @param element The element to get color from
@@ -48,7 +50,7 @@ export function getColor(
         undefined;
 
     if (color && DeprecatedColors.indexOf(color) > -1) {
-        color = undefined;
+        color = isBackground ? undefined : BlackColor;
     }
 
     if (darkColorHandler) {

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromWacTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromWacTest.ts
@@ -66,62 +66,42 @@ describe(ID, () => {
             blockGroupType: 'Document',
             blocks: [
                 {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'FormatContainer',
                     tagName: 'div',
+                    blockType: 'BlockGroup',
+                    format: {
+                        backgroundColor: 'rgb(255, 255, 255)',
+                        marginTop: '0px',
+                        marginRight: '0px',
+                        marginBottom: '0px',
+                        marginLeft: '0px',
+                    },
+                    blockGroupType: 'FormatContainer',
                     blocks: [
                         {
-                            blockType: 'BlockGroup',
-                            blockGroupType: 'FormatContainer',
                             tagName: 'div',
+                            blockType: 'BlockGroup',
+                            format: {
+                                marginTop: '2px',
+                                marginRight: '0px',
+                                marginBottom: '2px',
+                            },
+                            blockGroupType: 'FormatContainer',
                             blocks: [
                                 {
-                                    blockType: 'Table',
+                                    widths: [314.8000183105469, 314.8000183105469],
                                     rows: [
                                         {
-                                            height: jasmine.anything() as any,
-                                            format: {},
+                                            height: 22.5625,
                                             cells: [
                                                 {
+                                                    spanAbove: false,
+                                                    spanLeft: false,
+                                                    isHeader: false,
                                                     blockGroupType: 'TableCell',
                                                     blocks: [
                                                         {
-                                                            blockType: 'BlockGroup',
-                                                            blockGroupType: 'FormatContainer',
                                                             tagName: 'div',
-                                                            blocks: [
-                                                                {
-                                                                    blockType: 'Paragraph',
-                                                                    segments: [
-                                                                        {
-                                                                            segmentType: 'Text',
-                                                                            text: 'Test TableÂ ',
-                                                                            format: {
-                                                                                fontFamily:
-                                                                                    'Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, sans-serif',
-                                                                                fontSize: '11pt',
-                                                                                textColor:
-                                                                                    'rgb(0, 0, 0)',
-                                                                                lineHeight:
-                                                                                    '19.7625px',
-                                                                            },
-                                                                        },
-                                                                    ],
-                                                                    format: {
-                                                                        direction: 'ltr',
-                                                                        textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
-                                                                        marginLeft: '0px',
-                                                                        marginRight: '0px',
-                                                                        marginTop: '0px',
-                                                                        marginBottom: '0px',
-                                                                    },
-                                                                    decorator: {
-                                                                        tagName: 'p',
-                                                                        format: {},
-                                                                    },
-                                                                },
-                                                            ],
+                                                            blockType: 'BlockGroup',
                                                             format: {
                                                                 direction: 'ltr',
                                                                 textAlign: 'start',
@@ -132,6 +112,43 @@ describe(ID, () => {
                                                                 paddingRight: '7px',
                                                                 paddingLeft: '7px',
                                                             },
+                                                            blockGroupType: 'FormatContainer',
+                                                            blocks: [
+                                                                {
+                                                                    segments: [
+                                                                        {
+                                                                            text: 'Test TableÂ ',
+                                                                            segmentType: 'Text',
+                                                                            format: {
+                                                                                textColor:
+                                                                                    'rgb(0, 0, 0)',
+                                                                                fontFamily:
+                                                                                    'Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, sans-serif',
+                                                                                fontSize: '11pt',
+                                                                                lineHeight:
+                                                                                    '19.7625px',
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                    segmentFormat: {
+                                                                        textColor: 'rgb(0, 0, 0)',
+                                                                    },
+                                                                    blockType: 'Paragraph',
+                                                                    format: {
+                                                                        direction: 'ltr',
+                                                                        textAlign: 'start',
+                                                                        whiteSpace: 'pre-wrap',
+                                                                        marginTop: '0px',
+                                                                        marginRight: '0px',
+                                                                        marginBottom: '0px',
+                                                                        marginLeft: '0px',
+                                                                    },
+                                                                    decorator: {
+                                                                        tagName: 'p',
+                                                                        format: {},
+                                                                    },
+                                                                },
+                                                            ],
                                                         },
                                                     ],
                                                     format: {
@@ -144,53 +161,19 @@ describe(ID, () => {
                                                         verticalAlign: 'top',
                                                         width: '312px',
                                                     },
-                                                    spanLeft: false,
-                                                    spanAbove: false,
-                                                    isHeader: false,
                                                     dataset: {
                                                         celllook: '0',
                                                     },
                                                 },
                                                 {
+                                                    spanAbove: false,
+                                                    spanLeft: false,
+                                                    isHeader: false,
                                                     blockGroupType: 'TableCell',
                                                     blocks: [
                                                         {
-                                                            blockType: 'BlockGroup',
-                                                            blockGroupType: 'FormatContainer',
                                                             tagName: 'div',
-                                                            blocks: [
-                                                                {
-                                                                    blockType: 'Paragraph',
-                                                                    segments: [
-                                                                        {
-                                                                            segmentType: 'Text',
-                                                                            text: 'Test TableÂ ',
-                                                                            format: {
-                                                                                fontFamily:
-                                                                                    'Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, sans-serif',
-                                                                                fontSize: '11pt',
-                                                                                textColor:
-                                                                                    'rgb(0, 0, 0)',
-                                                                                lineHeight:
-                                                                                    '19.7625px',
-                                                                            },
-                                                                        },
-                                                                    ],
-                                                                    format: {
-                                                                        direction: 'ltr',
-                                                                        textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
-                                                                        marginLeft: '0px',
-                                                                        marginRight: '0px',
-                                                                        marginTop: '0px',
-                                                                        marginBottom: '0px',
-                                                                    },
-                                                                    decorator: {
-                                                                        tagName: 'p',
-                                                                        format: {},
-                                                                    },
-                                                                },
-                                                            ],
+                                                            blockType: 'BlockGroup',
                                                             format: {
                                                                 direction: 'ltr',
                                                                 textAlign: 'start',
@@ -201,6 +184,43 @@ describe(ID, () => {
                                                                 paddingRight: '7px',
                                                                 paddingLeft: '7px',
                                                             },
+                                                            blockGroupType: 'FormatContainer',
+                                                            blocks: [
+                                                                {
+                                                                    segments: [
+                                                                        {
+                                                                            text: 'Test TableÂ ',
+                                                                            segmentType: 'Text',
+                                                                            format: {
+                                                                                textColor:
+                                                                                    'rgb(0, 0, 0)',
+                                                                                fontFamily:
+                                                                                    'Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, sans-serif',
+                                                                                fontSize: '11pt',
+                                                                                lineHeight:
+                                                                                    '19.7625px',
+                                                                            },
+                                                                        },
+                                                                    ],
+                                                                    segmentFormat: {
+                                                                        textColor: 'rgb(0, 0, 0)',
+                                                                    },
+                                                                    blockType: 'Paragraph',
+                                                                    format: {
+                                                                        direction: 'ltr',
+                                                                        textAlign: 'start',
+                                                                        whiteSpace: 'pre-wrap',
+                                                                        marginTop: '0px',
+                                                                        marginRight: '0px',
+                                                                        marginBottom: '0px',
+                                                                        marginLeft: '0px',
+                                                                    },
+                                                                    decorator: {
+                                                                        tagName: 'p',
+                                                                        format: {},
+                                                                    },
+                                                                },
+                                                            ],
                                                         },
                                                     ],
                                                     format: {
@@ -213,18 +233,16 @@ describe(ID, () => {
                                                         verticalAlign: 'top',
                                                         width: '312px',
                                                     },
-                                                    spanLeft: false,
-                                                    spanAbove: false,
-                                                    isHeader: false,
                                                     dataset: {
                                                         celllook: '0',
                                                     },
                                                 },
                                             ],
+                                            format: {},
                                         },
                                     ],
-                                    format: <any>{
-                                        useBorderBox: true,
+                                    blockType: 'Table',
+                                    format: {
                                         direction: 'ltr',
                                         textAlign: 'start',
                                         marginTop: '0px',
@@ -233,22 +251,21 @@ describe(ID, () => {
                                         marginLeft: '0px',
                                         width: '0px',
                                         tableLayout: 'fixed',
+                                        useBorderBox: true,
                                         borderCollapse: true,
                                     },
-                                    widths: [jasmine.anything() as any, jasmine.anything() as any],
                                     dataset: {
                                         tablestyle: 'MsoTableGrid',
                                         tablelook: '1696',
                                     },
                                 },
                             ],
-                            format: {
-                                marginTop: '2px',
-                                marginRight: '0px',
-                                marginBottom: '2px',
-                            },
                         },
                     ],
+                },
+                {
+                    tagName: 'div',
+                    blockType: 'BlockGroup',
                     format: {
                         backgroundColor: 'rgb(255, 255, 255)',
                         marginTop: '0px',
@@ -256,27 +273,26 @@ describe(ID, () => {
                         marginBottom: '0px',
                         marginLeft: '0px',
                     },
-                },
-                {
-                    blockType: 'BlockGroup',
                     blockGroupType: 'FormatContainer',
-                    tagName: 'div',
                     blocks: [
                         {
-                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    segmentType: 'Text',
                                     text: 'Â ',
+                                    segmentType: 'Text',
                                     format: {
+                                        textColor: 'rgb(0, 0, 0)',
                                         fontFamily:
                                             'Aptos, Aptos_EmbeddedFont, Aptos_MSFontService, sans-serif',
                                         fontSize: '12pt',
-                                        textColor: 'rgb(0, 0, 0)',
                                         lineHeight: '20.925px',
                                     },
                                 },
                             ],
+                            segmentFormat: {
+                                textColor: 'rgb(0, 0, 0)',
+                            },
+                            blockType: 'Paragraph',
                             format: {
                                 direction: 'ltr',
                                 textAlign: 'start',
@@ -292,20 +308,12 @@ describe(ID, () => {
                             },
                         },
                     ],
-                    format: {
-                        backgroundColor: 'rgb(255, 255, 255)',
-                        marginTop: '0px',
-                        marginRight: '0px',
-                        marginBottom: '0px',
-                        marginLeft: '0px',
-                    },
                 },
                 {
-                    blockType: 'Paragraph',
                     segments: [
                         {
-                            segmentType: 'SelectionMarker',
                             isSelected: true,
+                            segmentType: 'SelectionMarker',
                             format: {},
                         },
                         {
@@ -313,6 +321,7 @@ describe(ID, () => {
                             format: {},
                         },
                     ],
+                    blockType: 'Paragraph',
                     format: {},
                 },
             ],

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromWacTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromWacTest.ts
@@ -88,10 +88,10 @@ describe(ID, () => {
                             blockGroupType: 'FormatContainer',
                             blocks: [
                                 {
-                                    widths: [314.8000183105469, 314.8000183105469],
+                                    widths: jasmine.anything() as any,
                                     rows: [
                                         {
-                                            height: 22.5625,
+                                            height: jasmine.anything() as any,
                                             cells: [
                                                 {
                                                     spanAbove: false,

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromWordTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromWordTest.ts
@@ -120,22 +120,20 @@ describe(ID, () => {
                     rows: [
                         {
                             height: jasmine.anything() as any,
+                            format: {},
                             cells: [
                                 {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    isHeader: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
+                                            blockType: 'Paragraph',
                                             segments: [
                                                 {
-                                                    text: 'Asdasdsad ',
                                                     segmentType: 'Text',
+                                                    text: 'Asdasdsad ',
                                                     format: {},
                                                 },
                                             ],
-                                            blockType: 'Paragraph',
                                             format: {
                                                 lineHeight: 'normal',
                                                 marginTop: '1em',
@@ -159,23 +157,23 @@ describe(ID, () => {
                                         verticalAlign: 'top',
                                         width: '233.75pt',
                                     },
+                                    spanLeft: false,
+                                    spanAbove: false,
+                                    isHeader: false,
                                     dataset: {},
                                 },
                                 {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    isHeader: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
+                                            blockType: 'Paragraph',
                                             segments: [
                                                 {
-                                                    text: 'asdadasd ',
                                                     segmentType: 'Text',
+                                                    text: 'asdadasd ',
                                                     format: {},
                                                 },
                                             ],
-                                            blockType: 'Paragraph',
                                             format: {
                                                 lineHeight: 'normal',
                                                 marginTop: '1em',
@@ -198,28 +196,30 @@ describe(ID, () => {
                                         verticalAlign: 'top',
                                         width: '233.75pt',
                                     },
+                                    spanLeft: false,
+                                    spanAbove: false,
+                                    isHeader: false,
                                     dataset: {},
                                 },
                             ],
-                            format: {},
                         },
                     ],
                     blockType: 'Table',
                     format: {
-                        borderCollapse: true,
                         useBorderBox: true,
+                        borderCollapse: true,
                     },
                     dataset: {},
                 },
                 {
+                    blockType: 'Paragraph',
                     segments: [
                         {
-                            text: ' ',
                             segmentType: 'Text',
+                            text: ' ',
                             format: {},
                         },
                     ],
-                    blockType: 'Paragraph',
                     format: {
                         marginTop: '1em',
                         marginBottom: '1em',
@@ -230,14 +230,16 @@ describe(ID, () => {
                     },
                 },
                 {
+                    blockType: 'Paragraph',
                     segments: [
                         {
+                            segmentType: 'Text',
                             text: 'asdsadasdasdsadasdsadsad ',
-                            segmentType: 'Text',
-                            format: {},
+                            format: {
+                                textColor: 'rgb(0, 0, 0)',
+                            },
                         },
                     ],
-                    blockType: 'Paragraph',
                     format: {
                         marginTop: '1em',
                         marginBottom: '1em',
@@ -248,19 +250,19 @@ describe(ID, () => {
                     },
                 },
                 {
+                    blockType: 'Paragraph',
                     segments: [
                         {
-                            text: ' ',
                             segmentType: 'Text',
+                            text: ' ',
                             format: {},
                         },
                         {
-                            isSelected: true,
                             segmentType: 'SelectionMarker',
+                            isSelected: true,
                             format: {},
                         },
                     ],
-                    blockType: 'Paragraph',
                     format: {
                         marginTop: '1em',
                         marginBottom: '1em',

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/processPastedContentFromWacTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/processPastedContentFromWacTest.ts
@@ -1660,9 +1660,9 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '20pt',
                                                                                 italic: false,
-                                                                                fontWeight: 'bold',
                                                                                 textColor:
                                                                                     'rgb(255, 255, 255)',
+                                                                                fontWeight: 'bold',
                                                                                 lineHeight:
                                                                                     '41.85px',
                                                                             },
@@ -1675,10 +1675,10 @@ describe('wordOnlineHandler', () => {
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '20pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(255, 255, 255)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '41.85px',
                                                                             },
@@ -1690,10 +1690,10 @@ describe('wordOnlineHandler', () => {
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '20pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(255, 255, 255)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '41.85px',
                                                                             },
@@ -1706,9 +1706,9 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '20pt',
                                                                                 italic: false,
-                                                                                fontWeight: 'bold',
                                                                                 textColor:
                                                                                     'rgb(255, 255, 255)',
+                                                                                fontWeight: 'bold',
                                                                                 lineHeight:
                                                                                     '41.85px',
                                                                             },
@@ -1721,10 +1721,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '20pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(255, 255, 255)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '41.85px',
                                                                             },
@@ -1733,15 +1733,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -1764,12 +1765,12 @@ describe('wordOnlineHandler', () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        backgroundColor: 'rgb(21, 96, 130)',
-                                                        width: '312px',
                                                         borderTop: '1px solid',
                                                         borderBottom: '1px solid rgb(0, 0, 0)',
                                                         borderLeft: '1px solid',
+                                                        backgroundColor: 'rgb(21, 96, 130)',
                                                         verticalAlign: 'middle',
+                                                        width: '312px',
                                                     },
                                                     spanLeft: false,
                                                     spanAbove: false,
@@ -1798,9 +1799,9 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '21.5pt',
                                                                                 italic: false,
-                                                                                fontWeight: 'bold',
                                                                                 textColor:
                                                                                     'rgb(255, 255, 255)',
+                                                                                fontWeight: 'bold',
                                                                                 lineHeight:
                                                                                     '44.175px',
                                                                             },
@@ -1813,10 +1814,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '21.5pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(255, 255, 255)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '44.175px',
                                                                             },
@@ -1825,15 +1826,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -1856,12 +1858,12 @@ describe('wordOnlineHandler', () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        backgroundColor: 'rgb(21, 96, 130)',
-                                                        width: '312px',
                                                         borderTop: '1px solid',
                                                         borderRight: '1px solid',
                                                         borderBottom: '1px solid rgb(0, 0, 0)',
+                                                        backgroundColor: 'rgb(21, 96, 130)',
                                                         verticalAlign: 'middle',
+                                                        width: '312px',
                                                     },
                                                     spanLeft: false,
                                                     spanAbove: false,
@@ -1895,9 +1897,9 @@ describe('wordOnlineHandler', () => {
                                                                                     'Aptos_MSFontService, Aptos_MSFontService_EmbeddedFont, Aptos_MSFontService_MSFontService, sans-serif',
                                                                                 fontSize: '14pt',
                                                                                 italic: false,
-                                                                                fontWeight: 'bold',
                                                                                 textColor:
                                                                                     'rgb(255, 255, 255)',
+                                                                                fontWeight: 'bold',
                                                                                 lineHeight:
                                                                                     '24.4125px',
                                                                             },
@@ -1910,10 +1912,10 @@ describe('wordOnlineHandler', () => {
                                                                                     'Aptos_MSFontService, Aptos_MSFontService_EmbeddedFont, Aptos_MSFontService_MSFontService, sans-serif',
                                                                                 fontSize: '14pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(255, 255, 255)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '24.4125px',
                                                                             },
@@ -1922,15 +1924,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -1953,13 +1956,13 @@ describe('wordOnlineHandler', () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        backgroundColor: 'rgb(0, 0, 0)',
-                                                        width: '624px',
                                                         borderTop: '1px solid rgb(0, 0, 0)',
                                                         borderRight: '1px solid',
                                                         borderBottom: '1px solid rgb(0, 0, 0)',
                                                         borderLeft: '1px solid',
+                                                        backgroundColor: 'rgb(0, 0, 0)',
                                                         verticalAlign: 'middle',
+                                                        width: '624px',
                                                     },
                                                     spanLeft: false,
                                                     spanAbove: false,
@@ -1974,13 +1977,13 @@ describe('wordOnlineHandler', () => {
                                                     format: {
                                                         direction: 'ltr',
                                                         textAlign: 'start',
-                                                        backgroundColor: 'rgb(0, 0, 0)',
-                                                        width: '624px',
                                                         borderTop: '1px solid rgb(0, 0, 0)',
                                                         borderRight: '1px solid',
                                                         borderBottom: '1px solid rgb(0, 0, 0)',
                                                         borderLeft: '1px solid',
+                                                        backgroundColor: 'rgb(0, 0, 0)',
                                                         verticalAlign: 'middle',
+                                                        width: '624px',
                                                     },
                                                     spanLeft: true,
                                                     spanAbove: false,
@@ -2014,10 +2017,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2030,10 +2033,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2042,15 +2045,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -2068,10 +2072,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2080,15 +2084,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -2107,10 +2112,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2123,10 +2128,10 @@ describe('wordOnlineHandler', () => {
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2138,10 +2143,10 @@ describe('wordOnlineHandler', () => {
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2154,10 +2159,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2166,15 +2171,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -2193,15 +2199,14 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
                                                                         },
-
                                                                         {
                                                                             segmentType: 'Text',
                                                                             text: 'benefits',
@@ -2210,10 +2215,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2226,10 +2231,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2242,10 +2247,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2258,10 +2263,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2274,10 +2279,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2286,15 +2291,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -2312,10 +2318,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight: '21px',
                                                                             },
                                                                         },
@@ -2323,15 +2329,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -2350,10 +2357,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight: '21px',
                                                                             },
                                                                         },
@@ -2365,10 +2372,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight: '21px',
                                                                             },
                                                                         },
@@ -2376,15 +2383,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -2402,10 +2410,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight: '21px',
                                                                             },
                                                                         },
@@ -2413,15 +2421,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -2440,10 +2449,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight: '21px',
                                                                             },
                                                                         },
@@ -2455,10 +2464,10 @@ describe('wordOnlineHandler', () => {
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight: '21px',
                                                                             },
                                                                         },
@@ -2469,10 +2478,10 @@ describe('wordOnlineHandler', () => {
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight: '21px',
                                                                             },
                                                                         },
@@ -2484,10 +2493,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight: '21px',
                                                                             },
                                                                         },
@@ -2499,10 +2508,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight: '21px',
                                                                             },
                                                                         },
@@ -2510,15 +2519,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -2537,10 +2547,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2553,10 +2563,10 @@ describe('wordOnlineHandler', () => {
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2568,10 +2578,10 @@ describe('wordOnlineHandler', () => {
                                                                                     'WordVisiCarriageReturn_MSFontService, "Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2584,10 +2594,10 @@ describe('wordOnlineHandler', () => {
                                                                                     '"Segoe UI", "Segoe UI_EmbeddedFont", "Segoe UI_MSFontService", sans-serif',
                                                                                 fontSize: '12pt',
                                                                                 italic: false,
-                                                                                fontWeight:
-                                                                                    'normal',
                                                                                 textColor:
                                                                                     'rgb(0, 0, 0)',
+                                                                                fontWeight:
+                                                                                    'normal',
                                                                                 lineHeight:
                                                                                     '23.7333px',
                                                                             },
@@ -2596,15 +2606,16 @@ describe('wordOnlineHandler', () => {
                                                                     format: {
                                                                         direction: 'ltr',
                                                                         textAlign: 'start',
-                                                                        whiteSpace: 'pre-wrap',
                                                                         marginLeft: '0px',
                                                                         marginRight: '0px',
+                                                                        whiteSpace: 'pre-wrap',
                                                                         marginTop: '0px',
                                                                         marginBottom: '0px',
                                                                     },
                                                                     segmentFormat: {
-                                                                        fontWeight: 'normal',
                                                                         italic: false,
+                                                                        fontWeight: 'normal',
+                                                                        textColor: 'rgb(0, 0, 0)',
                                                                     },
                                                                     decorator: {
                                                                         tagName: 'p',
@@ -2674,7 +2685,7 @@ describe('wordOnlineHandler', () => {
                                         width: '0px',
                                         tableLayout: 'fixed',
                                         borderCollapse: true,
-                                    } as any,
+                                    },
                                     widths: [],
                                     dataset: {
                                         tablelook: '1696',


### PR DESCRIPTION
Currently when we remove a deprecated color we set the textColor as undefined. However when we do this we will use the default text color.

For other operations other than paste it is fine, but for paste it causes that text that have a deprecated color to be set as the default format, so instead we fallback to black.

Source
![image](https://github.com/microsoft/roosterjs/assets/8291124/50785e46-01d1-4148-8cef-f469ae510d3f)

Before
![image](https://github.com/microsoft/roosterjs/assets/8291124/556e6734-bd3e-4f4a-8fb2-ed7a1c442cb5)

After![image](https://github.com/microsoft/roosterjs/assets/8291124/40ee31e3-87c4-493f-ae94-a3492e9f7c05)
