### PR TITLE
Support unit "inch" when parse value

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/parseValueWithUnit.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/parseValueWithUnit.ts
@@ -1,4 +1,6 @@
 const MarginValueRegex = /(-?\d+(\.\d+)?)([a-z]+|%)/;
+
+// According to https://developer.mozilla.org/en-US/docs/Glossary/CSS_pixel, 1in = 96px
 const PixelPerInch = 96;
 
 /**

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/parseValueWithUnit.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/parseValueWithUnit.ts
@@ -1,4 +1,5 @@
 const MarginValueRegex = /(-?\d+(\.\d+)?)([a-z]+|%)/;
+const PixelPerInch = 96;
 
 /**
  * Parse unit value with its unit
@@ -34,6 +35,9 @@ export function parseValueWithUnit(
                 break;
             case '%':
                 result = (getFontSize(currentSizePxOrElement) * num) / 100;
+                break;
+            case 'in':
+                result = num * PixelPerInch;
                 break;
             default:
                 // TODO: Support more unit if need

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/utils/parseValueWithUnitTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/utils/parseValueWithUnitTest.ts
@@ -17,7 +17,11 @@ describe('parseValueWithUnit with element', () => {
             const input = value + unit;
             const result = parseValueWithUnit(input, mockedElement);
 
-            expect(result).toBe(results[i], input);
+            if (Number.isNaN(results[i])) {
+                expect(result).toBeNaN();
+            } else {
+                expect(Math.abs(result - results[i])).toBeLessThan(1e-3, input);
+            }
         });
     }
 
@@ -70,6 +74,10 @@ describe('parseValueWithUnit with element', () => {
 
         expect(result).toBe(16);
     });
+
+    it('in to px', () => {
+        runTest('in', [0, 96, 105.6, -105.6]);
+    });
 });
 
 describe('parseValueWithUnit with number', () => {
@@ -78,7 +86,11 @@ describe('parseValueWithUnit with number', () => {
             const input = value + unit;
             const result = parseValueWithUnit(input, 20);
 
-            expect(result).toBe(results[i], input);
+            if (Number.isNaN(results[i])) {
+                expect(result).toBeNaN();
+            } else {
+                expect(Math.abs(result - results[i])).toBeLessThan(1e-3, input);
+            }
         });
     }
 
@@ -126,5 +138,9 @@ describe('parseValueWithUnit with number', () => {
         const result = parseValueWithUnit('16pt', undefined, 'pt');
 
         expect(result).toBe(16);
+    });
+
+    it('in to px', () => {
+        runTest('in', [0, 96, 105.6, -105.6]);
     });
 });


### PR DESCRIPTION
https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/239731/?triage=true

For a lot of times we got report that image send from roosterjs is not rendering well in Win32 Outlook. In most cases the image become very large.

The root cause is Win32 Outlook does not support image size specified by CSS, but it requires HTML attributes `width` and `height`. We already have code in `handleImage` to write these values, but the missing case is the original size is specified with "inch" in unit. So we need to support it in Content Model.