### PR TITLE
[Content Model] Add text align justify option 

### DIFF
--- a/demo/scripts/controls/ribbonButtons/contentModel/ContentModelRibbon.tsx
+++ b/demo/scripts/controls/ribbonButtons/contentModel/ContentModelRibbon.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { alignCenterButton } from './alignCenterButton';
+import { alignJustifyButton } from './alignJustifyButton';
 import { alignLeftButton } from './alignLeftButton';
 import { alignRightButton } from './alignRightButton';
 import { backgroundColorButton } from './backgroundColorButton';
@@ -83,6 +84,7 @@ const buttons = [
     alignLeftButton,
     alignCenterButton,
     alignRightButton,
+    alignJustifyButton,
     insertLinkButton,
     removeLinkButton,
     insertTableButton,

--- a/demo/scripts/controls/ribbonButtons/contentModel/alignJustifyButton.ts
+++ b/demo/scripts/controls/ribbonButtons/contentModel/alignJustifyButton.ts
@@ -1,0 +1,19 @@
+import { isContentModelEditor } from 'roosterjs-content-model-editor';
+import { RibbonButton } from 'roosterjs-react';
+import { setAlignment } from 'roosterjs-content-model-api';
+
+/**
+ * @internal
+ * "Align justify" button on the format ribbon
+ */
+export const alignJustifyButton: RibbonButton<'buttonNameAlignJustify'> = {
+    key: 'buttonNameAlignJustify',
+    unlocalizedText: 'Align justify',
+    iconName: 'AlignJustify',
+    onClick: editor => {
+        if (isContentModelEditor(editor)) {
+            setAlignment(editor, 'justify');
+        }
+        return true;
+    },
+};

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/block/setModelAlignment.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/block/setModelAlignment.ts
@@ -7,8 +7,8 @@ import type {
 } from 'roosterjs-content-model-types';
 
 const ResultMap: Record<
-    'left' | 'center' | 'right',
-    Record<'ltr' | 'rtl', 'start' | 'center' | 'end'>
+    'left' | 'center' | 'right' | 'justify',
+    Record<'ltr' | 'rtl', 'start' | 'center' | 'end' | 'justify'>
 > = {
     left: {
         ltr: 'start',
@@ -21,6 +21,10 @@ const ResultMap: Record<
     right: {
         ltr: 'end',
         rtl: 'start',
+    },
+    justify: {
+        ltr: 'justify',
+        rtl: 'justify',
     },
 };
 
@@ -56,10 +60,7 @@ export function setModelAlignment(
     );
 
     paragraphOrListItemOrTable.forEach(({ block }) => {
-        const newAlignment =
-            alignment === 'justify'
-                ? 'justify'
-                : ResultMap[alignment][block.format.direction == 'rtl' ? 'rtl' : 'ltr'];
+        const newAlignment = ResultMap[alignment][block.format.direction == 'rtl' ? 'rtl' : 'ltr'];
         if (block.blockType === 'Table' && alignment !== 'justify') {
             alignTable(
                 block,

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/block/setModelAlignment.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/block/setModelAlignment.ts
@@ -47,7 +47,7 @@ const TableAlignMap: Record<
  */
 export function setModelAlignment(
     model: ContentModelDocument,
-    alignment: 'left' | 'center' | 'right'
+    alignment: 'left' | 'center' | 'right' | 'justify'
 ) {
     const paragraphOrListItemOrTable = getOperationalBlocks<ContentModelListItem>(
         model,
@@ -56,8 +56,11 @@ export function setModelAlignment(
     );
 
     paragraphOrListItemOrTable.forEach(({ block }) => {
-        const newAligment = ResultMap[alignment][block.format.direction == 'rtl' ? 'rtl' : 'ltr'];
-        if (block.blockType === 'Table') {
+        const newAligment =
+            alignment === 'justify'
+                ? 'justify'
+                : ResultMap[alignment][block.format.direction == 'rtl' ? 'rtl' : 'ltr'];
+        if (block.blockType === 'Table' && alignment !== 'justify') {
             alignTable(
                 block,
                 TableAlignMap[alignment][block.format.direction == 'rtl' ? 'rtl' : 'ltr']

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/block/setModelAlignment.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/block/setModelAlignment.ts
@@ -56,7 +56,7 @@ export function setModelAlignment(
     );
 
     paragraphOrListItemOrTable.forEach(({ block }) => {
-        const newAligment =
+        const newAlignment =
             alignment === 'justify'
                 ? 'justify'
                 : ResultMap[alignment][block.format.direction == 'rtl' ? 'rtl' : 'ltr'];
@@ -66,8 +66,14 @@ export function setModelAlignment(
                 TableAlignMap[alignment][block.format.direction == 'rtl' ? 'rtl' : 'ltr']
             );
         } else if (block) {
+            if (block.blockType === 'BlockGroup' && block.blockGroupType === 'ListItem') {
+                block.blocks.forEach(b => {
+                    const { format } = b;
+                    format.textAlign = newAlignment;
+                });
+            }
             const { format } = block;
-            format.textAlign = newAligment;
+            format.textAlign = newAlignment;
         }
     });
 

--- a/packages-content-model/roosterjs-content-model-api/lib/publicApi/block/setAlignment.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/publicApi/block/setAlignment.ts
@@ -8,7 +8,7 @@ import type { IStandaloneEditor } from 'roosterjs-content-model-types';
  */
 export default function setAlignment(
     editor: IStandaloneEditor,
-    alignment: 'left' | 'center' | 'right'
+    alignment: 'left' | 'center' | 'right' | 'justify'
 ) {
     editor.focus();
 

--- a/packages-content-model/roosterjs-content-model-api/test/modelApi/block/setModelAlignmentTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/modelApi/block/setModelAlignmentTest.ts
@@ -904,4 +904,73 @@ describe('align left', () => {
         });
         expect(result).toBeTrue();
     });
+
+    it('align justify paragraph', () => {
+        const group = createContentModelDocument();
+        const para = createParagraph();
+        const text = createText('test');
+        text.isSelected = true;
+        para.segments.push(text);
+
+        group.blocks.push(para);
+
+        const result = setModelAlignment(group, 'justify');
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {
+                        textAlign: 'justify',
+                    },
+                    segments: [text],
+                },
+            ],
+        });
+        expect(result).toBeTruthy();
+    });
+
+    it('align justify list item', () => {
+        const group = createContentModelDocument();
+        const listLevel = createListLevel('OL');
+        const listItem = createListItem([listLevel]);
+        const para = createParagraph();
+        const para2 = createParagraph();
+        const text = createText('test');
+        const text2 = createText('test2');
+        text.isSelected = true;
+        text2.isSelected = true;
+        para.segments.push(text);
+        para2.segments.push(text2);
+
+        listItem.blocks.push(para, para2);
+
+        group.blocks.push(listItem);
+
+        const result = setModelAlignment(group, 'justify');
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockGroupType: 'ListItem',
+                    blockType: 'BlockGroup',
+                    levels: [
+                        {
+                            listType: 'OL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    blocks: [para, para2],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: { textAlign: 'justify' },
+                },
+            ],
+        });
+        expect(result).toBeTruthy();
+    });
 });

--- a/packages-content-model/roosterjs-content-model-api/test/publicApi/block/setAlignmentTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/publicApi/block/setAlignmentTest.ts
@@ -845,7 +845,7 @@ describe('setAlignment in list', () => {
 
     function runTest(
         list: ContentModelListItem,
-        alignment: 'left' | 'right' | 'center',
+        alignment: 'left' | 'right' | 'center' | 'justify',
         expectedList: ContentModelListItem | null
     ) {
         const model = createContentModelDocument();
@@ -916,7 +916,9 @@ describe('setAlignment in list', () => {
                 blocks: [
                     {
                         blockType: 'Paragraph',
-                        format: {},
+                        format: {
+                            textAlign: 'start',
+                        },
                         segments: [
                             {
                                 segmentType: 'Text',
@@ -948,7 +950,9 @@ describe('setAlignment in list', () => {
                 blocks: [
                     {
                         blockType: 'Paragraph',
-                        format: {},
+                        format: {
+                            textAlign: 'start',
+                        },
                         segments: [
                             {
                                 segmentType: 'Text',
@@ -1022,7 +1026,9 @@ describe('setAlignment in list', () => {
                 blocks: [
                     {
                         blockType: 'Paragraph',
-                        format: {},
+                        format: {
+                            textAlign: 'center',
+                        },
                         segments: [
                             {
                                 segmentType: 'Text',
@@ -1098,7 +1104,9 @@ describe('setAlignment in list', () => {
                 blocks: [
                     {
                         blockType: 'Paragraph',
-                        format: {},
+                        format: {
+                            textAlign: 'end',
+                        },
                         segments: [
                             {
                                 segmentType: 'Text',
@@ -1120,6 +1128,86 @@ describe('setAlignment in list', () => {
                 },
                 format: {
                     textAlign: 'end',
+                },
+            }
+        );
+    });
+
+    it('List - apply justify', () => {
+        runTest(
+            {
+                blockGroupType: 'ListItem',
+                blockType: 'BlockGroup',
+                levels: [
+                    {
+                        listType: 'OL',
+                        dataset: {},
+                        format: {},
+                    },
+                ],
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {
+                            textAlign: 'end',
+                        },
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: {},
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
+                                format: {},
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+                formatHolder: { segmentType: 'SelectionMarker', isSelected: true, format: {} },
+                format: {
+                    textAlign: 'end',
+                },
+            },
+            'justify',
+            {
+                blockGroupType: 'ListItem',
+                blockType: 'BlockGroup',
+                levels: [
+                    {
+                        listType: 'OL',
+                        dataset: {},
+                        format: {},
+                    },
+                ],
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        format: {
+                            textAlign: 'justify',
+                        },
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: {},
+                            },
+                            {
+                                segmentType: 'SelectionMarker',
+                                format: {},
+                                isSelected: true,
+                            },
+                        ],
+                    },
+                ],
+                formatHolder: {
+                    segmentType: 'SelectionMarker',
+                    isSelected: true,
+                    format: {},
+                },
+                format: {
+                    textAlign: 'justify',
                 },
             }
         );


### PR DESCRIPTION
Include a feature that allows users to align text as justified, as well as ensuring that when a list item is aligned, the text within the list item is also aligned.
![JustifyAlignText](https://github.com/microsoft/roosterjs/assets/87443959/85f4207d-fe39-4ec4-b101-d9c2f6a38a65)
![multipleListItemAlign](https://github.com/microsoft/roosterjs/assets/87443959/43041739-e71b-479a-a33f-7f9799944b38)

