### PR TITLE
[Bump RoosterJS] Content-Model: 0.26.1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
     "packages": "8.60.0",
     "packages-ui": "8.55.0",
-    "packages-content-model": "0.26.0",
+    "packages-content-model": "0.26.1",
     "overrides": {
         "roosterjs-editor-plugins": "8.60.2",
         "roosterjs-editor-adapter": "0.26.0"


### PR DESCRIPTION
Versions:

packages-content-model: 0.26.1

Adds a last minute fix for image selection on Mac