### PR TITLE
Content Model: Decouple test code from old code

### DIFF
--- a/packages-content-model/roosterjs-content-model-api/test/publicApi/segment/changeFontSizeTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/publicApi/segment/changeFontSizeTest.ts
@@ -1,6 +1,6 @@
 import changeFontSize from '../../../lib/publicApi/segment/changeFontSize';
 import { createDomToModelContext, domToContentModel } from 'roosterjs-content-model-dom';
-import { createRange } from 'roosterjs-editor-dom';
+import { createRange } from 'roosterjs-content-model-dom/test/testUtils';
 import { IStandaloneEditor } from 'roosterjs-content-model-types';
 import { segmentTestCommon } from './segmentTestCommon';
 import {

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/pasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/pasteTest.ts
@@ -9,9 +9,9 @@ import * as PPT from 'roosterjs-content-model-plugins/lib/paste/PowerPoint/proce
 import * as setProcessorF from 'roosterjs-content-model-plugins/lib/paste/utils/setProcessor';
 import * as WacComponents from 'roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents';
 import * as WordDesktopFile from 'roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop';
-import { ContentModelEditor } from 'roosterjs-content-model-editor';
 import { ContentModelPastePlugin } from 'roosterjs-content-model-plugins/lib/paste/ContentModelPastePlugin';
 import { expectEqual, initEditor } from 'roosterjs-content-model-plugins/test/paste/e2e/testUtils';
+import { StandaloneEditor } from '../../lib/editor/StandaloneEditor';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 import {
     ClipboardData,
@@ -36,7 +36,6 @@ describe('Paste ', () => {
     let mockedModel: ContentModelDocument;
     let mockedMergeModel: ContentModelDocument;
     let getFocusedPosition: jasmine.Spy;
-    let getContent: jasmine.Spy;
     let getVisibleViewport: jasmine.Spy;
     let mergeModelSpy: jasmine.Spy;
     let formatResult: boolean | undefined;
@@ -70,7 +69,6 @@ describe('Paste ', () => {
         createContentModel = jasmine.createSpy('createContentModel').and.returnValue(mockedModel);
         focus = jasmine.createSpy('focus');
         getFocusedPosition = jasmine.createSpy('getFocusedPosition').and.returnValue(mockedPos);
-        getContent = jasmine.createSpy('getContent');
         getVisibleViewport = jasmine.createSpy('getVisibleViewport');
         mergeModelSpy = spyOn(mergeModelFile, 'mergeModel').and.callFake(() => {
             mockedModel = mockedMergeModel;
@@ -104,16 +102,13 @@ describe('Paste ', () => {
         formatResult = undefined;
         context = undefined;
 
-        editor = new ContentModelEditor(div, {
+        editor = new StandaloneEditor(div, {
             plugins: [new ContentModelPastePlugin()],
             coreApiOverride: {
                 focus,
                 createContentModel,
                 getVisibleViewport,
                 formatContentModel,
-            },
-            legacyCoreApiOverride: {
-                getContent,
             },
         });
 
@@ -188,13 +183,13 @@ describe('Paste ', () => {
 });
 
 describe('paste with content model & paste plugin', () => {
-    let editor: ContentModelEditor | undefined;
+    let editor: StandaloneEditor | undefined;
     let div: HTMLDivElement | undefined;
 
     beforeEach(() => {
         div = document.createElement('div');
         document.body.appendChild(div);
-        editor = new ContentModelEditor(div, {
+        editor = new StandaloneEditor(div, {
             plugins: [new ContentModelPastePlugin()],
         });
         spyOn(addParserF, 'default').and.callThrough();
@@ -220,7 +215,7 @@ describe('paste with content model & paste plugin', () => {
         spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('wordDesktop');
         spyOn(WordDesktopFile, 'processPastedContentFromWordDesktop').and.callThrough();
 
-        editor?.paste(clipboardData);
+        editor?.pasteFromClipboard(clipboardData);
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(1);
         expect(addParserF.default).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 5);
@@ -231,7 +226,7 @@ describe('paste with content model & paste plugin', () => {
         spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('wacComponents');
         spyOn(WacComponents, 'processPastedContentWacComponents').and.callThrough();
 
-        editor?.paste(clipboardData);
+        editor?.pasteFromClipboard(clipboardData);
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(2);
         expect(addParserF.default).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 6);
@@ -242,7 +237,7 @@ describe('paste with content model & paste plugin', () => {
         spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('excelOnline');
         spyOn(ExcelF, 'processPastedContentFromExcel').and.callThrough();
 
-        editor?.paste(clipboardData);
+        editor?.pasteFromClipboard(clipboardData);
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(1);
         expect(addParserF.default).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 1);
@@ -253,7 +248,7 @@ describe('paste with content model & paste plugin', () => {
         spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('excelDesktop');
         spyOn(ExcelF, 'processPastedContentFromExcel').and.callThrough();
 
-        editor?.paste(clipboardData);
+        editor?.pasteFromClipboard(clipboardData);
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(1);
         expect(addParserF.default).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 1);
@@ -264,7 +259,7 @@ describe('paste with content model & paste plugin', () => {
         spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('powerPointDesktop');
         spyOn(PPT, 'processPastedContentFromPowerPoint').and.callThrough();
 
-        editor?.paste(clipboardData);
+        editor?.pasteFromClipboard(clipboardData);
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED);
@@ -276,7 +271,7 @@ describe('paste with content model & paste plugin', () => {
         spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('wordDesktop');
         spyOn(WordDesktopFile, 'processPastedContentFromWordDesktop').and.callThrough();
 
-        editor?.paste(clipboardData, true /* pasteAsText */);
+        editor?.pasteFromClipboard(clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(0);
@@ -287,7 +282,7 @@ describe('paste with content model & paste plugin', () => {
         spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('wacComponents');
         spyOn(WacComponents, 'processPastedContentWacComponents').and.callThrough();
 
-        editor?.paste(clipboardData, true /* pasteAsText */);
+        editor?.pasteFromClipboard(clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(0);
@@ -298,7 +293,7 @@ describe('paste with content model & paste plugin', () => {
         spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('excelOnline');
         spyOn(ExcelF, 'processPastedContentFromExcel').and.callThrough();
 
-        editor?.paste(clipboardData, true /* pasteAsText */);
+        editor?.pasteFromClipboard(clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(0);
@@ -309,7 +304,7 @@ describe('paste with content model & paste plugin', () => {
         spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('excelDesktop');
         spyOn(ExcelF, 'processPastedContentFromExcel').and.callThrough();
 
-        editor?.paste(clipboardData, true /* pasteAsText */);
+        editor?.pasteFromClipboard(clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(0);
@@ -320,7 +315,7 @@ describe('paste with content model & paste plugin', () => {
         spyOn(getPasteSourceF, 'getPasteSource').and.returnValue('powerPointDesktop');
         spyOn(PPT, 'processPastedContentFromPowerPoint').and.callThrough();
 
-        editor?.paste(clipboardData, true /* pasteAsText */);
+        editor?.pasteFromClipboard(clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
         expect(addParserF.default).toHaveBeenCalledTimes(0);
@@ -341,7 +336,7 @@ describe('paste with content model & paste plugin', () => {
         };
 
         let eventChecker: BeforePasteEvent = <any>{};
-        editor = new ContentModelEditor(div!, {
+        editor = new StandaloneEditor(div!, {
             plugins: [
                 {
                     initialize: () => {},
@@ -356,7 +351,7 @@ describe('paste with content model & paste plugin', () => {
             ],
         });
 
-        editor?.paste(clipboardData);
+        editor?.pasteFromClipboard(clipboardData);
 
         expect(eventChecker?.clipboardData).toEqual(clipboardData);
         expect(eventChecker?.htmlBefore).toBeTruthy();

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/setDOMSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/setDOMSelectionTest.ts
@@ -1,6 +1,4 @@
 import * as addRangeToSelection from '../../lib/corePlugin/utils/addRangeToSelection';
-import { createElement } from 'roosterjs-editor-dom';
-import { CreateElementData } from 'roosterjs-editor-types';
 import { DOMSelection, StandaloneEditorCore } from 'roosterjs-content-model-types';
 import { setDOMSelection } from '../../lib/coreApi/setDOMSelection';
 
@@ -666,41 +664,29 @@ describe('setDOMSelection', () => {
         });
 
         it('Select TH and TR in the same row', () => {
+            const table = document.createElement('table');
+            const tr1 = document.createElement('tr');
+            const th1 = document.createElement('th');
+            const td1 = document.createElement('td');
+            const tr2 = document.createElement('tr');
+            const th2 = document.createElement('th');
+            const td2 = document.createElement('td');
+
+            th1.appendChild(document.createTextNode('test'));
+            td1.appendChild(document.createTextNode('test'));
+            tr1.appendChild(th1);
+            tr1.appendChild(td1);
+
+            th2.appendChild(document.createTextNode('test'));
+            td2.appendChild(document.createTextNode('test'));
+            tr2.appendChild(th2);
+            tr2.appendChild(td2);
+
+            table.appendChild(tr1);
+            table.appendChild(tr2);
+
             runTest(
-                createElement(
-                    {
-                        tag: 'table',
-                        children: [
-                            {
-                                tag: 'TR',
-                                children: [
-                                    {
-                                        tag: 'TH',
-                                        children: ['test'],
-                                    },
-                                    {
-                                        tag: 'TD',
-                                        children: ['test'],
-                                    },
-                                ],
-                            },
-                            {
-                                tag: 'TR',
-                                children: [
-                                    {
-                                        tag: 'TH',
-                                        children: ['test'],
-                                    },
-                                    {
-                                        tag: 'TD',
-                                        children: ['test'],
-                                    },
-                                ],
-                            },
-                        ],
-                    },
-                    document
-                ) as HTMLTableElement,
+                table,
                 0,
                 0,
                 0,
@@ -773,41 +759,32 @@ describe('setDOMSelection', () => {
 });
 
 function buildTable(tbody: boolean, thead: boolean = false, tfoot: boolean = false) {
-    const getElement = (tag: string): CreateElementData => {
-        return {
-            tag,
-            children: [
-                {
-                    tag: 'TR',
-                    children: [
-                        {
-                            tag: 'TD',
-                            children: ['test'],
-                        },
-                        {
-                            tag: 'TD',
-                            children: ['test'],
-                        },
-                    ],
-                },
-                {
-                    tag: 'TR',
-                    children: [
-                        {
-                            tag: 'TD',
-                            children: ['test'],
-                        },
-                        {
-                            tag: 'TD',
-                            children: ['test'],
-                        },
-                    ],
-                },
-            ],
-        };
+    const getElement = (tag: string) => {
+        const container = document.createElement(tag);
+        const tr1 = document.createElement('tr');
+        const td1 = document.createElement('td');
+        const td2 = document.createElement('td');
+        const tr2 = document.createElement('tr');
+        const td3 = document.createElement('td');
+        const td4 = document.createElement('td');
+
+        td1.appendChild(document.createTextNode('test'));
+        td2.appendChild(document.createTextNode('test'));
+        tr1.appendChild(td1);
+        tr1.appendChild(td2);
+
+        td3.appendChild(document.createTextNode('test'));
+        td4.appendChild(document.createTextNode('test'));
+        tr2.appendChild(td3);
+        tr2.appendChild(td4);
+
+        container.appendChild(tr1);
+        container.appendChild(tr2);
+
+        return container;
     };
 
-    const children: (string | CreateElementData)[] = [];
+    const children: HTMLElement[] = [];
     if (thead) {
         children.push(getElement('thead'));
     }
@@ -818,41 +795,31 @@ function buildTable(tbody: boolean, thead: boolean = false, tfoot: boolean = fal
         children.push(getElement('tfoot'));
     }
     if (children.length === 0) {
-        children.push(
-            {
-                tag: 'TR',
-                children: [
-                    {
-                        tag: 'TD',
-                        children: ['test'],
-                    },
-                    {
-                        tag: 'TD',
-                        children: ['test'],
-                    },
-                ],
-            },
-            {
-                tag: 'TR',
-                children: [
-                    {
-                        tag: 'TD',
-                        children: ['test'],
-                    },
-                    {
-                        tag: 'TD',
-                        children: ['test'],
-                    },
-                ],
-            }
-        );
+        const tr1 = document.createElement('tr');
+        const td1 = document.createElement('td');
+        const td2 = document.createElement('td');
+        const tr2 = document.createElement('tr');
+        const td3 = document.createElement('td');
+        const td4 = document.createElement('td');
+
+        td1.appendChild(document.createTextNode('test'));
+        td2.appendChild(document.createTextNode('test'));
+        tr1.appendChild(td1);
+        tr1.appendChild(td2);
+
+        td3.appendChild(document.createTextNode('test'));
+        td4.appendChild(document.createTextNode('test'));
+        tr2.appendChild(td3);
+        tr2.appendChild(td4);
+
+        children.push(tr1, tr2);
     }
 
-    return createElement(
-        {
-            tag: 'table',
-            children,
-        },
-        document
-    ) as HTMLTableElement;
+    const table = document.createElement('table');
+
+    children.forEach(node => {
+        table.appendChild(node);
+    });
+
+    return table;
 }

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelCopyPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelCopyPastePluginTest.ts
@@ -7,7 +7,7 @@ import * as iterateSelectionsFile from '../../lib/publicApi/selection/iterateSel
 import * as normalizeContentModel from 'roosterjs-content-model-dom/lib/modelApi/common/normalizeContentModel';
 import * as transformColor from '../../lib/publicApi/color/transformColor';
 import { createModelToDomContext, createTable, createTableCell } from 'roosterjs-content-model-dom';
-import { createRange } from 'roosterjs-editor-dom';
+import { createRange } from 'roosterjs-content-model-dom/test/testUtils';
 import { setEntityElementClasses } from 'roosterjs-content-model-dom/test/domUtils/entityUtilTest';
 import {
     ContentModelDocument,

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/utils/contentModelDomIndexerTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/utils/contentModelDomIndexerTest.ts
@@ -1,6 +1,6 @@
 import * as setSelection from '../../../lib/publicApi/selection/setSelection';
 import { contentModelDomIndexer } from '../../../lib/corePlugin/utils/contentModelDomIndexer';
-import { createRange } from 'roosterjs-editor-dom';
+import { createRange } from 'roosterjs-content-model-dom/test/testUtils';
 import {
     ContentModelDocument,
     ContentModelSegment,

--- a/packages-content-model/roosterjs-content-model-core/test/metadata/handleListItemWithMetadataTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/metadata/handleListItemWithMetadataTest.ts
@@ -1,5 +1,5 @@
 import * as applyFormat from 'roosterjs-content-model-dom/lib/modelToDom/utils/applyFormat';
-import { expectHtml } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { expectHtml } from 'roosterjs-content-model-dom/test/testUtils';
 import { handleList as originalHandleList } from 'roosterjs-content-model-dom/lib/modelToDom/handlers/handleList';
 import { handleListItem } from 'roosterjs-content-model-dom/lib/modelToDom/handlers/handleListItem';
 import {

--- a/packages-content-model/roosterjs-content-model-core/test/metadata/handleListWithMetadataTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/metadata/handleListWithMetadataTest.ts
@@ -1,4 +1,4 @@
-import { expectHtml, itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { expectHtml } from 'roosterjs-content-model-dom/test/testUtils';
 import { handleList } from 'roosterjs-content-model-dom/lib/modelToDom/handlers/handleList';
 import { ModelToDomContext } from 'roosterjs-content-model-types';
 import {
@@ -118,7 +118,7 @@ describe('handleList with metadata', () => {
         });
     });
 
-    itChromeOnly('Context has OL, single OL list item, do not reuse existing OL element', () => {
+    it('Context has OL, single OL list item, do not reuse existing OL element', () => {
         const existingOL = document.createElement('ol');
         const listItem = createListItem([
             createListLevel('OL', {}, { editingInfo: JSON.stringify({ orderedStyleType: 2 }) }),
@@ -150,7 +150,7 @@ describe('handleList with metadata', () => {
         });
     });
 
-    itChromeOnly('Context has OL, 2 level OL list item, reuse existing OL element', () => {
+    it('Context has OL, 2 level OL list item, reuse existing OL element', () => {
         const existingOL = document.createElement('ol');
         const listItem = createListItem([
             createListLevel('OL'),
@@ -187,7 +187,7 @@ describe('handleList with metadata', () => {
         });
     });
 
-    itChromeOnly('Context has OL, 2 level OL list item, do not reuse existing OL element', () => {
+    it('Context has OL, 2 level OL list item, do not reuse existing OL element', () => {
         const existingOL = document.createElement('ol');
         const listItem = createListItem([
             createListLevel(
@@ -209,9 +209,10 @@ describe('handleList with metadata', () => {
 
         handleList(document, parent, listItem, context, null);
 
-        expect(parent.outerHTML).toBe(
-            '<div><ol></ol><ol start="2" data-editing-info="{&quot;unorderedStyleType&quot;:3}" style="list-style-type: decimal;"><ol start="1" style="list-style-type: lower-alpha;"></ol></ol></div>'
-        );
+        expectHtml(parent.outerHTML, [
+            '<div><ol></ol><ol start="2" data-editing-info="{&quot;unorderedStyleType&quot;:3}" style="list-style-type: decimal;"><ol start="1" style="list-style-type: lower-alpha;"></ol></ol></div>',
+            '<div><ol></ol><ol start="2" style="list-style-type: decimal;" data-editing-info="{&quot;unorderedStyleType&quot;:3}"><ol start="1" style="list-style-type: lower-alpha;"></ol></ol></div>',
+        ]);
         expect(context.listFormat).toEqual({
             threadItemCounts: [1, 0],
             nodeStack: [

--- a/packages-content-model/roosterjs-content-model-core/test/utils/paste/createPasteFragmentTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/utils/paste/createPasteFragmentTest.ts
@@ -1,7 +1,7 @@
 import * as moveChildNodes from 'roosterjs-content-model-dom/lib/domUtils/moveChildNodes';
 import { ClipboardData, PasteType } from 'roosterjs-content-model-types';
 import { createPasteFragment } from '../../../lib/utils/paste/createPasteFragment';
-import { expectHtml } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { expectHtml } from 'roosterjs-content-model-dom/test/testUtils';
 
 describe('createPasteFragment', () => {
     let moveChildNodesSpy: jasmine.Spy;

--- a/packages-content-model/roosterjs-content-model-core/test/utils/paste/retrieveHtmlInfoTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/utils/paste/retrieveHtmlInfoTest.ts
@@ -1,6 +1,6 @@
 import { ClipboardData } from 'roosterjs-content-model-types';
 import { HtmlFromClipboard, retrieveHtmlInfo } from '../../../lib/utils/paste/retrieveHtmlInfo';
-import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { itChromeOnly } from 'roosterjs-content-model-dom/test/testUtils';
 
 describe('retrieveHtmlInfo', () => {
     function runTest(

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/delimiterProcessorTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/delimiterProcessorTest.ts
@@ -1,7 +1,7 @@
 import * as delimiterProcessorFile from '../../../lib/domToModel/processors/childProcessor';
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
-import { createRange } from 'roosterjs-editor-dom';
+import { createRange } from '../../testUtils';
 import { delimiterProcessor } from '../../../lib/domToModel/processors/delimiterProcessor';
 import { DomToModelContext } from 'roosterjs-content-model-types';
 

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/textProcessorTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/processors/textProcessorTest.ts
@@ -4,7 +4,7 @@ import { addSegment } from '../../../lib/modelApi/common/addSegment';
 import { createContentModelDocument } from '../../../lib/modelApi/creators/createContentModelDocument';
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
 import { createParagraph } from '../../../lib/modelApi/creators/createParagraph';
-import { createRange } from 'roosterjs-editor-dom';
+import { createRange } from '../../testUtils';
 import { createSelectionMarker } from '../../../lib/modelApi/creators/createSelectionMarker';
 import { createText } from '../../../lib/modelApi/creators/createText';
 import { textProcessor } from '../../../lib/domToModel/processors/textProcessor';

--- a/packages-content-model/roosterjs-content-model-dom/test/endToEndTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/endToEndTest.ts
@@ -2,7 +2,7 @@ import * as createGeneralBlock from '../lib/modelApi/creators/createGeneralBlock
 import { contentModelToDom } from '../lib/modelToDom/contentModelToDom';
 import { createDomToModelContext, createModelToDomContext } from '../lib';
 import { domToContentModel } from '../lib/domToModel/domToContentModel';
-import { expectHtml } from 'roosterjs-editor-api/test/TestHelper';
+import { expectHtml } from './testUtils';
 import {
     ContentModelBlockFormat,
     ContentModelDocument,

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/common/backgroundColorFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/common/backgroundColorFormatHandlerTest.ts
@@ -2,7 +2,7 @@ import { backgroundColorFormatHandler } from '../../../lib/formatHandlers/common
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { DeprecatedColors } from '../../../lib/formatHandlers/utils/color';
-import { expectHtml } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { expectHtml } from '../../testUtils';
 import {
     BackgroundColorFormat,
     DomToModelContext,

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/common/borderFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/common/borderFormatHandlerTest.ts
@@ -2,7 +2,6 @@ import { BorderFormat, DomToModelContext, ModelToDomContext } from 'roosterjs-co
 import { borderFormatHandler } from '../../../lib/formatHandlers/common/borderFormatHandler';
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
-import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
 
 describe('borderFormatHandler.parse', () => {
     let div: HTMLElement;
@@ -51,7 +50,7 @@ describe('borderFormatHandler.parse', () => {
         });
     });
 
-    itChromeOnly('Has border width none value', () => {
+    it('Has border width none value', () => {
         div.style.borderWidth = '1px 2px 3px 4px';
         div.style.borderStyle = 'none';
         div.style.borderColor = 'red';
@@ -59,10 +58,10 @@ describe('borderFormatHandler.parse', () => {
         borderFormatHandler.parse(format, div, context, {});
 
         expect(format).toEqual({
-            borderTop: '1px none red',
-            borderRight: '2px none red',
-            borderBottom: '3px none red',
-            borderLeft: '4px none red',
+            borderTop: jasmine.stringMatching(/1px (none )?red/),
+            borderRight: jasmine.stringMatching(/2px (none )?red/),
+            borderBottom: jasmine.stringMatching(/3px (none )?red/),
+            borderLeft: jasmine.stringMatching(/4px (none )?red/),
         });
     });
 
@@ -171,7 +170,7 @@ describe('borderFormatHandler.apply', () => {
         expect(div.outerHTML).toEqual('<div style="border-top: 1px solid red;"></div>');
     });
 
-    itChromeOnly('Has border color - empty values', () => {
+    it('Has border color - empty values', () => {
         format.borderTop = 'red';
 
         borderFormatHandler.apply(format, div, context);
@@ -179,7 +178,7 @@ describe('borderFormatHandler.apply', () => {
         expect(div.outerHTML).toEqual('<div style="border-top: red;"></div>');
     });
 
-    itChromeOnly('Use independant border radius 1', () => {
+    it('Use independant border radius 1', () => {
         format.borderBottomLeftRadius = '2px';
         format.borderBottomRightRadius = '3px';
         format.borderTopRightRadius = '3px';

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/segment/textColorFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/segment/textColorFormatHandlerTest.ts
@@ -2,7 +2,7 @@ import { createDomToModelContext } from '../../../lib/domToModel/context/createD
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { defaultHTMLStyleMap } from '../../../lib/config/defaultHTMLStyleMap';
 import { DeprecatedColors } from '../../../lib';
-import { expectHtml } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { expectHtml } from '../../testUtils';
 import { textColorFormatHandler } from '../../../lib/formatHandlers/segment/textColorFormatHandler';
 import {
     DomToModelContext,

--- a/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleImageTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleImageTest.ts
@@ -1,7 +1,7 @@
 import * as stackFormat from '../../../lib/modelToDom/utils/stackFormat';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
+import { expectHtml } from '../../testUtils';
 import { handleImage } from '../../../lib/modelToDom/handlers/handleImage';
-import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
 import {
     ContentModelBlock,
     ContentModelBlockHandler,
@@ -25,14 +25,14 @@ describe('handleSegment', () => {
 
     function runTest(
         segment: ContentModelImage,
-        expectedInnerHTML: string,
+        expectedInnerHTML: string[],
         expectedCreateBlockFromContentModelCalledTimes: number
     ) {
         parent = document.createElement('div');
 
         handleImage(document, parent, segment, context, []);
 
-        expect(parent.innerHTML).toBe(expectedInnerHTML);
+        expectHtml(parent.innerHTML, expectedInnerHTML);
         expect(handleBlock).toHaveBeenCalledTimes(expectedCreateBlockFromContentModelCalledTimes);
     }
 
@@ -44,7 +44,7 @@ describe('handleSegment', () => {
             dataset: {},
         };
 
-        runTest(segment, '<span><img src="http://test.com/test"></span>', 0);
+        runTest(segment, ['<span><img src="http://test.com/test"></span>'], 0);
 
         expect(context.imageSelection).toBeUndefined();
     });
@@ -58,7 +58,7 @@ describe('handleSegment', () => {
             dataset: {},
         };
 
-        runTest(segment, '<span><img src="http://test.com/test"></span>', 0);
+        runTest(segment, ['<span><img src="http://test.com/test"></span>'], 0);
 
         expect(context.imageSelection!.image.src).toBe('http://test.com/test');
     });
@@ -73,7 +73,7 @@ describe('handleSegment', () => {
             dataset: {},
         };
 
-        runTest(segment, '<span><img src="http://test.com/test" alt="a" title="b"></span>', 0);
+        runTest(segment, ['<span><img src="http://test.com/test" alt="a" title="b"></span>'], 0);
     });
 
     it('image segment with link', () => {
@@ -85,10 +85,10 @@ describe('handleSegment', () => {
             dataset: {},
         };
 
-        runTest(segment, '<span><a href="/test"><img src="http://test.com/test"></a></span>', 0);
+        runTest(segment, ['<span><a href="/test"><img src="http://test.com/test"></a></span>'], 0);
     });
 
-    itChromeOnly('image segment with size', () => {
+    it('image segment with size', () => {
         const segment: ContentModelImage = {
             segmentType: 'Image',
             src: 'http://test.com/test',
@@ -99,7 +99,10 @@ describe('handleSegment', () => {
 
         runTest(
             segment,
-            '<span><a href="/test"><img src="http://test.com/test" width="100" height="200" style="width: 100px; height: 200px;"></a></span>',
+            [
+                '<span><a href="/test"><img src="http://test.com/test" width="100" height="200" style="width: 100px; height: 200px;"></a></span>',
+                '<span><a href="/test"><img src="http://test.com/test" style="width: 100px; height: 200px;" width="100" height="200"></a></span>',
+            ],
             0
         );
     });
@@ -117,7 +120,7 @@ describe('handleSegment', () => {
 
         runTest(
             segment,
-            '<span><a href="/test"><img src="http://test.com/test" data-a="b"></a></span>',
+            ['<span><a href="/test"><img src="http://test.com/test" data-a="b"></a></span>'],
             0
         );
     });
@@ -133,7 +136,7 @@ describe('handleSegment', () => {
 
         spyOn(stackFormat, 'stackFormat').and.callThrough();
 
-        runTest(segment, '<span><a href="/test"><img src="http://test.com/test"></a></span>', 0);
+        runTest(segment, ['<span><a href="/test"><img src="http://test.com/test"></a></span>'], 0);
 
         expect(stackFormat.stackFormat).toHaveBeenCalledTimes(1);
         expect((<jasmine.Spy>stackFormat.stackFormat).calls.argsFor(0)[1]).toBe('a');

--- a/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleListTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleListTest.ts
@@ -3,7 +3,7 @@ import { ContentModelListItem, ModelToDomContext } from 'roosterjs-content-model
 import { createListItem } from '../../../lib/modelApi/creators/createListItem';
 import { createListLevel } from '../../../lib/modelApi/creators/createListLevel';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
-import { expectHtml } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { expectHtml } from '../../testUtils';
 import { handleList } from '../../../lib/modelToDom/handlers/handleList';
 import { NumberingListType } from 'roosterjs-content-model-core/lib/constants/NumberingListType';
 

--- a/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleSegmentDecoratorTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelToDom/handlers/handleSegmentDecoratorTest.ts
@@ -1,5 +1,5 @@
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
-import { expectHtml } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { expectHtml } from '../../testUtils';
 import { handleSegmentDecorator } from '../../../lib/modelToDom/handlers/handleSegmentDecorator';
 import {
     ContentModelCode,

--- a/packages-content-model/roosterjs-content-model-dom/test/testUtils.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/testUtils.ts
@@ -1,0 +1,31 @@
+export function expectHtml(actualHtml: string, expectedHtml: string | string[]) {
+    expectedHtml = Array.isArray(expectedHtml) ? expectedHtml : [expectedHtml];
+    expect(expectedHtml.indexOf(actualHtml)).toBeGreaterThanOrEqual(0, actualHtml);
+}
+
+export function createRange(node1: Node, offset1?: number, node2?: Node, offset2?: number): Range {
+    const range = document.createRange();
+
+    if (typeof offset1 == 'number') {
+        range.setStart(node1, offset1);
+    } else {
+        range.selectNode(node1);
+    }
+
+    if (node2 && typeof offset2 == 'number') {
+        range.setEnd(node2, offset2);
+    }
+
+    return range;
+}
+
+declare var __karma__: any;
+
+export function itChromeOnly(
+    expectation: string,
+    assertion?: jasmine.ImplementationCallback,
+    timeout?: number
+) {
+    const func = __karma__.config.browser == 'Chrome' ? it : xit;
+    return func(expectation, assertion, timeout);
+}

--- a/packages-content-model/roosterjs-content-model-plugins/package.json
+++ b/packages-content-model/roosterjs-content-model-plugins/package.json
@@ -4,7 +4,6 @@
     "dependencies": {
         "tslib": "^2.3.1",
         "roosterjs-content-model-core": "",
-        "roosterjs-content-model-editor": "",
         "roosterjs-content-model-dom": "",
         "roosterjs-content-model-types": ""
     },

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelOnlineTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelOnlineTest.ts
@@ -1,6 +1,5 @@
 import * as processPastedContentFromExcel from '../../../lib/paste/Excel/processPastedContentFromExcel';
 import { expectEqual, initEditor } from './testUtils';
-import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 import type { ClipboardData, IStandaloneEditor } from 'roosterjs-content-model-types';
 
@@ -43,7 +42,7 @@ describe(ID, () => {
         expect(processPastedContentFromExcel.processPastedContentFromExcel).toHaveBeenCalled();
     });
 
-    itChromeOnly('E2E Table with table cells with text color', () => {
+    it('E2E Table with table cells with text color', () => {
         const CD = <ClipboardData>(<any>{
             types: ['text/plain', 'text/html'],
             text:

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelTest.ts
@@ -1,6 +1,6 @@
 import * as processPastedContentFromExcel from '../../../lib/paste/Excel/processPastedContentFromExcel';
 import { expectEqual, initEditor } from './testUtils';
-import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { itChromeOnly } from 'roosterjs-content-model-dom/test/testUtils';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 import type { ClipboardData, IStandaloneEditor } from 'roosterjs-content-model-types';
 
@@ -30,7 +30,7 @@ describe(ID, () => {
         document.getElementById(ID)?.remove();
     });
 
-    itChromeOnly('E2E', () => {
+    it('E2E', () => {
         spyOn(processPastedContentFromExcel, 'processPastedContentFromExcel').and.callThrough();
 
         editor.pasteFromClipboard(clipboardData);
@@ -39,7 +39,7 @@ describe(ID, () => {
         expect(processPastedContentFromExcel.processPastedContentFromExcel).toHaveBeenCalled();
     });
 
-    itChromeOnly('E2E paste as image', () => {
+    it('E2E paste as image', () => {
         spyOn(processPastedContentFromExcel, 'processPastedContentFromExcel').and.callThrough();
 
         editor.pasteFromClipboard(clipboardData, 'asImage');

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromWordTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromWordTest.ts
@@ -2,7 +2,7 @@ import * as wordFile from '../../../lib/paste/WordDesktop/processPastedContentFr
 import { ClipboardData, DomToModelOption, IStandaloneEditor } from 'roosterjs-content-model-types';
 import { cloneModel } from 'roosterjs-content-model-core';
 import { expectEqual, initEditor } from './testUtils';
-import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { itChromeOnly } from 'roosterjs-content-model-dom/test/testUtils';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 
 const ID = 'CM_Paste_From_WORD_E2E';

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteTest.ts
@@ -1,7 +1,7 @@
 import * as wordFile from '../../../lib/paste/WordDesktop/processPastedContentFromWordDesktop';
 import { ClipboardData, DomToModelOption, IStandaloneEditor } from 'roosterjs-content-model-types';
 import { expectEqual, initEditor } from './testUtils';
-import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { itChromeOnly } from 'roosterjs-content-model-dom/test/testUtils';
 import { tableProcessor } from 'roosterjs-content-model-dom';
 
 const ID = 'CM_Paste_E2E';

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/pasteSourceValidations/getPasteSourceTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/pasteSourceValidations/getPasteSourceTest.ts
@@ -1,12 +1,16 @@
 import { BeforePasteEvent, ClipboardData } from 'roosterjs-content-model-types';
 import { getPasteSource } from '../../../lib/paste/pasteSourceValidations/getPasteSource';
 import { PastePropertyNames } from '../../../lib/paste/pasteSourceValidations/constants';
-import {
-    EXCEL_ATTRIBUTE_VALUE,
-    getWacElement,
-    POWERPOINT_ATTRIBUTE_VALUE,
-    WORD_ATTRIBUTE_VALUE,
-} from 'roosterjs-editor-plugins/test/paste/pasteTestUtils';
+
+const EXCEL_ATTRIBUTE_VALUE = 'urn:schemas-microsoft-com:office:excel';
+const POWERPOINT_ATTRIBUTE_VALUE = 'PowerPoint.Slide';
+const WORD_ATTRIBUTE_VALUE = 'urn:schemas-microsoft-com:office:word';
+
+const getWacElement = (): HTMLElement => {
+    const element = document.createElement('span');
+    element.classList.add('WACImageContainer');
+    return element;
+};
 
 describe('getPasteSourceTest | ', () => {
     it('Is Word', () => {

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/processPastedContentFromExcelTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/processPastedContentFromExcelTest.ts
@@ -1,5 +1,4 @@
 import * as PastePluginFile from '../../lib/paste/Excel/processPastedContentFromExcel';
-import { Browser } from 'roosterjs-editor-dom';
 import { ContentModelDocument } from 'roosterjs-content-model-types';
 import { createBeforePasteEventMock } from './processPastedContentFromWordDesktopTest';
 import { processPastedContentFromExcel } from '../../lib/paste/Excel/processPastedContentFromExcel';
@@ -46,7 +45,7 @@ describe('processPastedContentFromExcelTest', () => {
         );
 
         //Assert
-        if (expected && Browser.isChrome) {
+        if (expected) {
             expect(div.innerHTML.replace(' ', '')).toBe(expected.replace(' ', ''));
         }
 
@@ -357,9 +356,7 @@ describe('Do not run scenarios', () => {
         }
         moveChildNodes(div, fragment1);
 
-        if (Browser.isChrome) {
-            expect(div.innerHTML).toEqual(result);
-        }
+        expect(div.innerHTML).toEqual(result);
     }
 
     it('excel is modified', () => {

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/processPastedContentFromWacTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/processPastedContentFromWacTest.ts
@@ -1,8 +1,7 @@
-import { Browser } from 'roosterjs-editor-dom';
 import { ContentModelDocument } from 'roosterjs-content-model-types';
 import { createBeforePasteEventMock } from './processPastedContentFromWordDesktopTest';
 import { expectEqual } from './e2e/testUtils';
-import { itChromeOnly } from 'roosterjs-editor-dom/test/DomTestHelper';
+import { itChromeOnly } from 'roosterjs-content-model-dom/test/testUtils';
 import { pasteDisplayFormatParser } from 'roosterjs-content-model-core/lib/override/pasteDisplayFormatParser';
 import { processPastedContentWacComponents } from '../../lib/paste/WacComponents/processPastedContentWacComponents';
 import {
@@ -1400,10 +1399,10 @@ describe('wordOnlineHandler', () => {
                                             marginRight: '0px',
                                             marginBottom: '0px',
                                             marginLeft: '0px',
-                                            borderTop: Browser.isFirefox ? 'medium none' : '',
-                                            borderRight: Browser.isFirefox ? 'medium none' : '',
-                                            borderBottom: Browser.isFirefox ? 'medium none' : '',
-                                            borderLeft: Browser.isFirefox ? 'medium none' : '',
+                                            borderTop: '',
+                                            borderRight: '',
+                                            borderBottom: '',
+                                            borderLeft: '',
                                             verticalAlign: 'top',
                                         },
                                         dataset: {},

--- a/packages-content-model/roosterjs-content-model/lib/createEditor.ts
+++ b/packages-content-model/roosterjs-content-model/lib/createEditor.ts
@@ -1,10 +1,11 @@
-import { ContentModelEditor } from 'roosterjs-content-model-editor';
 import { ContentModelEditPlugin, ContentModelPastePlugin } from 'roosterjs-content-model-plugins';
+import { StandaloneEditor } from 'roosterjs-content-model-core';
 import type {
-    ContentModelEditorOptions,
-    IContentModelEditor,
-} from 'roosterjs-content-model-editor';
-import type { EditorPlugin } from 'roosterjs-content-model-types';
+    ContentModelDocument,
+    EditorPlugin,
+    IStandaloneEditor,
+    StandaloneEditorOptions,
+} from 'roosterjs-content-model-types';
 
 /**
  * Create a Content Model Editor using the given options
@@ -14,25 +15,25 @@ import type { EditorPlugin } from 'roosterjs-content-model-types';
  * @param initialContent The initial content to show in editor. It can't be removed by undo, user need to manually remove it if needed.
  * @returns The ContentModelEditor instance
  */
-export function createContentModelEditor(
+export function createEditor(
     contentDiv: HTMLDivElement,
     additionalPlugins?: EditorPlugin[],
-    initialContent?: string
-): IContentModelEditor {
+    initialModel?: ContentModelDocument
+): IStandaloneEditor {
     const plugins = [
         new ContentModelPastePlugin(),
         new ContentModelEditPlugin(),
         ...(additionalPlugins ?? []),
     ];
 
-    const options: ContentModelEditorOptions = {
+    const options: StandaloneEditorOptions = {
         plugins: plugins,
-        initialContent: initialContent,
+        initialModel,
         defaultSegmentFormat: {
             fontFamily: 'Calibri,Arial,Helvetica,sans-serif',
             fontSize: '11pt',
             textColor: '#000000',
         },
     };
-    return new ContentModelEditor(contentDiv, options);
+    return new StandaloneEditor(contentDiv, options);
 }

--- a/packages-content-model/roosterjs-content-model/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model/lib/index.ts
@@ -1,7 +1,6 @@
-export { createContentModelEditor } from './createContentModelEditor';
+export { createEditor } from './createEditor';
 export * from 'roosterjs-content-model-types';
 export * from 'roosterjs-content-model-dom';
 export * from 'roosterjs-content-model-core';
 export * from 'roosterjs-content-model-api';
-export * from 'roosterjs-content-model-editor';
 export * from 'roosterjs-content-model-plugins';

--- a/packages-content-model/roosterjs-content-model/package.json
+++ b/packages-content-model/roosterjs-content-model/package.json
@@ -7,7 +7,6 @@
         "roosterjs-content-model-dom": "",
         "roosterjs-content-model-core": "",
         "roosterjs-content-model-api": "",
-        "roosterjs-content-model-editor": "",
         "roosterjs-content-model-plugins": ""
     },
     "version": "0.0.0",

--- a/tools/tsconfig.doc.json
+++ b/tools/tsconfig.doc.json
@@ -33,6 +33,9 @@
             "../packages/roosterjs/lib/index.ts",
             "../packages-content-model/roosterjs-content-model-types/lib/index.ts",
             "../packages-content-model/roosterjs-content-model-dom/lib/index.ts",
+            "../packages-content-model/roosterjs-content-model-core/lib/index.ts",
+            "../packages-content-model/roosterjs-content-model-api/lib/index.ts",
+            "../packages-content-model/roosterjs-content-model-plugins/lib/index.ts",
             "../packages-content-model/roosterjs-content-model-editor/lib/index.ts",
             "../packages-content-model/roosterjs-content-model/lib/index.ts"
         ],


### PR DESCRIPTION
After we have decoupled content model code from old code, now it is time to decouple test code.

After this change, only `roosterjs-content-model-editor` package has dependency to old code which is expected.