### PR TITLE
Fix GetFormatState not returning Font size after paste

### DIFF
--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/common/retrieveModelFormatState.ts
@@ -1,3 +1,4 @@
+import { parseValueWithUnit } from 'roosterjs-content-model-dom/lib';
 import {
     extractBorderValues,
     getClosestAncestorBlockGroupIndex,
@@ -150,7 +151,13 @@ function retrieveSegmentFormat(
     mergeValue(result, 'letterSpacing', mergedFormat.letterSpacing, isFirst);
 
     mergeValue(result, 'fontName', mergedFormat.fontFamily, isFirst);
-    mergeValue(result, 'fontSize', mergedFormat.fontSize, isFirst);
+    mergeValue(
+        result,
+        'fontSize',
+        mergedFormat.fontSize,
+        isFirst,
+        val => parseValueWithUnit(val, undefined, 'pt') + 'pt'
+    );
     mergeValue(result, 'backgroundColor', mergedFormat.backgroundColor, isFirst);
     mergeValue(result, 'textColor', mergedFormat.textColor, isFirst);
     mergeValue(result, 'fontWeight', mergedFormat.fontWeight, isFirst);
@@ -232,13 +239,14 @@ function mergeValue<K extends keyof ContentModelFormatState>(
     format: ContentModelFormatState,
     key: K,
     newValue: ContentModelFormatState[K] | undefined,
-    isFirst: boolean
+    isFirst: boolean,
+    parseFn: (val: ContentModelFormatState[K]) => ContentModelFormatState[K] = val => val
 ) {
     if (isFirst) {
         if (newValue !== undefined) {
             format[key] = newValue;
         }
-    } else if (newValue !== format[key]) {
+    } else if (parseFn(newValue) !== parseFn(format[key])) {
         delete format[key];
     }
 }

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/common/retrieveModelFormatState.ts
@@ -1,4 +1,4 @@
-import { parseValueWithUnit } from 'roosterjs-content-model-dom/lib';
+import { parseValueWithUnit } from 'roosterjs-content-model-dom';
 import {
     extractBorderValues,
     getClosestAncestorBlockGroupIndex,

--- a/packages-content-model/roosterjs-content-model-api/test/modelApi/common/retrieveModelFormatStateTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/modelApi/common/retrieveModelFormatStateTest.ts
@@ -781,4 +781,34 @@ describe('retrieveModelFormatState', () => {
             canAddImageAltText: false,
         });
     });
+
+    it('With same format but using px and pt', () => {
+        const model = createContentModelDocument({});
+        const result: ContentModelFormatState = {};
+        const para = createParagraph();
+        const text1 = createText('test1', { fontSize: '16pt' });
+        const text2 = createText('test2', { fontSize: '21.3333px' });
+        para.segments.push(text1, text2);
+
+        text1.isSelected = true;
+        text2.isSelected = true;
+
+        spyOn(iterateSelections, 'iterateSelections').and.callFake((path, callback) => {
+            callback([path], undefined, para, [text1, text2]);
+            return false;
+        });
+
+        retrieveModelFormatState(model, null, result);
+
+        expect(result).toEqual({
+            isBlockQuote: false,
+            isBold: false,
+            isSuperscript: false,
+            isSubscript: false,
+            fontSize: '16pt',
+            isCodeInline: false,
+            canUnlink: false,
+            canAddImageAltText: false,
+        });
+    });
 });


### PR DESCRIPTION
### The problem.
Right now, if we copy and paste the content from one block to another block, And then we select both blocks, The function getFormatState is not returning Font Size. But the font size of the text in the selections look to be the same.

### Fix
After debugging found out that Browser will transform Font size using `pt` to use `px` when copying something. So after paste the font size will have different units (`pt` vs `px`) but same computed style result. To fix this, update the retrieveModelFormatState, and when we are validating that the current selection have the same font size, always transform to pt so same font sized with different unit should still return the correct format state

### Before 
![FormatStateF](https://github.com/microsoft/roosterjs/assets/8291124/eea8ba61-d498-4438-9dda-07c7a7ce0120)

### After 
![FormatStateAft](https://github.com/microsoft/roosterjs/assets/8291124/d078c24f-0316-4c0f-aa73-7b78d1a7fcc9)