### PR TITLE
Fix pending format

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/createContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/createContentModel.ts
@@ -14,6 +14,9 @@ import type { CreateContentModel } from 'roosterjs-content-model-types';
  * @param selectionOverride When passed, use this selection range instead of current selection in editor
  */
 export const createContentModel: CreateContentModel = (core, option, selectionOverride) => {
+    // Flush all mutations if any, so that we can get an up-to-date Content Model
+    core.cache.textMutationObserver?.flushMutations();
+
     let cachedModel = selectionOverride ? null : core.cache.cachedModel;
 
     if (cachedModel && core.lifecycle.shadowEditFragment) {

--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/formatContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/formatContentModel.ts
@@ -21,9 +21,6 @@ import type {
 export const formatContentModel: FormatContentModel = (core, formatter, options) => {
     const { apiName, onNodeCreated, getChangeData, changeSource, rawEvent, selectionOverride } =
         options || {};
-
-    core.cache.textMutationObserver?.flushMutations();
-
     const model = core.api.createContentModel(core, undefined /*option*/, selectionOverride);
     const context: FormatWithContentModelContext = {
         newEntities: [],

--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/formatContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/formatContentModel.ts
@@ -22,6 +22,8 @@ export const formatContentModel: FormatContentModel = (core, formatter, options)
     const { apiName, onNodeCreated, getChangeData, changeSource, rawEvent, selectionOverride } =
         options || {};
 
+    core.cache.textMutationObserver?.flushMutations();
+
     const model = core.api.createContentModel(core, undefined /*option*/, selectionOverride);
     const context: FormatWithContentModelContext = {
         newEntities: [],

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCachePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCachePlugin.ts
@@ -85,6 +85,14 @@ class ContentModelCachePlugin implements PluginWithState<ContentModelCachePlugin
         }
 
         switch (event.eventType) {
+            case 'keyDown':
+            case 'input':
+                if (!this.state.textMutationObserver) {
+                    // When updating cache is not enabled, need to clear the cache to make sure other plugins can get an up-to-date content model
+                    this.invalidateCache();
+                }
+                break;
+
             case 'selectionChanged':
                 this.updateCachedModel(this.editor);
                 break;

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/utils/textMutationObserver.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/utils/textMutationObserver.ts
@@ -24,16 +24,21 @@ class TextMutationObserverImpl implements TextMutationObserver {
     }
 
     flushMutations() {
-        this.observer.takeRecords();
+        const mutations = this.observer.takeRecords();
+
+        this.onMutationInternal(mutations);
     }
 
     private onMutationInternal = (mutations: MutationRecord[]) => {
         const firstTarget = mutations[0]?.target;
-        const isTextChangeOnly = mutations.every(
-            mutation => mutation.type == 'characterData' && mutation.target == firstTarget
-        );
 
-        this.onMutation(isTextChangeOnly);
+        if (firstTarget) {
+            const isTextChangeOnly = mutations.every(
+                mutation => mutation.type == 'characterData' && mutation.target == firstTarget
+            );
+
+            this.onMutation(isTextChangeOnly);
+        }
     };
 }
 

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/createContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/createContentModelTest.ts
@@ -201,4 +201,24 @@ describe('createContentModel with selection', () => {
             type: 'table',
         } as any);
     });
+
+    it('Flush mutation before create model', () => {
+        const cachedModel = 'MODEL1' as any;
+        const updatedModel = 'MODEL2' as any;
+        const flushMutationsSpy = jasmine.createSpy('flushMutations').and.callFake(() => {
+            core.cache.cachedModel = updatedModel;
+        });
+
+        core.cache.cachedModel = cachedModel;
+        core.lifecycle = {};
+
+        core.cache.textMutationObserver = {
+            flushMutations: flushMutationsSpy,
+        } as any;
+
+        const model = createContentModel(core);
+
+        expect(model).toBe(updatedModel);
+        expect(flushMutationsSpy).toHaveBeenCalledTimes(1);
+    });
 });

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/formatContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/formatContentModelTest.ts
@@ -837,20 +837,4 @@ describe('formatContentModel', () => {
             } as any);
         });
     });
-
-    describe('Cache related logic', () => {
-        it('Flush mutation before create model', () => {
-            const callback = jasmine.createSpy('callback').and.returnValue(true);
-            const flushMutationsSpy = jasmine.createSpy('flushMutations');
-
-            core.cache.textMutationObserver = {
-                flushMutations: flushMutationsSpy,
-            } as any;
-
-            formatContentModel(core, callback);
-
-            expect(callback).toHaveBeenCalledTimes(1);
-            expect(flushMutationsSpy).toHaveBeenCalledBefore(createContentModel);
-        });
-    });
 });

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/formatContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/formatContentModelTest.ts
@@ -837,4 +837,20 @@ describe('formatContentModel', () => {
             } as any);
         });
     });
+
+    describe('Cache related logic', () => {
+        it('Flush mutation before create model', () => {
+            const callback = jasmine.createSpy('callback').and.returnValue(true);
+            const flushMutationsSpy = jasmine.createSpy('flushMutations');
+
+            core.cache.textMutationObserver = {
+                flushMutations: flushMutationsSpy,
+            } as any;
+
+            formatContentModel(core, callback);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(flushMutationsSpy).toHaveBeenCalledBefore(createContentModel);
+        });
+    });
 });

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelCachePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelCachePluginTest.ts
@@ -98,7 +98,10 @@ describe('ContentModelCachePlugin', () => {
                 } as any,
             });
 
-            expect(plugin.getState()).toEqual({});
+            expect(plugin.getState()).toEqual({
+                cachedModel: undefined,
+                cachedSelection: undefined,
+            });
         });
 
         it('Other key without selection', () => {
@@ -109,7 +112,10 @@ describe('ContentModelCachePlugin', () => {
                 } as any,
             });
 
-            expect(plugin.getState()).toEqual({});
+            expect(plugin.getState()).toEqual({
+                cachedModel: undefined,
+                cachedSelection: undefined,
+            });
         });
 
         it('Other key with collapsed selection', () => {
@@ -127,7 +133,8 @@ describe('ContentModelCachePlugin', () => {
             });
 
             expect(state).toEqual({
-                cachedSelection: { type: 'range', range: { collapsed: true } as any },
+                cachedModel: undefined,
+                cachedSelection: undefined,
             });
         });
 
@@ -146,10 +153,8 @@ describe('ContentModelCachePlugin', () => {
             });
 
             expect(state).toEqual({
-                cachedSelection: {
-                    type: 'range',
-                    range: { collapsed: false } as any,
-                },
+                cachedModel: undefined,
+                cachedSelection: undefined,
             });
         });
 
@@ -178,8 +183,6 @@ describe('ContentModelCachePlugin', () => {
 
         it('No cached range, no cached model', () => {
             const state = plugin.getState();
-            state.cachedModel = undefined;
-            state.cachedSelection = undefined;
 
             const selection = 'MockedRange' as any;
             getDOMSelectionSpy.and.returnValue(selection);

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/utils/textMutationObserverTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/utils/textMutationObserverTest.ts
@@ -110,6 +110,25 @@ describe('TextMutationObserverImpl', () => {
             window.setTimeout(resolve, 10);
         });
 
+        expect(onMutation).toHaveBeenCalledWith(true);
+    });
+
+    it('flush mutation without change', async () => {
+        const div = document.createElement('div');
+        const text = document.createTextNode('test');
+
+        div.appendChild(text);
+
+        const onMutation = jasmine.createSpy('onMutation');
+        const observer = TextMutationObserver.createTextMutationObserver(div, onMutation);
+
+        observer.startObserving();
+        observer.flushMutations();
+
+        await new Promise<void>(resolve => {
+            window.setTimeout(resolve, 10);
+        });
+
         expect(onMutation).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Change #2344 breaks pending format. Because:
1. When cache is not enabled, we need to clear cached element whenever user made some change via keyDown event or input event. So we need to add back the event handlers in `ContentModelCachePlugin`
2. When cache is enabled, we need to make sure cache is up-to-date before we get Content Model. So we need to call `flushMutations` from `createContentModel` API and trigger `onMutation` call back if there is reasonable mutations then `ContentModelCachePlugin` will handle them.