### PR TITLE
Fix shadow edit

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/getDOMSelection.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/getDOMSelection.ts
@@ -8,15 +8,15 @@ import type {
  * @internal
  */
 export const getDOMSelection: GetDOMSelection = core => {
-    const selection = core.selection.selection;
+    if (core.lifecycle.shadowEditFragment) {
+        return null;
+    } else {
+        const selection = core.selection.selection;
 
-    return core.lifecycle.shadowEditFragment
-        ? null // 1. In shadow editor, always return null
-        : selection && selection.type != 'range'
-        ? selection // 2. Editor has Table Selection or Image Selection, use it
-        : core.api.hasFocus(core)
-        ? getNewSelection(core) // 3. Not Table/Image selection, and editor has focus, pull a latest selection from DOM
-        : selection; // 4. Fallback to cached selection for all other cases
+        return selection && (selection.type != 'range' || !core.api.hasFocus(core))
+            ? selection
+            : getNewSelection(core);
+    }
 };
 
 function getNewSelection(core: StandaloneEditorCore): DOMSelection | null {

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/getDOMSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/getDOMSelectionTest.ts
@@ -163,4 +163,23 @@ describe('getDOMSelection', () => {
 
         expect(result).toBe(mockedSelection);
     });
+
+    it('no cached selection, editor does not have focus', () => {
+        const mockedNewSelection = 'NEWSELECTION' as any;
+
+        hasFocusSpy.and.returnValue(false);
+        containsSpy.and.returnValue(true);
+
+        getSelectionSpy.and.returnValue({
+            rangeCount: 1,
+            getRangeAt: () => mockedNewSelection,
+        });
+
+        const result = getDOMSelection(core);
+
+        expect(result).toEqual({
+            type: 'range',
+            range: mockedNewSelection,
+        });
+    });
 });


### PR DESCRIPTION
Change #2332 breaks shadow edit, because when we get selection (in `getDOMSelection.ts`), we are checking if editor has focus.

- When editor has focus, we always get selection from window.getSelection(), this is correct
- When editor does not have focus, we always get selection from the saved one -- this is the problem. When we are clicking away from editor, onBlur event will be triggered and in that case editor does not have focus but we are still able to get selection from window. So we need to first see if saved selection object is available, then fallback to window.getSelection() when editor does not have focus.