### PR TITLE
Content Model #2305 Update format on selection marker in formatSegmentWithContentModel

### DIFF
--- a/packages-content-model/roosterjs-content-model-api/lib/publicApi/utils/formatSegmentWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/publicApi/utils/formatSegmentWithContentModel.ts
@@ -59,6 +59,15 @@ export function formatSegmentWithContentModel(
                 ? [[pendingFormat, null, null]]
                 : segmentAndParagraphs.map(item => [item[0].format, item[0], item[1]]);
 
+            //  If there is a pending format and the selection is collapsed, we need to apply the format to the selection marker either
+           if (pendingFormat && isCollapsedSelection) {
+                formatsAndSegments.push([
+                    segmentAndParagraphs[0][0].format,
+                    segmentAndParagraphs[0][0],
+                    segmentAndParagraphs[0][1],
+                ]);
+            }
+
             const isTurningOff = segmentHasStyleCallback
                 ? formatsAndSegments.every(([format, segment, paragraph]) =>
                       segmentHasStyleCallback(format, segment, paragraph)


### PR DESCRIPTION
As mentioned in #2305,If user set font size twice, the `fontSize` format on `SelectionMarker` won't be updated to the latest state. But if `applyDefaultFormat` in `ContentModelFormatPlugin` is called, it will use the style on the current selectoin marker to generate the new pending format and lose the latest font size style. 

To resolve this issue, when there is a pending format, and the selection is collapsed, we need to also update the format on selection marker.