### PR TITLE
Add write permission to deploy action

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,6 +6,8 @@ on:
 jobs:
     build-and-deploy:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
         steps:
             - name: Checkout
               uses: actions/checkout@v2.3.1


### PR DESCRIPTION
According to https://docs.opensource.microsoft.com/github/apps/permission-changes/#what-steps-must-i-take-to-avoid-a-bad-time and https://github.com/JamesIves/github-pages-deploy-action/blob/dev/README.md, we need to add a write permission to our `build-and-deploy` github action since it is using GITHUB_TOKEN to deploy demo site and reference documents to github_pages.