### PR TITLE
Content Model: Fix 252481

### DIFF
--- a/packages-content-model/roosterjs-content-model-dom/lib/config/defaultHTMLStyleMap.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/config/defaultHTMLStyleMap.ts
@@ -77,7 +77,7 @@ export const defaultHTMLStyleMap: DefaultStyleMap = {
     },
     main: blockElement,
     nav: blockElement,
-    ol: blockElement,
+    ol: { ...blockElement, paddingInlineStart: '40px' },
     p: {
         display: 'block',
         marginTop: '1em',
@@ -121,5 +121,5 @@ export const defaultHTMLStyleMap: DefaultStyleMap = {
     u: {
         textDecoration: 'underline',
     },
-    ul: blockElement,
+    ul: { ...blockElement, paddingInlineStart: '40px' },
 };

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/block/paddingFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/block/paddingFormatHandler.ts
@@ -1,5 +1,6 @@
+import { directionFormatHandler } from './directionFormatHandler';
 import type { FormatHandler } from '../FormatHandler';
-import type { PaddingFormat } from 'roosterjs-content-model-types';
+import type { DirectionFormat, PaddingFormat } from 'roosterjs-content-model-types';
 
 const PaddingKeys: (keyof PaddingFormat & keyof CSSStyleDeclaration)[] = [
     'paddingTop',
@@ -8,16 +9,42 @@ const PaddingKeys: (keyof PaddingFormat & keyof CSSStyleDeclaration)[] = [
     'paddingLeft',
 ];
 
+const AlternativeKeyLtr: Partial<Record<
+    keyof PaddingFormat,
+    keyof CSSStyleDeclaration | undefined
+>> = {
+    paddingLeft: 'paddingInlineStart',
+};
+
+const AlternativeKeyRtl: Partial<Record<
+    keyof PaddingFormat,
+    keyof CSSStyleDeclaration | undefined
+>> = {
+    paddingRight: 'paddingInlineStart',
+};
+
 /**
  * @internal
  */
-export const paddingFormatHandler: FormatHandler<PaddingFormat> = {
-    parse: (format, element, _, defaultStyle) => {
+export const paddingFormatHandler: FormatHandler<PaddingFormat & DirectionFormat> = {
+    parse: (format, element, context, defaultStyle) => {
+        directionFormatHandler.parse(format, element, context, defaultStyle);
+
         PaddingKeys.forEach(key => {
             let value = element.style[key];
-            const defaultValue = defaultStyle[key] ?? '0px';
+            const alterativeKey = (format.direction == 'rtl'
+                ? AlternativeKeyRtl
+                : AlternativeKeyLtr)[key];
+            const defaultValue: string =
+                (defaultStyle[key] ??
+                    (alterativeKey ? defaultStyle[alterativeKey] : undefined) ??
+                    '0px') + '';
 
-            if (value == '0') {
+            if (!value) {
+                value = defaultValue;
+            }
+
+            if (!value || value == '0') {
                 value = '0px';
             }
 
@@ -26,10 +53,21 @@ export const paddingFormatHandler: FormatHandler<PaddingFormat> = {
             }
         });
     },
-    apply: (format, element) => {
+    apply: (format, element, context) => {
         PaddingKeys.forEach(key => {
             const value = format[key];
-            if (value) {
+            let defaultValue: string | undefined = undefined;
+
+            if (element.tagName == 'OL' || element.tagName == 'UL') {
+                if (
+                    (format.direction == 'rtl' && key == 'paddingRight') ||
+                    (format.direction != 'rtl' && key == 'paddingLeft')
+                ) {
+                    defaultValue = '40px';
+                }
+            }
+
+            if (value && value != defaultValue) {
                 element.style[key] = value;
             }
         });

--- a/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/block/paddingFormatHandlerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/formatHandlers/block/paddingFormatHandlerTest.ts
@@ -1,11 +1,17 @@
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
-import { DomToModelContext, ModelToDomContext, PaddingFormat } from 'roosterjs-content-model-types';
+import { defaultHTMLStyleMap } from '../../../lib/config/defaultHTMLStyleMap';
 import { paddingFormatHandler } from '../../../lib/formatHandlers/block/paddingFormatHandler';
+import {
+    DirectionFormat,
+    DomToModelContext,
+    ModelToDomContext,
+    PaddingFormat,
+} from 'roosterjs-content-model-types';
 
 describe('paddingFormatHandler.parse', () => {
     let div: HTMLElement;
-    let format: PaddingFormat;
+    let format: PaddingFormat & DirectionFormat;
     let context: DomToModelContext;
 
     beforeEach(() => {
@@ -47,11 +53,89 @@ describe('paddingFormatHandler.parse', () => {
             paddingBottom: '20px',
         });
     });
+
+    it('Default padding in OL, LTR', () => {
+        paddingFormatHandler.parse(format, div, context, defaultHTMLStyleMap.ol!);
+
+        expect(format).toEqual({});
+    });
+
+    it('Default padding in OL, RTL', () => {
+        div.style.direction = 'rtl';
+
+        paddingFormatHandler.parse(format, div, context, defaultHTMLStyleMap.ol!);
+
+        expect(format).toEqual({
+            direction: 'rtl',
+        });
+    });
+
+    it('Default padding in UL, LTR', () => {
+        paddingFormatHandler.parse(format, div, context, defaultHTMLStyleMap.ul!);
+
+        expect(format).toEqual({});
+    });
+
+    it('Default padding in UL, RTL', () => {
+        div.style.direction = 'rtl';
+
+        paddingFormatHandler.parse(format, div, context, defaultHTMLStyleMap.ul!);
+
+        expect(format).toEqual({
+            direction: 'rtl',
+        });
+    });
+
+    it('Customized padding in OL, LTR', () => {
+        div.style.paddingLeft = '0';
+        paddingFormatHandler.parse(format, div, context, defaultHTMLStyleMap.ol!);
+
+        expect(format).toEqual({
+            paddingLeft: '0px',
+        });
+    });
+
+    it('Customized padding in OL, RTL', () => {
+        div.style.direction = 'rtl';
+        div.style.paddingLeft = '0';
+        div.style.paddingRight = '20px';
+
+        paddingFormatHandler.parse(format, div, context, defaultHTMLStyleMap.ol!);
+
+        expect(format).toEqual({
+            direction: 'rtl',
+            paddingRight: '20px',
+        });
+    });
+
+    it('Customized padding in UL, LTR', () => {
+        div.style.paddingLeft = '20px';
+
+        paddingFormatHandler.parse(format, div, context, defaultHTMLStyleMap.ul!);
+
+        expect(format).toEqual({
+            paddingLeft: '20px',
+        });
+    });
+
+    it('Customized padding in UL, RTL', () => {
+        div.style.direction = 'rtl';
+        div.style.paddingLeft = '20px';
+        div.style.paddingRight = '60px';
+
+        paddingFormatHandler.parse(format, div, context, defaultHTMLStyleMap.ul!);
+
+        expect(format).toEqual({
+            direction: 'rtl',
+            paddingLeft: '20px',
+            paddingRight: '60px',
+        });
+    });
 });
 
 describe('paddingFormatHandler.apply', () => {
     let div: HTMLElement;
-    let format: PaddingFormat;
+    let format: PaddingFormat & DirectionFormat;
     let context: ModelToDomContext;
 
     beforeEach(() => {
@@ -74,5 +158,65 @@ describe('paddingFormatHandler.apply', () => {
         paddingFormatHandler.apply(format, div, context);
 
         expect(div.outerHTML).toBe('<div style="padding: 1px 2px 3px 4px;"></div>');
+    });
+
+    it('OL has no padding', () => {
+        const ol = document.createElement('ol');
+
+        paddingFormatHandler.apply(format, ol, context);
+
+        expect(ol.outerHTML).toBe('<ol></ol>');
+    });
+
+    it('OL has default padding', () => {
+        const ol = document.createElement('ol');
+
+        format.paddingLeft = '40px';
+
+        paddingFormatHandler.apply(format, ol, context);
+
+        expect(ol.outerHTML).toBe('<ol></ol>');
+    });
+
+    it('OL has padding', () => {
+        const ol = document.createElement('ol');
+
+        format.paddingLeft = '60px';
+
+        paddingFormatHandler.apply(format, ol, context);
+
+        expect(ol.outerHTML).toBe('<ol style="padding-left: 60px;"></ol>');
+    });
+
+    it('UL has padding', () => {
+        const ul = document.createElement('ul');
+
+        format.paddingLeft = '60px';
+
+        paddingFormatHandler.apply(format, ul, context);
+
+        expect(ul.outerHTML).toBe('<ul style="padding-left: 60px;"></ul>');
+    });
+
+    it('OL has padding-left in RTL', () => {
+        const ol = document.createElement('ol');
+
+        format.paddingLeft = '40px';
+        format.direction = 'rtl';
+
+        paddingFormatHandler.apply(format, ol, context);
+
+        expect(ol.outerHTML).toBe('<ol style="padding-left: 40px;"></ol>');
+    });
+
+    it('OL has padding-right in RTL', () => {
+        const ol = document.createElement('ol');
+
+        format.paddingRight = '40px';
+        format.direction = 'rtl';
+
+        paddingFormatHandler.apply(format, ol, context);
+
+        expect(ol.outerHTML).toBe('<ol></ol>');
     });
 });


### PR DESCRIPTION
https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/252481/?triage=true

When there is "padding: 0" specified to OL/UL, we need to respect it since it will override the default "padding-inline-start: 40px" value.

So add a default value in `defaultHTMLStyleMap`, and read it in paddingFormatHandler, use this value as default value for OL/UL. When current value is not the same with default value, specify the value in format object.