### PR TITLE
Content Model: Add back ContentModelBeforePasteEvent

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/utils/eventConverter.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/utils/eventConverter.ts
@@ -1,5 +1,6 @@
 import { convertDomSelectionToRangeEx, convertRangeExToDomSelection } from './selectionConverter';
 import { createDefaultHtmlSanitizerOptions } from 'roosterjs-editor-dom';
+import type { ContentModelBeforePasteEvent } from '../../publicTypes/ContentModelBeforePasteEvent';
 import {
     KnownAnnounceStrings as OldKnownAnnounceStrings,
     PasteType as OldPasteType,
@@ -133,20 +134,23 @@ export function oldEventToNewEvent<TOldEvent extends OldEvent>(
 
         case PluginEventType.BeforePaste:
             const refBeforePasteEvent = refEvent?.eventType == 'beforePaste' ? refEvent : undefined;
+            const cmBeforePasteEvent = input as ContentModelBeforePasteEvent;
 
             return {
                 eventType: 'beforePaste',
                 clipboardData: input.clipboardData,
-                customizedMerge: refBeforePasteEvent?.customizedMerge,
-                domToModelOption: refBeforePasteEvent?.domToModelOption ?? {
-                    additionalAllowedTags: [],
-                    additionalDisallowedTags: [],
-                    additionalFormatParsers: {},
-                    formatParserOverride: {},
-                    processorOverride: {},
-                    styleSanitizers: {},
-                    attributeSanitizers: {},
-                },
+                customizedMerge:
+                    cmBeforePasteEvent.customizedMerge ?? refBeforePasteEvent?.customizedMerge,
+                domToModelOption: cmBeforePasteEvent.domToModelOption ??
+                    refBeforePasteEvent?.domToModelOption ?? {
+                        additionalAllowedTags: [],
+                        additionalDisallowedTags: [],
+                        additionalFormatParsers: {},
+                        formatParserOverride: {},
+                        processorOverride: {},
+                        styleSanitizers: {},
+                        attributeSanitizers: {},
+                    },
                 eventDataCache: input.eventDataCache,
                 fragment: input.fragment,
                 htmlAfter: input.htmlAfter,
@@ -349,7 +353,7 @@ export function newEventToOldEvent(input: NewEvent, refEvent?: OldEvent): OldEve
             const refBeforePasteEvent =
                 refEvent?.eventType == PluginEventType.BeforePaste ? refEvent : undefined;
 
-            return {
+            const oldBeforePasteEvent: ContentModelBeforePasteEvent = {
                 eventType: PluginEventType.BeforePaste,
                 clipboardData: input.clipboardData,
                 eventDataCache: input.eventDataCache,
@@ -360,7 +364,11 @@ export function newEventToOldEvent(input: NewEvent, refEvent?: OldEvent): OldEve
                 pasteType: PasteTypeNewToOld[input.pasteType],
                 sanitizingOption:
                     refBeforePasteEvent?.sanitizingOption ?? createDefaultHtmlSanitizerOptions(),
+                domToModelOption: input.domToModelOption,
+                customizedMerge: input.customizedMerge,
             };
+
+            return oldBeforePasteEvent;
 
         case 'beforeSetContent':
             return {

--- a/packages-content-model/roosterjs-content-model-editor/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/index.ts
@@ -10,6 +10,7 @@ export {
 export { IContentModelEditor, ContentModelEditorOptions } from './publicTypes/IContentModelEditor';
 export { ContextMenuPluginState } from './publicTypes/ContextMenuPluginState';
 export { ContentModelCorePluginState } from './publicTypes/ContentModelCorePlugins';
+export { ContentModelBeforePasteEvent } from './publicTypes/ContentModelBeforePasteEvent';
 
 export { ContentModelEditor } from './editor/ContentModelEditor';
 export { isContentModelEditor } from './editor/isContentModelEditor';

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelBeforePasteEvent.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelBeforePasteEvent.ts
@@ -1,0 +1,20 @@
+import type { BeforePasteEvent } from 'roosterjs-editor-types';
+import type {
+    DomToModelOptionForPaste,
+    MergePastedContentFunc,
+} from 'roosterjs-content-model-types';
+
+/**
+ * A temporary event type to be compatible with both legacy plugin and content model editor
+ */
+export interface ContentModelBeforePasteEvent extends BeforePasteEvent {
+    /**
+     * domToModel Options to use when creating the content model from the paste fragment
+     */
+    readonly domToModelOption: DomToModelOptionForPaste;
+
+    /**
+     * customizedMerge Customized merge function to use when merging the paste fragment into the editor
+     */
+    customizedMerge?: MergePastedContentFunc;
+}

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/utils/eventConverterTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/utils/eventConverterTest.ts
@@ -8,6 +8,7 @@ import {
 } from 'roosterjs-editor-types';
 import type { ContentChangedEvent, PluginEvent as OldEvent } from 'roosterjs-editor-types';
 import type { PluginEvent as NewEvent } from 'roosterjs-content-model-types';
+import type { ContentModelBeforePasteEvent } from '../../../lib/publicTypes/ContentModelBeforePasteEvent';
 
 describe('oldEventToNewEvent', () => {
     function runTest(
@@ -744,7 +745,9 @@ describe('newEventToOldEvent', () => {
                     preserveHtmlComments: false,
                     unknownTagReplacement: null,
                 },
-            }
+                customizedMerge: mockedCustomizedMerge,
+                domToModelOption: mockedDomToModelOption,
+            } as ContentModelBeforePasteEvent
         );
     });
 
@@ -792,7 +795,9 @@ describe('newEventToOldEvent', () => {
                 htmlAttributes: mockedHTmlAttributes,
                 pasteType: PasteType.AsImage,
                 sanitizingOption: mockedSanitizeOption,
-            }
+                customizedMerge: mockedCustomizedMerge,
+                domToModelOption: mockedDomToModelOption,
+            } as ContentModelBeforePasteEvent
         );
     });
 


### PR DESCRIPTION
Given that there are still a lot of plugins that is still using old `EditorPlugin` interface and is still handling `BeforePasteEvent` with Content Model related properties (e.g. `domToModelOption`, `customizedMerge`), we need a temporary interface that can be used by old plugin and can carry Content Model related properties. So add back `ContentModelBeforePasteEvent` interface into `roosterjs-content-model-editor` package. Later after we finish porting all those plugins we can remove this interface.