### PR TITLE
Fix undo snapshot for entity

### DIFF
--- a/demo/scripts/controls/sidePane/contentModelApiPlayground/insertEntity/InsertEntityPane.tsx
+++ b/demo/scripts/controls/sidePane/contentModelApiPlayground/insertEntity/InsertEntityPane.tsx
@@ -105,37 +105,36 @@ export default class InsertEntityPane extends React.Component<ApiPaneProps, Inse
 
         if (node) {
             const editor = this.props.getEditor();
+            const options: InsertEntityOptions = {
+                contentNode: node,
+                focusAfterEntity: focusAfterEntity,
+            };
 
-            editor.addUndoSnapshot(() => {
-                const options: InsertEntityOptions = {
-                    contentNode: node,
-                    focusAfterEntity: focusAfterEntity,
-                };
+            editor.focus();
 
-                if (isBlock) {
-                    insertEntity(
-                        editor as IStandaloneEditor & IEditor,
-                        entityType,
-                        true,
-                        insertAtRoot
-                            ? 'root'
-                            : insertAtTop
-                            ? 'begin'
-                            : insertAtBottom
-                            ? 'end'
-                            : 'focus',
-                        options
-                    );
-                } else {
-                    insertEntity(
-                        editor as IStandaloneEditor & IEditor,
-                        entityType,
-                        isBlock,
-                        insertAtTop ? 'begin' : insertAtBottom ? 'end' : 'focus',
-                        options
-                    );
-                }
-            });
+            if (isBlock) {
+                insertEntity(
+                    editor as IStandaloneEditor & IEditor,
+                    entityType,
+                    true,
+                    insertAtRoot
+                        ? 'root'
+                        : insertAtTop
+                        ? 'begin'
+                        : insertAtBottom
+                        ? 'end'
+                        : 'focus',
+                    options
+                );
+            } else {
+                insertEntity(
+                    editor as IStandaloneEditor & IEditor,
+                    entityType,
+                    isBlock,
+                    insertAtTop ? 'begin' : insertAtBottom ? 'end' : 'focus',
+                    options
+                );
+            }
         }
     };
 

--- a/packages-content-model/roosterjs-content-model-core/lib/corePlugin/utils/entityDelimiterUtils.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/corePlugin/utils/entityDelimiterUtils.ts
@@ -40,7 +40,7 @@ export function preventTypeInDelimiter(node: HTMLElement, editor: IStandaloneEdi
                 element => !!element
             ) as HTMLElement[]
         );
-        editor.formatContentModel(model => {
+        editor.formatContentModel((model, context) => {
             iterateSelections(model, (_path, _tableContext, block, _segments) => {
                 if (block?.blockType == 'Paragraph') {
                     block.segments.forEach(segment => {
@@ -50,6 +50,9 @@ export function preventTypeInDelimiter(node: HTMLElement, editor: IStandaloneEdi
                     });
                 }
             });
+
+            context.skipUndoSnapshot = true;
+
             return true;
         });
     }
@@ -123,7 +126,18 @@ function removeDelimiterAttr(node: Element | undefined | null, checkEntity: bool
 function getFocusedElement(selection: RangeSelection): HTMLElement | null {
     const { range, isReverted } = selection;
     let node: Node | null = isReverted ? range.startContainer : range.endContainer;
-    const offset = isReverted ? range.startOffset : range.endOffset;
+    let offset = isReverted ? range.startOffset : range.endOffset;
+
+    while (node?.lastChild) {
+        if (offset == node.childNodes.length) {
+            node = node.lastChild;
+            offset = node.childNodes.length;
+        } else {
+            node = node.childNodes[offset];
+            offset = 0;
+        }
+    }
+
     if (!isNodeOfType(node, 'ELEMENT_NODE')) {
         if (node.textContent != ZeroWidthSpace && (node.textContent || '').length == offset) {
             node = node.nextSibling ?? node.parentElement?.closest(DelimiterSelector) ?? null;
@@ -190,6 +204,7 @@ export function handleDelimiterKeyDownEvent(editor: IStandaloneEditor, event: Ke
                     event.rawEvent.preventDefault();
                     editor.formatContentModel(handleEnterInlineEntity);
                 } else {
+                    editor.takeSnapshot();
                     editor
                         .getDocument()
                         .defaultView?.requestAnimationFrame(() =>

--- a/packages-content-model/roosterjs-content-model-core/test/coreApi/formatContentModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/coreApi/formatContentModelTest.ts
@@ -806,9 +806,7 @@ describe('formatContentModel', () => {
             expect(setContentModel).toHaveBeenCalledWith(core, mockedModel, undefined, undefined);
             expect(core.undo).toEqual({
                 isNested: false,
-                snapshotsManager: {
-                    hasNewContent: false,
-                },
+                snapshotsManager: {},
                 posContainer: mockedContainer,
                 posOffset: mockedOffset,
             } as any);
@@ -827,7 +825,9 @@ describe('formatContentModel', () => {
             expect(setContentModel).toHaveBeenCalledWith(core, mockedModel, undefined, undefined);
             expect(core.undo).toEqual({
                 isNested: true,
-                snapshotsManager: {},
+                snapshotsManager: {
+                    hasNewContent: true,
+                },
             } as any);
         });
     });


### PR DESCRIPTION
1. When call `formatContentModel`, we are triggering `ContentChangedEvent` after adding undo snapshot. However, when insert entity, we rely on ContentChangedEvent to let EntityPlugin allocate entity ID for entity. So with today's implementation we will add an undo snapshot before entity gets id, so when we restore this undo snapshot, it is possible the entity is not correctly restored. To fix it. I let `formatContentModel` trigger `ContentChangedEvent` first, then add undo snapshot
2. When handle keydown event for entity delimiter, it is possible the selection range we got is on upper container. This happens when I add "editor.focus()" before calling `insertEntity`. The old code fixes this by calling position.normalize(). Now that we have removed Position class from StandaloneEditor, we will do a minimum implementation of position.normalize() before we check entity delimiter.