### PR TITLE
Fix 2 shadow edit issue

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/setContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/setContentModel.ts
@@ -36,7 +36,7 @@ export const setContentModel: SetContentModel = (core, model, option, onNodeCrea
 
         if (!option?.ignoreSelection && selection) {
             core.api.setDOMSelection(core, selection);
-        } else if (!selection || selection.type !== 'range') {
+        } else {
             core.selection.selection = selection;
         }
 

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/setContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/setContentModelTest.ts
@@ -3,9 +3,6 @@ import * as createModelToDomContext from 'roosterjs-content-model-dom/lib/modelT
 import { setContentModel } from '../../lib/coreApi/setContentModel';
 import { StandaloneEditorCore } from 'roosterjs-content-model-types';
 
-const mockedRange = {
-    type: 'image',
-} as any;
 const mockedDoc = 'DOCUMENT' as any;
 const mockedModel = 'MODEL' as any;
 const mockedEditorContext = 'EDITORCONTEXT' as any;
@@ -23,9 +20,7 @@ describe('setContentModel', () => {
     let getDOMSelectionSpy: jasmine.Spy;
 
     beforeEach(() => {
-        contentModelToDomSpy = spyOn(contentModelToDom, 'contentModelToDom').and.returnValue(
-            mockedRange
-        );
+        contentModelToDomSpy = spyOn(contentModelToDom, 'contentModelToDom');
         createEditorContext = jasmine
             .createSpy('createEditorContext')
             .and.returnValue(mockedEditorContext);
@@ -56,6 +51,12 @@ describe('setContentModel', () => {
     });
 
     it('no default option, no shadow edit', () => {
+        const mockedRange = {
+            type: 'image',
+        } as any;
+
+        contentModelToDomSpy.and.returnValue(mockedRange);
+
         setContentModel(core, mockedModel);
 
         expect(createModelToDomContextSpy).not.toHaveBeenCalled();
@@ -76,6 +77,12 @@ describe('setContentModel', () => {
     });
 
     it('with default option, no shadow edit', () => {
+        const mockedRange = {
+            type: 'image',
+        } as any;
+
+        contentModelToDomSpy.and.returnValue(mockedRange);
+
         setContentModel(core, mockedModel);
 
         expect(createModelToDomContextWithConfigSpy).toHaveBeenCalledWith(
@@ -95,6 +102,11 @@ describe('setContentModel', () => {
     it('with default option, no shadow edit, with additional option', () => {
         const defaultOption = { o: 'OPTION' } as any;
         const additionalOption = { o: 'OPTION1', o2: 'OPTION2' } as any;
+        const mockedRange = {
+            type: 'image',
+        } as any;
+
+        contentModelToDomSpy.and.returnValue(mockedRange);
 
         core.modelToDomSettings.builtIn = defaultOption;
         setContentModel(core, mockedModel, additionalOption);
@@ -117,6 +129,11 @@ describe('setContentModel', () => {
 
     it('no default option, with shadow edit', () => {
         core.lifecycle.shadowEditFragment = {} as any;
+        const mockedRange = {
+            type: 'image',
+        } as any;
+
+        contentModelToDomSpy.and.returnValue(mockedRange);
 
         setContentModel(core, mockedModel);
 
@@ -135,6 +152,12 @@ describe('setContentModel', () => {
     });
 
     it('restore selection ', () => {
+        const mockedRange = {
+            type: 'image',
+        } as any;
+
+        contentModelToDomSpy.and.returnValue(mockedRange);
+
         core.selection = {
             selection: null,
             selectionStyleNode: null,
@@ -160,5 +183,69 @@ describe('setContentModel', () => {
         );
         expect(setDOMSelectionSpy).not.toHaveBeenCalled();
         expect(core.selection.selection).toBe(mockedRange);
+    });
+
+    it('restore range selection ', () => {
+        const mockedRange = {
+            type: 'range',
+        } as any;
+
+        contentModelToDomSpy.and.returnValue(mockedRange);
+
+        core.selection = {
+            selection: null,
+            selectionStyleNode: null,
+        };
+        setContentModel(core, mockedModel, {
+            ignoreSelection: true,
+        });
+
+        expect(createModelToDomContextSpy).toHaveBeenCalledWith(
+            mockedEditorContext,
+            undefined,
+            undefined,
+            {
+                ignoreSelection: true,
+            }
+        );
+        expect(contentModelToDomSpy).toHaveBeenCalledWith(
+            mockedDoc,
+            mockedDiv,
+            mockedModel,
+            mockedContext,
+            undefined
+        );
+        expect(setDOMSelectionSpy).not.toHaveBeenCalled();
+        expect(core.selection.selection).toBe(mockedRange);
+    });
+
+    it('restore null selection ', () => {
+        contentModelToDomSpy.and.returnValue(null);
+
+        core.selection = {
+            selection: null,
+            selectionStyleNode: null,
+        };
+        setContentModel(core, mockedModel, {
+            ignoreSelection: true,
+        });
+
+        expect(createModelToDomContextSpy).toHaveBeenCalledWith(
+            mockedEditorContext,
+            undefined,
+            undefined,
+            {
+                ignoreSelection: true,
+            }
+        );
+        expect(contentModelToDomSpy).toHaveBeenCalledWith(
+            mockedDoc,
+            mockedDiv,
+            mockedModel,
+            mockedContext,
+            undefined
+        );
+        expect(setDOMSelectionSpy).not.toHaveBeenCalled();
+        expect(core.selection.selection).toBe(null);
     });
 });

--- a/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/TableCellSelection/TableCellSelection.ts
@@ -4,9 +4,9 @@ import { handleKeyDownEvent } from './keyUtils/handleKeyDownEvent';
 import { handleKeyUpEvent } from './keyUtils/handleKeyUpEvent';
 import { handleMouseDownEvent } from './mouseUtils/handleMouseDownEvent';
 import { handleScrollEvent } from './mouseUtils/handleScrollEvent';
-import { PluginEventType, SelectionRangeTypes } from 'roosterjs-editor-types';
+import { PluginEventType } from 'roosterjs-editor-types';
 import type { TableCellSelectionState } from './TableCellSelectionState';
-import type { EditorPlugin, IEditor, PluginEvent, TableSelection } from 'roosterjs-editor-types';
+import type { EditorPlugin, IEditor, PluginEvent } from 'roosterjs-editor-types';
 
 /**
  * TableCellSelectionPlugin help highlight table cells
@@ -14,7 +14,6 @@ import type { EditorPlugin, IEditor, PluginEvent, TableSelection } from 'rooster
 export default class TableCellSelection implements EditorPlugin {
     private editor: IEditor | null = null;
     private state: TableCellSelectionState | null;
-    private shadowEditCoordinatesBackup: TableSelection | null = null;
 
     constructor() {
         this.state = {
@@ -62,12 +61,6 @@ export default class TableCellSelection implements EditorPlugin {
     onPluginEvent(event: PluginEvent) {
         if (this.editor && this.state) {
             switch (event.eventType) {
-                case PluginEventType.EnteredShadowEdit:
-                    this.handleEnteredShadowEdit(this.state, this.editor);
-                    break;
-                case PluginEventType.LeavingShadowEdit:
-                    this.handleLeavingShadowEdit(this.state, this.editor);
-                    break;
                 case PluginEventType.MouseDown:
                     if (!this.state.startedSelection) {
                         handleMouseDownEvent(event, this.state, this.editor);
@@ -98,27 +91,6 @@ export default class TableCellSelection implements EditorPlugin {
                     this.editor.select(null);
                     break;
             }
-        }
-    }
-
-    private handleLeavingShadowEdit(state: TableCellSelectionState, editor: IEditor) {
-        if (state.firstTable && state.tableSelection && state.firstTable) {
-            const table = editor.queryElements('#' + state.firstTable.id);
-            if (table.length == 1) {
-                state.firstTable = table[0] as HTMLTableElement;
-                editor.select(state.firstTable, this.shadowEditCoordinatesBackup);
-                this.shadowEditCoordinatesBackup = null;
-            }
-        }
-    }
-
-    private handleEnteredShadowEdit(state: TableCellSelectionState, editor: IEditor) {
-        const selection = editor.getSelectionRangeEx();
-        if (selection.type == SelectionRangeTypes.TableSelection) {
-            this.shadowEditCoordinatesBackup = selection.coordinates ?? null;
-            state.firstTable = selection.table;
-            state.tableSelection = true;
-            editor.select(selection.table, null);
         }
     }
 }


### PR DESCRIPTION
1. Shadow edit with one drop down, then directly go to another drop down, shadow edit will not work: https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/247916/?triage=true
2. Shadow edit will be auto applied when editor is in table selection: https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/235389/?triage=true

Fix:
1. Always restore selection to editor core when turn off shadow edit, so when go to next shadow edit, selection can still be correctly retrieved
2. Remove the code handling table selection for shadow editor from `TableCellSelection` plugin. @BryanValverdeU please take a look here if it is ok.
