### PR TITLE
[Mac] Do not handle enter input on mac

### DIFF
--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -8,9 +8,8 @@ import type { DOMSelection } from 'roosterjs-content-model-types';
  */
 export function keyboardInput(editor: IContentModelEditor, rawEvent: KeyboardEvent) {
     const selection = editor.getDOMSelection();
-    const isMac = editor.getEnvironment().isMac;
 
-    if (shouldInputWithContentModel(selection, rawEvent, isMac)) {
+    if (shouldInputWithContentModel(selection, rawEvent, editor.isInIME())) {
         editor.takeSnapshot();
 
         editor.formatContentModel(
@@ -48,7 +47,7 @@ export function keyboardInput(editor: IContentModelEditor, rawEvent: KeyboardEve
 function shouldInputWithContentModel(
     selection: DOMSelection | null,
     rawEvent: KeyboardEvent,
-    isMac?: boolean
+    isInIME: boolean
 ) {
     if (!selection) {
         return false; // Nothing to delete
@@ -56,7 +55,7 @@ function shouldInputWithContentModel(
         !isModifierKey(rawEvent) &&
         (rawEvent.key == 'Enter' || rawEvent.key == 'Space' || rawEvent.key.length == 1)
     ) {
-        return selection.type != 'range' || (!selection.range.collapsed && !isMac); // TODO: Also handle Enter key even selection is collapsed
+        return selection.type != 'range' || (!selection.range.collapsed && !isInIME); // TODO: Also handle Enter key even selection is collapsed
     } else {
         return false;
     }

--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -8,8 +8,9 @@ import type { DOMSelection } from 'roosterjs-content-model-types';
  */
 export function keyboardInput(editor: IContentModelEditor, rawEvent: KeyboardEvent) {
     const selection = editor.getDOMSelection();
+    const isMac = editor.getEnvironment().isMac;
 
-    if (shouldInputWithContentModel(selection, rawEvent)) {
+    if (shouldInputWithContentModel(selection, rawEvent, isMac)) {
         editor.takeSnapshot();
 
         editor.formatContentModel(
@@ -44,14 +45,18 @@ export function keyboardInput(editor: IContentModelEditor, rawEvent: KeyboardEve
     }
 }
 
-function shouldInputWithContentModel(selection: DOMSelection | null, rawEvent: KeyboardEvent) {
+function shouldInputWithContentModel(
+    selection: DOMSelection | null,
+    rawEvent: KeyboardEvent,
+    isMac?: boolean
+) {
     if (!selection) {
         return false; // Nothing to delete
     } else if (
         !isModifierKey(rawEvent) &&
         (rawEvent.key == 'Enter' || rawEvent.key == 'Space' || rawEvent.key.length == 1)
     ) {
-        return selection.type != 'range' || !selection.range.collapsed; // TODO: Also handle Enter key even selection is collapsed
+        return selection.type != 'range' || (!selection.range.collapsed && !isMac); // TODO: Also handle Enter key even selection is collapsed
     } else {
         return false;
     }

--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -55,7 +55,10 @@ function shouldInputWithContentModel(
         !isModifierKey(rawEvent) &&
         (rawEvent.key == 'Enter' || rawEvent.key == 'Space' || rawEvent.key.length == 1)
     ) {
-        return selection.type != 'range' || (!selection.range.collapsed && !isInIME); // TODO: Also handle Enter key even selection is collapsed
+        return (
+            selection.type != 'range' ||
+            (!selection.range.collapsed && !rawEvent.isComposing && !isInIME)
+        ); // TODO: Also handle Enter key even selection is collapsed
     } else {
         return false;
     }

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
@@ -14,7 +14,7 @@ describe('keyboardInput', () => {
     let formatContentModelSpy: jasmine.Spy;
     let getDOMSelectionSpy: jasmine.Spy;
     let deleteSelectionSpy: jasmine.Spy;
-    let getEnvironmentSpy: jasmine.Spy;
+    let isInIMESpy: jasmine.Spy;
     let mockedModel: ContentModelDocument;
     let normalizeContentModelSpy: jasmine.Spy;
     let mockedContext: FormatWithContentModelContext;
@@ -38,15 +38,13 @@ describe('keyboardInput', () => {
         getDOMSelectionSpy = jasmine.createSpy('getDOMSelection');
         deleteSelectionSpy = spyOn(deleteSelection, 'deleteSelection');
         normalizeContentModelSpy = spyOn(normalizeContentModel, 'normalizeContentModel');
-        getEnvironmentSpy = jasmine.createSpy('getEnvironment').and.returnValue({
-            isMac: false,
-        });
+        isInIMESpy = jasmine.createSpy('isInIME').and.returnValue(false);
 
         editor = {
             getDOMSelection: getDOMSelectionSpy,
             takeSnapshot: takeSnapshotSpy,
             formatContentModel: formatContentModelSpy,
-            getEnvironment: getEnvironmentSpy,
+            isInIME: isInIMESpy,
         } as any;
     });
 

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
@@ -91,6 +91,7 @@ describe('keyboardInput', () => {
 
         const rawEvent = {
             key: 'A',
+            isComposing: false,
         } as any;
 
         keyboardInput(editor, rawEvent);

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
@@ -14,6 +14,7 @@ describe('keyboardInput', () => {
     let formatContentModelSpy: jasmine.Spy;
     let getDOMSelectionSpy: jasmine.Spy;
     let deleteSelectionSpy: jasmine.Spy;
+    let getEnvironmentSpy: jasmine.Spy;
     let mockedModel: ContentModelDocument;
     let normalizeContentModelSpy: jasmine.Spy;
     let mockedContext: FormatWithContentModelContext;
@@ -37,11 +38,15 @@ describe('keyboardInput', () => {
         getDOMSelectionSpy = jasmine.createSpy('getDOMSelection');
         deleteSelectionSpy = spyOn(deleteSelection, 'deleteSelection');
         normalizeContentModelSpy = spyOn(normalizeContentModel, 'normalizeContentModel');
+        getEnvironmentSpy = jasmine.createSpy('getEnvironment').and.returnValue({
+            isMac: false,
+        });
 
         editor = {
             getDOMSelection: getDOMSelectionSpy,
             takeSnapshot: takeSnapshotSpy,
             formatContentModel: formatContentModelSpy,
+            getEnvironment: getEnvironmentSpy,
         } as any;
     });
 


### PR DESCRIPTION
**Problem:** Asians characters relay on enter key to the transformation on mac, so it selects the text range before to the conversion, it will make content model handle the enter input wrongly, removing the asians character. 
![demosite-japanese-bug](https://github.com/microsoft/roosterjs/assets/87443959/d99f33a3-8df3-41c6-ba69-774459db6c57)

**Fix:** Do not handle not collapsed ranges in mac. 
![japanse-fix](https://github.com/microsoft/roosterjs/assets/87443959/3f656ed6-5fdb-4054-939c-96dc1ea954d0)

