### PR TITLE
Standalone Editor step 1: Stop using interface IEditor

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCachePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCachePlugin.ts
@@ -19,7 +19,7 @@ import type {
  * ContentModel cache plugin manages cached Content Model, and refresh the cache when necessary
  */
 class ContentModelCachePlugin implements PluginWithState<ContentModelCachePluginState> {
-    private editor: (IEditor & IStandaloneEditor) | null = null;
+    private editor: IStandaloneEditor | null = null;
     private state: ContentModelCachePluginState;
 
     /**

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCopyPastePlugin.ts
@@ -37,7 +37,7 @@ import type { IEditor, PluginWithState } from 'roosterjs-editor-types';
  * Copy and paste plugin for handling onCopy and onPaste event
  */
 class ContentModelCopyPastePlugin implements PluginWithState<CopyPastePluginState> {
-    private editor: (IStandaloneEditor & IEditor) | null = null;
+    private editor: IStandaloneEditor | null = null;
     private disposer: (() => void) | null = null;
     private state: CopyPastePluginState;
 
@@ -155,15 +155,17 @@ class ContentModelCopyPastePlugin implements PluginWithState<CopyPastePluginStat
                     addRangeToSelection(doc, newRange);
                 }
 
-                this.editor.runAsync(e => {
-                    const editor = e as IStandaloneEditor & IEditor;
+                doc.defaultView?.requestAnimationFrame(() => {
+                    if (!this.editor) {
+                        return;
+                    }
 
                     cleanUpAndRestoreSelection(tempDiv);
-                    editor.focus();
-                    editor.setDOMSelection(selection);
+                    this.editor.focus();
+                    this.editor.setDOMSelection(selection);
 
                     if (isCut) {
-                        editor.formatContentModel(
+                        this.editor.formatContentModel(
                             (model, context) => {
                                 if (
                                     deleteSelection(model, [deleteEmptyList], context)
@@ -200,7 +202,7 @@ class ContentModelCopyPastePlugin implements PluginWithState<CopyPastePluginStat
                     this.state.allowedCustomPasteType
                 ).then((clipboardData: ClipboardData) => {
                     if (!editor.isDisposed()) {
-                        editor.paste(clipboardData);
+                        editor.pasteFromClipboard(clipboardData);
                     }
                 });
             }

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelFormatPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelFormatPlugin.ts
@@ -19,7 +19,7 @@ const ProcessKey = 'Process';
  * 1. Handle pending format changes when selection is collapsed
  */
 class ContentModelFormatPlugin implements PluginWithState<ContentModelFormatPluginState> {
-    private editor: (IStandaloneEditor & IEditor) | null = null;
+    private editor: IStandaloneEditor | null = null;
     private hasDefaultFormat = false;
     private state: ContentModelFormatPluginState;
 

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/EntityPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/EntityPlugin.ts
@@ -1,3 +1,4 @@
+import { EntityOperation as LegacyEntityOperation, PluginEventType } from 'roosterjs-editor-types';
 import { findAllEntities } from './utils/findAllEntities';
 import { transformColor } from '../publicApi/color/transformColor';
 import {
@@ -8,7 +9,6 @@ import {
     isEntityElement,
     parseEntityClassName,
 } from 'roosterjs-content-model-dom';
-import { EntityOperation as LegacyEntityOperation, PluginEventType } from 'roosterjs-editor-types';
 import type {
     ChangedEntity,
     ContentModelContentChangedEvent,
@@ -43,7 +43,7 @@ const EntityOperationMap: Record<EntityOperation, LegacyEntityOperation> = {
  * Entity Plugin helps handle all operations related to an entity and generate entity specified events
  */
 class EntityPlugin implements PluginWithState<EntityPluginState> {
-    private editor: (IEditor & IStandaloneEditor) | null = null;
+    private editor: IStandaloneEditor | null = null;
     private state: EntityPluginState;
 
     /**
@@ -109,12 +109,12 @@ class EntityPlugin implements PluginWithState<EntityPluginState> {
         }
     }
 
-    private handleMouseUpEvent(editor: IEditor & IStandaloneEditor, event: PluginMouseUpEvent) {
+    private handleMouseUpEvent(editor: IStandaloneEditor, event: PluginMouseUpEvent) {
         const { rawEvent, isClicking } = event;
         let node: Node | null = rawEvent.target as Node;
 
         if (isClicking && this.editor) {
-            while (node && this.editor.contains(node)) {
+            while (node && this.editor.isNodeInEditor(node)) {
                 if (isEntityElement(node)) {
                     this.triggerEvent(editor, node as HTMLElement, 'click', rawEvent);
                     break;
@@ -125,10 +125,7 @@ class EntityPlugin implements PluginWithState<EntityPluginState> {
         }
     }
 
-    private handleContentChangedEvent(
-        editor: IStandaloneEditor & IEditor,
-        event?: ContentChangedEvent
-    ) {
+    private handleContentChangedEvent(editor: IStandaloneEditor, event?: ContentChangedEvent) {
         const cmEvent = event as ContentModelContentChangedEvent | undefined;
         const modifiedEntities: ChangedEntity[] =
             cmEvent?.changedEntities ?? this.getChangedEntities(editor);
@@ -235,10 +232,7 @@ class EntityPlugin implements PluginWithState<EntityPluginState> {
         return result;
     }
 
-    private handleExtractContentWithDomEvent(
-        editor: IEditor & IStandaloneEditor,
-        root: HTMLElement
-    ) {
+    private handleExtractContentWithDomEvent(editor: IStandaloneEditor, root: HTMLElement) {
         getAllEntityWrappers(root).forEach(element => {
             element.removeAttribute('contentEditable');
 
@@ -247,7 +241,7 @@ class EntityPlugin implements PluginWithState<EntityPluginState> {
     }
 
     private triggerEvent(
-        editor: IEditor & IStandaloneEditor,
+        editor: IStandaloneEditor,
         wrapper: HTMLElement,
         operation: EntityOperation,
         rawEvent?: Event,

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/LifecyclePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/LifecyclePlugin.ts
@@ -24,7 +24,7 @@ const DefaultBackColor = '#ffffff';
  * Lifecycle plugin handles editor initialization and disposing
  */
 class LifecyclePlugin implements PluginWithState<LifecyclePluginState> {
-    private editor: (IStandaloneEditor & IEditor) | null = null;
+    private editor: IStandaloneEditor | null = null;
     private state: LifecyclePluginState;
     private initialModel: ContentModelDocument;
     private initializer: (() => void) | null = null;

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/SelectionPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/SelectionPlugin.ts
@@ -13,7 +13,7 @@ const MouseMiddleButton = 1;
 const MouseRightButton = 2;
 
 class SelectionPlugin implements PluginWithState<SelectionPluginState> {
-    private editor: (IStandaloneEditor & IEditor) | null = null;
+    private editor: IStandaloneEditor | null = null;
     private state: SelectionPluginState;
     private disposer: (() => void) | null = null;
 
@@ -198,7 +198,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
     };
 
     private onMouseDownDocument = (event: MouseEvent) => {
-        if (this.editor && !this.editor.contains(event.target as Node)) {
+        if (this.editor && !this.editor.isNodeInEditor(event.target as Node)) {
             this.onBlur();
         }
     };

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/UndoPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/UndoPlugin.ts
@@ -23,7 +23,7 @@ const Enter = 'Enter';
  * Provides snapshot based undo service for Editor
  */
 class UndoPlugin implements PluginWithState<UndoPluginState> {
-    private editor: (IStandaloneEditor & IEditor) | null = null;
+    private editor: IStandaloneEditor | null = null;
     private state: UndoPluginState;
 
     /**

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/utils/applyDefaultFormat.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/utils/applyDefaultFormat.ts
@@ -1,6 +1,5 @@
 import { deleteSelection } from '../../publicApi/selection/deleteSelection';
 import { isBlockElement, isNodeOfType, normalizeContentModel } from 'roosterjs-content-model-dom';
-import type { IEditor } from 'roosterjs-editor-types';
 import type { ContentModelSegmentFormat, IStandaloneEditor } from 'roosterjs-content-model-types';
 
 /**
@@ -10,7 +9,7 @@ import type { ContentModelSegmentFormat, IStandaloneEditor } from 'roosterjs-con
  * @param defaultFormat The default segment format to apply
  */
 export function applyDefaultFormat(
-    editor: IStandaloneEditor & IEditor,
+    editor: IStandaloneEditor,
     defaultFormat: ContentModelSegmentFormat
 ) {
     const selection = editor.getDOMSelection();
@@ -21,7 +20,7 @@ export function applyDefaultFormat(
     if (posContainer) {
         let node: Node | null = posContainer;
 
-        while (node && editor.contains(node)) {
+        while (node && editor.isNodeInEditor(node)) {
             if (isNodeOfType(node, 'ELEMENT_NODE')) {
                 if (node.getAttribute?.('style')) {
                     return;

--- a/packages-content-model/roosterjs-content-model-core/lib/editor/createStandaloneEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/editor/createStandaloneEditorCore.ts
@@ -13,7 +13,6 @@ import type {
     StandaloneEditorCorePlugins,
     StandaloneEditorOptions,
     UnportedCoreApiMap,
-    UnportedCorePluginState,
 } from 'roosterjs-content-model-types';
 
 /**
@@ -25,7 +24,6 @@ export function createStandaloneEditorCore(
     contentDiv: HTMLDivElement,
     options: StandaloneEditorOptions,
     unportedCoreApiMap: UnportedCoreApiMap,
-    unportedCorePluginState: UnportedCorePluginState,
     tempPlugins: EditorPlugin[]
 ): StandaloneEditorCore {
     const corePlugins = createStandaloneEditorCorePlugins(options, contentDiv);
@@ -54,7 +52,6 @@ export function createStandaloneEditorCore(
         domToModelSettings: createDomToModelSettings(options),
         modelToDomSettings: createModelToDomSettings(options),
         ...getPluginState(corePlugins),
-        ...unportedCorePluginState,
     };
 }
 

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/pasteTest.ts
@@ -9,7 +9,7 @@ import * as PPT from 'roosterjs-content-model-plugins/lib/paste/PowerPoint/proce
 import * as setProcessorF from 'roosterjs-content-model-plugins/lib/paste/utils/setProcessor';
 import * as WacComponents from 'roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents';
 import * as WordDesktopFile from 'roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop';
-import { BeforePasteEvent, IEditor, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
+import { BeforePasteEvent, PluginEvent, PluginEventType } from 'roosterjs-editor-types';
 import { ContentModelEditor } from 'roosterjs-content-model-editor';
 import { ContentModelPastePlugin } from 'roosterjs-content-model-plugins/lib/paste/ContentModelPastePlugin';
 import { expectEqual, initEditor } from 'roosterjs-content-model-plugins/test/paste/e2e/testUtils';
@@ -29,7 +29,7 @@ let clipboardData: ClipboardData;
 const DEFAULT_TIMES_ADD_PARSER_CALLED = 4;
 
 describe('Paste ', () => {
-    let editor: IStandaloneEditor & IEditor;
+    let editor: IStandaloneEditor;
     let createContentModel: jasmine.Spy;
     let focus: jasmine.Spy;
     let mockedModel: ContentModelDocument;
@@ -124,18 +124,14 @@ describe('Paste ', () => {
     });
 
     it('Execute', () => {
-        try {
-            editor.paste(clipboardData);
-        } catch (e) {
-            console.log(e);
-        }
+        editor.pasteFromClipboard(clipboardData);
 
         expect(formatResult).toBeTrue();
         expect(mockedModel).toEqual(mockedMergeModel);
     });
 
     it('Execute | As plain text', () => {
-        editor.paste(clipboardData, true /* asText */);
+        editor.pasteFromClipboard(clipboardData, 'asPlainText');
 
         expect(formatResult).toBeTrue();
         expect(mockedModel).toEqual(mockedMergeModel);
@@ -159,7 +155,7 @@ describe('Paste ', () => {
             },
         });
 
-        editor.paste(clipboardData);
+        editor.pasteFromClipboard(clipboardData);
 
         editor.createContentModel(<DomToModelOption>{
             processorOverride: {
@@ -367,7 +363,7 @@ describe('paste with content model & paste plugin', () => {
 });
 
 describe('Paste with clipboardData', () => {
-    let editor: IEditor & IStandaloneEditor = undefined!;
+    let editor: IStandaloneEditor = undefined!;
     const ID = 'EDITOR_ID';
 
     beforeEach(() => {
@@ -393,7 +389,7 @@ describe('Paste with clipboardData', () => {
         clipboardData.rawHtml =
             '<html><head></head><body><p style="color: windowtext;">Test</p></body></html>';
 
-        editor.paste(clipboardData);
+        editor.pasteFromClipboard(clipboardData);
 
         const model = editor.createContentModel(<DomToModelOption>{
             processorOverride: {
@@ -436,7 +432,7 @@ describe('Paste with clipboardData', () => {
         clipboardData.rawHtml =
             '<html><head></head><body><a href="file://mylocalfile">Link</a></body></html>';
 
-        editor.paste(clipboardData);
+        editor.pasteFromClipboard(clipboardData);
 
         const model = editor.createContentModel(<DomToModelOption>{
             processorOverride: {
@@ -468,7 +464,7 @@ describe('Paste with clipboardData', () => {
         clipboardData.rawHtml =
             '<html><head></head><body><a href="https://github.com/microsoft/roosterjs">Link</a></body></html>';
 
-        editor.paste(clipboardData);
+        editor.pasteFromClipboard(clipboardData);
 
         const model = editor.createContentModel(<DomToModelOption>{
             processorOverride: {

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelCopyPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelCopyPastePluginTest.ts
@@ -141,12 +141,19 @@ describe('ContentModelCopyPastePlugin |', () => {
             getDOMSelection: getDOMSelectionSpy,
             setDOMSelection: setDOMSelectionSpy,
             getDocument() {
-                return document;
+                return {
+                    createRange: () => document.createRange(),
+                    defaultView: {
+                        requestAnimationFrame: (func: Function) => {
+                            func();
+                        },
+                    },
+                };
             },
             isDarkMode: () => {
                 return false;
             },
-            paste: (ar1: any) => {
+            pasteFromClipboard: (ar1: any) => {
                 pasteSpy(ar1);
             },
             getDarkColorHandler: () => mockedDarkColorHandler,

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelFormatPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelFormatPluginTest.ts
@@ -278,7 +278,7 @@ describe('ContentModelFormatPlugin for default format', () => {
         contentDiv = document.createElement('div');
 
         editor = ({
-            contains: (e: Node) => contentDiv != e && contentDiv.contains(e),
+            isNodeInEditor: (e: Node) => contentDiv != e && contentDiv.contains(e),
             getDOMSelection,
             getPendingFormat: getPendingFormatSpy,
             cacheContentModel: cacheContentModelSpy,

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/EntityPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/EntityPluginTest.ts
@@ -17,7 +17,7 @@ describe('EntityPlugin', () => {
     let createContentModelSpy: jasmine.Spy;
     let triggerPluginEventSpy: jasmine.Spy;
     let isDarkModeSpy: jasmine.Spy;
-    let containsSpy: jasmine.Spy;
+    let isNodeInEditorSpy: jasmine.Spy;
     let transformColorSpy: jasmine.Spy;
     let mockedDarkColorHandler: DarkColorHandler;
 
@@ -25,7 +25,7 @@ describe('EntityPlugin', () => {
         createContentModelSpy = jasmine.createSpy('createContentModel');
         triggerPluginEventSpy = jasmine.createSpy('triggerPluginEvent');
         isDarkModeSpy = jasmine.createSpy('isDarkMode');
-        containsSpy = jasmine.createSpy('contains');
+        isNodeInEditorSpy = jasmine.createSpy('isNodeInEditor');
         transformColorSpy = spyOn(transformColor, 'transformColor');
         mockedDarkColorHandler = 'DARKCOLORHANDLER' as any;
 
@@ -33,7 +33,7 @@ describe('EntityPlugin', () => {
             createContentModel: createContentModelSpy,
             triggerPluginEvent: triggerPluginEventSpy,
             isDarkMode: isDarkModeSpy,
-            contains: containsSpy,
+            isNodeInEditor: isNodeInEditorSpy,
             getDarkColorHandler: () => mockedDarkColorHandler,
         } as any;
         plugin = createEntityPlugin();
@@ -561,7 +561,7 @@ describe('EntityPlugin', () => {
                 target: mockedNode,
             } as any;
 
-            containsSpy.and.returnValue(true);
+            isNodeInEditorSpy.and.returnValue(true);
 
             plugin.onPluginEvent({
                 eventType: PluginEventType.MouseUp,
@@ -581,7 +581,7 @@ describe('EntityPlugin', () => {
                 target: mockedNode,
             } as any;
 
-            containsSpy.and.returnValue(true);
+            isNodeInEditorSpy.and.returnValue(true);
             spyOn(entityUtils, 'isEntityElement').and.returnValue(true);
 
             plugin.onPluginEvent({
@@ -617,7 +617,7 @@ describe('EntityPlugin', () => {
                 target: mockedNode2,
             } as any;
 
-            containsSpy.and.returnValue(true);
+            isNodeInEditorSpy.and.returnValue(true);
             spyOn(entityUtils, 'isEntityElement').and.callFake(node => node == mockedNode1);
 
             plugin.onPluginEvent({
@@ -649,7 +649,7 @@ describe('EntityPlugin', () => {
                 target: mockedNode,
             } as any;
 
-            containsSpy.and.returnValue(true);
+            isNodeInEditorSpy.and.returnValue(true);
             spyOn(entityUtils, 'isEntityElement').and.returnValue(true);
 
             plugin.onPluginEvent({

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/utils/applyDefaultFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/utils/applyDefaultFormatTest.ts
@@ -1,7 +1,6 @@
 import * as deleteSelection from '../../../lib/publicApi/selection/deleteSelection';
 import * as normalizeContentModel from 'roosterjs-content-model-dom/lib/modelApi/common/normalizeContentModel';
 import { applyDefaultFormat } from '../../../lib/corePlugin/utils/applyDefaultFormat';
-import { IEditor } from 'roosterjs-editor-types';
 import {
     ContentModelDocument,
     ContentModelFormatter,
@@ -21,7 +20,7 @@ import {
 } from 'roosterjs-content-model-dom';
 
 describe('applyDefaultFormat', () => {
-    let editor: IStandaloneEditor & IEditor;
+    let editor: IStandaloneEditor;
     let getDOMSelectionSpy: jasmine.Spy;
     let formatContentModelSpy: jasmine.Spy;
     let deleteSelectionSpy: jasmine.Spy;
@@ -65,7 +64,7 @@ describe('applyDefaultFormat', () => {
             );
 
         editor = {
-            contains: () => true,
+            isNodeInEditor: () => true,
             getDOMSelection: getDOMSelectionSpy,
             formatContentModel: formatContentModelSpy,
             takeSnapshot: takeSnapshotSpy,

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/utils/applyPendingFormatTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/utils/applyPendingFormatTest.ts
@@ -1,7 +1,6 @@
 import * as iterateSelections from '../../../lib/publicApi/selection/iterateSelections';
 import * as normalizeContentModel from 'roosterjs-content-model-dom/lib/modelApi/common/normalizeContentModel';
 import { applyPendingFormat } from '../../../lib/corePlugin/utils/applyPendingFormat';
-import { IEditor } from 'roosterjs-editor-types';
 import {
     ContentModelDocument,
     ContentModelParagraph,
@@ -55,7 +54,7 @@ describe('applyPendingFormat', () => {
 
         const editor = ({
             formatContentModel: formatContentModelSpy,
-        } as any) as IStandaloneEditor & IEditor;
+        } as any) as IStandaloneEditor;
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
             callback([model], undefined, paragraph, [marker]);
@@ -129,7 +128,7 @@ describe('applyPendingFormat', () => {
 
         const editor = ({
             formatContentModel: formatContentModelSpy,
-        } as any) as IStandaloneEditor & IEditor;
+        } as any) as IStandaloneEditor;
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
             callback([model], undefined, paragraph, [marker]);
@@ -188,7 +187,7 @@ describe('applyPendingFormat', () => {
         const formatContentModelSpy = jasmine.createSpy('formatContentModel');
         const editor = ({
             formatContentModel: formatContentModelSpy,
-        } as any) as IStandaloneEditor & IEditor;
+        } as any) as IStandaloneEditor;
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
             callback([model], undefined, paragraph, [marker]);
@@ -248,7 +247,7 @@ describe('applyPendingFormat', () => {
 
         const editor = ({
             formatContentModel: formatContentModelSpy,
-        } as any) as IStandaloneEditor & IEditor;
+        } as any) as IStandaloneEditor;
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
             callback([model], undefined, paragraph, [text]);
@@ -299,7 +298,7 @@ describe('applyPendingFormat', () => {
 
         const editor = ({
             formatContentModel: formatContentModelSpy,
-        } as any) as IStandaloneEditor & IEditor;
+        } as any) as IStandaloneEditor;
 
         spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
             callback([model], undefined, paragraph, [marker]);

--- a/packages-content-model/roosterjs-content-model-editor/lib/corePlugins/ContextMenuPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/corePlugins/ContextMenuPlugin.ts
@@ -1,0 +1,110 @@
+import { PluginEventType } from 'roosterjs-editor-types';
+import type { ContentModelEditorOptions } from '../publicTypes/IContentModelEditor';
+import type { ContextMenuPluginState } from '../publicTypes/ContextMenuPluginState';
+import type {
+    ContextMenuProvider,
+    EditorPlugin,
+    IEditor,
+    PluginEvent,
+    PluginWithState,
+} from 'roosterjs-editor-types';
+
+/**
+ * Edit Component helps handle Content edit features
+ */
+class ContextMenuPlugin implements PluginWithState<ContextMenuPluginState> {
+    private editor: IEditor | null = null;
+    private state: ContextMenuPluginState;
+    private disposer: (() => void) | null = null;
+
+    /**
+     * Construct a new instance of EditPlugin
+     * @param options The editor options
+     */
+    constructor(options: ContentModelEditorOptions) {
+        this.state = {
+            contextMenuProviders:
+                options.plugins?.filter<ContextMenuProvider<any>>(isContextMenuProvider) || [],
+        };
+    }
+
+    /**
+     * Get a friendly name of  this plugin
+     */
+    getName() {
+        return 'Edit';
+    }
+
+    /**
+     * Initialize this plugin. This should only be called from Editor
+     * @param editor Editor instance
+     */
+    initialize(editor: IEditor) {
+        this.editor = editor;
+        this.disposer = this.editor.addDomEventHandler('contextmenu', this.onContextMenuEvent);
+    }
+
+    /**
+     * Dispose this plugin
+     */
+    dispose() {
+        this.disposer?.();
+        this.disposer = null;
+        this.editor = null;
+    }
+
+    /**
+     * Get plugin state object
+     */
+    getState() {
+        return this.state;
+    }
+
+    /**
+     * Handle events triggered from editor
+     * @param event PluginEvent object
+     */
+    onPluginEvent(event: PluginEvent) {}
+
+    private onContextMenuEvent = (e: Event) => {
+        const event = e as MouseEvent;
+        const allItems: any[] = [];
+
+        // TODO: Remove dependency to ContentSearcher
+        const searcher = this.editor?.getContentSearcherOfCursor();
+        const elementBeforeCursor = searcher?.getInlineElementBefore();
+
+        let eventTargetNode = event.target as Node;
+        if (event.button != 2 && elementBeforeCursor) {
+            eventTargetNode = elementBeforeCursor.getContainerNode();
+        }
+        this.state.contextMenuProviders.forEach(provider => {
+            const items = provider.getContextMenuItems(eventTargetNode) ?? [];
+            if (items?.length > 0) {
+                if (allItems.length > 0) {
+                    allItems.push(null);
+                }
+
+                allItems.push(...items);
+            }
+        });
+        this.editor?.triggerPluginEvent(PluginEventType.ContextMenu, {
+            rawEvent: event,
+            items: allItems,
+        });
+    };
+}
+
+function isContextMenuProvider(source: EditorPlugin): source is ContextMenuProvider<any> {
+    return !!(<ContextMenuProvider<any>>source)?.getContextMenuItems;
+}
+
+/**
+ * @internal
+ * Create a new instance of EditPlugin.
+ */
+export function createContextMenuPlugin(
+    options: ContentModelEditorOptions
+): PluginWithState<ContextMenuPluginState> {
+    return new ContextMenuPlugin(options);
+}

--- a/packages-content-model/roosterjs-content-model-editor/lib/corePlugins/createCorePlugins.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/corePlugins/createCorePlugins.ts
@@ -1,8 +1,8 @@
+import { createContextMenuPlugin } from './ContextMenuPlugin';
 import { createEditPlugin } from './EditPlugin';
 import { createEventTypeTranslatePlugin } from './EventTypeTranslatePlugin';
 import { createNormalizeTablePlugin } from './NormalizeTablePlugin';
 import type { UnportedCorePlugins } from '../publicTypes/ContentModelCorePlugins';
-import type { UnportedCorePluginState } from 'roosterjs-content-model-types';
 import type { ContentModelEditorOptions } from '../publicTypes/IContentModelEditor';
 
 /**
@@ -19,16 +19,6 @@ export function createCorePlugins(options: ContentModelEditorOptions): UnportedC
         eventTranslate: map.eventTranslate || createEventTypeTranslatePlugin(),
         edit: map.edit || createEditPlugin(),
         normalizeTable: map.normalizeTable || createNormalizeTablePlugin(),
-    };
-}
-
-/**
- * @internal
- * Get plugin state of core plugins
- * @param corePlugins ContentModelCorePlugins object
- */
-export function getPluginState(corePlugins: UnportedCorePlugins): UnportedCorePluginState {
-    return {
-        edit: corePlugins.edit.getState(),
+        contextMenu: map.contextMenu || createContextMenuPlugin(options),
     };
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/ContentModelEditor.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/ContentModelEditor.ts
@@ -91,6 +91,7 @@ import type {
     Snapshot,
     SnapshotsManager,
     DOMEventRecord,
+    PasteType,
 } from 'roosterjs-content-model-types';
 
 /**
@@ -448,9 +449,7 @@ export class ContentModelEditor implements IContentModelEditor {
         applyCurrentFormat: boolean = false,
         pasteAsImage: boolean = false
     ) {
-        const core = this.getCore();
-        core.api.paste(
-            core,
+        this.pasteFromClipboard(
             clipboardData,
             pasteAsText
                 ? 'asPlainText'
@@ -1210,6 +1209,27 @@ export class ContentModelEditor implements IContentModelEditor {
         const core = this.getCore();
 
         return core.api.getVisibleViewport(core);
+    }
+
+    /**
+     * Check if the given DOM node is in editor
+     * @param node The node to check
+     */
+    isNodeInEditor(node: Node): boolean {
+        const core = this.getCore();
+
+        return core.contentDiv.contains(node);
+    }
+
+    /**
+     * Paste into editor using a clipboardData object
+     * @param clipboardData Clipboard data retrieved from clipboard
+     * @param pasteType Type of paste
+     */
+    pasteFromClipboard(clipboardData: ClipboardData, pasteType: PasteType = 'normal') {
+        const core = this.getCore();
+
+        core.api.paste(core, clipboardData, pasteType);
     }
 
     /**

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/createEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/createEditorCore.ts
@@ -1,5 +1,6 @@
 import { coreApiMap } from '../coreApi/coreApiMap';
-import { createCorePlugins, getPluginState } from '../corePlugins/createCorePlugins';
+import { createContextMenuPlugin } from '../corePlugins/ContextMenuPlugin';
+import { createCorePlugins } from '../corePlugins/createCorePlugins';
 import { createModelFromHtml, createStandaloneEditorCore } from 'roosterjs-content-model-core';
 import type { ContentModelEditorCore } from '../publicTypes/ContentModelEditorCore';
 import type { ContentModelEditorOptions } from '../publicTypes/IContentModelEditor';
@@ -16,11 +17,11 @@ export function createEditorCore(
     options: ContentModelEditorOptions
 ): ContentModelEditorCore {
     const corePlugins = createCorePlugins(options);
-    const pluginState = getPluginState(corePlugins);
     const additionalPlugins: EditorPlugin[] = [
         corePlugins.eventTranslate,
         corePlugins.edit,
         ...(options.plugins ?? []),
+        createContextMenuPlugin(options),
         corePlugins.normalizeTable,
     ].filter(x => !!x);
 
@@ -40,13 +41,13 @@ export function createEditorCore(
         contentDiv,
         options,
         coreApiMap,
-        pluginState,
         additionalPlugins
     );
 
     const core: ContentModelEditorCore = {
         ...standaloneEditorCore,
-        ...pluginState,
+        edit: corePlugins.edit.getState(),
+        contextMenu: corePlugins.contextMenu.getState(),
         zoomScale: zoomScale,
         sizeTransformer: (size: number) => size / zoomScale,
         disposeErrorHandler: options.disposeErrorHandler,

--- a/packages-content-model/roosterjs-content-model-editor/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/index.ts
@@ -4,6 +4,7 @@ export {
     ContentModelCorePlugins,
     UnportedCorePlugins,
 } from './publicTypes/ContentModelCorePlugins';
+export { ContextMenuPluginState } from './publicTypes/ContextMenuPluginState';
 
 export { ContentModelEditor } from './editor/ContentModelEditor';
 export { isContentModelEditor } from './editor/isContentModelEditor';

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelCorePlugins.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelCorePlugins.ts
@@ -1,3 +1,4 @@
+import type { ContextMenuPluginState } from './ContextMenuPluginState';
 import type { StandaloneEditorCorePlugins } from 'roosterjs-content-model-types';
 import type { EditPluginState, EditorPlugin, PluginWithState } from 'roosterjs-editor-types';
 
@@ -20,6 +21,11 @@ export interface UnportedCorePlugins {
      * NormalizeTable plugin makes sure each table in editor has TBODY/THEAD/TFOOT tag around TR tags
      */
     readonly normalizeTable: EditorPlugin;
+
+    /**
+     * ContextMenu plugin handles Context Menu
+     */
+    readonly contextMenu: PluginWithState<ContextMenuPluginState>;
 }
 
 /**

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelEditorCore.ts
@@ -1,6 +1,8 @@
+import type { ContextMenuPluginState } from './ContextMenuPluginState';
 import type { CompatibleExperimentalFeatures } from 'roosterjs-editor-types/lib/compatibleTypes';
 import type {
     CustomData,
+    EditPluginState,
     EditorPlugin,
     ExperimentalFeatures,
     SizeTransformer,
@@ -49,4 +51,14 @@ export interface ContentModelEditorCore extends StandaloneEditorCore {
      * Enabled experimental features
      */
     experimentalFeatures: (ExperimentalFeatures | CompatibleExperimentalFeatures)[];
+
+    /**
+     * Unported core plugin state: EditPlugin
+     */
+    edit: EditPluginState;
+
+    /**
+     * Unported core plugin state: ContextMenuPlugin
+     */
+    contextMenu: ContextMenuPluginState;
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContextMenuPluginState.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContextMenuPluginState.ts
@@ -1,0 +1,11 @@
+import type { ContextMenuProvider } from 'roosterjs-editor-types';
+
+/**
+ * The state object for DOMEventPlugin
+ */
+export interface ContextMenuPluginState {
+    /**
+     * Context menu providers, that can provide context menu items
+     */
+    contextMenuProviders: ContextMenuProvider<any>[];
+}

--- a/packages-content-model/roosterjs-content-model-editor/test/corePlugins/ContextMenuPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/corePlugins/ContextMenuPluginTest.ts
@@ -1,0 +1,93 @@
+import { ContextMenuPluginState } from '../../lib/publicTypes/ContextMenuPluginState';
+import { createContextMenuPlugin } from '../../lib/corePlugins/ContextMenuPlugin';
+import { IEditor, PluginEventType, PluginWithState } from 'roosterjs-editor-types';
+import { IStandaloneEditor } from 'roosterjs-content-model-types';
+
+describe('ContextMenu handle other event', () => {
+    let plugin: PluginWithState<ContextMenuPluginState>;
+    let addEventListener: jasmine.Spy;
+    let removeEventListener: jasmine.Spy;
+    let triggerPluginEvent: jasmine.Spy;
+    let eventMap: Record<string, any>;
+    let getElementAtCursorSpy: jasmine.Spy;
+    let triggerContentChangedEventSpy: jasmine.Spy;
+    let editor: IEditor & IStandaloneEditor;
+
+    beforeEach(() => {
+        addEventListener = jasmine.createSpy('addEventListener');
+        removeEventListener = jasmine.createSpy('.removeEventListener');
+        triggerPluginEvent = jasmine.createSpy('triggerPluginEvent');
+        getElementAtCursorSpy = jasmine.createSpy('getElementAtCursor');
+        triggerContentChangedEventSpy = jasmine.createSpy('triggerContentChangedEvent');
+
+        editor = <IEditor & IStandaloneEditor>(<any>{
+            getDocument: () => ({
+                addEventListener,
+                removeEventListener,
+            }),
+            triggerPluginEvent,
+            getEnvironment: () => ({}),
+            addDomEventHandler: (name: string, handler: Function) => {
+                eventMap = {
+                    [name]: {
+                        beforeDispatch: handler,
+                    },
+                };
+            },
+            getElementAtCursor: getElementAtCursorSpy,
+            triggerContentChangedEvent: triggerContentChangedEventSpy,
+        });
+    });
+
+    afterEach(() => {
+        plugin.dispose();
+    });
+
+    it('Ctor with parameter', () => {
+        const mockedPlugin1 = {} as any;
+        const mockedPlugin2 = {
+            getContextMenuItems: () => {},
+        } as any;
+
+        plugin = createContextMenuPlugin({
+            plugins: [mockedPlugin1, mockedPlugin2],
+        });
+        plugin.initialize(editor);
+
+        const state = plugin.getState();
+
+        expect(state).toEqual({
+            contextMenuProviders: [mockedPlugin2],
+        });
+    });
+
+    it('Trigger contextmenu event, skip reselect', () => {
+        plugin = createContextMenuPlugin({});
+        plugin.initialize(editor);
+
+        editor.getContentSearcherOfCursor = () => null!;
+        const state = plugin.getState();
+        const mockedItems1 = ['Item1', 'Item2'];
+        const mockedItems2 = ['Item3', 'Item4'];
+
+        state.contextMenuProviders = [
+            {
+                getContextMenuItems: () => mockedItems1,
+            } as any,
+            {
+                getContextMenuItems: () => mockedItems2,
+            } as any,
+        ];
+
+        const mockedEvent = {
+            target: {},
+        };
+
+        eventMap.contextmenu.beforeDispatch(mockedEvent);
+
+        expect(triggerPluginEvent).toHaveBeenCalledWith(PluginEventType.ContextMenu, {
+            rawEvent: mockedEvent,
+            items: ['Item1', 'Item2', null, 'Item3', 'Item4'],
+        });
+    });
+});

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/createEditorCoreTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/createEditorCoreTest.ts
@@ -1,6 +1,7 @@
 import * as ContentModelCachePlugin from 'roosterjs-content-model-core/lib/corePlugin/ContentModelCachePlugin';
 import * as ContentModelCopyPastePlugin from 'roosterjs-content-model-core/lib/corePlugin/ContentModelCopyPastePlugin';
 import * as ContentModelFormatPlugin from 'roosterjs-content-model-core/lib/corePlugin/ContentModelFormatPlugin';
+import * as ContextMenuPlugin from '../../lib/corePlugins/ContextMenuPlugin';
 import * as createStandaloneEditorDefaultSettings from 'roosterjs-content-model-core/lib/editor/createStandaloneEditorDefaultSettings';
 import * as DOMEventPlugin from 'roosterjs-content-model-core/lib/corePlugin/DOMEventPlugin';
 import * as EditPlugin from '../../lib/corePlugins/EditPlugin';
@@ -21,6 +22,7 @@ const mockedLifecycleState = 'LIFECYCLESTATE' as any;
 const mockedUndoState = 'UNDOSTATE' as any;
 const mockedEntityState = 'ENTITYSTATE' as any;
 const mockedCopyPasteState = 'COPYPASTESTATE' as any;
+const mockedContextMenuState = 'CONTEXTMENU' as any;
 const mockedCacheState = 'CACHESTATE' as any;
 const mockedFormatState = 'FORMATSTATE' as any;
 const mockedSelectionState = 'SELECTION' as any;
@@ -33,6 +35,9 @@ const mockedCachePlugin = {
 } as any;
 const mockedCopyPastePlugin = {
     getState: () => mockedCopyPasteState,
+} as any;
+const mockedContextMenuPlugin = {
+    getState: () => mockedContextMenuState,
 } as any;
 const mockedEditPlugin = {
     getState: () => mockedEditState,
@@ -79,6 +84,9 @@ describe('createEditorCore', () => {
             mockedCopyPastePlugin
         );
         spyOn(EditPlugin, 'createEditPlugin').and.returnValue(mockedEditPlugin);
+        spyOn(ContextMenuPlugin, 'createContextMenuPlugin').and.returnValue(
+            mockedContextMenuPlugin
+        );
         spyOn(UndoPlugin, 'createUndoPlugin').and.returnValue(mockedUndoPlugin);
         spyOn(DOMEventPlugin, 'createDOMEventPlugin').and.returnValue(mockedDOMEventPlugin);
         spyOn(SelectionPlugin, 'createSelectionPlugin').and.returnValue(mockedSelectionPlugin);
@@ -113,6 +121,7 @@ describe('createEditorCore', () => {
                 mockedEntityPlugin,
                 mockedEventTranslatePlugin,
                 mockedEditPlugin,
+                mockedContextMenuPlugin,
                 mockedNormalizeTablePlugin,
                 mockedUndoPlugin,
                 mockedLifecyclePlugin,
@@ -126,6 +135,7 @@ describe('createEditorCore', () => {
             cache: mockedCacheState,
             format: mockedFormatState,
             selection: mockedSelectionState,
+            contextMenu: mockedContextMenuState,
             trustedHTMLHandler: defaultTrustHtmlHandler,
             zoomScale: 1,
             sizeTransformer: jasmine.anything(),
@@ -173,6 +183,7 @@ describe('createEditorCore', () => {
                 mockedEntityPlugin,
                 mockedEventTranslatePlugin,
                 mockedEditPlugin,
+                mockedContextMenuPlugin,
                 mockedNormalizeTablePlugin,
                 mockedUndoPlugin,
                 mockedLifecyclePlugin,
@@ -186,6 +197,7 @@ describe('createEditorCore', () => {
             cache: mockedCacheState,
             format: mockedFormatState,
             selection: mockedSelectionState,
+            contextMenu: mockedContextMenuState,
             trustedHTMLHandler: defaultTrustHtmlHandler,
             zoomScale: 1,
             sizeTransformer: jasmine.anything(),

--- a/packages-content-model/roosterjs-content-model-types/lib/editor/IStandaloneEditor.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/editor/IStandaloneEditor.ts
@@ -1,3 +1,5 @@
+import type { PasteType } from '../enum/PasteType';
+import type { ClipboardData } from '../parameter/ClipboardData';
 import type { DOMEventRecord } from '../parameter/DOMEventRecord';
 import type { SnapshotsManager } from '../parameter/SnapshotsManager';
 import type { Snapshot } from '../parameter/Snapshot';
@@ -13,7 +15,12 @@ import type {
     ContentModelFormatter,
     FormatWithContentModelOptions,
 } from '../parameter/FormatWithContentModelOptions';
-import type { PluginEventData, PluginEventFromType, PluginEventType } from 'roosterjs-editor-types';
+import type {
+    DarkColorHandler,
+    PluginEventData,
+    PluginEventFromType,
+    PluginEventType,
+} from 'roosterjs-editor-types';
 
 /**
  * An interface of standalone Content Model editor.
@@ -80,8 +87,6 @@ export interface IStandaloneEditor {
      */
     getPendingFormat(): ContentModelSegmentFormat | null;
 
-    //#region Editor API copied from legacy editor, will be ported to use Content Model instead
-
     /**
      * Get whether this editor is disposed
      * @returns True if editor is disposed, otherwise false
@@ -126,6 +131,12 @@ export interface IStandaloneEditor {
     isDarkMode(): boolean;
 
     /**
+     * Set the dark mode state and transforms the content to match the new state.
+     * @param isDarkMode The next status of dark mode. True if the editor should be in dark mode, false if not.
+     */
+    setDarkModeState(isDarkMode?: boolean): void;
+
+    /**
      * Get current zoom scale, default value is 1
      * When editor is put under a zoomed container, need to pass the zoom scale number using EditorOptions.zoomScale
      * to let editor behave correctly especially for those mouse drag/drop behaviors
@@ -156,5 +167,51 @@ export interface IStandaloneEditor {
      */
     attachDomEvent(eventMap: Record<string, DOMEventRecord>): () => void;
 
-    //#endregion
+    /**
+     * Check if editor is in Shadow Edit mode
+     */
+    isInShadowEdit(): boolean;
+
+    /**
+     * Make the editor in "Shadow Edit" mode.
+     * In Shadow Edit mode, all format change will finally be ignored.
+     * This can be used for building a live preview feature for format button, to allow user
+     * see format result without really apply it.
+     * This function can be called repeated. If editor is already in shadow edit mode, we can still
+     * use this function to do more shadow edit operation.
+     */
+    startShadowEdit(): void;
+
+    /**
+     * Leave "Shadow Edit" mode, all changes made during shadow edit will be discarded
+     */
+    stopShadowEdit(): void;
+
+    /**
+     * Check if the given DOM node is in editor
+     * @param node The node to check
+     */
+    isNodeInEditor(node: Node): boolean;
+
+    /**
+     * Paste into editor using a clipboardData object
+     * @param clipboardData Clipboard data retrieved from clipboard
+     * @param pasteType Type of paste
+     */
+    pasteFromClipboard(clipboardData: ClipboardData, pasteType?: PasteType): void;
+
+    /**
+     * Get a darkColorHandler object for this editor.
+     */
+    getDarkColorHandler(): DarkColorHandler;
+
+    /**
+     * Dispose this editor, dispose all plugins and custom data
+     */
+    dispose(): void;
+    /**
+     * Check if focus is in editor now
+     * @returns true if focus is in editor, otherwise false
+     */
+    hasFocus(): boolean;
 }

--- a/packages-content-model/roosterjs-content-model-types/lib/editor/StandaloneEditorCore.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/editor/StandaloneEditorCore.ts
@@ -17,10 +17,7 @@ import type {
     TrustedHTMLHandler,
 } from 'roosterjs-editor-types';
 import type { ContentModelDocument } from '../group/ContentModelDocument';
-import type {
-    StandaloneEditorCorePluginState,
-    UnportedCorePluginState,
-} from '../pluginState/StandaloneEditorPluginState';
+import type { StandaloneEditorCorePluginState } from '../pluginState/StandaloneEditorPluginState';
 import type { DOMSelection } from '../selection/DOMSelection';
 import type { DomToModelOption } from '../context/DomToModelOption';
 import type { DomToModelSettings } from '../context/DomToModelSettings';
@@ -412,9 +409,7 @@ export interface StandaloneCoreApiMap extends PortedCoreApiMap, UnportedCoreApiM
 /**
  * Represents the core data structure of a Content Model editor
  */
-export interface StandaloneEditorCore
-    extends StandaloneEditorCorePluginState,
-        UnportedCorePluginState {
+export interface StandaloneEditorCore extends StandaloneEditorCorePluginState {
     /**
      * The content DIV element of this editor
      */

--- a/packages-content-model/roosterjs-content-model-types/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/index.ts
@@ -226,10 +226,7 @@ export {
 export { StandaloneEditorCorePlugins } from './editor/StandaloneEditorCorePlugins';
 
 export { ContentModelCachePluginState } from './pluginState/ContentModelCachePluginState';
-export {
-    StandaloneEditorCorePluginState,
-    UnportedCorePluginState,
-} from './pluginState/StandaloneEditorPluginState';
+export { StandaloneEditorCorePluginState } from './pluginState/StandaloneEditorPluginState';
 export {
     ContentModelFormatPluginState,
     PendingFormat,

--- a/packages-content-model/roosterjs-content-model-types/lib/pluginState/DOMEventPluginState.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/pluginState/DOMEventPluginState.ts
@@ -1,5 +1,3 @@
-import type { ContextMenuProvider } from 'roosterjs-editor-types';
-
 /**
  * The state object for DOMEventPlugin
  */
@@ -13,11 +11,6 @@ export interface DOMEventPluginState {
      * Scroll container of editor
      */
     scrollContainer: HTMLElement;
-
-    /**
-     * Context menu providers, that can provide context menu items
-     */
-    contextMenuProviders: ContextMenuProvider<any>[];
 
     /**
      * Whether mouse up event handler is added

--- a/packages-content-model/roosterjs-content-model-types/lib/pluginState/StandaloneEditorPluginState.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/pluginState/StandaloneEditorPluginState.ts
@@ -1,7 +1,6 @@
 import type { CopyPastePluginState } from './CopyPastePluginState';
 import type { UndoPluginState } from './UndoPluginState';
 import type { SelectionPluginState } from './SelectionPluginState';
-import type { EditPluginState } from 'roosterjs-editor-types';
 import type { ContentModelCachePluginState } from './ContentModelCachePluginState';
 import type { ContentModelFormatPluginState } from './ContentModelFormatPluginState';
 import type { DOMEventPluginState } from './DOMEventPluginState';
@@ -52,12 +51,4 @@ export interface StandaloneEditorCorePluginState {
      * Plugin state for UndoPlugin
      */
     undo: UndoPluginState;
-}
-
-/**
- * Temporary core plugin state for Content Model editor (unported part)
- * TODO: Port these plugins
- */
-export interface UnportedCorePluginState {
-    edit: EditPluginState;
 }


### PR DESCRIPTION
Stop using interface `IEditor` in ported plugins and APIs.

To make build work, we still have some workaround to cast editor to be `IEditor & IStandaloneEditor` in several places. This will be removed in future steps.

In order to make those plugins can work with `IStandaloneEditor`, added some editor API in `IStandaloneEditor` interface:

- setDarkModeState
- isInShadowEdit
- startShadowEdit
- stopShadowEdit
- isNodeInEditor (replacement of `contains`)
- pasteFromClipboard (replacement of `paste`)
- getDarkColorHandler
- hasFocus
- dispose

In plugin `DOMEventPlugin` there are some code related to context menu is still using some old API that will not be ported, so split them into a new plugin `ContextMenuPlugin` and put into `roosterjs-content-model-editor` package. We will port it later.

