### PR TITLE
Code clean up: Remove IStandaloneEditor.setContentModel

### DIFF
--- a/demo/scripts/controls/sidePane/contentModel/buttons/exportButton.ts
+++ b/demo/scripts/controls/sidePane/contentModel/buttons/exportButton.ts
@@ -1,4 +1,3 @@
-import { ChangeSource } from 'roosterjs-editor-types';
 import { getCurrentContentModel } from '../currentModel';
 import { isContentModelEditor } from 'roosterjs-content-model-editor';
 import { RibbonButton } from 'roosterjs-react';
@@ -11,10 +10,11 @@ export const exportButton: RibbonButton<'buttonNameExport'> = {
         const model = getCurrentContentModel(editor);
 
         if (model && isContentModelEditor(editor)) {
-            editor.addUndoSnapshot(() => {
-                editor.focus();
-                editor.setContentModel(model);
-            }, ChangeSource.SetContent);
+            editor.formatContentModel(currentModel => {
+                currentModel.blocks = model.blocks;
+
+                return true;
+            });
         }
     },
 };

--- a/packages-content-model/roosterjs-content-model-api/test/publicApi/block/setAlignmentTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/publicApi/block/setAlignmentTest.ts
@@ -821,13 +821,11 @@ describe('setAlignment in table', () => {
 
 describe('setAlignment in list', () => {
     let editor: IStandaloneEditor;
-    let setContentModel: jasmine.Spy<IStandaloneEditor['setContentModel']>;
     let createContentModel: jasmine.Spy<IStandaloneEditor['createContentModel']>;
     let triggerEvent: jasmine.Spy;
     let getVisibleViewport: jasmine.Spy;
 
     beforeEach(() => {
-        setContentModel = jasmine.createSpy('setContentModel');
         createContentModel = jasmine.createSpy('createContentModel');
         triggerEvent = jasmine.createSpy('triggerEvent');
         getVisibleViewport = jasmine.createSpy('getVisibleViewport');
@@ -835,7 +833,6 @@ describe('setAlignment in list', () => {
         editor = ({
             focus: () => {},
             addUndoSnapshot: (callback: Function) => callback(),
-            setContentModel,
             createContentModel,
             isDarkMode: () => false,
             triggerEvent,

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/LifecyclePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/LifecyclePlugin.ts
@@ -1,14 +1,6 @@
 import { ChangeSource } from '../constants/ChangeSource';
-import {
-    createBr,
-    createContentModelDocument,
-    createParagraph,
-    createSelectionMarker,
-    setColor,
-} from 'roosterjs-content-model-dom';
+import { setColor } from 'roosterjs-content-model-dom';
 import type {
-    ContentModelDocument,
-    ContentModelSegmentFormat,
     IStandaloneEditor,
     LifecyclePluginState,
     PluginEvent,
@@ -26,7 +18,6 @@ const DefaultBackColor = '#ffffff';
 class LifecyclePlugin implements PluginWithState<LifecyclePluginState> {
     private editor: IStandaloneEditor | null = null;
     private state: LifecyclePluginState;
-    private initialModel: ContentModelDocument;
     private initializer: (() => void) | null = null;
     private disposer: (() => void) | null = null;
     private adjustColor: () => void;
@@ -37,9 +28,6 @@ class LifecyclePlugin implements PluginWithState<LifecyclePluginState> {
      * @param contentDiv The editor content DIV
      */
     constructor(options: StandaloneEditorOptions, contentDiv: HTMLDivElement) {
-        this.initialModel =
-            options.initialModel ?? this.createInitModel(options.defaultSegmentFormat);
-
         // Make the container editable and set its selection styles
         if (contentDiv.getAttribute(ContentEditableAttributeName) === null) {
             this.initializer = () => {
@@ -76,12 +64,6 @@ class LifecyclePlugin implements PluginWithState<LifecyclePluginState> {
      */
     initialize(editor: IStandaloneEditor) {
         this.editor = editor;
-
-        this.editor.setContentModel(this.initialModel, { ignoreSelection: true });
-
-        // Initial model is only used once. After that we can just clean it up to make sure we don't cache anything useless
-        // including the cached DOM element inside the model.
-        this.initialModel = createContentModelDocument();
 
         // Set content DIV to be editable
         this.initializer?.();
@@ -149,16 +131,6 @@ class LifecyclePlugin implements PluginWithState<LifecyclePluginState> {
                 darkColorHandler
             );
         }
-    }
-
-    private createInitModel(format?: ContentModelSegmentFormat) {
-        const model = createContentModelDocument(format);
-        const paragraph = createParagraph(false /*isImplicit*/, undefined /*blockFormat*/, format);
-
-        paragraph.segments.push(createSelectionMarker(format), createBr(format));
-        model.blocks.push(paragraph);
-
-        return model;
     }
 }
 

--- a/packages-content-model/roosterjs-content-model-core/lib/editor/StandaloneEditor.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/editor/StandaloneEditor.ts
@@ -1,4 +1,5 @@
 import { ChangeSource } from '../constants/ChangeSource';
+import { createEmptyModel } from 'roosterjs-content-model-dom';
 import { createStandaloneEditorCore } from './createStandaloneEditorCore';
 import { transformColor } from '../publicApi/color/transformColor';
 import type {
@@ -14,8 +15,6 @@ import type {
     EditorEnvironment,
     FormatWithContentModelOptions,
     IStandaloneEditor,
-    ModelToDomOption,
-    OnNodeCreated,
     PasteType,
     PluginEventData,
     PluginEventFromType,
@@ -47,7 +46,10 @@ export class StandaloneEditor implements IStandaloneEditor {
 
         onBeforeInitializePlugins?.();
 
-        this.getCore().plugins.forEach(plugin => plugin.initialize(this));
+        const initialModel = options.initialModel ?? createEmptyModel(options.defaultSegmentFormat);
+
+        this.core.api.setContentModel(this.core, initialModel, { ignoreSelection: true });
+        this.core.plugins.forEach(plugin => plugin.initialize(this));
     }
 
     /**
@@ -91,22 +93,6 @@ export class StandaloneEditor implements IStandaloneEditor {
         const core = this.getCore();
 
         return core.api.createContentModel(core, option, selectionOverride);
-    }
-
-    /**
-     * Set content with content model
-     * @param model The content model to set
-     * @param option Additional options to customize the behavior of Content Model to DOM conversion
-     * @param onNodeCreated An optional callback that will be called when a DOM node is created
-     */
-    setContentModel(
-        model: ContentModelDocument,
-        option?: ModelToDomOption,
-        onNodeCreated?: OnNodeCreated
-    ): DOMSelection | null {
-        const core = this.getCore();
-
-        return core.api.setContentModel(core, model, option, onNodeCreated);
     }
 
     /**

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/LifecyclePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/LifecyclePluginTest.ts
@@ -9,14 +9,12 @@ describe('LifecyclePlugin', () => {
         const plugin = createLifecyclePlugin({}, div);
         const triggerEvent = jasmine.createSpy('triggerEvent');
         const state = plugin.getState();
-        const setContentModelSpy = jasmine.createSpy('setContentModel');
 
         plugin.initialize(<IStandaloneEditor>(<any>{
             triggerEvent,
             getFocusedPosition: () => <any>null,
             getColorManager: () => <DarkColorHandler | null>null,
             isDarkMode: () => false,
-            setContentModel: setContentModelSpy,
         }));
 
         expect(state).toEqual({
@@ -29,23 +27,6 @@ describe('LifecyclePlugin', () => {
         expect(div.innerHTML).toBe('');
         expect(triggerEvent).toHaveBeenCalledTimes(1);
         expect(triggerEvent.calls.argsFor(0)[0]).toBe('editorReady');
-        expect(setContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(setContentModelSpy).toHaveBeenCalledWith(
-            {
-                blockGroupType: 'Document',
-                blocks: [
-                    {
-                        blockType: 'Paragraph',
-                        segments: [
-                            { segmentType: 'SelectionMarker', isSelected: true, format: {} },
-                            { segmentType: 'Br', format: {} },
-                        ],
-                        format: {},
-                    },
-                ],
-            },
-            { ignoreSelection: true }
-        );
 
         plugin.dispose();
         expect(div.isContentEditable).toBeFalse();
@@ -65,23 +46,18 @@ describe('LifecyclePlugin', () => {
         );
         const triggerEvent = jasmine.createSpy('triggerEvent');
         const state = plugin.getState();
-        const setContentModelSpy = jasmine.createSpy('setContentModel');
 
         plugin.initialize(<IStandaloneEditor>(<any>{
             triggerEvent,
             getFocusedPosition: () => <any>null,
             getColorManager: () => <DarkColorHandler | null>null,
             isDarkMode: () => false,
-            setContentModel: setContentModelSpy,
         }));
 
         expect(state).toEqual({
             isDarkMode: false,
             shadowEditFragment: null,
         });
-
-        expect(setContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(setContentModelSpy).toHaveBeenCalledWith(mockedModel, { ignoreSelection: true });
 
         expect(div.isContentEditable).toBeTrue();
         expect(div.style.userSelect).toBe('text');
@@ -97,38 +73,18 @@ describe('LifecyclePlugin', () => {
         div.contentEditable = 'true';
         const plugin = createLifecyclePlugin({}, div);
         const triggerEvent = jasmine.createSpy('triggerEvent');
-        const setContentModelSpy = jasmine.createSpy('setContentModel');
 
         plugin.initialize(<IStandaloneEditor>(<any>{
             triggerEvent,
             getFocusedPosition: () => <any>null,
             getColorManager: () => <DarkColorHandler | null>null,
             isDarkMode: () => false,
-            setContentModel: setContentModelSpy,
         }));
 
         expect(div.isContentEditable).toBeTrue();
         expect(div.style.userSelect).toBe('');
         expect(triggerEvent).toHaveBeenCalledTimes(1);
         expect(triggerEvent.calls.argsFor(0)[0]).toBe('editorReady');
-
-        expect(setContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(setContentModelSpy).toHaveBeenCalledWith(
-            {
-                blockGroupType: 'Document',
-                blocks: [
-                    {
-                        blockType: 'Paragraph',
-                        segments: [
-                            { segmentType: 'SelectionMarker', isSelected: true, format: {} },
-                            { segmentType: 'Br', format: {} },
-                        ],
-                        format: {},
-                    },
-                ],
-            },
-            { ignoreSelection: true }
-        );
 
         plugin.dispose();
         expect(div.isContentEditable).toBeTrue();
@@ -139,33 +95,14 @@ describe('LifecyclePlugin', () => {
         div.contentEditable = 'false';
         const plugin = createLifecyclePlugin({}, div);
         const triggerEvent = jasmine.createSpy('triggerEvent');
-        const setContentModelSpy = jasmine.createSpy('setContentModel');
 
         plugin.initialize(<IStandaloneEditor>(<any>{
             triggerEvent,
             getFocusedPosition: () => <any>null,
             getColorManager: () => <DarkColorHandler | null>null,
             isDarkMode: () => false,
-            setContentModel: setContentModelSpy,
         }));
 
-        expect(setContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(setContentModelSpy).toHaveBeenCalledWith(
-            {
-                blockGroupType: 'Document',
-                blocks: [
-                    {
-                        blockType: 'Paragraph',
-                        segments: [
-                            { segmentType: 'SelectionMarker', isSelected: true, format: {} },
-                            { segmentType: 'Br', format: {} },
-                        ],
-                        format: {},
-                    },
-                ],
-            },
-            { ignoreSelection: true }
-        );
         expect(div.isContentEditable).toBeFalse();
         expect(div.style.userSelect).toBe('');
         expect(triggerEvent).toHaveBeenCalledTimes(1);
@@ -180,7 +117,6 @@ describe('LifecyclePlugin', () => {
         const plugin = createLifecyclePlugin({}, div);
         const triggerEvent = jasmine.createSpy('triggerEvent');
         const state = plugin.getState();
-        const setContentModelSpy = jasmine.createSpy('setContentModel');
         const mockedDarkColorHandler = 'HANDLER' as any;
 
         const setColorSpy = spyOn(color, 'setColor');
@@ -188,7 +124,6 @@ describe('LifecyclePlugin', () => {
         plugin.initialize(<IStandaloneEditor>(<any>{
             triggerEvent,
             getColorManager: () => mockedDarkColorHandler,
-            setContentModel: setContentModelSpy,
         }));
 
         expect(setColorSpy).toHaveBeenCalledTimes(2);
@@ -212,7 +147,6 @@ describe('LifecyclePlugin', () => {
         const plugin = createLifecyclePlugin({}, div);
         const triggerEvent = jasmine.createSpy('triggerEvent');
         const state = plugin.getState();
-        const setContentModelSpy = jasmine.createSpy('setContentModel');
         const mockedDarkColorHandler = 'HANDLER' as any;
 
         const setColorSpy = spyOn(color, 'setColor');
@@ -220,7 +154,6 @@ describe('LifecyclePlugin', () => {
         plugin.initialize(<IStandaloneEditor>(<any>{
             triggerEvent,
             getColorManager: () => mockedDarkColorHandler,
-            setContentModel: setContentModelSpy,
         }));
 
         expect(setColorSpy).toHaveBeenCalledTimes(2);
@@ -266,7 +199,6 @@ describe('LifecyclePlugin', () => {
         );
         const triggerEvent = jasmine.createSpy('triggerEvent');
         const state = plugin.getState();
-        const setContentModelSpy = jasmine.createSpy('setContentModel');
         const mockedDarkColorHandler = 'HANDLER' as any;
 
         const setColorSpy = spyOn(color, 'setColor');
@@ -274,7 +206,6 @@ describe('LifecyclePlugin', () => {
         plugin.initialize(<IStandaloneEditor>(<any>{
             triggerEvent,
             getDarkColorHandler: () => mockedDarkColorHandler,
-            setContentModel: setContentModelSpy,
         }));
 
         expect(setColorSpy).toHaveBeenCalledTimes(0);

--- a/packages-content-model/roosterjs-content-model-dom/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/index.ts
@@ -46,6 +46,7 @@ export { createGeneralBlock } from './modelApi/creators/createGeneralBlock';
 export { createEntity } from './modelApi/creators/createEntity';
 export { createDivider } from './modelApi/creators/createDivider';
 export { createListLevel } from './modelApi/creators/createListLevel';
+export { createEmptyModel } from './modelApi/creators/createEmptyModel';
 
 export { addBlock } from './modelApi/common/addBlock';
 export { addCode } from './modelApi/common/addDecorators';

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelApi/creators/createEmptyModel.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelApi/creators/createEmptyModel.ts
@@ -1,0 +1,22 @@
+import { createBr } from './createBr';
+import { createContentModelDocument } from './createContentModelDocument';
+import { createParagraph } from './createParagraph';
+import { createSelectionMarker } from './createSelectionMarker';
+import type {
+    ContentModelDocument,
+    ContentModelSegmentFormat,
+} from 'roosterjs-content-model-types';
+
+/**
+ * Create an empty Content Model Document with initial empty line and insert point with default format
+ * @param format @optional The default format to be applied to this Content Model
+ */
+export function createEmptyModel(format?: ContentModelSegmentFormat): ContentModelDocument {
+    const model = createContentModelDocument(format);
+    const paragraph = createParagraph(false /*isImplicit*/, undefined /*blockFormat*/, format);
+
+    paragraph.segments.push(createSelectionMarker(format), createBr(format));
+    model.blocks.push(paragraph);
+
+    return model;
+}

--- a/packages-content-model/roosterjs-content-model-dom/test/modelApi/creators/createEmptyModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelApi/creators/createEmptyModelTest.ts
@@ -1,0 +1,59 @@
+import { ContentModelSegmentFormat } from 'roosterjs-content-model-types';
+import { createEmptyModel } from '../../../lib/modelApi/creators/createEmptyModel';
+
+describe('createEmptyModel', () => {
+    it('no param', () => {
+        const result = createEmptyModel();
+
+        expect(result).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('with param', () => {
+        const mockedFormat: ContentModelSegmentFormat = {
+            fontFamily: 'Arial',
+        };
+        const result = createEmptyModel(mockedFormat);
+
+        expect(result).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: mockedFormat,
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: mockedFormat,
+                        },
+                    ],
+                    segmentFormat: mockedFormat,
+                },
+            ],
+            format: mockedFormat,
+        });
+    });
+});

--- a/packages-content-model/roosterjs-content-model-editor/test/editor/ContentModelEditorTest.ts
+++ b/packages-content-model/roosterjs-content-model-editor/test/editor/ContentModelEditorTest.ts
@@ -1,6 +1,4 @@
-import * as contentModelToDom from 'roosterjs-content-model-dom/lib/modelToDom/contentModelToDom';
 import * as createDomToModelContext from 'roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext';
-import * as createModelToDomContext from 'roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext';
 import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
 import * as findAllEntities from 'roosterjs-content-model-core/lib/corePlugin/utils/findAllEntities';
 import { ContentModelEditor } from '../../lib/editor/ContentModelEditor';
@@ -88,80 +86,6 @@ describe('ContentModelEditor', () => {
             mockedConfig,
             editorContext
         );
-    });
-
-    it('setContentModel with normal selection', () => {
-        const mockedRange = {
-            type: 'range',
-            range: document.createRange(),
-        } as any;
-        const mockedModel = 'MockedModel' as any;
-        const mockedContext = 'MockedContext' as any;
-        const mockedConfig = 'MockedConfig' as any;
-
-        spyOn(contentModelToDom, 'contentModelToDom').and.returnValue(mockedRange);
-        spyOn(createModelToDomContext, 'createModelToDomContextWithConfig').and.returnValue(
-            mockedContext
-        );
-        spyOn(createModelToDomContext, 'createModelToDomConfig').and.returnValue(mockedConfig);
-
-        const div = document.createElement('div');
-        const editor = new ContentModelEditor(div);
-
-        spyOn((editor as any).core.api, 'createEditorContext').and.returnValue(editorContext);
-
-        const selection = editor.setContentModel(mockedModel);
-
-        expect(contentModelToDom.contentModelToDom).toHaveBeenCalledTimes(2);
-        expect(contentModelToDom.contentModelToDom).toHaveBeenCalledWith(
-            document,
-            div,
-            mockedModel,
-            mockedContext,
-            undefined
-        );
-        expect(createModelToDomContext.createModelToDomContextWithConfig).toHaveBeenCalledWith(
-            mockedConfig,
-            editorContext
-        );
-        expect(selection).toBe(mockedRange);
-    });
-
-    it('setContentModel', () => {
-        const mockedRange = {
-            type: 'range',
-            range: document.createRange(),
-        } as any;
-        const mockedModel = 'MockedModel' as any;
-        const mockedContext = 'MockedContext' as any;
-        const mockedConfig = 'MockedConfig' as any;
-
-        spyOn(contentModelToDom, 'contentModelToDom').and.returnValue(mockedRange);
-        spyOn(createModelToDomContext, 'createModelToDomContextWithConfig').and.returnValue(
-            mockedContext
-        );
-        spyOn(createModelToDomContext, 'createModelToDomConfig').and.returnValue(mockedConfig);
-
-        const div = document.createElement('div');
-        const editor = new ContentModelEditor(div);
-
-        spyOn((editor as any).core.api, 'createEditorContext').and.returnValue(editorContext);
-
-        const selection = editor.setContentModel(mockedModel);
-
-        expect(contentModelToDom.contentModelToDom).toHaveBeenCalledTimes(2);
-        expect(contentModelToDom.contentModelToDom).toHaveBeenCalledWith(
-            document,
-            div,
-            mockedModel,
-            mockedContext,
-            undefined
-        );
-        expect(createModelToDomContext.createModelToDomContextWithConfig).toHaveBeenCalledWith(
-            mockedConfig,
-            editorContext
-        );
-        expect(selection).toBe(mockedRange);
     });
 
     it('createContentModel in EditorReady event', () => {

--- a/packages-content-model/roosterjs-content-model-types/lib/editor/IStandaloneEditor.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/editor/IStandaloneEditor.ts
@@ -11,8 +11,6 @@ import type { ContentModelSegmentFormat } from '../format/ContentModelSegmentFor
 import type { DOMSelection } from '../selection/DOMSelection';
 import type { DomToModelOption } from '../context/DomToModelOption';
 import type { EditorEnvironment } from '../parameter/EditorEnvironment';
-import type { ModelToDomOption } from '../context/ModelToDomOption';
-import type { OnNodeCreated } from '../context/ModelToDomSettings';
 import type {
     ContentModelFormatter,
     FormatWithContentModelOptions,
@@ -36,18 +34,6 @@ export interface IStandaloneEditor {
         option?: DomToModelOption,
         selectionOverride?: DOMSelection
     ): ContentModelDocument;
-
-    /**
-     * Set content with content model
-     * @param model The content model to set
-     * @param option Additional options to customize the behavior of Content Model to DOM conversion
-     * @param onNodeCreated An optional callback that will be called when a DOM node is created
-     */
-    setContentModel(
-        model: ContentModelDocument,
-        option?: ModelToDomOption,
-        onNodeCreated?: OnNodeCreated
-    ): DOMSelection | null;
 
     /**
      * Get current running environment, such as if editor is running on Mac


### PR DESCRIPTION
I'm cleaning up the Content Model code by removing some public methods that is not widely used.

- IStandaloneEditor.setContentModel: This function is used for flushing existing content using a given Content Model. We don't need it since this functionality should be replaced by `IStandaloneEditor.formatContentModel`.