### PR TITLE
Bump roosterjs version to 8.60.0

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,9 +1,8 @@
 {
-    "packages": "8.59.0",
+    "packages": "8.60.0",
     "packages-ui": "8.55.0",
     "packages-content-model": "0.25.0",
     "overrides": {
-        "roosterjs-editor-core": "8.59.1",
-        "roosterjs-editor-plugins": "8.60.1"
+        "roosterjs-editor-plugins": "8.60.2"
     }
 }


### PR DESCRIPTION
I realized that I missed some file change to do version bump. Since there are already multiple old packages got changed, let's do a full version bump for all old packages.