### PR TITLE
Fix demo site

### DIFF
--- a/tools/buildTools/buildDemo.js
+++ b/tools/buildTools/buildDemo.js
@@ -77,9 +77,8 @@ async function buildDemoSite() {
                 [/^roosterjs-editor-plugins\/.*$/, 'roosterjs'],
                 [/^roosterjs-react\/.*$/, 'roosterjsReact'],
                 [/^roosterjs-react$/, 'roosterjsReact'],
-                [/^roosterjs-content-model((?!-editor).)*\/.*$/, 'roosterjsContentModel'],
             ],
-            []
+            ['roosterjs-editor-adapter']
         ),
         stats: 'minimal',
         mode: 'production',

--- a/tools/buildTools/buildDemo.js
+++ b/tools/buildTools/buildDemo.js
@@ -77,6 +77,7 @@ async function buildDemoSite() {
                 [/^roosterjs-editor-plugins\/.*$/, 'roosterjs'],
                 [/^roosterjs-react\/.*$/, 'roosterjsReact'],
                 [/^roosterjs-react$/, 'roosterjsReact'],
+                [/^roosterjs-content-model((?!-editor).)*\/.*$/, 'roosterjsContentModel'],
             ],
             ['roosterjs-editor-adapter']
         ),


### PR DESCRIPTION
My previous change (https://github.com/microsoft/roosterjs/pull/2411) breaks content model demo site because of package renaming. 

Here is a fix to make sure the new package (`roosterjs-editor-adapter`) can be corrected bundled into demo.js