### PR TITLE
Disable list features in Content Model Demo Site 

### DIFF
--- a/demo/scripts/controls/sidePane/editorOptions/getDefaultContentEditFeatureSettings.ts
+++ b/demo/scripts/controls/sidePane/editorOptions/getDefaultContentEditFeatureSettings.ts
@@ -4,12 +4,28 @@ import { getObjectKeys } from 'roosterjs-editor-dom';
 
 export default function getDefaultContentEditFeatureSettings(): ContentEditFeatureSettings {
     const allFeatures = getAllFeatures();
+
     return {
         ...getObjectKeys(allFeatures).reduce((settings, key) => {
             settings[key] = !allFeatures[key].defaultDisabled;
             return settings;
         }, <ContentEditFeatureSettings>{}),
-        indentWhenAltShiftRight: true,
-        outdentWhenAltShiftLeft: true,
+        ...listFeatures,
     };
 }
+
+const listFeatures = {
+    autoBullet: false,
+    indentWhenTab: false,
+    outdentWhenShiftTab: false,
+    outdentWhenBackspaceOnEmptyFirstLine: false,
+    outdentWhenEnterOnEmptyLine: false,
+    mergeInNewLineWhenBackspaceOnFirstChar: false,
+    maintainListChain: false,
+    maintainListChainWhenDelete: false,
+    autoNumberingList: false,
+    autoBulletList: false,
+    mergeListOnBackspaceAfterList: false,
+    outdentWhenAltShiftLeft: false,
+    indentWhenAltShiftRight: false,
+};


### PR DESCRIPTION
Disable the classic editor ContentEdit list features on ContentModel Editor, then we can test and debug only the new content model edit plugin features without have the impact of the classic editor code.  