### PR TITLE
Code cleanup: Remove parameter onNodeCreated

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/setContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/setContentModel.ts
@@ -23,12 +23,13 @@ export const setContentModel: SetContentModel = (core, model, option, onNodeCrea
           )
         : createModelToDomContextWithConfig(core.modelToDomSettings.calculated, editorContext);
 
+    modelToDomContext.onNodeCreated = onNodeCreated;
+
     const selection = contentModelToDom(
         core.contentDiv.ownerDocument,
         core.contentDiv,
         model,
-        modelToDomContext,
-        onNodeCreated
+        modelToDomContext
     );
 
     if (!core.lifecycle.shadowEditFragment) {

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCopyPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelCopyPastePlugin.ts
@@ -131,12 +131,15 @@ class ContentModelCopyPastePlugin implements PluginWithState<CopyPastePluginStat
             }
 
             const tempDiv = this.getTempDiv(this.editor.getDocument());
+            const context = createModelToDomContext();
+
+            context.onNodeCreated = onNodeCreated;
+
             const selectionForCopy = contentModelToDom(
                 tempDiv.ownerDocument,
                 tempDiv,
                 pasteModel,
-                createModelToDomContext(),
-                onNodeCreated
+                context
             );
 
             let newRange: Range | null = selectionForCopy

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/setContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/setContentModelTest.ts
@@ -6,7 +6,7 @@ import { StandaloneEditorCore } from 'roosterjs-content-model-types';
 const mockedDoc = 'DOCUMENT' as any;
 const mockedModel = 'MODEL' as any;
 const mockedEditorContext = 'EDITORCONTEXT' as any;
-const mockedContext = 'CONTEXT' as any;
+const mockedContext = { name: 'CONTEXT' } as any;
 const mockedDiv = { ownerDocument: mockedDoc } as any;
 const mockedConfig = 'CONFIG' as any;
 
@@ -68,8 +68,7 @@ describe('setContentModel', () => {
             mockedDoc,
             mockedDiv,
             mockedModel,
-            mockedContext,
-            undefined
+            mockedContext
         );
         expect(setDOMSelectionSpy).toHaveBeenCalledWith(core, mockedRange);
         expect(core.cache.cachedSelection).toBe(mockedRange);
@@ -93,8 +92,7 @@ describe('setContentModel', () => {
             mockedDoc,
             mockedDiv,
             mockedModel,
-            mockedContext,
-            undefined
+            mockedContext
         );
         expect(setDOMSelectionSpy).toHaveBeenCalledWith(core, mockedRange);
     });
@@ -121,8 +119,7 @@ describe('setContentModel', () => {
             mockedDoc,
             mockedDiv,
             mockedModel,
-            mockedContext,
-            undefined
+            mockedContext
         );
         expect(setDOMSelectionSpy).toHaveBeenCalledWith(core, mockedRange);
     });
@@ -145,8 +142,7 @@ describe('setContentModel', () => {
             mockedDoc,
             mockedDiv,
             mockedModel,
-            mockedContext,
-            undefined
+            mockedContext
         );
         expect(setDOMSelectionSpy).not.toHaveBeenCalled();
     });
@@ -178,8 +174,7 @@ describe('setContentModel', () => {
             mockedDoc,
             mockedDiv,
             mockedModel,
-            mockedContext,
-            undefined
+            mockedContext
         );
         expect(setDOMSelectionSpy).not.toHaveBeenCalled();
         expect(core.selection.selection).toBe(mockedRange);
@@ -212,8 +207,7 @@ describe('setContentModel', () => {
             mockedDoc,
             mockedDiv,
             mockedModel,
-            mockedContext,
-            undefined
+            mockedContext
         );
         expect(setDOMSelectionSpy).not.toHaveBeenCalled();
         expect(core.selection.selection).toBe(mockedRange);
@@ -242,8 +236,7 @@ describe('setContentModel', () => {
             mockedDoc,
             mockedDiv,
             mockedModel,
-            mockedContext,
-            undefined
+            mockedContext
         );
         expect(setDOMSelectionSpy).not.toHaveBeenCalled();
         expect(core.selection.selection).toBe(null);

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelCopyPastePluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/ContentModelCopyPastePluginTest.ts
@@ -213,8 +213,7 @@ describe('ContentModelCopyPastePlugin |', () => {
                 document,
                 div,
                 pasteModelValue,
-                createModelToDomContext(),
-                onNodeCreated
+                { ...createModelToDomContext(), onNodeCreated }
             );
             expect(createContentModelSpy).toHaveBeenCalled();
             expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
@@ -261,8 +260,7 @@ describe('ContentModelCopyPastePlugin |', () => {
                 document,
                 div,
                 pasteModelValue,
-                createModelToDomContext(),
-                onNodeCreated
+                { ...createModelToDomContext(), onNodeCreated }
             );
             expect(createContentModelSpy).toHaveBeenCalled();
             expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
@@ -305,8 +303,7 @@ describe('ContentModelCopyPastePlugin |', () => {
                 document,
                 div,
                 pasteModelValue,
-                createModelToDomContext(),
-                onNodeCreated
+                { ...createModelToDomContext(), onNodeCreated }
             );
             expect(createContentModelSpy).toHaveBeenCalled();
             expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
@@ -377,8 +374,7 @@ describe('ContentModelCopyPastePlugin |', () => {
                 document,
                 div,
                 pasteModelValue,
-                createModelToDomContext(),
-                onNodeCreated
+                { ...createModelToDomContext(), onNodeCreated }
             );
             expect(createContentModelSpy).toHaveBeenCalled();
             expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
@@ -452,8 +448,7 @@ describe('ContentModelCopyPastePlugin |', () => {
                 document,
                 div,
                 pasteModelValue,
-                createModelToDomContext(),
-                onNodeCreated
+                { ...createModelToDomContext(), onNodeCreated }
             );
             expect(createContentModelSpy).toHaveBeenCalled();
             expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
@@ -502,8 +497,7 @@ describe('ContentModelCopyPastePlugin |', () => {
                 document,
                 div,
                 pasteModelValue,
-                createModelToDomContext(),
-                onNodeCreated
+                { ...createModelToDomContext(), onNodeCreated }
             );
             expect(createContentModelSpy).toHaveBeenCalled();
             expect(iterateSelectionsFile.iterateSelections).toHaveBeenCalled();
@@ -551,8 +545,7 @@ describe('ContentModelCopyPastePlugin |', () => {
                 document,
                 div,
                 pasteModelValue,
-                createModelToDomContext(),
-                onNodeCreated
+                { ...createModelToDomContext(), onNodeCreated }
             );
             expect(createContentModelSpy).toHaveBeenCalled();
             expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);

--- a/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/contentModelToDom.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/modelToDom/contentModelToDom.ts
@@ -5,7 +5,6 @@ import type {
     DOMSelection,
     ModelToDomBlockAndSegmentNode,
     ModelToDomContext,
-    OnNodeCreated,
 } from 'roosterjs-content-model-types';
 
 /**
@@ -16,18 +15,14 @@ import type {
  * won't be touched.
  * @param model The content model document to generate DOM tree from
  * @param context The context object for Content Model to DOM conversion
- * @param onNodeCreated Callback invoked when a DOM node is created
  * @returns The selection range created in DOM tree from this model, or null when there is no selection
  */
 export function contentModelToDom(
     doc: Document,
     root: Node,
     model: ContentModelDocument,
-    context: ModelToDomContext,
-    onNodeCreated?: OnNodeCreated
+    context: ModelToDomContext
 ): DOMSelection | null {
-    context.onNodeCreated = onNodeCreated;
-
     context.modelHandlers.blockGroupChildren(doc, root, model, context);
 
     const range = extractSelectionRange(doc, context);


### PR DESCRIPTION
Remove parameter `onNodeCreated` from API `contentModelToDom`, because it already has parameter `context` which can contain this parameter.