### PR TITLE
Override TextColorParser on paste to not handle variable based styles

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/override/pasteTextColorFormatParser.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/override/pasteTextColorFormatParser.ts
@@ -28,7 +28,8 @@ function isVariableBasedStyle(color: string) {
             .split(COMMA)
             .every(
                 variable =>
-                    variable.trim().startsWith(TWO_DASHES) || variable.trim().startsWith(VAR_PREFIX)
+                    variable.trim().startsWith(TWO_DASHES) ||
+                    variable.trim().startsWith(VAR_PREFIX + TWO_DASHES)
             )
     );
 }

--- a/packages-content-model/roosterjs-content-model-core/lib/override/pasteTextColorFormatParser.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/override/pasteTextColorFormatParser.ts
@@ -1,6 +1,10 @@
 import type { ContentModelSegmentFormat, FormatParser } from 'roosterjs-content-model-types';
 
 const VAR_PREFIX = 'var(';
+const START_BRACKET = '(';
+const END_BRACKET = ')';
+const COMMA = ',';
+const TWO_DASHES = '--';
 
 /**
  * @internal
@@ -11,7 +15,18 @@ export const pasteTextColorFormatParser: FormatParser<ContentModelSegmentFormat>
     context,
     defaultStyle
 ): void => {
-    if (!element.style.color.startsWith(VAR_PREFIX)) {
+    if (!isVariableBasedStyle(element)) {
         context.defaultFormatParsers.textColor?.(format, element, context, defaultStyle);
     }
 };
+
+function isVariableBasedStyle(element: HTMLElement) {
+    const color = element.style.color;
+    return (
+        color.startsWith(VAR_PREFIX) &&
+        color
+            .substring(color.indexOf(START_BRACKET) + 1, color.lastIndexOf(END_BRACKET))
+            .split(COMMA)
+            .every(variable => variable.trim().startsWith(TWO_DASHES))
+    );
+}

--- a/packages-content-model/roosterjs-content-model-core/lib/override/pasteTextColorFormatParser.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/override/pasteTextColorFormatParser.ts
@@ -1,0 +1,17 @@
+import type { ContentModelSegmentFormat, FormatParser } from 'roosterjs-content-model-types';
+
+const VAR_PREFIX = 'var(';
+
+/**
+ * @internal
+ */
+export const pasteTextColorFormatParser: FormatParser<ContentModelSegmentFormat> = (
+    format,
+    element,
+    context,
+    defaultStyle
+): void => {
+    if (!element.style.color.startsWith(VAR_PREFIX)) {
+        context.defaultFormatParsers.textColor?.(format, element, context, defaultStyle);
+    }
+};

--- a/packages-content-model/roosterjs-content-model-core/lib/override/pasteTextColorFormatParser.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/override/pasteTextColorFormatParser.ts
@@ -15,18 +15,20 @@ export const pasteTextColorFormatParser: FormatParser<ContentModelSegmentFormat>
     context,
     defaultStyle
 ): void => {
-    if (!isVariableBasedStyle(element)) {
+    if (!isVariableBasedStyle(element.style.color)) {
         context.defaultFormatParsers.textColor?.(format, element, context, defaultStyle);
     }
 };
 
-function isVariableBasedStyle(element: HTMLElement) {
-    const color = element.style.color;
+function isVariableBasedStyle(color: string) {
     return (
         color.startsWith(VAR_PREFIX) &&
         color
             .substring(color.indexOf(START_BRACKET) + 1, color.lastIndexOf(END_BRACKET))
             .split(COMMA)
-            .every(variable => variable.trim().startsWith(TWO_DASHES))
+            .every(
+                variable =>
+                    variable.trim().startsWith(TWO_DASHES) || variable.trim().startsWith(VAR_PREFIX)
+            )
     );
 }

--- a/packages-content-model/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
@@ -6,6 +6,7 @@ import { getSegmentTextFormat } from '../../publicApi/domUtils/getSegmentTextFor
 import { getSelectedSegments } from '../../publicApi/selection/collectSelections';
 import { mergeModel } from '../../publicApi/model/mergeModel';
 import { pasteDisplayFormatParser } from '../../override/pasteDisplayFormatParser';
+import { pasteTextColorFormatParser } from '../../override/pasteTextColorFormatParser';
 import { pasteTextProcessor } from '../../override/pasteTextProcessor';
 import { PasteType } from 'roosterjs-editor-types';
 import type { MergeModelOption } from '../../publicApi/model/mergeModel';
@@ -53,6 +54,7 @@ export function mergePasteContent(
             },
             formatParserOverride: {
                 display: pasteDisplayFormatParser,
+                textColor: pasteTextColorFormatParser,
             },
             additionalFormatParsers: {
                 container: [containerWidthFormatParser],

--- a/packages-content-model/roosterjs-content-model-core/test/overrides/pasteTextColorFormatParserTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/overrides/pasteTextColorFormatParserTest.ts
@@ -1,0 +1,83 @@
+import { pasteTextColorFormatParser } from '../../lib/override/pasteTextColorFormatParser';
+
+describe('pasteTextColorFormatParser', () => {
+    it('Do not handle', () => {
+        const element = document.createElement('div');
+        element.style.color = 'var(--variable)';
+        const format = {};
+        const textColorSpy = jasmine.createSpy('defaultTextColorParser');
+
+        pasteTextColorFormatParser(
+            format,
+            element,
+            <any>{
+                defaultFormatParsers: {
+                    textColor: textColorSpy,
+                },
+            },
+            <any>{}
+        );
+
+        expect(textColorSpy).not.toHaveBeenCalled();
+    });
+
+    it('Handle, name based color', () => {
+        const element = document.createElement('div');
+        element.style.color = 'white';
+        const format = {};
+        const textColorSpy = jasmine.createSpy('defaultTextColorParser');
+
+        pasteTextColorFormatParser(
+            format,
+            element,
+            <any>{
+                defaultFormatParsers: {
+                    textColor: textColorSpy,
+                },
+            },
+            <any>{}
+        );
+
+        expect(textColorSpy).toHaveBeenCalled();
+    });
+
+    it('Handle, rgb color', () => {
+        const element = document.createElement('div');
+        element.style.color = 'rgb(77,77,77)';
+        const format = {};
+        const textColorSpy = jasmine.createSpy('defaultTextColorParser');
+
+        pasteTextColorFormatParser(
+            format,
+            element,
+            <any>{
+                defaultFormatParsers: {
+                    textColor: textColorSpy,
+                },
+            },
+            <any>{}
+        );
+
+        expect(textColorSpy).toHaveBeenCalled();
+    });
+
+    it('Handle, rgb color', () => {
+        const element = document.createElement('div');
+        element.style.color = '#FFF';
+        const format = {};
+        const textColorSpy = jasmine.createSpy('defaultTextColorParser');
+
+        pasteTextColorFormatParser(
+            format,
+            element,
+            <any>{
+                defaultFormatParsers: {
+                    textColor: textColorSpy,
+                },
+            },
+            <any>{}
+        );
+
+        expect(textColorSpy).toHaveBeenCalled();
+    });
+});

--- a/packages-content-model/roosterjs-content-model-core/test/overrides/pasteTextColorFormatParserTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/overrides/pasteTextColorFormatParserTest.ts
@@ -41,7 +41,7 @@ describe('pasteTextColorFormatParser', () => {
         expect(textColorSpy).not.toHaveBeenCalled();
     });
 
-    it('Handle, variable based with fallback not not variable', () => {
+    it('Handle, variable based with fallback that is not a variable', () => {
         const element = document.createElement('div');
         element.style.color = 'var(--variable, white)';
         const format = {};
@@ -61,9 +61,29 @@ describe('pasteTextColorFormatParser', () => {
         expect(textColorSpy).toHaveBeenCalled();
     });
 
-    it('Handle, variable based with fallback not not variable', () => {
+    it('Handle, variable based with fallback that is not a variable 2', () => {
         const element = document.createElement('div');
         element.style.color = 'var(--variable, var(--variable), white)';
+        const format = {};
+        const textColorSpy = jasmine.createSpy('defaultTextColorParser');
+
+        pasteTextColorFormatParser(
+            format,
+            element,
+            <any>{
+                defaultFormatParsers: {
+                    textColor: textColorSpy,
+                },
+            },
+            <any>{}
+        );
+
+        expect(textColorSpy).toHaveBeenCalled();
+    });
+
+    it('Handle, variable based with fallback that is not a variable 3', () => {
+        const element = document.createElement('div');
+        element.style.color = 'var(--variable, var(--variable, white))';
         const format = {};
         const textColorSpy = jasmine.createSpy('defaultTextColorParser');
 

--- a/packages-content-model/roosterjs-content-model-core/test/overrides/pasteTextColorFormatParserTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/overrides/pasteTextColorFormatParserTest.ts
@@ -21,6 +21,46 @@ describe('pasteTextColorFormatParser', () => {
         expect(textColorSpy).not.toHaveBeenCalled();
     });
 
+    it('Do not handle 2', () => {
+        const element = document.createElement('div');
+        element.style.color = 'var(--variable, --customProp2)';
+        const format = {};
+        const textColorSpy = jasmine.createSpy('defaultTextColorParser');
+
+        pasteTextColorFormatParser(
+            format,
+            element,
+            <any>{
+                defaultFormatParsers: {
+                    textColor: textColorSpy,
+                },
+            },
+            <any>{}
+        );
+
+        expect(textColorSpy).not.toHaveBeenCalled();
+    });
+
+    it('Handle, variable based with fallback not not variable', () => {
+        const element = document.createElement('div');
+        element.style.color = 'var(--variable, white)';
+        const format = {};
+        const textColorSpy = jasmine.createSpy('defaultTextColorParser');
+
+        pasteTextColorFormatParser(
+            format,
+            element,
+            <any>{
+                defaultFormatParsers: {
+                    textColor: textColorSpy,
+                },
+            },
+            <any>{}
+        );
+
+        expect(textColorSpy).toHaveBeenCalled();
+    });
+
     it('Handle, name based color', () => {
         const element = document.createElement('div');
         element.style.color = 'white';

--- a/packages-content-model/roosterjs-content-model-core/test/overrides/pasteTextColorFormatParserTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/overrides/pasteTextColorFormatParserTest.ts
@@ -23,7 +23,7 @@ describe('pasteTextColorFormatParser', () => {
 
     it('Do not handle 2', () => {
         const element = document.createElement('div');
-        element.style.color = 'var(--variable, --customProp2)';
+        element.style.color = 'var(--variable, var(--customProp2))';
         const format = {};
         const textColorSpy = jasmine.createSpy('defaultTextColorParser');
 
@@ -44,6 +44,26 @@ describe('pasteTextColorFormatParser', () => {
     it('Handle, variable based with fallback not not variable', () => {
         const element = document.createElement('div');
         element.style.color = 'var(--variable, white)';
+        const format = {};
+        const textColorSpy = jasmine.createSpy('defaultTextColorParser');
+
+        pasteTextColorFormatParser(
+            format,
+            element,
+            <any>{
+                defaultFormatParsers: {
+                    textColor: textColorSpy,
+                },
+            },
+            <any>{}
+        );
+
+        expect(textColorSpy).toHaveBeenCalled();
+    });
+
+    it('Handle, variable based with fallback not not variable', () => {
+        const element = document.createElement('div');
+        element.style.color = 'var(--variable, var(--variable), white)';
         const format = {};
         const textColorSpy = jasmine.createSpy('defaultTextColorParser');
 

--- a/packages-content-model/roosterjs-content-model-core/test/utils/paste/mergePasteContentTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/utils/paste/mergePasteContentTest.ts
@@ -7,6 +7,7 @@ import { containerWidthFormatParser } from '../../../lib/override/containerWidth
 import { createContentModelDocument } from 'roosterjs-content-model-dom';
 import { mergePasteContent } from '../../../lib/utils/paste/mergePasteContent';
 import { pasteDisplayFormatParser } from '../../../lib/override/pasteDisplayFormatParser';
+import { pasteTextColorFormatParser } from '../../../lib/override/pasteTextColorFormatParser';
 import { pasteTextProcessor } from '../../../lib/override/pasteTextProcessor';
 import { PasteType } from 'roosterjs-editor-types';
 import {
@@ -391,6 +392,7 @@ describe('mergePasteContent', () => {
                 },
                 formatParserOverride: {
                     display: pasteDisplayFormatParser,
+                    textColor: pasteTextColorFormatParser,
                 },
                 additionalFormatParsers: {
                     container: [containerWidthFormatParser],

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
@@ -166,6 +166,7 @@ export const defaultFormatKeysPerCategory: {
         'margin',
         'size',
         'tableLayout',
+        'textColor',
     ],
     tableBorder: ['borderBox', 'tableSpacing'],
     tableCellBorder: ['borderBox'],

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
@@ -166,7 +166,6 @@ export const defaultFormatKeysPerCategory: {
         'margin',
         'size',
         'tableLayout',
-        'textColor',
     ],
     tableBorder: ['borderBox', 'tableSpacing'],
     tableCellBorder: ['borderBox'],


### PR DESCRIPTION
Override TextColorParser on paste to not handle variable based styles, since these styles are usually not provided in the clipboard. And instead just use the container text color