### PR TITLE
Backfix #2359, bump roosterjs-content-model-editor to 0.24.2

### DIFF
--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/ContentModelEditor.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/ContentModelEditor.ts
@@ -955,12 +955,14 @@ export class ContentModelEditor extends StandaloneEditor implements IContentMode
     ) {
         const core = this.getCore();
 
-        transformColor(
-            node,
-            true /*includeSelf*/,
-            direction == ColorTransformDirection.DarkToLight ? 'darkToLight' : 'lightToDark',
-            core.darkColorHandler
-        );
+        if (core.lifecycle.isDarkMode) {
+            transformColor(
+                node,
+                true /*includeSelf*/,
+                direction == ColorTransformDirection.DarkToLight ? 'darkToLight' : 'lightToDark',
+                core.darkColorHandler
+            );
+        }
     }
 
     /**

--- a/versions.json
+++ b/versions.json
@@ -5,6 +5,6 @@
     "overrides": {
         "roosterjs-editor-core": "8.59.1",
         "roosterjs-editor-plugins": "8.60.0",
-        "roosterjs-content-model-editor": "0.24.1"
+        "roosterjs-content-model-editor": "0.24.2"
     }
 }


### PR DESCRIPTION
Backfix #2359, bump roosterjs-content-model-editor to 0.24.2