### PR TITLE
[Hot Fix]- Bump RoosterJS Plugins 8.59.3

### DIFF
--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -9,7 +9,7 @@ import type { DOMSelection } from 'roosterjs-content-model-types';
 export function keyboardInput(editor: IContentModelEditor, rawEvent: KeyboardEvent) {
     const selection = editor.getDOMSelection();
 
-    if (shouldInputWithContentModel(selection, rawEvent)) {
+    if (shouldInputWithContentModel(selection, rawEvent, editor.isInIME())) {
         editor.takeSnapshot();
 
         editor.formatContentModel(
@@ -44,14 +44,21 @@ export function keyboardInput(editor: IContentModelEditor, rawEvent: KeyboardEve
     }
 }
 
-function shouldInputWithContentModel(selection: DOMSelection | null, rawEvent: KeyboardEvent) {
+function shouldInputWithContentModel(
+    selection: DOMSelection | null,
+    rawEvent: KeyboardEvent,
+    isInIME: boolean
+) {
     if (!selection) {
         return false; // Nothing to delete
     } else if (
         !isModifierKey(rawEvent) &&
         (rawEvent.key == 'Enter' || rawEvent.key == 'Space' || rawEvent.key.length == 1)
     ) {
-        return selection.type != 'range' || !selection.range.collapsed; // TODO: Also handle Enter key even selection is collapsed
+        return (
+            selection.type != 'range' ||
+            (!selection.range.collapsed && !rawEvent.isComposing && !isInIME)
+        ); // TODO: Also handle Enter key even selection is collapsed
     } else {
         return false;
     }

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
@@ -14,6 +14,7 @@ describe('keyboardInput', () => {
     let formatContentModelSpy: jasmine.Spy;
     let getDOMSelectionSpy: jasmine.Spy;
     let deleteSelectionSpy: jasmine.Spy;
+    let isInIMESpy: jasmine.Spy;
     let mockedModel: ContentModelDocument;
     let normalizeContentModelSpy: jasmine.Spy;
     let mockedContext: FormatWithContentModelContext;
@@ -37,11 +38,13 @@ describe('keyboardInput', () => {
         getDOMSelectionSpy = jasmine.createSpy('getDOMSelection');
         deleteSelectionSpy = spyOn(deleteSelection, 'deleteSelection');
         normalizeContentModelSpy = spyOn(normalizeContentModel, 'normalizeContentModel');
+        isInIMESpy = jasmine.createSpy('isInIME').and.returnValue(false);
 
         editor = {
             getDOMSelection: getDOMSelectionSpy,
             takeSnapshot: takeSnapshotSpy,
             formatContentModel: formatContentModelSpy,
+            isInIME: isInIMESpy,
         } as any;
     });
 
@@ -88,6 +91,7 @@ describe('keyboardInput', () => {
 
         const rawEvent = {
             key: 'A',
+            isComposing: false,
         } as any;
 
         keyboardInput(editor, rawEvent);

--- a/versions.json
+++ b/versions.json
@@ -4,6 +4,6 @@
     "packages-content-model": "0.22.0",
     "overrides": {
         "roosterjs-editor-core": "8.59.1",
-        "roosterjs-editor-plugins": "8.59.2"
+        "roosterjs-editor-plugins": "8.59.3"
     }
 }


### PR DESCRIPTION
Bump rooster-content-model plugin to 8.59.3
Release fix [PR 2301- Fix IME input sequence for mac](https://github.com/microsoft/roosterjs/pull/2301). 
