### PR TITLE
Code cleanup: Remove TODO and support RTL when toggle blockquote

### DIFF
--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/block/setModelDirection.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/block/setModelDirection.ts
@@ -56,7 +56,6 @@ function internalSetDirection(
         format.direction = direction;
 
         // Adjust margin when change direction
-        // TODO: make margin and padding direction-aware, like what we did for textAlign. So no need to adjust them here
         const marginLeft = format.marginLeft;
         const paddingLeft = format.paddingLeft;
 

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/block/toggleModelBlockQuote.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/block/toggleModelBlockQuote.ts
@@ -17,7 +17,8 @@ import type {
  */
 export function toggleModelBlockQuote(
     model: ContentModelDocument,
-    format: ContentModelFormatContainerFormat
+    formatLtr: ContentModelFormatContainerFormat,
+    formatRtl: ContentModelFormatContainerFormat
 ): boolean {
     const paragraphOfQuote = getOperationalBlocks<
         ContentModelFormatContainer | ContentModelListItem
@@ -30,12 +31,14 @@ export function toggleModelBlockQuote(
         });
     } else {
         const step1Results: WrapBlockStep1Result<ContentModelFormatContainer>[] = [];
-        const creator = () => createFormatContainer('blockquote', format);
+        const creator = (isRtl: boolean) =>
+            createFormatContainer('blockquote', isRtl ? formatRtl : formatLtr);
         const canMerge = (
+            isRtl: boolean,
             target: ContentModelBlock,
             current?: ContentModelFormatContainer
         ): target is ContentModelFormatContainer =>
-            canMergeQuote(target, current?.format || format);
+            canMergeQuote(target, current?.format || (isRtl ? formatRtl : formatLtr));
 
         paragraphOfQuote.forEach(({ block, parent }) => {
             if (isQuote(block)) {

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/common/retrieveModelFormatState.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/common/retrieveModelFormatState.ts
@@ -122,8 +122,6 @@ export function retrieveModelFormatState(
                     firstTableContext = tableContext;
                 }
             }
-
-            // TODO: Support Code block in format state for Content Model
         },
         {
             includeListFormatHolder: 'never',
@@ -161,8 +159,6 @@ function retrieveSegmentFormat(
     mergeValue(result, 'backgroundColor', mergedFormat.backgroundColor, isFirst);
     mergeValue(result, 'textColor', mergedFormat.textColor, isFirst);
     mergeValue(result, 'fontWeight', mergedFormat.fontWeight, isFirst);
-
-    //TODO: handle block owning segments with different line-heights
     mergeValue(result, 'lineHeight', mergedFormat.lineHeight, isFirst);
 }
 

--- a/packages-content-model/roosterjs-content-model-api/lib/modelApi/list/setListType.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/modelApi/list/setListType.ts
@@ -88,8 +88,6 @@ export function setListType(model: ContentModelDocument, listType: 'OL' | 'UL') 
                         }
                     );
 
-                    // Since there is only one paragraph under the list item, no need to keep its paragraph element (DIV).
-                    // TODO: Do we need to keep the CSS styles applied to original DIV?
                     if (block.blockType == 'Paragraph') {
                         block.isImplicit = true;
                     }

--- a/packages-content-model/roosterjs-content-model-api/lib/publicApi/block/toggleBlockQuote.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/publicApi/block/toggleBlockQuote.ts
@@ -4,8 +4,12 @@ import type {
     IStandaloneEditor,
 } from 'roosterjs-content-model-types';
 
-const DefaultQuoteFormat: ContentModelFormatContainerFormat = {
-    borderLeft: '3px solid rgb(200, 200, 200)', // TODO: Support RTL
+const DefaultQuoteFormatLtr: ContentModelFormatContainerFormat = {
+    borderLeft: '3px solid rgb(200, 200, 200)',
+    textColor: 'rgb(102, 102, 102)',
+};
+const DefaultQuoteFormatRtl: ContentModelFormatContainerFormat = {
+    borderRight: '3px solid rgb(200, 200, 200)',
     textColor: 'rgb(102, 102, 102)',
 };
 const BuildInQuoteFormat: ContentModelFormatContainerFormat = {
@@ -13,7 +17,6 @@ const BuildInQuoteFormat: ContentModelFormatContainerFormat = {
     marginBottom: '1em',
     marginLeft: '40px',
     marginRight: '40px',
-    paddingLeft: '10px',
 };
 
 /**
@@ -25,11 +28,19 @@ const BuildInQuoteFormat: ContentModelFormatContainerFormat = {
  */
 export default function toggleBlockQuote(
     editor: IStandaloneEditor,
-    quoteFormat: ContentModelFormatContainerFormat = DefaultQuoteFormat
+    quoteFormat?: ContentModelFormatContainerFormat,
+    quoteFormatRtl?: ContentModelFormatContainerFormat
 ) {
-    const fullQuoteFormat = {
+    const fullQuoteFormatLtr: ContentModelFormatContainerFormat = {
         ...BuildInQuoteFormat,
-        ...quoteFormat,
+        paddingLeft: '10px',
+        ...(quoteFormat ?? DefaultQuoteFormatLtr),
+    };
+    const fullQuoteFormatRtl: ContentModelFormatContainerFormat = {
+        ...BuildInQuoteFormat,
+        paddingRight: '10px',
+        direction: 'rtl',
+        ...(quoteFormatRtl ?? quoteFormat ?? DefaultQuoteFormatRtl),
     };
 
     editor.focus();
@@ -38,7 +49,7 @@ export default function toggleBlockQuote(
         (model, context) => {
             context.newPendingFormat = 'preserve';
 
-            return toggleModelBlockQuote(model, fullQuoteFormat);
+            return toggleModelBlockQuote(model, fullQuoteFormatLtr, fullQuoteFormatRtl);
         },
         {
             apiName: 'toggleBlockQuote',

--- a/packages-content-model/roosterjs-content-model-api/lib/publicApi/segment/changeCapitalization.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/publicApi/segment/changeCapitalization.ts
@@ -40,7 +40,6 @@ export default function changeCapitalization(
                     break;
 
                 case 'sentence':
-                    // TODO: Add rules on punctuation for internationalization - TASK 104769
                     const punctuationMarks = '[\\.\\!\\?]';
                     // Find a match of a word character either:
                     // - At the beginning of a string with or without preceding whitespace, for

--- a/packages-content-model/roosterjs-content-model-api/test/modelApi/block/toggleModelBlockQuoteTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/modelApi/block/toggleModelBlockQuoteTest.ts
@@ -11,7 +11,7 @@ describe('toggleModelBlockQuote', () => {
     it('empty model', () => {
         const doc = createContentModelDocument();
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -27,7 +27,7 @@ describe('toggleModelBlockQuote', () => {
         para.segments.push(text);
         doc.blocks.push(para);
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -56,7 +56,7 @@ describe('toggleModelBlockQuote', () => {
         doc.blocks.push(para);
         text.isSelected = true;
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -99,7 +99,7 @@ describe('toggleModelBlockQuote', () => {
         text1.isSelected = true;
         text2.isSelected = true;
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -140,6 +140,99 @@ describe('toggleModelBlockQuote', () => {
         });
     });
 
+    it('Has multiple selection, with RTL, do not merge', () => {
+        const doc = createContentModelDocument();
+        const para1 = createParagraph();
+        const text1 = createText('test1');
+        const para2 = createParagraph();
+        const text2 = createText('test2');
+        const para3 = createParagraph();
+        const text3 = createText('test3');
+
+        para1.segments.push(text1);
+        para2.segments.push(text2);
+        para3.segments.push(text3);
+
+        para2.format.direction = 'rtl';
+
+        doc.blocks.push(para1, para2, para3);
+        text1.isSelected = true;
+        text2.isSelected = true;
+        text3.isSelected = true;
+
+        toggleModelBlockQuote(doc, {}, { direction: 'rtl' });
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'FormatContainer',
+                    tagName: 'blockquote',
+                    format: {},
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            format: {},
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test1',
+                                    format: {},
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'FormatContainer',
+                    tagName: 'blockquote',
+                    format: {
+                        direction: 'rtl',
+                    },
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            format: {
+                                direction: 'rtl',
+                            },
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test2',
+                                    format: {},
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'FormatContainer',
+                    tagName: 'blockquote',
+                    format: {},
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            format: {},
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test3',
+                                    format: {},
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
     it('Has single selection, merge before', () => {
         const doc = createContentModelDocument();
         const para1 = createParagraph();
@@ -155,7 +248,7 @@ describe('toggleModelBlockQuote', () => {
         doc.blocks.push(para2);
         text2.isSelected = true;
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -210,7 +303,7 @@ describe('toggleModelBlockQuote', () => {
         doc.blocks.push(quote);
         text1.isSelected = true;
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -271,7 +364,7 @@ describe('toggleModelBlockQuote', () => {
         doc.blocks.push(quote3);
         text2.isSelected = true;
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -343,7 +436,7 @@ describe('toggleModelBlockQuote', () => {
         doc.blocks.push(quote3);
         text2.isSelected = true;
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -436,7 +529,7 @@ describe('toggleModelBlockQuote', () => {
         text2.isSelected = true;
         text3.isSelected = true;
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -512,7 +605,7 @@ describe('toggleModelBlockQuote', () => {
 
         text1.isSelected = true;
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -575,7 +668,7 @@ describe('toggleModelBlockQuote', () => {
         text1.isSelected = true;
         text2.isSelected = true;
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',
@@ -637,7 +730,7 @@ describe('toggleModelBlockQuote', () => {
 
         text2.isSelected = true;
 
-        toggleModelBlockQuote(doc, {});
+        toggleModelBlockQuote(doc, {}, {});
 
         expect(doc).toEqual({
             blockGroupType: 'Document',

--- a/packages-content-model/roosterjs-content-model-api/test/modelApi/common/wrapBlockTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/modelApi/common/wrapBlockTest.ts
@@ -225,7 +225,7 @@ describe('wrapBlockStep2', () => {
             ],
         });
         expect(canMerge).toHaveBeenCalledTimes(1);
-        expect(canMerge).toHaveBeenCalledWith(undefined, quote);
+        expect(canMerge).toHaveBeenCalledWith(false, undefined, quote);
     });
 
     it('Has results, can merge', () => {
@@ -270,8 +270,8 @@ describe('wrapBlockStep2', () => {
         wrapBlockStep2(result, canMerge as any);
 
         expect(canMerge).toHaveBeenCalledTimes(2);
-        expect(canMerge).toHaveBeenCalledWith(quote4, quote3);
-        expect(canMerge).toHaveBeenCalledWith(quote2, quote1);
+        expect(canMerge).toHaveBeenCalledWith(false, quote4, quote3);
+        expect(canMerge).toHaveBeenCalledWith(false, quote2, quote1);
         expect(doc).toEqual({
             blockGroupType: 'Document',
             blocks: [

--- a/packages-content-model/roosterjs-content-model-api/test/publicApi/block/toggleBlockQuoteTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/publicApi/block/toggleBlockQuoteTest.ts
@@ -39,15 +39,28 @@ describe('toggleBlockQuote', () => {
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
         expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledTimes(1);
-        expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledWith(fakeModel, {
-            marginTop: '1em',
-            marginBottom: '1em',
-            marginLeft: '40px',
-            marginRight: '40px',
-            paddingLeft: '10px',
-            a: 'b',
-            c: 'd',
-        } as any);
+        expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledWith(
+            fakeModel,
+            {
+                marginTop: '1em',
+                marginBottom: '1em',
+                marginLeft: '40px',
+                marginRight: '40px',
+                paddingLeft: '10px',
+                a: 'b',
+                c: 'd',
+            } as any,
+            {
+                marginTop: '1em',
+                marginBottom: '1em',
+                marginLeft: '40px',
+                marginRight: '40px',
+                paddingRight: '10px',
+                direction: 'rtl',
+                a: 'b',
+                c: 'd',
+            } as any
+        );
         expect(context).toEqual({
             newEntities: [],
             newImages: [],
@@ -63,15 +76,28 @@ describe('toggleBlockQuote', () => {
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
         expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledTimes(1);
-        expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledWith(fakeModel, {
-            marginTop: '1em',
-            marginBottom: '1em',
-            marginLeft: '40px',
-            marginRight: '40px',
-            paddingLeft: '10px',
-            lineHeight: '2',
-            textColor: 'red',
-        } as any);
+        expect(toggleModelBlockQuote.toggleModelBlockQuote).toHaveBeenCalledWith(
+            fakeModel,
+            {
+                marginTop: '1em',
+                marginBottom: '1em',
+                marginLeft: '40px',
+                marginRight: '40px',
+                paddingLeft: '10px',
+                lineHeight: '2',
+                textColor: 'red',
+            } as any,
+            {
+                marginTop: '1em',
+                marginBottom: '1em',
+                marginLeft: '40px',
+                marginRight: '40px',
+                paddingRight: '10px',
+                lineHeight: '2',
+                textColor: 'red',
+                direction: 'rtl',
+            }
+        );
         expect(context).toEqual({
             newEntities: [],
             newImages: [],

--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/switchShadowEdit.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/switchShadowEdit.ts
@@ -9,15 +9,11 @@ import type { SwitchShadowEdit } from 'roosterjs-content-model-types';
  * @param isOn True to switch On, False to switch Off
  */
 export const switchShadowEdit: SwitchShadowEdit = (editorCore, isOn): void => {
-    // TODO: Use strong-typed editor core object
     const core = editorCore;
 
     if (isOn != !!core.lifecycle.shadowEditFragment) {
         if (isOn) {
             const model = !core.cache.cachedModel ? core.api.createContentModel(core) : null;
-
-            // Fake object, not used in Content Model Editor, just to satisfy original editor code
-            // TODO: we can remove them once we have standalone Content Model Editor
             const fragment = core.contentDiv.ownerDocument.createDocumentFragment();
             const clonedRoot = core.contentDiv.cloneNode(true /*deep*/);
 

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelFormatPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/ContentModelFormatPlugin.ts
@@ -48,7 +48,6 @@ class ContentModelFormatPlugin implements PluginWithState<ContentModelFormatPlug
      * @param editor The editor object
      */
     initialize(editor: IStandaloneEditor) {
-        // TODO: Later we may need a different interface for Content Model editor plugin
         this.editor = editor;
         this.hasDefaultFormat =
             getObjectKeys(this.state.defaultFormat).filter(

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/SelectionPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/SelectionPlugin.ts
@@ -22,7 +22,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         this.state = {
             selection: null,
             selectionStyleNode: null,
-            imageSelectionBorderColor: options.imageSelectionBorderColor, // TODO: Move to Selection core plugin
+            imageSelectionBorderColor: options.imageSelectionBorderColor,
         };
     }
 

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/domUtils/borderValues.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/domUtils/borderValues.ts
@@ -29,7 +29,7 @@ export function extractBorderValues(combinedBorder?: string): Border {
         } else if (BorderSizeRegex.test(v) && !result.width) {
             result.width = v;
         } else if (v && !result.color) {
-            result.color = v; // TODO: Do we need to use a regex to match all possible colors?
+            result.color = v;
         }
     });
 

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/selection/deleteSegment.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/selection/deleteSegment.ts
@@ -83,8 +83,6 @@ export function deleteSegment(
                 segments.splice(index, 1);
                 return true;
             } else {
-                // No op if a general segment is not selected, let browser handle general segment
-                // TODO: Need to revisit this
                 return false;
             }
     }

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/selection/iterateSelections.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/selection/iterateSelections.ts
@@ -68,8 +68,6 @@ export function iterateSelections(
 ): void {
     const internalCallback: IterateSelectionsCallback = (path, tableContext, block, segments) => {
         if (!!(block as ContentModelBlockWithCache)?.cachedElement) {
-            // TODO: This is a temporary solution. A better solution would be making all results from iterationSelection() to be readonly,
-            // use a util function to change it to be editable before edit them where we clear its cached element
             delete (block as ContentModelBlockWithCache).cachedElement;
         }
 

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/entityProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/processors/entityProcessor.ts
@@ -23,7 +23,6 @@ export const entityProcessor: ElementProcessor<HTMLElement> = (group, element, c
 
             parseFormat(element, context.formatParsers.entity, entityModel.entityFormat, context);
 
-            // TODO: Need to handle selection for editable entity
             if (context.isInSelection) {
                 entityModel.isSelected = true;
             }

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/parseValueWithUnit.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/utils/parseValueWithUnit.ts
@@ -41,9 +41,6 @@ export function parseValueWithUnit(
             case 'in':
                 result = num * PixelPerInch;
                 break;
-            default:
-                // TODO: Support more unit if need
-                break;
         }
     }
 

--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/ContentModelEditPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/ContentModelEditPlugin.ts
@@ -30,7 +30,6 @@ export class ContentModelEditPlugin implements EditorPlugin {
      * @param editor The editor object
      */
     initialize(editor: IStandaloneEditor) {
-        // TODO: Later we may need a different interface for Content Model editor plugin
         this.editor = editor;
     }
 

--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -57,7 +57,7 @@ function shouldInputWithContentModel(
         return (
             selection.type != 'range' ||
             (!selection.range.collapsed && !rawEvent.isComposing && !isInIME)
-        ); // TODO: Also handle Enter key even selection is collapsed
+        );
     } else {
         return false;
     }

--- a/packages-content-model/roosterjs-content-model-plugins/lib/paste/ContentModelPastePlugin.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/paste/ContentModelPastePlugin.ts
@@ -50,7 +50,6 @@ export class ContentModelPastePlugin implements EditorPlugin {
      * @param editor The editor object
      */
     initialize(editor: IStandaloneEditor) {
-        // TODO: Later we may need a different interface for Content Model editor plugin
         this.editor = editor;
     }
 


### PR DESCRIPTION
1. Remove all "TODO" comment in Content Model code since they are either solved or not needed any more
2. The only one we still need is to support RTL when toggle BlockQuote, so add support to it.