### PR TITLE
Content Model: Fix table text color

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/ContentModelEditor.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/ContentModelEditor.ts
@@ -955,12 +955,14 @@ export class ContentModelEditor extends StandaloneEditor implements IContentMode
     ) {
         const core = this.getCore();
 
-        transformColor(
-            node,
-            true /*includeSelf*/,
-            direction == ColorTransformDirection.DarkToLight ? 'darkToLight' : 'lightToDark',
-            core.darkColorHandler
-        );
+        if (core.lifecycle.isDarkMode) {
+            transformColor(
+                node,
+                true /*includeSelf*/,
+                direction == ColorTransformDirection.DarkToLight ? 'darkToLight' : 'lightToDark',
+                core.darkColorHandler
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
There are several places calling `transformToDarkColor` API without dark mode checking, including `editTable`.

Originally there is a check to dark mode inside this API, and do nothing if current editor is in light mode. But with recent change this check is gone.

Fix: Add a check to dark mode in `ContentModelEditor.transformToDarkColor`.