### PR TITLE
Add API formatTableWithContentModel

### DIFF
--- a/packages-content-model/roosterjs-content-model-api/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/index.ts
@@ -40,4 +40,6 @@ export { default as adjustImageSelection } from './publicApi/image/adjustImageSe
 export { default as setParagraphMargin } from './publicApi/block/setParagraphMargin';
 export { default as toggleCode } from './publicApi/segment/toggleCode';
 export { default as insertEntity } from './publicApi/entity/insertEntity';
+
+export { formatTableWithContentModel } from './publicApi/utils/formatTableWithContentModel';
 export { setListType } from './modelApi/list/setListType';

--- a/packages-content-model/roosterjs-content-model-api/lib/publicApi/table/editTable.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/publicApi/table/editTable.ts
@@ -2,7 +2,7 @@ import { alignTable } from '../../modelApi/table/alignTable';
 import { deleteTable } from '../../modelApi/table/deleteTable';
 import { deleteTableColumn } from '../../modelApi/table/deleteTableColumn';
 import { deleteTableRow } from '../../modelApi/table/deleteTableRow';
-import { ensureFocusableParagraphForTable } from '../../modelApi/table/ensureFocusableParagraphForTable';
+import { formatTableWithContentModel } from '../utils/formatTableWithContentModel';
 import { insertTableColumn } from '../../modelApi/table/insertTableColumn';
 import { insertTableRow } from '../../modelApi/table/insertTableRow';
 import { mergeTableCells } from '../../modelApi/table/mergeTableCells';
@@ -10,24 +10,11 @@ import { mergeTableColumn } from '../../modelApi/table/mergeTableColumn';
 import { mergeTableRow } from '../../modelApi/table/mergeTableRow';
 import { splitTableCellHorizontally } from '../../modelApi/table/splitTableCellHorizontally';
 import { splitTableCellVertically } from '../../modelApi/table/splitTableCellVertically';
-
-import {
-    hasSelectionInBlock,
-    applyTableFormat,
-    getFirstSelectedTable,
-    normalizeTable,
-    setSelection,
-} from 'roosterjs-content-model-core';
 import type { TableOperation, IStandaloneEditor } from 'roosterjs-content-model-types';
 import {
     alignTableCellHorizontally,
     alignTableCellVertically,
 } from '../../modelApi/table/alignTableCell';
-import {
-    createSelectionMarker,
-    hasMetadata,
-    setParagraphNotImplicit,
-} from 'roosterjs-content-model-dom';
 
 /**
  * Format current focused table with the given format
@@ -37,98 +24,67 @@ import {
 export default function editTable(editor: IStandaloneEditor, operation: TableOperation) {
     editor.focus();
 
-    editor.formatContentModel(
-        model => {
-            const [tableModel, path] = getFirstSelectedTable(model);
+    formatTableWithContentModel(editor, 'editTable', tableModel => {
+        switch (operation) {
+            case 'alignCellLeft':
+            case 'alignCellCenter':
+            case 'alignCellRight':
+                alignTableCellHorizontally(tableModel, operation);
+                break;
+            case 'alignCellTop':
+            case 'alignCellMiddle':
+            case 'alignCellBottom':
+                alignTableCellVertically(tableModel, operation);
+                break;
+            case 'alignCenter':
+            case 'alignLeft':
+            case 'alignRight':
+                alignTable(tableModel, operation);
+                break;
 
-            if (tableModel) {
-                switch (operation) {
-                    case 'alignCellLeft':
-                    case 'alignCellCenter':
-                    case 'alignCellRight':
-                        alignTableCellHorizontally(tableModel, operation);
-                        break;
-                    case 'alignCellTop':
-                    case 'alignCellMiddle':
-                    case 'alignCellBottom':
-                        alignTableCellVertically(tableModel, operation);
-                        break;
-                    case 'alignCenter':
-                    case 'alignLeft':
-                    case 'alignRight':
-                        alignTable(tableModel, operation);
-                        break;
+            case 'deleteColumn':
+                deleteTableColumn(tableModel);
+                break;
 
-                    case 'deleteColumn':
-                        deleteTableColumn(tableModel);
-                        break;
+            case 'deleteRow':
+                deleteTableRow(tableModel);
+                break;
 
-                    case 'deleteRow':
-                        deleteTableRow(tableModel);
-                        break;
+            case 'deleteTable':
+                deleteTable(tableModel);
+                break;
 
-                    case 'deleteTable':
-                        deleteTable(tableModel);
-                        break;
+            case 'insertAbove':
+            case 'insertBelow':
+                insertTableRow(tableModel, operation);
+                break;
 
-                    case 'insertAbove':
-                    case 'insertBelow':
-                        insertTableRow(tableModel, operation);
-                        break;
+            case 'insertLeft':
+            case 'insertRight':
+                insertTableColumn(tableModel, operation);
+                break;
 
-                    case 'insertLeft':
-                    case 'insertRight':
-                        insertTableColumn(tableModel, operation);
-                        break;
+            case 'mergeAbove':
+            case 'mergeBelow':
+                mergeTableRow(tableModel, operation);
+                break;
 
-                    case 'mergeAbove':
-                    case 'mergeBelow':
-                        mergeTableRow(tableModel, operation);
-                        break;
+            case 'mergeCells':
+                mergeTableCells(tableModel);
+                break;
 
-                    case 'mergeCells':
-                        mergeTableCells(tableModel);
-                        break;
+            case 'mergeLeft':
+            case 'mergeRight':
+                mergeTableColumn(tableModel, operation);
+                break;
 
-                    case 'mergeLeft':
-                    case 'mergeRight':
-                        mergeTableColumn(tableModel, operation);
-                        break;
+            case 'splitHorizontally':
+                splitTableCellHorizontally(tableModel);
+                break;
 
-                    case 'splitHorizontally':
-                        splitTableCellHorizontally(tableModel);
-                        break;
-
-                    case 'splitVertically':
-                        splitTableCellVertically(tableModel);
-                        break;
-                }
-
-                if (!hasSelectionInBlock(tableModel)) {
-                    const paragraph = ensureFocusableParagraphForTable(model, path, tableModel);
-
-                    if (paragraph) {
-                        const marker = createSelectionMarker(model.format);
-
-                        paragraph.segments.unshift(marker);
-                        setParagraphNotImplicit(paragraph);
-                        setSelection(model, marker);
-                    }
-                }
-
-                normalizeTable(tableModel, model.format);
-
-                if (hasMetadata(tableModel)) {
-                    applyTableFormat(tableModel, undefined /*newFormat*/, true /*keepCellShade*/);
-                }
-
-                return true;
-            } else {
-                return false;
-            }
-        },
-        {
-            apiName: 'editTable',
+            case 'splitVertically':
+                splitTableCellVertically(tableModel);
+                break;
         }
-    );
+    });
 }

--- a/packages-content-model/roosterjs-content-model-api/lib/publicApi/utils/formatSegmentWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/publicApi/utils/formatSegmentWithContentModel.ts
@@ -7,6 +7,7 @@ import type {
     ContentModelSegmentFormat,
     IStandaloneEditor,
 } from 'roosterjs-content-model-types';
+
 /**
  * @internal
  */

--- a/packages-content-model/roosterjs-content-model-api/lib/publicApi/utils/formatTableWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/publicApi/utils/formatTableWithContentModel.ts
@@ -18,7 +18,11 @@ import type {
 } from 'roosterjs-content-model-types';
 
 /**
- * @internal
+ * Invoke a callback to format the selected table using Content Model
+ * @param editor The editor object
+ * @param apiName Name of API this calling this function. This is mostly for logging.
+ * @param callback The callback to format the table. It will be called with current selected table. If no table is selected, it will not be called.
+ * @param selectionOverride Override the current selection. If we want to format a table even currently it is not selected, we can use this parameter to override current selection
  */
 export function formatTableWithContentModel(
     editor: IStandaloneEditor,

--- a/packages-content-model/roosterjs-content-model-api/lib/publicApi/utils/formatTableWithContentModel.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/publicApi/utils/formatTableWithContentModel.ts
@@ -1,0 +1,64 @@
+import { ensureFocusableParagraphForTable } from '../../modelApi/table/ensureFocusableParagraphForTable';
+import {
+    createSelectionMarker,
+    hasMetadata,
+    setParagraphNotImplicit,
+} from 'roosterjs-content-model-dom';
+import {
+    hasSelectionInBlock,
+    applyTableFormat,
+    getFirstSelectedTable,
+    normalizeTable,
+    setSelection,
+} from 'roosterjs-content-model-core';
+import type {
+    ContentModelTable,
+    IStandaloneEditor,
+    TableSelection,
+} from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ */
+export function formatTableWithContentModel(
+    editor: IStandaloneEditor,
+    apiName: string,
+    callback: (tableModel: ContentModelTable) => void,
+    selectionOverride?: TableSelection
+) {
+    editor.formatContentModel(
+        model => {
+            const [tableModel, path] = getFirstSelectedTable(model);
+
+            if (tableModel) {
+                callback(tableModel);
+
+                if (!hasSelectionInBlock(tableModel)) {
+                    const paragraph = ensureFocusableParagraphForTable(model, path, tableModel);
+
+                    if (paragraph) {
+                        const marker = createSelectionMarker(model.format);
+
+                        paragraph.segments.unshift(marker);
+                        setParagraphNotImplicit(paragraph);
+                        setSelection(model, marker);
+                    }
+                }
+
+                normalizeTable(tableModel, model.format);
+
+                if (hasMetadata(tableModel)) {
+                    applyTableFormat(tableModel, undefined /*newFormat*/, true /*keepCellShade*/);
+                }
+
+                return true;
+            } else {
+                return false;
+            }
+        },
+        {
+            apiName,
+            selectionOverride,
+        }
+    );
+}

--- a/packages-content-model/roosterjs-content-model-api/test/publicApi/table/editTableTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/publicApi/table/editTableTest.ts
@@ -1,0 +1,243 @@
+import * as alignTable from '../../../lib/modelApi/table/alignTable';
+import * as alignTableCell from '../../../lib/modelApi/table/alignTableCell';
+import * as deleteTable from '../../../lib/modelApi/table/deleteTable';
+import * as deleteTableColumn from '../../../lib/modelApi/table/deleteTableColumn';
+import * as deleteTableRow from '../../../lib/modelApi/table/deleteTableRow';
+import * as formatTableWithContentModel from '../../../lib/publicApi/utils/formatTableWithContentModel';
+import * as insertTableColumn from '../../../lib/modelApi/table/insertTableColumn';
+import * as insertTableRow from '../../../lib/modelApi/table/insertTableRow';
+import * as mergeTableCells from '../../../lib/modelApi/table/mergeTableCells';
+import * as mergeTableColumn from '../../../lib/modelApi/table/mergeTableColumn';
+import * as mergeTableRow from '../../../lib/modelApi/table/mergeTableRow';
+import * as splitTableCellHorizontally from '../../../lib/modelApi/table/splitTableCellHorizontally';
+import * as splitTableCellVertically from '../../../lib/modelApi/table/splitTableCellVertically';
+import editTable from '../../../lib/publicApi/table/editTable';
+import { IStandaloneEditor, TableOperation } from 'roosterjs-content-model-types';
+
+describe('editTable', () => {
+    let editor: IStandaloneEditor;
+    let focusSpy: jasmine.Spy;
+    let formatTableWithContentModelSpy: jasmine.Spy;
+    const mockedTable = 'TABLE' as any;
+
+    function runTest(operation: TableOperation, expectedSpy: jasmine.Spy, ...parameters: string[]) {
+        editTable(editor, operation);
+
+        expect(formatTableWithContentModelSpy).toHaveBeenCalledWith(
+            editor,
+            'editTable',
+            jasmine.anything()
+        );
+        expect(expectedSpy).toHaveBeenCalledWith(mockedTable, ...parameters);
+    }
+
+    beforeEach(() => {
+        focusSpy = jasmine.createSpy('focus');
+        formatTableWithContentModelSpy = spyOn(
+            formatTableWithContentModel,
+            'formatTableWithContentModel'
+        ).and.callFake((editorParam, apiParam, callback) => {
+            callback(mockedTable);
+        });
+
+        editor = {
+            focus: focusSpy,
+        } as any;
+    });
+
+    describe('alignTableCellHorizontally', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(alignTableCell, 'alignTableCellHorizontally');
+        });
+
+        it('alignCellLeft', () => {
+            runTest('alignCellLeft', spy, 'alignCellLeft');
+        });
+
+        it('alignCellCenter', () => {
+            runTest('alignCellCenter', spy, 'alignCellCenter');
+        });
+
+        it('alignCellRight', () => {
+            runTest('alignCellRight', spy, 'alignCellRight');
+        });
+    });
+
+    describe('alignTableCellVertically', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(alignTableCell, 'alignTableCellVertically');
+        });
+
+        it('alignCellTop', () => {
+            runTest('alignCellTop', spy, 'alignCellTop');
+        });
+
+        it('alignCellMiddle', () => {
+            runTest('alignCellMiddle', spy, 'alignCellMiddle');
+        });
+
+        it('alignCellBottom', () => {
+            runTest('alignCellBottom', spy, 'alignCellBottom');
+        });
+    });
+
+    describe('alignTable', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(alignTable, 'alignTable');
+        });
+
+        it('alignCenter', () => {
+            runTest('alignCenter', spy, 'alignCenter');
+        });
+
+        it('alignLeft', () => {
+            runTest('alignLeft', spy, 'alignLeft');
+        });
+
+        it('alignRight', () => {
+            runTest('alignRight', spy, 'alignRight');
+        });
+    });
+
+    describe('deleteTableColumn', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(deleteTableColumn, 'deleteTableColumn');
+        });
+
+        it('deleteColumn', () => {
+            runTest('deleteColumn', spy);
+        });
+    });
+
+    describe('deleteTableRow', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(deleteTableRow, 'deleteTableRow');
+        });
+
+        it('deleteRow', () => {
+            runTest('deleteRow', spy);
+        });
+    });
+
+    describe('deleteTable', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(deleteTable, 'deleteTable');
+        });
+
+        it('deleteTable', () => {
+            runTest('deleteTable', spy);
+        });
+    });
+
+    describe('insertTableRow', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(insertTableRow, 'insertTableRow');
+        });
+
+        it('insertAbove', () => {
+            runTest('insertAbove', spy, 'insertAbove');
+        });
+
+        it('insertBelow', () => {
+            runTest('insertBelow', spy, 'insertBelow');
+        });
+    });
+
+    describe('insertTableColumn', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(insertTableColumn, 'insertTableColumn');
+        });
+
+        it('insertLeft', () => {
+            runTest('insertLeft', spy, 'insertLeft');
+        });
+
+        it('insertRight', () => {
+            runTest('insertRight', spy, 'insertRight');
+        });
+    });
+
+    describe('mergeTableRow', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(mergeTableRow, 'mergeTableRow');
+        });
+
+        it('mergeAbove', () => {
+            runTest('mergeAbove', spy, 'mergeAbove');
+        });
+
+        it('mergeBelow', () => {
+            runTest('mergeBelow', spy, 'mergeBelow');
+        });
+    });
+
+    describe('mergeTableCells', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(mergeTableCells, 'mergeTableCells');
+        });
+
+        it('mergeCells', () => {
+            runTest('mergeCells', spy);
+        });
+    });
+
+    describe('mergeTableColumn', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(mergeTableColumn, 'mergeTableColumn');
+        });
+
+        it('mergeLeft', () => {
+            runTest('mergeLeft', spy, 'mergeLeft');
+        });
+
+        it('mergeRight', () => {
+            runTest('mergeRight', spy, 'mergeRight');
+        });
+    });
+
+    describe('splitTableCellHorizontally', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(splitTableCellHorizontally, 'splitTableCellHorizontally');
+        });
+
+        it('splitHorizontally', () => {
+            runTest('splitHorizontally', spy);
+        });
+    });
+
+    describe('splitTableCellVertically', () => {
+        let spy: jasmine.Spy;
+
+        beforeEach(() => {
+            spy = spyOn(splitTableCellVertically, 'splitTableCellVertically');
+        });
+
+        it('splitVertically', () => {
+            runTest('splitVertically', spy);
+        });
+    });
+});

--- a/packages-content-model/roosterjs-content-model-api/test/publicApi/utils/formatTableWithContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/publicApi/utils/formatTableWithContentModelTest.ts
@@ -1,0 +1,284 @@
+import * as applyTableFormat from 'roosterjs-content-model-core/lib/publicApi/table/applyTableFormat';
+import * as ensureFocusableParagraphForTable from '../../../lib/modelApi/table/ensureFocusableParagraphForTable';
+import * as hasSelectionInBlock from 'roosterjs-content-model-core/lib/publicApi/selection/hasSelectionInBlock';
+import * as normalizeTable from 'roosterjs-content-model-core/lib/publicApi/table/normalizeTable';
+import { ContentModelDocument, IStandaloneEditor } from 'roosterjs-content-model-types';
+import { formatTableWithContentModel } from '../../../lib/publicApi/utils/formatTableWithContentModel';
+import {
+    createContentModelDocument,
+    createTable,
+    createTableCell,
+} from 'roosterjs-content-model-dom';
+
+describe('formatTableWithContentModel', () => {
+    let editor: IStandaloneEditor;
+    let formatContentModelSpy: jasmine.Spy;
+    let model: ContentModelDocument;
+    let formatResult: boolean | undefined;
+
+    beforeEach(() => {
+        formatResult = undefined;
+        formatContentModelSpy = jasmine
+            .createSpy('formatContentModel')
+            .and.callFake((callback: Function) => {
+                formatResult = callback(model);
+            });
+        editor = {
+            formatContentModel: formatContentModelSpy,
+        } as any;
+    });
+
+    it('Empty model', () => {
+        model = createContentModelDocument();
+        const callback = jasmine.createSpy('callback');
+
+        formatTableWithContentModel(editor, 'editTable', callback);
+
+        expect(callback).not.toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalledWith(jasmine.anything(), {
+            apiName: 'editTable',
+            selectionOverride: undefined,
+        });
+        expect(formatResult).toBeFalse();
+    });
+
+    it('Model with table but not selected', () => {
+        model = createContentModelDocument();
+        const table = createTable(1);
+        const tableCell = createTableCell();
+
+        table.rows[0].cells.push(tableCell);
+        model.blocks.push(table);
+
+        const callback = jasmine.createSpy('callback');
+
+        formatTableWithContentModel(editor, 'editTable', callback);
+
+        expect(callback).not.toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalledWith(jasmine.anything(), {
+            apiName: 'editTable',
+            selectionOverride: undefined,
+        });
+        expect(formatResult).toBeFalse();
+    });
+
+    it('Model with selected table, has selection in block, no metadata', () => {
+        model = createContentModelDocument();
+        const table = createTable(1);
+        const tableCell = createTableCell();
+
+        tableCell.isSelected = true;
+
+        table.rows[0].cells.push(tableCell);
+        model.blocks.push(table);
+
+        spyOn(hasSelectionInBlock, 'default').and.returnValue(true);
+        spyOn(ensureFocusableParagraphForTable, 'ensureFocusableParagraphForTable');
+        spyOn(normalizeTable, 'normalizeTable');
+        spyOn(applyTableFormat, 'applyTableFormat');
+
+        const callback = jasmine.createSpy('callback');
+
+        formatTableWithContentModel(editor, 'editTable', callback);
+
+        expect(callback).toHaveBeenCalledWith(table);
+        expect(formatContentModelSpy).toHaveBeenCalledWith(jasmine.anything(), {
+            apiName: 'editTable',
+            selectionOverride: undefined,
+        });
+        expect(
+            ensureFocusableParagraphForTable.ensureFocusableParagraphForTable
+        ).not.toHaveBeenCalled();
+        expect(normalizeTable.normalizeTable).toHaveBeenCalledWith(table, undefined);
+        expect(applyTableFormat.applyTableFormat).not.toHaveBeenCalled();
+        expect(formatResult).toBeTrue();
+    });
+
+    it('Model with selected table, no selection in block, no metadata', () => {
+        model = createContentModelDocument();
+        const table = createTable(1);
+        const tableCell = createTableCell();
+
+        tableCell.isSelected = true;
+
+        table.rows[0].cells.push(tableCell);
+        model.blocks.push(table);
+
+        spyOn(hasSelectionInBlock, 'default').and.returnValue(false);
+        spyOn(
+            ensureFocusableParagraphForTable,
+            'ensureFocusableParagraphForTable'
+        ).and.callThrough();
+        spyOn(normalizeTable, 'normalizeTable');
+        spyOn(applyTableFormat, 'applyTableFormat');
+
+        const callback = jasmine.createSpy('callback');
+
+        formatTableWithContentModel(editor, 'editTable', callback);
+
+        expect(callback).toHaveBeenCalledWith(table);
+        expect(formatContentModelSpy).toHaveBeenCalledWith(jasmine.anything(), {
+            apiName: 'editTable',
+            selectionOverride: undefined,
+        });
+        expect(
+            ensureFocusableParagraphForTable.ensureFocusableParagraphForTable
+        ).toHaveBeenCalledWith(model, [model], table);
+        expect(normalizeTable.normalizeTable).toHaveBeenCalledWith(table, undefined);
+        expect(applyTableFormat.applyTableFormat).not.toHaveBeenCalled();
+        expect(formatResult).toBeTrue();
+        expect(tableCell).toEqual({
+            blockGroupType: 'TableCell',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+            spanLeft: false,
+            spanAbove: false,
+            isHeader: false,
+            dataset: {},
+        });
+    });
+
+    it('Model with selected table, no selection in block, has metadata', () => {
+        model = createContentModelDocument();
+        const table = createTable(1);
+        const tableCell = createTableCell();
+
+        tableCell.isSelected = true;
+
+        table.dataset.editingInfo = '{}';
+        table.rows[0].cells.push(tableCell);
+        model.blocks.push(table);
+
+        spyOn(hasSelectionInBlock, 'default').and.returnValue(false);
+        spyOn(
+            ensureFocusableParagraphForTable,
+            'ensureFocusableParagraphForTable'
+        ).and.callThrough();
+        spyOn(normalizeTable, 'normalizeTable');
+        spyOn(applyTableFormat, 'applyTableFormat');
+
+        const callback = jasmine.createSpy('callback');
+
+        formatTableWithContentModel(editor, 'editTable', callback);
+
+        expect(callback).toHaveBeenCalledWith(table);
+        expect(formatContentModelSpy).toHaveBeenCalledWith(jasmine.anything(), {
+            apiName: 'editTable',
+            selectionOverride: undefined,
+        });
+        expect(
+            ensureFocusableParagraphForTable.ensureFocusableParagraphForTable
+        ).toHaveBeenCalledWith(model, [model], table);
+        expect(normalizeTable.normalizeTable).toHaveBeenCalledWith(table, undefined);
+        expect(applyTableFormat.applyTableFormat).toHaveBeenCalledWith(table, undefined, true);
+        expect(formatResult).toBeTrue();
+        expect(tableCell).toEqual({
+            blockGroupType: 'TableCell',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+            spanLeft: false,
+            spanAbove: false,
+            isHeader: false,
+            dataset: {},
+        });
+    });
+
+    it('With default format and additional parameters', () => {
+        model = createContentModelDocument({
+            fontSize: '10pt',
+        });
+        const table = createTable(1);
+        const tableCell = createTableCell();
+
+        tableCell.isSelected = true;
+
+        table.dataset.editingInfo = '{}';
+        table.rows[0].cells.push(tableCell);
+        model.blocks.push(table);
+
+        spyOn(hasSelectionInBlock, 'default').and.returnValue(false);
+        spyOn(
+            ensureFocusableParagraphForTable,
+            'ensureFocusableParagraphForTable'
+        ).and.callThrough();
+        spyOn(normalizeTable, 'normalizeTable');
+        spyOn(applyTableFormat, 'applyTableFormat');
+
+        const callback = jasmine.createSpy('callback');
+        const mockedSelection = 'SELECTION' as any;
+
+        formatTableWithContentModel(editor, 'editTable', callback, mockedSelection);
+
+        expect(callback).toHaveBeenCalledWith(table);
+        expect(formatContentModelSpy).toHaveBeenCalledWith(jasmine.anything(), {
+            apiName: 'editTable',
+            selectionOverride: mockedSelection,
+        });
+        expect(
+            ensureFocusableParagraphForTable.ensureFocusableParagraphForTable
+        ).toHaveBeenCalledWith(model, [model], table);
+        expect(normalizeTable.normalizeTable).toHaveBeenCalledWith(table, { fontSize: '10pt' });
+        expect(applyTableFormat.applyTableFormat).toHaveBeenCalledWith(table, undefined, true);
+        expect(formatResult).toBeTrue();
+        expect(tableCell).toEqual({
+            blockGroupType: 'TableCell',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: { fontSize: '10pt' },
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: { fontSize: '10pt' },
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontSize: '10pt',
+                    },
+                },
+            ],
+            format: {},
+            spanLeft: false,
+            spanAbove: false,
+            isHeader: false,
+            dataset: {},
+        });
+    });
+});


### PR DESCRIPTION
Split the existing `editTable` API, extract a new common function `formatTableWithContentModel`, so we can easily write new table format API with the common code.

This is a preparation step of TableEdit plugin porting.