### PR TITLE
Correct package version of roosterjs-content-model-editor

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -5,6 +5,6 @@
     "overrides": {
         "roosterjs-editor-core": "8.59.1",
         "roosterjs-editor-plugins": "8.60.0",
-        "roosterjs-content-model-editor": "8.24.1"
+        "roosterjs-content-model-editor": "0.24.1"
     }
 }


### PR DESCRIPTION
I made a mistake when specify the version override, so correct it here:
`roosterjs-content-model-editor` 8.24.1 => 0.24.1

I have manually published this version and just make this change for tracking in github. I'll later unpublish the wrong version.