### PR TITLE
Content Model Fidelity: Add TextColor Parser to tables

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
@@ -166,6 +166,7 @@ export const defaultFormatKeysPerCategory: {
         'margin',
         'size',
         'tableLayout',
+        'textColor',
     ],
     tableBorder: ['borderBox', 'tableSpacing'],
     tableCellBorder: ['borderBox'],

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteTest.ts
@@ -203,6 +203,7 @@ describe(ID, () => {
                         width: '170pt',
                         useBorderBox: true,
                         borderCollapse: true,
+                        textColor: 'rgb(0, 0, 0)',
                     },
                     widths: <any>jasmine.anything(),
                     dataset: {},


### PR DESCRIPTION
Add text color parser to tables. to fix some issues on paste from other HTML sources.

Source
Source link: https://learn.microsoft.com/en-us/licensing/contact-us#nca-united-states

Before
![image](https://github.com/microsoft/roosterjs/assets/8291124/d19db62f-df8a-4154-9eb1-7fd6f5be8eee)

After:
![image](https://github.com/microsoft/roosterjs/assets/8291124/8b4b77e9-7b24-4a9c-b8c5-e9fad4ee0688)
