### PR TITLE
Code clean up: small refactor to paste code

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/paste.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/paste.ts
@@ -1,4 +1,3 @@
-import { ChangeSource } from '../constants/ChangeSource';
 import { cloneModel } from '../publicApi/model/cloneModel';
 import { convertInlineCss } from '../utils/paste/convertInlineCss';
 import { createPasteFragment } from '../utils/paste/createPasteFragment';
@@ -38,49 +37,37 @@ export const paste: Paste = (
         clipboardData.modelBeforePaste = cloneModel(core.api.createContentModel(core), CloneOption);
     }
 
-    core.api.formatContentModel(
-        core,
-        (model, context) => {
-            // 1. Prepare variables
-            const doc = createDOMFromHtml(clipboardData.rawHtml, core.trustedHTMLHandler);
+    // 1. Prepare variables
+    const doc = createDOMFromHtml(clipboardData.rawHtml, core.trustedHTMLHandler);
 
-            // 2. Handle HTML from clipboard
-            const htmlFromClipboard = retrieveHtmlInfo(doc, clipboardData);
+    // 2. Handle HTML from clipboard
+    const htmlFromClipboard = retrieveHtmlInfo(doc, clipboardData);
 
-            // 3. Create target fragment
-            const sourceFragment = createPasteFragment(
-                core.contentDiv.ownerDocument,
-                clipboardData,
-                pasteType,
-                (clipboardData.rawHtml == clipboardData.html
-                    ? doc
-                    : createDOMFromHtml(clipboardData.html, core.trustedHTMLHandler)
-                )?.body
-            );
-
-            // 4. Trigger BeforePaste event to allow plugins modify the fragment
-            const eventResult = generatePasteOptionFromPlugins(
-                core,
-                clipboardData,
-                sourceFragment,
-                htmlFromClipboard,
-                pasteType
-            );
-
-            // 5. Convert global CSS to inline CSS
-            convertInlineCss(eventResult.fragment, htmlFromClipboard.globalCssRules);
-
-            // 6. Merge pasted content into main Content Model
-            mergePasteContent(model, context, eventResult, core.domToModelSettings.customized);
-
-            return true;
-        },
-        {
-            changeSource: ChangeSource.Paste,
-            getChangeData: () => clipboardData,
-            apiName: 'paste',
-        }
+    // 3. Create target fragment
+    const sourceFragment = createPasteFragment(
+        core.contentDiv.ownerDocument,
+        clipboardData,
+        pasteType,
+        (clipboardData.rawHtml == clipboardData.html
+            ? doc
+            : createDOMFromHtml(clipboardData.html, core.trustedHTMLHandler)
+        )?.body
     );
+
+    // 4. Trigger BeforePaste event to allow plugins modify the fragment
+    const eventResult = generatePasteOptionFromPlugins(
+        core,
+        clipboardData,
+        sourceFragment,
+        htmlFromClipboard,
+        pasteType
+    );
+
+    // 5. Convert global CSS to inline CSS
+    convertInlineCss(eventResult.fragment, htmlFromClipboard.globalCssRules);
+
+    // 6. Merge pasted content into main Content Model
+    mergePasteContent(core, eventResult, clipboardData);
 };
 
 function createDOMFromHtml(

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCopyPastePlugin.ts
@@ -109,7 +109,7 @@ class ContentModelCopyPastePlugin implements PluginWithState<CopyPastePluginStat
         const selection = this.editor.getDOMSelection();
 
         if (selection && (selection.type != 'range' || !selection.range.collapsed)) {
-            const model = this.editor.createContentModel(undefined /* option */, selection);
+            const model = this.editor.createContentModel();
             const cacheProcessor = this.editor.isDarkMode() ? this.processEntityColor : false;
 
             const pasteModel = cloneModel(model, {

--- a/packages-content-model/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
@@ -1,3 +1,4 @@
+import { ChangeSource } from '../../constants/ChangeSource';
 import { containerSizeFormatParser } from '../../override/containerSizeFormatParser';
 import { createDomToModelContext, domToContentModel } from 'roosterjs-content-model-dom';
 import { createPasteEntityProcessor } from '../../override/pasteEntityProcessor';
@@ -10,10 +11,10 @@ import { pasteTextProcessor } from '../../override/pasteTextProcessor';
 import type { MergeModelOption } from '../../publicApi/model/mergeModel';
 import type {
     BeforePasteEvent,
+    ClipboardData,
     ContentModelDocument,
     ContentModelSegmentFormat,
-    DomToModelOption,
-    FormatWithContentModelContext,
+    StandaloneEditorCore,
 } from 'roosterjs-content-model-types';
 
 const EmptySegmentFormat: Required<ContentModelSegmentFormat> = {
@@ -34,51 +35,65 @@ const EmptySegmentFormat: Required<ContentModelSegmentFormat> = {
  * @internal
  */
 export function mergePasteContent(
-    model: ContentModelDocument,
-    context: FormatWithContentModelContext,
+    core: StandaloneEditorCore,
     eventResult: BeforePasteEvent,
-    defaultDomToModelOptions: DomToModelOption
+    clipboardData: ClipboardData
 ) {
     const { fragment, domToModelOption, customizedMerge, pasteType } = eventResult;
-    const selectedSegment = getSelectedSegments(model, true /*includeFormatHolder*/)[0];
-    const domToModelContext = createDomToModelContext(
-        undefined /*editorContext*/,
-        defaultDomToModelOptions,
-        {
-            processorOverride: {
-                '#text': pasteTextProcessor,
-                entity: createPasteEntityProcessor(domToModelOption),
-                '*': createPasteGeneralProcessor(domToModelOption),
-            },
-            formatParserOverride: {
-                display: pasteDisplayFormatParser,
-            },
-            additionalFormatParsers: {
-                container: [containerSizeFormatParser],
-            },
+
+    core.api.formatContentModel(
+        core,
+        (model, context) => {
+            const selectedSegment = getSelectedSegments(model, true /*includeFormatHolder*/)[0];
+            const domToModelContext = createDomToModelContext(
+                undefined /*editorContext*/,
+                core.domToModelSettings.customized,
+                {
+                    processorOverride: {
+                        '#text': pasteTextProcessor,
+                        entity: createPasteEntityProcessor(domToModelOption),
+                        '*': createPasteGeneralProcessor(domToModelOption),
+                    },
+                    formatParserOverride: {
+                        display: pasteDisplayFormatParser,
+                    },
+                    additionalFormatParsers: {
+                        container: [containerSizeFormatParser],
+                    },
+                },
+                domToModelOption
+            );
+
+            domToModelContext.segmentFormat = selectedSegment
+                ? getSegmentTextFormat(selectedSegment)
+                : {};
+
+            const pasteModel = domToContentModel(fragment, domToModelContext);
+            const mergeOption: MergeModelOption = {
+                mergeFormat: pasteType == 'mergeFormat' ? 'keepSourceEmphasisFormat' : 'none',
+                mergeTable: shouldMergeTable(pasteModel),
+            };
+
+            const insertPoint = customizedMerge
+                ? customizedMerge(model, pasteModel)
+                : mergeModel(model, pasteModel, context, mergeOption);
+
+            if (insertPoint) {
+                context.newPendingFormat = {
+                    ...EmptySegmentFormat,
+                    ...model.format,
+                    ...insertPoint.marker.format,
+                };
+            }
+
+            return true;
         },
-        domToModelOption
+        {
+            changeSource: ChangeSource.Paste,
+            getChangeData: () => clipboardData,
+            apiName: 'paste',
+        }
     );
-
-    domToModelContext.segmentFormat = selectedSegment ? getSegmentTextFormat(selectedSegment) : {};
-
-    const pasteModel = domToContentModel(fragment, domToModelContext);
-    const mergeOption: MergeModelOption = {
-        mergeFormat: pasteType == 'mergeFormat' ? 'keepSourceEmphasisFormat' : 'none',
-        mergeTable: shouldMergeTable(pasteModel),
-    };
-
-    const insertPoint = customizedMerge
-        ? customizedMerge(model, pasteModel)
-        : mergeModel(model, pasteModel, context, mergeOption);
-
-    if (insertPoint) {
-        context.newPendingFormat = {
-            ...EmptySegmentFormat,
-            ...model.format,
-            ...insertPoint.marker.format,
-        };
-    }
 }
 
 function shouldMergeTable(pasteModel: ContentModelDocument): boolean | undefined {

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/isContentModelEditor.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/isContentModelEditor.ts
@@ -9,5 +9,5 @@ import type { IEditor } from 'roosterjs-editor-types';
 export function isContentModelEditor(editor: IEditor): editor is IContentModelEditor {
     const contentModelEditor = editor as IContentModelEditor;
 
-    return !!contentModelEditor.createContentModel;
+    return !!contentModelEditor.formatContentModel;
 }

--- a/packages-content-model/roosterjs-content-model-editor/lib/editor/isContentModelEditor.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/editor/isContentModelEditor.ts
@@ -9,5 +9,5 @@ import type { IEditor } from 'roosterjs-editor-types';
 export function isContentModelEditor(editor: IEditor): editor is IContentModelEditor {
     const contentModelEditor = editor as IContentModelEditor;
 
-    return !!contentModelEditor.formatContentModel;
+    return !!contentModelEditor.createContentModel;
 }


### PR DESCRIPTION
When paste:

- Before change: Create Content Model, then trigger BeforePaste event, then merge
- After change: Trigger BeforePaste event, then create content model, then merge

With this refactor, now it is allowed to do any change to editor content model when handle BeforePaste event, so that merge will be on top of the changed model.