### PR TITLE
Convert inline CSS when create init model

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/coreApi/paste.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/coreApi/paste.ts
@@ -1,5 +1,5 @@
 import { cloneModel } from '../publicApi/model/cloneModel';
-import { convertInlineCss } from '../utils/paste/convertInlineCss';
+import { convertInlineCss } from '../utils/convertInlineCss';
 import { createPasteFragment } from '../utils/paste/createPasteFragment';
 import { generatePasteOptionFromPlugins } from '../utils/paste/generatePasteOptionFromPlugins';
 import { mergePasteContent } from '../utils/paste/mergePasteContent';

--- a/packages-content-model/roosterjs-content-model-core/lib/override/pasteEntityProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/override/pasteEntityProcessor.ts
@@ -1,6 +1,6 @@
 import { AllowedTags, DisallowedTags, sanitizeElement } from '../utils/sanitizeElement';
 import type {
-    DomToModelOptionForPaste,
+    DomToModelOptionForSanitizing,
     ElementProcessor,
     ValueSanitizer,
 } from 'roosterjs-content-model-types';
@@ -13,7 +13,7 @@ const DefaultStyleSanitizers: Readonly<Record<string, ValueSanitizer>> = {
  * @internal
  */
 export function createPasteEntityProcessor(
-    options: DomToModelOptionForPaste
+    options: DomToModelOptionForSanitizing
 ): ElementProcessor<HTMLElement> {
     const allowedTags = AllowedTags.concat(options.additionalAllowedTags);
     const disallowedTags = DisallowedTags.concat(options.additionalDisallowedTags);

--- a/packages-content-model/roosterjs-content-model-core/lib/override/pasteGeneralProcessor.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/override/pasteGeneralProcessor.ts
@@ -1,7 +1,7 @@
 import { AllowedTags, createSanitizedElement, DisallowedTags } from '../utils/sanitizeElement';
 import { moveChildNodes } from 'roosterjs-content-model-dom';
 import type {
-    DomToModelOptionForPaste,
+    DomToModelOptionForSanitizing,
     ElementProcessor,
     ValueSanitizer,
 } from 'roosterjs-content-model-types';
@@ -22,7 +22,7 @@ const DefaultStyleSanitizers: Readonly<Record<string, ValueSanitizer>> = {
  * @internal
  */
 export function createPasteGeneralProcessor(
-    options: DomToModelOptionForPaste
+    options: DomToModelOptionForSanitizing
 ): ElementProcessor<HTMLElement> {
     const allowedTags = AllowedTags.concat(options.additionalAllowedTags);
     const disallowedTags = DisallowedTags.concat(options.additionalDisallowedTags);

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
@@ -1,10 +1,6 @@
 import { convertInlineCss, retrieveCssRules } from '../../utils/convertInlineCss';
-import {
-    createDomToModelContext,
-    createEmptyModel,
-    domToContentModel,
-    parseFormat,
-} from 'roosterjs-content-model-dom';
+import { createDomToModelContextForSanitizing } from 'roosterjs-content-model-core/lib/utils/createDomToModelContextForSanitizing';
+import { createEmptyModel, domToContentModel, parseFormat } from 'roosterjs-content-model-dom';
 import type {
     ContentModelDocument,
     ContentModelSegmentFormat,
@@ -30,12 +26,7 @@ export function createModelFromHtml(
         : null;
 
     if (doc?.body) {
-        const context = createDomToModelContext(
-            {
-                defaultFormat: defaultSegmentFormat,
-            },
-            options
-        );
+        const context = createDomToModelContextForSanitizing(defaultSegmentFormat, options);
         const cssRules = doc ? retrieveCssRules(doc) : [];
 
         convertInlineCss(doc, cssRules);

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
@@ -1,5 +1,5 @@
 import { convertInlineCss, retrieveCssRules } from '../../utils/convertInlineCss';
-import { createDomToModelContextForSanitizing } from 'roosterjs-content-model-core/lib/utils/createDomToModelContextForSanitizing';
+import { createDomToModelContextForSanitizing } from '../../utils/createDomToModelContextForSanitizing';
 import { createEmptyModel, domToContentModel, parseFormat } from 'roosterjs-content-model-dom';
 import type {
     ContentModelDocument,

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
@@ -1,4 +1,8 @@
 import {
+    convertInlineCss,
+    retrieveCssRules,
+} from 'roosterjs-content-model-core/lib/utils/convertInlineCss';
+import {
     createDomToModelContext,
     createEmptyModel,
     domToContentModel,
@@ -25,15 +29,20 @@ export function createModelFromHtml(
 ): ContentModelDocument {
     const doc = new DOMParser().parseFromString(trustedHTMLHandler?.(html) ?? html, 'text/html');
 
-    return doc?.body
-        ? domToContentModel(
-              doc.body,
-              createDomToModelContext(
-                  {
-                      defaultFormat: defaultSegmentFormat,
-                  },
-                  options
-              )
-          )
-        : createEmptyModel(defaultSegmentFormat);
+    if (doc?.body) {
+        const cssRules = doc ? retrieveCssRules(doc) : [];
+
+        convertInlineCss(doc, cssRules);
+        return domToContentModel(
+            doc.body,
+            createDomToModelContext(
+                {
+                    defaultFormat: defaultSegmentFormat,
+                },
+                options
+            )
+        );
+    } else {
+        return createEmptyModel(defaultSegmentFormat);
+    }
 }

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
@@ -1,11 +1,9 @@
-import {
-    convertInlineCss,
-    retrieveCssRules,
-} from 'roosterjs-content-model-core/lib/utils/convertInlineCss';
+import { convertInlineCss, retrieveCssRules } from '../../utils/convertInlineCss';
 import {
     createDomToModelContext,
     createEmptyModel,
     domToContentModel,
+    parseFormat,
 } from 'roosterjs-content-model-dom';
 import type {
     ContentModelDocument,
@@ -30,18 +28,18 @@ export function createModelFromHtml(
     const doc = new DOMParser().parseFromString(trustedHTMLHandler?.(html) ?? html, 'text/html');
 
     if (doc?.body) {
+        const context = createDomToModelContext(
+            {
+                defaultFormat: defaultSegmentFormat,
+            },
+            options
+        );
         const cssRules = doc ? retrieveCssRules(doc) : [];
 
         convertInlineCss(doc, cssRules);
-        return domToContentModel(
-            doc.body,
-            createDomToModelContext(
-                {
-                    defaultFormat: defaultSegmentFormat,
-                },
-                options
-            )
-        );
+        parseFormat(doc.body, context.formatParsers.segmentOnBlock, context.segmentFormat, context);
+
+        return domToContentModel(doc.body, context);
     } else {
         return createEmptyModel(defaultSegmentFormat);
     }

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/createModelFromHtml.ts
@@ -25,7 +25,9 @@ export function createModelFromHtml(
     trustedHTMLHandler?: TrustedHTMLHandler,
     defaultSegmentFormat?: ContentModelSegmentFormat
 ): ContentModelDocument {
-    const doc = new DOMParser().parseFromString(trustedHTMLHandler?.(html) ?? html, 'text/html');
+    const doc = html
+        ? new DOMParser().parseFromString(trustedHTMLHandler?.(html) ?? html, 'text/html')
+        : null;
 
     if (doc?.body) {
         const context = createDomToModelContext(

--- a/packages-content-model/roosterjs-content-model-core/lib/utils/convertInlineCss.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/utils/convertInlineCss.ts
@@ -1,5 +1,39 @@
 import { toArray } from 'roosterjs-content-model-dom';
-import type { CssRule } from './retrieveHtmlInfo';
+
+/**
+ * @internal
+ */
+export interface CssRule {
+    selectors: string[];
+    text: string;
+}
+
+/**
+ * @internal
+ */
+export function retrieveCssRules(doc: Document): CssRule[] {
+    const styles = toArray(doc.querySelectorAll('style'));
+    const result: CssRule[] = [];
+
+    styles.forEach(styleNode => {
+        const sheet = styleNode.sheet as CSSStyleSheet;
+
+        for (let ruleIndex = 0; ruleIndex < sheet.cssRules.length; ruleIndex++) {
+            const rule = sheet.cssRules[ruleIndex] as CSSStyleRule;
+
+            if (rule.type == CSSRule.STYLE_RULE && rule.selectorText) {
+                result.push({
+                    selectors: rule.selectorText.split(','),
+                    text: rule.style.cssText,
+                });
+            }
+        }
+
+        styleNode.parentNode?.removeChild(styleNode);
+    });
+
+    return result;
+}
 
 /**
  * @internal

--- a/packages-content-model/roosterjs-content-model-core/lib/utils/createDomToModelContextForSanitizing.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/utils/createDomToModelContextForSanitizing.ts
@@ -1,0 +1,57 @@
+import { containerSizeFormatParser } from '../override/containerSizeFormatParser';
+import { createDomToModelContext } from 'roosterjs-content-model-dom';
+import { createPasteEntityProcessor } from '../override/pasteEntityProcessor';
+import { createPasteGeneralProcessor } from '../override/pasteGeneralProcessor';
+import { pasteDisplayFormatParser } from '../override/pasteDisplayFormatParser';
+import { pasteTextProcessor } from '../override/pasteTextProcessor';
+import type {
+    ContentModelSegmentFormat,
+    DomToModelContext,
+    DomToModelOption,
+    DomToModelOptionForSanitizing,
+} from 'roosterjs-content-model-types';
+
+const DefaultSanitizingOption: DomToModelOptionForSanitizing = {
+    processorOverride: {},
+    formatParserOverride: {},
+    additionalFormatParsers: {},
+    additionalAllowedTags: [],
+    additionalDisallowedTags: [],
+    styleSanitizers: {},
+    attributeSanitizers: {},
+};
+
+/**
+ * @internal
+ */
+export function createDomToModelContextForSanitizing(
+    defaultFormat?: ContentModelSegmentFormat,
+    defaultOption?: DomToModelOption,
+    additionalSanitizingOption?: DomToModelOptionForSanitizing
+): DomToModelContext {
+    const sanitizingOption: DomToModelOptionForSanitizing = {
+        ...DefaultSanitizingOption,
+        ...additionalSanitizingOption,
+    };
+
+    return createDomToModelContext(
+        {
+            defaultFormat,
+        },
+        defaultOption,
+        {
+            processorOverride: {
+                '#text': pasteTextProcessor,
+                entity: createPasteEntityProcessor(sanitizingOption),
+                '*': createPasteGeneralProcessor(sanitizingOption),
+            },
+            formatParserOverride: {
+                display: pasteDisplayFormatParser,
+            },
+            additionalFormatParsers: {
+                container: [containerSizeFormatParser],
+            },
+        },
+        sanitizingOption
+    );
+}

--- a/packages-content-model/roosterjs-content-model-core/lib/utils/paste/generatePasteOptionFromPlugins.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/utils/paste/generatePasteOptionFromPlugins.ts
@@ -2,7 +2,7 @@ import type { HtmlFromClipboard } from './retrieveHtmlInfo';
 import type {
     BeforePasteEvent,
     ClipboardData,
-    DomToModelOptionForPaste,
+    DomToModelOptionForSanitizing,
     PasteType,
     StandaloneEditorCore,
 } from 'roosterjs-content-model-types';
@@ -17,7 +17,7 @@ export function generatePasteOptionFromPlugins(
     htmlFromClipboard: HtmlFromClipboard,
     pasteType: PasteType
 ): BeforePasteEvent {
-    const domToModelOption: DomToModelOptionForPaste = {
+    const domToModelOption: DomToModelOptionForSanitizing = {
         additionalAllowedTags: [],
         additionalDisallowedTags: [],
         additionalFormatParsers: {},

--- a/packages-content-model/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
@@ -1,13 +1,9 @@
 import { ChangeSource } from '../../constants/ChangeSource';
-import { containerSizeFormatParser } from '../../override/containerSizeFormatParser';
-import { createDomToModelContext, domToContentModel } from 'roosterjs-content-model-dom';
-import { createPasteEntityProcessor } from '../../override/pasteEntityProcessor';
-import { createPasteGeneralProcessor } from '../../override/pasteGeneralProcessor';
+import { createDomToModelContextForSanitizing } from '../createDomToModelContextForSanitizing';
+import { domToContentModel } from 'roosterjs-content-model-dom';
 import { getSegmentTextFormat } from '../../publicApi/domUtils/getSegmentTextFormat';
 import { getSelectedSegments } from '../../publicApi/selection/collectSelections';
 import { mergeModel } from '../../publicApi/model/mergeModel';
-import { pasteDisplayFormatParser } from '../../override/pasteDisplayFormatParser';
-import { pasteTextProcessor } from '../../override/pasteTextProcessor';
 import type { MergeModelOption } from '../../publicApi/model/mergeModel';
 import type {
     BeforePasteEvent,
@@ -45,22 +41,9 @@ export function mergePasteContent(
         core,
         (model, context) => {
             const selectedSegment = getSelectedSegments(model, true /*includeFormatHolder*/)[0];
-            const domToModelContext = createDomToModelContext(
-                undefined /*editorContext*/,
+            const domToModelContext = createDomToModelContextForSanitizing(
+                undefined /*defaultFormat*/,
                 core.domToModelSettings.customized,
-                {
-                    processorOverride: {
-                        '#text': pasteTextProcessor,
-                        entity: createPasteEntityProcessor(domToModelOption),
-                        '*': createPasteGeneralProcessor(domToModelOption),
-                    },
-                    formatParserOverride: {
-                        display: pasteDisplayFormatParser,
-                    },
-                    additionalFormatParsers: {
-                        container: [containerSizeFormatParser],
-                    },
-                },
                 domToModelOption
             );
 

--- a/packages-content-model/roosterjs-content-model-core/lib/utils/paste/retrieveHtmlInfo.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/utils/paste/retrieveHtmlInfo.ts
@@ -1,16 +1,10 @@
 import { isNodeOfType, toArray } from 'roosterjs-content-model-dom';
+import { retrieveCssRules } from '../convertInlineCss';
+import type { CssRule } from '../convertInlineCss';
 import type { ClipboardData } from 'roosterjs-content-model-types';
 
 const START_FRAGMENT = '<!--StartFragment-->';
 const END_FRAGMENT = '<!--EndFragment-->';
-
-/**
- * @internal
- */
-export interface CssRule {
-    selectors: string[];
-    text: string;
-}
 
 /**
  * @internal
@@ -75,30 +69,6 @@ function retrieveMetadata(doc: Document): Record<string, string> {
 
     toArray(doc.querySelectorAll('meta')).forEach(meta => {
         result[meta.name] = meta.content;
-    });
-
-    return result;
-}
-
-function retrieveCssRules(doc: Document): CssRule[] {
-    const styles = toArray(doc.querySelectorAll('style'));
-    const result: CssRule[] = [];
-
-    styles.forEach(styleNode => {
-        const sheet = styleNode.sheet as CSSStyleSheet;
-
-        for (let ruleIndex = 0; ruleIndex < sheet.cssRules.length; ruleIndex++) {
-            const rule = sheet.cssRules[ruleIndex] as CSSStyleRule;
-
-            if (rule.type == CSSRule.STYLE_RULE && rule.selectorText) {
-                result.push({
-                    selectors: rule.selectorText.split(','),
-                    text: rule.style.cssText,
-                });
-            }
-        }
-
-        styleNode.parentNode?.removeChild(styleNode);
     });
 
     return result;

--- a/packages-content-model/roosterjs-content-model-core/test/publicApi/model/createModelFromHtmlTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/publicApi/model/createModelFromHtmlTest.ts
@@ -1,0 +1,206 @@
+import * as convertInlineCss from '../../../lib/utils/convertInlineCss';
+import * as createDomToModelContext from 'roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext';
+import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
+import * as parseFormat from 'roosterjs-content-model-dom/lib/domToModel/utils/parseFormat';
+import { ContentModelSegmentFormat } from 'roosterjs-content-model-types';
+import { createModelFromHtml } from '../../../lib/publicApi/model/createModelFromHtml';
+
+describe('createModelFromHtml', () => {
+    it('Empty html, no options', () => {
+        const html = '';
+        const model = createModelFromHtml(html);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Valid html, no options', () => {
+        const html = '<div style="font-size:20px">test</div>';
+        const model = createModelFromHtml(html);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: { fontSize: '20px' },
+                        },
+                    ],
+                    segmentFormat: { fontSize: '20px' },
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('Valid html with style on BODY and global CSS, no options', () => {
+        const html =
+            '<html><head><style>div {font-family: Arial}</style></head><body style="color:red"><div style="font-size:20px">test</div></body></html>';
+        const model = createModelFromHtml(html);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: { fontSize: '20px', textColor: 'red', fontFamily: 'Arial' },
+                        },
+                    ],
+                    segmentFormat: { fontSize: '20px', fontFamily: 'Arial' },
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('Valid html, with options', () => {
+        const html = '<div style="font-size:20px">test</div>';
+        const mockedOptions = 'OPTIONS' as any;
+        const mockedContext = {
+            formatParsers: {
+                segmentOnBlock: 'PARSERS',
+            },
+            segmentFormat: 'SEGMENT',
+        } as any;
+        const createContextSpy = spyOn(
+            createDomToModelContext,
+            'createDomToModelContext'
+        ).and.returnValue(mockedContext);
+        const parseFormatSpy = spyOn(parseFormat, 'parseFormat');
+        const mockedDoc = {
+            body: 'BODY',
+        } as any;
+        const mockedModel = 'MODEL' as any;
+        const domToContentModelSpy = spyOn(domToContentModel, 'domToContentModel').and.returnValue(
+            mockedModel
+        );
+        const domParserSpy = spyOn(DOMParser.prototype, 'parseFromString').and.returnValue(
+            mockedDoc
+        );
+        const mockedRules = 'RULES' as any;
+        const retrieveCssRulesSpy = spyOn(convertInlineCss, 'retrieveCssRules').and.returnValue(
+            mockedRules
+        );
+        const convertInlineCssSpy = spyOn(convertInlineCss, 'convertInlineCss');
+        const mockedTrustedHtmlHandler = jasmine
+            .createSpy('trustHandler')
+            .and.returnValue('TRUSTEDHTML');
+        const mockedDefaultSegmentFormat = 'FORMAT' as any;
+
+        const model = createModelFromHtml(
+            html,
+            mockedOptions,
+            mockedTrustedHtmlHandler,
+            mockedDefaultSegmentFormat
+        );
+
+        expect(model).toEqual(mockedModel);
+        expect(mockedTrustedHtmlHandler).toHaveBeenCalledWith(html);
+        expect(domParserSpy).toHaveBeenCalledWith('TRUSTEDHTML', 'text/html');
+        expect(parseFormatSpy).toHaveBeenCalledTimes(1);
+        expect(parseFormatSpy).toHaveBeenCalledWith(
+            'BODY' as any,
+            'PARSERS' as any,
+            'SEGMENT' as any,
+            mockedContext
+        );
+        expect(createContextSpy).toHaveBeenCalledTimes(1);
+        expect(createContextSpy).toHaveBeenCalledWith(
+            {
+                defaultFormat: mockedDefaultSegmentFormat,
+            },
+            mockedOptions
+        );
+        expect(domToContentModelSpy).toHaveBeenCalledWith('BODY' as any, mockedContext);
+        expect(retrieveCssRulesSpy).toHaveBeenCalledWith(mockedDoc);
+        expect(convertInlineCssSpy).toHaveBeenCalledWith(mockedDoc, mockedRules);
+    });
+
+    it('Empty html, with options', () => {
+        const mockedOptions = 'OPTIONS' as any;
+        const mockedContext = {
+            formatParsers: {
+                segmentOnBlock: 'PARSERS',
+            },
+            segmentFormat: 'SEGMENT',
+        } as any;
+        const createContextSpy = spyOn(
+            createDomToModelContext,
+            'createDomToModelContext'
+        ).and.returnValue(mockedContext);
+        const parseFormatSpy = spyOn(parseFormat, 'parseFormat');
+        const mockedDoc = {
+            body: 'BODY',
+        } as any;
+        const mockedModel = 'MODEL' as any;
+        const domToContentModelSpy = spyOn(domToContentModel, 'domToContentModel').and.returnValue(
+            mockedModel
+        );
+        const domParserSpy = spyOn(DOMParser.prototype, 'parseFromString').and.returnValue(
+            mockedDoc
+        );
+        const mockedRules = 'RULES' as any;
+        const retrieveCssRulesSpy = spyOn(convertInlineCss, 'retrieveCssRules').and.returnValue(
+            mockedRules
+        );
+        const convertInlineCssSpy = spyOn(convertInlineCss, 'convertInlineCss');
+        const segmentFormat: ContentModelSegmentFormat = { fontSize: '10pt' };
+
+        const model = createModelFromHtml('', mockedOptions, undefined, segmentFormat);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segmentFormat: { fontSize: '10pt' },
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: { fontSize: '10pt' },
+                        },
+                        {
+                            segmentType: 'Br',
+                            format: { fontSize: '10pt' },
+                        },
+                    ],
+                },
+            ],
+            format: { fontSize: '10pt' },
+        });
+        expect(domParserSpy).not.toHaveBeenCalled();
+        expect(parseFormatSpy).not.toHaveBeenCalled();
+        expect(createContextSpy).not.toHaveBeenCalled();
+        expect(domToContentModelSpy).not.toHaveBeenCalled();
+        expect(retrieveCssRulesSpy).not.toHaveBeenCalled();
+        expect(convertInlineCssSpy).not.toHaveBeenCalled();
+    });
+});

--- a/packages-content-model/roosterjs-content-model-core/test/publicApi/model/createModelFromHtmlTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/publicApi/model/createModelFromHtmlTest.ts
@@ -1,5 +1,5 @@
 import * as convertInlineCss from '../../../lib/utils/convertInlineCss';
-import * as createDomToModelContext from 'roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext';
+import * as createDomToModelContextForSanitizing from '../../../lib/utils/createDomToModelContextForSanitizing';
 import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
 import * as parseFormat from 'roosterjs-content-model-dom/lib/domToModel/utils/parseFormat';
 import { ContentModelSegmentFormat } from 'roosterjs-content-model-types';
@@ -89,8 +89,8 @@ describe('createModelFromHtml', () => {
             segmentFormat: 'SEGMENT',
         } as any;
         const createContextSpy = spyOn(
-            createDomToModelContext,
-            'createDomToModelContext'
+            createDomToModelContextForSanitizing,
+            'createDomToModelContextForSanitizing'
         ).and.returnValue(mockedContext);
         const parseFormatSpy = spyOn(parseFormat, 'parseFormat');
         const mockedDoc = {
@@ -131,12 +131,7 @@ describe('createModelFromHtml', () => {
             mockedContext
         );
         expect(createContextSpy).toHaveBeenCalledTimes(1);
-        expect(createContextSpy).toHaveBeenCalledWith(
-            {
-                defaultFormat: mockedDefaultSegmentFormat,
-            },
-            mockedOptions
-        );
+        expect(createContextSpy).toHaveBeenCalledWith(mockedDefaultSegmentFormat, mockedOptions);
         expect(domToContentModelSpy).toHaveBeenCalledWith('BODY' as any, mockedContext);
         expect(retrieveCssRulesSpy).toHaveBeenCalledWith(mockedDoc);
         expect(convertInlineCssSpy).toHaveBeenCalledWith(mockedDoc, mockedRules);
@@ -151,8 +146,8 @@ describe('createModelFromHtml', () => {
             segmentFormat: 'SEGMENT',
         } as any;
         const createContextSpy = spyOn(
-            createDomToModelContext,
-            'createDomToModelContext'
+            createDomToModelContextForSanitizing,
+            'createDomToModelContextForSanitizing'
         ).and.returnValue(mockedContext);
         const parseFormatSpy = spyOn(parseFormat, 'parseFormat');
         const mockedDoc = {

--- a/packages-content-model/roosterjs-content-model-core/test/utils/convertInlineCssTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/utils/convertInlineCssTest.ts
@@ -1,5 +1,4 @@
-import { convertInlineCss } from '../../../lib/utils/paste/convertInlineCss';
-import { CssRule } from '../../../lib/utils/paste/retrieveHtmlInfo';
+import { convertInlineCss, CssRule } from '../../lib/utils/convertInlineCss';
 
 describe('convertInlineCss', () => {
     it('Empty DOM, empty CSS', () => {

--- a/packages-content-model/roosterjs-content-model-core/test/utils/createDomToModelContextForSanitizingTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/utils/createDomToModelContextForSanitizingTest.ts
@@ -1,0 +1,112 @@
+import * as createDomToModelContext from 'roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext';
+import * as createPasteEntityProcessor from '../../lib/override/pasteEntityProcessor';
+import * as createPasteGeneralProcessor from '../../lib/override/pasteGeneralProcessor';
+import { containerSizeFormatParser } from '../../lib/override/containerSizeFormatParser';
+import { createDomToModelContextForSanitizing } from '../../lib/utils/createDomToModelContextForSanitizing';
+import { DomToModelOptionForSanitizing } from 'roosterjs-content-model-types';
+import { pasteDisplayFormatParser } from '../../lib/override/pasteDisplayFormatParser';
+import { pasteTextProcessor } from '../../lib/override/pasteTextProcessor';
+
+describe('createDomToModelContextForSanitizing', () => {
+    const mockedPasteGeneralProcessor = 'GENERALPROCESSOR' as any;
+    const mockedPasteEntityProcessor = 'ENTITYPROCESSOR' as any;
+    const mockedResult = 'CONTEXT' as any;
+    const defaultOptions: DomToModelOptionForSanitizing = {
+        processorOverride: {},
+        formatParserOverride: {},
+        additionalFormatParsers: {},
+        additionalAllowedTags: [],
+        additionalDisallowedTags: [],
+        styleSanitizers: {},
+        attributeSanitizers: {},
+    };
+    let createDomToModelContextSpy: jasmine.Spy;
+
+    let createPasteGeneralProcessorSpy: jasmine.Spy;
+    let createPasteEntityProcessorSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        createPasteGeneralProcessorSpy = spyOn(
+            createPasteGeneralProcessor,
+            'createPasteGeneralProcessor'
+        ).and.returnValue(mockedPasteGeneralProcessor);
+        createPasteEntityProcessorSpy = spyOn(
+            createPasteEntityProcessor,
+            'createPasteEntityProcessor'
+        ).and.returnValue(mockedPasteEntityProcessor);
+
+        createDomToModelContextSpy = spyOn(
+            createDomToModelContext,
+            'createDomToModelContext'
+        ).and.returnValue(mockedResult);
+    });
+
+    it('no options', () => {
+        const context = createDomToModelContextForSanitizing();
+
+        expect(context).toBe(mockedResult);
+        expect(createDomToModelContextSpy).toHaveBeenCalledWith(
+            {
+                defaultFormat: undefined,
+            },
+            undefined,
+            {
+                processorOverride: {
+                    '#text': pasteTextProcessor,
+                    entity: mockedPasteEntityProcessor,
+                    '*': mockedPasteGeneralProcessor,
+                },
+                formatParserOverride: {
+                    display: pasteDisplayFormatParser,
+                },
+                additionalFormatParsers: {
+                    container: [containerSizeFormatParser],
+                },
+            },
+            defaultOptions
+        );
+        expect(createPasteGeneralProcessorSpy).toHaveBeenCalledWith(defaultOptions);
+        expect(createPasteEntityProcessorSpy).toHaveBeenCalledWith(defaultOptions);
+    });
+
+    it('with options', () => {
+        const mockedDefaultFormat = 'FORMAT' as any;
+        const mockedOption = 'OPTION' as any;
+        const mockedAdditionalOption = { a: 'b' } as any;
+
+        const context = createDomToModelContextForSanitizing(
+            mockedDefaultFormat,
+            mockedOption,
+            mockedAdditionalOption
+        );
+
+        const additionalOption = {
+            ...defaultOptions,
+            ...mockedAdditionalOption,
+        };
+
+        expect(context).toBe(mockedResult);
+        expect(createDomToModelContextSpy).toHaveBeenCalledWith(
+            {
+                defaultFormat: mockedDefaultFormat,
+            },
+            mockedOption,
+            {
+                processorOverride: {
+                    '#text': pasteTextProcessor,
+                    entity: mockedPasteEntityProcessor,
+                    '*': mockedPasteGeneralProcessor,
+                },
+                formatParserOverride: {
+                    display: pasteDisplayFormatParser,
+                },
+                additionalFormatParsers: {
+                    container: [containerSizeFormatParser],
+                },
+            },
+            additionalOption
+        );
+        expect(createPasteGeneralProcessorSpy).toHaveBeenCalledWith(additionalOption);
+        expect(createPasteEntityProcessorSpy).toHaveBeenCalledWith(additionalOption);
+    });
+});

--- a/packages-content-model/roosterjs-content-model-core/test/utils/paste/mergePasteContentTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/utils/paste/mergePasteContentTest.ts
@@ -1,13 +1,8 @@
-import * as createDomToModelContext from 'roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext';
-import * as createPasteEntityProcessor from '../../../lib/override/pasteEntityProcessor';
-import * as createPasteGeneralProcessor from '../../../lib/override/pasteGeneralProcessor';
+import * as createDomToModelContextForSanitizing from '../../../lib/utils/createDomToModelContextForSanitizing';
 import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
 import * as mergeModelFile from '../../../lib/publicApi/model/mergeModel';
-import { containerSizeFormatParser } from '../../../lib/override/containerSizeFormatParser';
 import { createContentModelDocument } from 'roosterjs-content-model-dom';
 import { mergePasteContent } from '../../../lib/utils/paste/mergePasteContent';
-import { pasteDisplayFormatParser } from '../../../lib/override/pasteDisplayFormatParser';
-import { pasteTextProcessor } from '../../../lib/override/pasteTextProcessor';
 import {
     ContentModelDocument,
     ContentModelFormatter,
@@ -348,8 +343,6 @@ describe('mergePasteContent', () => {
             paragraph: null!,
             path: [],
         };
-        const mockedPasteGeneralProcessor = 'GENERALPROCESSOR' as any;
-        const mockedPasteEntityProcessor = 'ENTITYPROCESSOR' as any;
         const mockedDomToModelContext = {
             name: 'DOMTOMODELCONTEXT',
         } as any;
@@ -358,17 +351,9 @@ describe('mergePasteContent', () => {
             pasteModel
         );
         const mergeModelSpy = spyOn(mergeModelFile, 'mergeModel').and.returnValue(insertPoint);
-        const createPasteGeneralProcessorSpy = spyOn(
-            createPasteGeneralProcessor,
-            'createPasteGeneralProcessor'
-        ).and.returnValue(mockedPasteGeneralProcessor);
-        const createPasteEntityProcessorSpy = spyOn(
-            createPasteEntityProcessor,
-            'createPasteEntityProcessor'
-        ).and.returnValue(mockedPasteEntityProcessor);
         const createDomToModelContextSpy = spyOn(
-            createDomToModelContext,
-            'createDomToModelContext'
+            createDomToModelContextForSanitizing,
+            'createDomToModelContextForSanitizing'
         ).and.returnValue(mockedDomToModelContext);
 
         const mockedDomToModelOptions = 'OPTION1' as any;
@@ -413,24 +398,9 @@ describe('mergePasteContent', () => {
             mergeFormat: 'none',
             mergeTable: false,
         });
-        expect(createPasteGeneralProcessorSpy).toHaveBeenCalledWith(mockedDefaultDomToModelOptions);
-        expect(createPasteEntityProcessorSpy).toHaveBeenCalledWith(mockedDefaultDomToModelOptions);
         expect(createDomToModelContextSpy).toHaveBeenCalledWith(
             undefined,
             mockedDomToModelOptions,
-            {
-                processorOverride: {
-                    '#text': pasteTextProcessor,
-                    entity: mockedPasteEntityProcessor,
-                    '*': mockedPasteGeneralProcessor,
-                },
-                formatParserOverride: {
-                    display: pasteDisplayFormatParser,
-                },
-                additionalFormatParsers: {
-                    container: [containerSizeFormatParser],
-                },
-            },
             mockedDefaultDomToModelOptions
         );
         expect(mockedDomToModelContext.segmentFormat).toEqual({ lineHeight: '1pt' });

--- a/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelBeforePasteEvent.ts
+++ b/packages-content-model/roosterjs-content-model-editor/lib/publicTypes/ContentModelBeforePasteEvent.ts
@@ -1,6 +1,6 @@
 import type { BeforePasteEvent } from 'roosterjs-editor-types';
 import type {
-    DomToModelOptionForPaste,
+    DomToModelOptionForSanitizing,
     MergePastedContentFunc,
 } from 'roosterjs-content-model-types';
 
@@ -11,7 +11,7 @@ export interface ContentModelBeforePasteEvent extends BeforePasteEvent {
     /**
      * domToModel Options to use when creating the content model from the paste fragment
      */
-    readonly domToModelOption: DomToModelOptionForPaste;
+    readonly domToModelOption: DomToModelOptionForSanitizing;
 
     /**
      * customizedMerge Customized merge function to use when merging the paste fragment into the editor

--- a/packages-content-model/roosterjs-content-model-types/lib/context/DomToModelOption.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/context/DomToModelOption.ts
@@ -1,3 +1,4 @@
+import type { ValueSanitizer } from '../parameter/ValueSanitizer';
 import type {
     ElementProcessorMap,
     FormatParsers,
@@ -22,4 +23,29 @@ export interface DomToModelOption {
      * Provide additional format parsers for each format type
      */
     additionalFormatParsers?: Partial<FormatParsersPerCategory>;
+}
+
+/**
+ * Options for DOM to Content Model conversion for paste only
+ */
+export interface DomToModelOptionForSanitizing extends Required<DomToModelOption> {
+    /**
+     * Additional allowed HTML tags in lower case. Element with these tags will be preserved
+     */
+    readonly additionalAllowedTags: Lowercase<string>[];
+
+    /**
+     * Additional disallowed HTML tags in lower case. Elements with these tags will be dropped
+     */
+    readonly additionalDisallowedTags: Lowercase<string>[];
+
+    /**
+     * Additional sanitizers for CSS styles
+     */
+    readonly styleSanitizers: Record<string, ValueSanitizer>;
+
+    /**
+     * Additional sanitizers for CSS styles
+     */
+    readonly attributeSanitizers: Record<string, ValueSanitizer>;
 }

--- a/packages-content-model/roosterjs-content-model-types/lib/event/BeforePasteEvent.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/event/BeforePasteEvent.ts
@@ -1,35 +1,9 @@
+import type { DomToModelOptionForSanitizing } from '../context/DomToModelOption';
 import type { PasteType } from '../enum/PasteType';
 import type { ClipboardData } from '../parameter/ClipboardData';
 import type { BasePluginEvent } from './BasePluginEvent';
-import type { DomToModelOption } from '../context/DomToModelOption';
 import type { ContentModelDocument } from '../group/ContentModelDocument';
 import type { InsertPoint } from '../selection/InsertPoint';
-import type { ValueSanitizer } from '../parameter/ValueSanitizer';
-
-/**
- * Options for DOM to Content Model conversion for paste only
- */
-export interface DomToModelOptionForPaste extends Required<DomToModelOption> {
-    /**
-     * Additional allowed HTML tags in lower case. Element with these tags will be preserved
-     */
-    readonly additionalAllowedTags: Lowercase<string>[];
-
-    /**
-     * Additional disallowed HTML tags in lower case. Elements with these tags will be dropped
-     */
-    readonly additionalDisallowedTags: Lowercase<string>[];
-
-    /**
-     * Additional sanitizers for CSS styles
-     */
-    readonly styleSanitizers: Record<string, ValueSanitizer>;
-
-    /**
-     * Additional sanitizers for CSS styles
-     */
-    readonly attributeSanitizers: Record<string, ValueSanitizer>;
-}
 
 /**
  * A function type used by merging pasted content into current Content Model
@@ -79,7 +53,7 @@ export interface BeforePasteEvent extends BasePluginEvent<'beforePaste'> {
     /**
      * domToModel Options to use when creating the content model from the paste fragment
      */
-    readonly domToModelOption: DomToModelOptionForPaste;
+    readonly domToModelOption: DomToModelOptionForSanitizing;
 
     /**
      * customizedMerge Customized merge function to use when merging the paste fragment into the editor

--- a/packages-content-model/roosterjs-content-model-types/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/index.ts
@@ -182,7 +182,7 @@ export {
     ContentModelSegmentHandler,
     ContentModelBlockHandler,
 } from './context/ContentModelHandler';
-export { DomToModelOption } from './context/DomToModelOption';
+export { DomToModelOption, DomToModelOptionForSanitizing } from './context/DomToModelOption';
 export { ModelToDomOption } from './context/ModelToDomOption';
 export { DomIndexer } from './context/DomIndexer';
 export { TextMutationObserver } from './context/TextMutationObserver';
@@ -289,11 +289,7 @@ export { BasePluginEvent, BasePluginDomEvent } from './event/BasePluginEvent';
 export { BeforeCutCopyEvent } from './event/BeforeCutCopyEvent';
 export { BeforeDisposeEvent } from './event/BeforeDisposeEvent';
 export { BeforeKeyboardEditingEvent } from './event/BeforeKeyboardEditingEvent';
-export {
-    BeforePasteEvent,
-    DomToModelOptionForPaste,
-    MergePastedContentFunc,
-} from './event/BeforePasteEvent';
+export { BeforePasteEvent, MergePastedContentFunc } from './event/BeforePasteEvent';
 export { BeforeSetContentEvent } from './event/BeforeSetContentEvent';
 export { ContentChangedEvent, ChangedEntity } from './event/ContentChangedEvent';
 export { ContextMenuEvent } from './event/ContextMenuEvent';


### PR DESCRIPTION
Today we have an API `createModelFromHtml`. We use it in `ContentModelEditor` to build initialization options to convert HTML to initial Content Model.
In this change I'm adding the following functionalities into this function:
- Convert global CSS to inline CSS
- Do HTML sanitization on general model and entity
- Parse format on BODY element into context so that inner elements can apply those format