### PR TITLE
Port ShortcutPlugin

### DIFF
--- a/demo/scripts/controls/StandaloneEditorMainPane.tsx
+++ b/demo/scripts/controls/StandaloneEditorMainPane.tsx
@@ -17,7 +17,7 @@ import { alignCenterButton } from './ribbonButtons/contentModel/alignCenterButto
 import { alignJustifyButton } from './ribbonButtons/contentModel/alignJustifyButton';
 import { alignLeftButton } from './ribbonButtons/contentModel/alignLeftButton';
 import { alignRightButton } from './ribbonButtons/contentModel/alignRightButton';
-import { AutoFormatPlugin, EditPlugin } from 'roosterjs-content-model-plugins';
+import { AutoFormatPlugin, EditPlugin, ShortcutPlugin } from 'roosterjs-content-model-plugins';
 import { backgroundColorButton } from './ribbonButtons/contentModel/backgroundColorButton';
 import { blockQuoteButton } from './ribbonButtons/contentModel/blockQuoteButton';
 import { boldButton } from './ribbonButtons/contentModel/boldButton';
@@ -165,6 +165,7 @@ class ContentModelEditorMainPane extends MainPaneBase<ContentModelMainPaneState>
     private contentModelRibbonPlugin: RibbonPlugin;
     private contentAutoFormatPlugin: AutoFormatPlugin;
     private snapshotPlugin: ContentModelSnapshotPlugin;
+    private shortcutPlugin: ShortcutPlugin;
     private formatPainterPlugin: ContentModelFormatPainterPlugin;
     private snapshots: Snapshots<Snapshot>;
     private buttons: ContentModelRibbonButton<any>[] = [
@@ -251,6 +252,7 @@ class ContentModelEditorMainPane extends MainPaneBase<ContentModelMainPaneState>
         this.contentModelPanePlugin = new ContentModelPanePlugin();
         this.contentModelEditPlugin = new EditPlugin();
         this.contentAutoFormatPlugin = new AutoFormatPlugin();
+        this.shortcutPlugin = new ShortcutPlugin();
         this.contentModelRibbonPlugin = new ContentModelRibbonPlugin();
         this.formatPainterPlugin = new ContentModelFormatPainterPlugin();
         this.state = {
@@ -347,6 +349,7 @@ class ContentModelEditorMainPane extends MainPaneBase<ContentModelMainPaneState>
                                 this.formatPainterPlugin,
                                 this.contentModelEditPlugin,
                                 this.contentAutoFormatPlugin,
+                                this.shortcutPlugin,
                             ]}
                             defaultSegmentFormat={defaultFormat}
                             inDarkMode={this.state.isDarkMode}

--- a/packages-content-model/roosterjs-content-model-core/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/index.ts
@@ -43,6 +43,7 @@ export { isPunctuation, isSpace, normalizeText } from './publicApi/domUtils/stri
 export { parseTableCells, createTableRanges } from './publicApi/domUtils/tableCellUtils';
 export { getSegmentTextFormat } from './publicApi/domUtils/getSegmentTextFormat';
 export { readFile } from './publicApi/domUtils/readFile';
+export { cacheGetEventData } from './publicApi/domUtils/cacheGetEventData';
 
 export { undo } from './publicApi/undo/undo';
 export { redo } from './publicApi/undo/redo';

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/domUtils/cacheGetEventData.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/domUtils/cacheGetEventData.ts
@@ -16,10 +16,8 @@ export function cacheGetEventData<T, E extends PluginEvent>(
         event.eventDataCache && event.eventDataCache.hasOwnProperty(key)
             ? <T>event.eventDataCache[key]
             : getter(event);
-    if (event) {
-        event.eventDataCache = event.eventDataCache || {};
-        event.eventDataCache[key] = result;
-    }
+    event.eventDataCache = event.eventDataCache || {};
+    event.eventDataCache[key] = result;
 
     return result;
 }

--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/domUtils/cacheGetEventData.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/domUtils/cacheGetEventData.ts
@@ -1,0 +1,25 @@
+import type { PluginEvent } from 'roosterjs-content-model-types';
+
+/**
+ * Gets the cached event data by cache key from event object if there is already one.
+ * Otherwise, call getter function to create one, and cache it.
+ * @param event The event object
+ * @param key Cache key string, need to be unique
+ * @param getter Getter function to get the object when it is not in cache yet
+ */
+export function cacheGetEventData<T, E extends PluginEvent>(
+    event: E,
+    key: string,
+    getter: (event: E) => T
+): T {
+    const result =
+        event.eventDataCache && event.eventDataCache.hasOwnProperty(key)
+            ? <T>event.eventDataCache[key]
+            : getter(event);
+    if (event) {
+        event.eventDataCache = event.eventDataCache || {};
+        event.eventDataCache[key] = result;
+    }
+
+    return result;
+}

--- a/packages-content-model/roosterjs-content-model-core/test/publicApi/domUtils/cacheGetEventDataTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/publicApi/domUtils/cacheGetEventDataTest.ts
@@ -1,0 +1,31 @@
+import { cacheGetEventData } from '../../../lib/publicApi/domUtils/cacheGetEventData';
+import { EditorReadyEvent } from 'roosterjs-content-model-types';
+
+describe('cacheGetEventData', () => {
+    const cacheKey = '__Key';
+    it('get cached data', () => {
+        const event: EditorReadyEvent = {
+            eventType: 'editorReady',
+        };
+
+        const mockedData = 'DATA';
+        const mockedGetter = jasmine.createSpy('getter').and.returnValue(mockedData);
+
+        const data = cacheGetEventData(event, cacheKey, mockedGetter);
+
+        expect(data).toBe(mockedData);
+        expect(mockedGetter).toHaveBeenCalledTimes(1);
+        expect(mockedGetter).toHaveBeenCalledWith(event);
+        expect(event).toEqual({
+            eventType: 'editorReady',
+            eventDataCache: {
+                [cacheKey]: mockedData,
+            },
+        });
+
+        const data2 = cacheGetEventData(event, cacheKey, mockedGetter);
+
+        expect(data2).toBe(mockedData);
+        expect(mockedGetter).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages-content-model/roosterjs-content-model-plugins/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/index.ts
@@ -1,3 +1,20 @@
 export { PastePlugin } from './paste/PastePlugin';
 export { EditPlugin } from './edit/EditPlugin';
 export { AutoFormatPlugin, AutoFormatOptions } from './autoFormat/AutoFormatPlugin';
+
+export {
+    ShortcutBold,
+    ShortcutItalic,
+    ShortcutUnderline,
+    ShortcutClearFormat,
+    ShortcutUndo,
+    ShortcutUndo2,
+    ShortcutRedo,
+    ShortcutRedoMacOS,
+    ShortcutBullet,
+    ShortcutNumbering,
+    ShortcutIncreaseFont,
+    ShortcutDecreaseFont,
+} from './shortcut/shortcuts';
+export { ShortcutPlugin } from './shortcut/ShortcutPlugin';
+export { ShortcutCommand } from './shortcut/ShortcutCommand';

--- a/packages-content-model/roosterjs-content-model-plugins/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/index.ts
@@ -17,4 +17,4 @@ export {
     ShortcutDecreaseFont,
 } from './shortcut/shortcuts';
 export { ShortcutPlugin } from './shortcut/ShortcutPlugin';
-export { ShortcutCommand } from './shortcut/ShortcutCommand';
+export { ShortcutKeyDefinition, ShortcutCommand } from './shortcut/ShortcutCommand';

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutCommand.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutCommand.ts
@@ -1,9 +1,9 @@
 import type { IEditor } from 'roosterjs-content-model-types';
 
 /**
- * Represents a command for shortcut
+ * Definition of the shortcut key
  */
-export interface ShortcutCommand {
+export interface ShortcutKeyDefinition {
     /**
      * Modifier key for this shortcut, allowed values are:
      * ctrl: Ctrl key (or Meta key on MacOS)
@@ -20,16 +20,28 @@ export interface ShortcutCommand {
      * Key for this shortcut. The value should be the value of KeyboardEvent.key string
      */
     key: string;
+}
+
+/**
+ * Represents a command for shortcut
+ */
+export interface ShortcutCommand {
+    /**
+     * Definition of the shortcut key
+     */
+    shortcutKey: ShortcutKeyDefinition;
+
+    /**
+     * @optional Required environment for this command
+     * all: (Default) This feature is available for all environments
+     * mac: This feature is available on MacOS only
+     * nonMac: This feature is available on OS other than MacOS
+     */
+    environment?: 'all' | 'mac' | 'nonMac';
 
     /**
      * The callback function to invoke when this shortcut is triggered
      * @param editor The editor object
      */
-    onCommand: (editor: IEditor) => void;
-
-    /**
-     * Whether this command is disabled. By default it is treated as false
-     * @param editor The editor object
-     */
-    isDisabled?: (editor: IEditor) => boolean;
+    onClick: (editor: IEditor) => void;
 }

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutCommand.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutCommand.ts
@@ -1,0 +1,35 @@
+import type { IEditor } from 'roosterjs-content-model-types';
+
+/**
+ * Represents a command for shortcut
+ */
+export interface ShortcutCommand {
+    /**
+     * Modifier key for this shortcut, allowed values are:
+     * ctrl: Ctrl key (or Meta key on MacOS)
+     * alt: Alt key
+     */
+    modifierKey: 'ctrl' | 'alt';
+
+    /**
+     * Whether ALT key is required for this shortcut
+     */
+    shiftKey: boolean;
+
+    /**
+     * Key for this shortcut. The value should be the value of KeyboardEvent.key string
+     */
+    key: string;
+
+    /**
+     * The callback function to invoke when this shortcut is triggered
+     * @param editor The editor object
+     */
+    onCommand: (editor: IEditor) => void;
+
+    /**
+     * Whether this command is disabled. By default it is treated as false
+     * @param editor The editor object
+     */
+    isDisabled?: (editor: IEditor) => boolean;
+}

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutCommand.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutCommand.ts
@@ -17,9 +17,12 @@ export interface ShortcutKeyDefinition {
     shiftKey: boolean;
 
     /**
-     * Key for this shortcut. The value should be the value of KeyboardEvent.key string
+     * Key code for this shortcut. The value should be the value of KeyboardEvent.which
+     * We are still using key code here rather than key name (event.key)  although event.which is deprecated because of globalization.
+     * For example, on US keyboard, Shift+Comma="<" but on Spanish keyboard it is ":"
+     * And we still want the shortcut key to be registered on  the same key, in that case key name is different but key code keeps the same.
      */
-    key: string;
+    which: number;
 }
 
 /**

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
@@ -1,5 +1,5 @@
 import { cacheGetEventData } from 'roosterjs-content-model-core/lib';
-import { ShortcutCommand } from './ShortcutCommand';
+import type { ShortcutCommand } from './ShortcutCommand';
 import {
     ShortcutBold,
     ShortcutBullet,

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
@@ -1,0 +1,134 @@
+import { cacheGetEventData } from 'roosterjs-content-model-core/lib';
+import { ShortcutCommand } from './ShortcutCommand';
+import {
+    ShortcutBold,
+    ShortcutBullet,
+    ShortcutClearFormat,
+    ShortcutDecreaseFont,
+    ShortcutIncreaseFont,
+    ShortcutItalic,
+    ShortcutNumbering,
+    ShortcutRedo,
+    ShortcutRedoMacOS,
+    ShortcutUnderline,
+    ShortcutUndo,
+    ShortcutUndo2,
+} from './shortcuts';
+import type {
+    EditorPlugin,
+    IEditor,
+    KeyDownEvent,
+    PluginEvent,
+} from 'roosterjs-content-model-types';
+
+const defaultShortcuts: ShortcutCommand[] = [
+    ShortcutBold,
+    ShortcutItalic,
+    ShortcutUnderline,
+    ShortcutClearFormat,
+    ShortcutUndo,
+    ShortcutUndo2,
+    ShortcutRedo,
+    ShortcutRedoMacOS,
+    ShortcutBullet,
+    ShortcutNumbering,
+    ShortcutIncreaseFont,
+    ShortcutDecreaseFont,
+];
+const CommandCacheKey = '__ShortcutCommandCache';
+
+/**
+ * Shortcut plugin hook on the specified shortcut keys and trigger related format API
+ */
+export class ShortcutPlugin implements EditorPlugin {
+    private editor: IEditor | null = null;
+
+    /**
+     * Create a new instance of ShortcutPlugin
+     * @param [shortcuts=defaultShortcuts] Allowed commands
+     */
+    constructor(private shortcuts: ShortcutCommand[] = defaultShortcuts) {}
+
+    /**
+     * Get name of this plugin
+     */
+    getName() {
+        return 'Shortcut';
+    }
+
+    /**
+     * The first method that editor will call to a plugin when editor is initializing.
+     * It will pass in the editor instance, plugin should take this chance to save the
+     * editor reference so that it can call to any editor method or format API later.
+     * @param editor The editor object
+     */
+    initialize(editor: IEditor) {
+        this.editor = editor;
+    }
+
+    /**
+     * The last method that editor will call to a plugin before it is disposed.
+     * Plugin can take this chance to clear the reference to editor. After this method is
+     * called, plugin should not call to any editor method since it will result in error.
+     */
+    dispose() {
+        this.editor = null;
+    }
+
+    /**
+     * Check if the plugin should handle the given event exclusively.
+     * Handle an event exclusively means other plugin will not receive this event in
+     * onPluginEvent method.
+     * If two plugins will return true in willHandleEventExclusively() for the same event,
+     * the final result depends on the order of the plugins are added into editor
+     * @param event The event to check:
+     */
+    willHandleEventExclusively(event: PluginEvent) {
+        return (
+            event.eventType == 'keyDown' &&
+            (event.rawEvent.ctrlKey || event.rawEvent.altKey) &&
+            !!this.cacheGetCommand(event)
+        );
+    }
+
+    /**
+     * Core method for a plugin. Once an event happens in editor, editor will call this
+     * method of each plugin to handle the event as long as the event is not handled
+     * exclusively by another plugin.
+     * @param event The event to handle:
+     */
+    onPluginEvent(event: PluginEvent) {
+        if (this.editor && event.eventType == 'keyDown') {
+            const command = this.cacheGetCommand(event);
+
+            if (command) {
+                command.onCommand(this.editor);
+                event.rawEvent.preventDefault();
+            }
+        }
+    }
+
+    private cacheGetCommand(event: KeyDownEvent) {
+        return cacheGetEventData(event, CommandCacheKey, event => {
+            const editor = this.editor;
+
+            return (
+                editor &&
+                this.shortcuts.filter(
+                    command =>
+                        (!command.isDisabled || !command.isDisabled(editor)) &&
+                        this.matchShortcut(command, event.rawEvent)
+                )[0]
+            );
+        });
+    }
+
+    private matchShortcut(command: ShortcutCommand, event: KeyboardEvent) {
+        const { ctrlKey, altKey, shiftKey, key } = event;
+        const matchModifier =
+            (command.modifierKey == 'ctrl' && ctrlKey && !altKey) ||
+            (command.modifierKey == 'alt' && altKey && !ctrlKey);
+
+        return matchModifier && shiftKey == command.shiftKey && command.key == key;
+    }
+}

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
@@ -139,12 +139,12 @@ export class ShortcutPlugin implements EditorPlugin {
     }
 
     private matchShortcut(shortcutKey: ShortcutKeyDefinition, event: KeyboardEvent) {
-        const { ctrlKey, altKey, shiftKey, key, metaKey } = event;
+        const { ctrlKey, altKey, shiftKey, which, metaKey } = event;
         const ctrlOrMeta = this.isMac ? metaKey : ctrlKey;
         const matchModifier =
             (shortcutKey.modifierKey == 'ctrl' && ctrlOrMeta && !altKey) ||
             (shortcutKey.modifierKey == 'alt' && altKey && !ctrlOrMeta);
 
-        return matchModifier && shiftKey == shortcutKey.shiftKey && shortcutKey.key == key;
+        return matchModifier && shiftKey == shortcutKey.shiftKey && shortcutKey.which == which;
     }
 }

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
@@ -1,4 +1,4 @@
-import { cacheGetEventData } from 'roosterjs-content-model-core/lib';
+import { cacheGetEventData } from 'roosterjs-content-model-core';
 import type { ShortcutCommand } from './ShortcutCommand';
 import {
     ShortcutBold,

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
@@ -17,7 +17,7 @@ export const ShortcutBold: ShortcutCommand = {
     modifierKey: 'ctrl',
     shiftKey: false,
     key: 'b',
-    onCommand: toggleBold,
+    onCommand: editor => toggleBold(editor),
 };
 
 /**
@@ -27,7 +27,7 @@ export const ShortcutItalic: ShortcutCommand = {
     modifierKey: 'ctrl',
     shiftKey: false,
     key: 'i',
-    onCommand: toggleItalic,
+    onCommand: editor => toggleItalic(editor),
 };
 
 /**
@@ -37,7 +37,7 @@ export const ShortcutUnderline: ShortcutCommand = {
     modifierKey: 'ctrl',
     shiftKey: false,
     key: 'u',
-    onCommand: toggleUnderline,
+    onCommand: editor => toggleUnderline(editor),
 };
 
 /**
@@ -47,7 +47,7 @@ export const ShortcutClearFormat: ShortcutCommand = {
     modifierKey: 'ctrl',
     shiftKey: false,
     key: ' ',
-    onCommand: clearFormat,
+    onCommand: editor => clearFormat(editor),
 };
 
 /**
@@ -57,7 +57,7 @@ export const ShortcutUndo: ShortcutCommand = {
     modifierKey: 'ctrl',
     shiftKey: false,
     key: 'z',
-    onCommand: undo,
+    onCommand: editor => undo(editor),
 };
 
 /**
@@ -67,7 +67,7 @@ export const ShortcutUndo2: ShortcutCommand = {
     modifierKey: 'alt',
     shiftKey: false,
     key: 'Backspace',
-    onCommand: undo,
+    onCommand: editor => undo(editor),
     isDisabled: editor => !!editor.getEnvironment().isMac,
 };
 
@@ -78,7 +78,8 @@ export const ShortcutRedo: ShortcutCommand = {
     modifierKey: 'ctrl',
     shiftKey: false,
     key: 'y',
-    onCommand: redo,
+    onCommand: editor => redo(editor),
+    isDisabled: editor => !!editor.getEnvironment().isMac,
 };
 
 /**
@@ -88,7 +89,7 @@ export const ShortcutRedoMacOS: ShortcutCommand = {
     modifierKey: 'ctrl',
     shiftKey: true,
     key: 'z',
-    onCommand: redo,
+    onCommand: editor => redo(editor),
     isDisabled: editor => !editor.getEnvironment().isMac,
 };
 
@@ -99,7 +100,7 @@ export const ShortcutBullet: ShortcutCommand = {
     modifierKey: 'ctrl',
     shiftKey: false,
     key: '.',
-    onCommand: toggleBullet,
+    onCommand: editor => toggleBullet(editor),
 };
 
 /**
@@ -109,7 +110,7 @@ export const ShortcutNumbering: ShortcutCommand = {
     modifierKey: 'ctrl',
     shiftKey: false,
     key: '/',
-    onCommand: toggleNumbering,
+    onCommand: editor => toggleNumbering(editor),
 };
 
 /**

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
@@ -12,123 +12,171 @@ import type { ShortcutCommand } from './ShortcutCommand';
 
 /**
  * Shortcut command for Bold
+ * Windows: Ctrl + B
+ * MacOS: Meta + B
  */
 export const ShortcutBold: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: false,
-    key: 'b',
-    onCommand: editor => toggleBold(editor),
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: false,
+        key: 'b',
+    },
+    onClick: editor => toggleBold(editor),
 };
 
 /**
  * Shortcut command for Italic
+ * Windows: Ctrl + I
+ * MacOS: Meta + I
  */
 export const ShortcutItalic: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: false,
-    key: 'i',
-    onCommand: editor => toggleItalic(editor),
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: false,
+        key: 'i',
+    },
+    onClick: editor => toggleItalic(editor),
 };
 
 /**
  * Shortcut command for Underline
+ * Windows: Ctrl + U
+ * MacOS: Meta + U
  */
 export const ShortcutUnderline: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: false,
-    key: 'u',
-    onCommand: editor => toggleUnderline(editor),
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: false,
+        key: 'u',
+    },
+    onClick: editor => toggleUnderline(editor),
 };
 
 /**
  * Shortcut command for Clear Format
+ * Windows: Ctrl + Space
+ * MacOS: Meta + Space
  */
 export const ShortcutClearFormat: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: false,
-    key: ' ',
-    onCommand: editor => clearFormat(editor),
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: false,
+        key: ' ',
+    },
+    onClick: editor => clearFormat(editor),
 };
 
 /**
- * Shortcut command for Undo
+ * Shortcut command for Undo 1
+ * Windows: Ctrl + Z
+ * MacOS: Meta + Z
  */
 export const ShortcutUndo: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: false,
-    key: 'z',
-    onCommand: editor => undo(editor),
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: false,
+        key: 'z',
+    },
+    onClick: editor => undo(editor),
 };
 
 /**
- * Shortcut command for Undo (Alt+Backspace, non-MacOS)
+ * Shortcut command for Undo 2
+ * Windows: Alt + Backspace
+ * MacOS: N/A
  */
 export const ShortcutUndo2: ShortcutCommand = {
-    modifierKey: 'alt',
-    shiftKey: false,
-    key: 'Backspace',
-    onCommand: editor => undo(editor),
-    isDisabled: editor => !!editor.getEnvironment().isMac,
+    shortcutKey: {
+        modifierKey: 'alt',
+        shiftKey: false,
+        key: 'Backspace',
+    },
+    onClick: editor => undo(editor),
+    environment: 'nonMac',
 };
 
 /**
- * Shortcut command for Redo (Non-MacOS)
+ * Shortcut command for Redo 1
+ * Windows: Ctrl + Y
+ * MacOS: N/A
  */
 export const ShortcutRedo: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: false,
-    key: 'y',
-    onCommand: editor => redo(editor),
-    isDisabled: editor => !!editor.getEnvironment().isMac,
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: false,
+        key: 'y',
+    },
+    onClick: editor => redo(editor),
+    environment: 'nonMac',
 };
 
 /**
- * Shortcut command for Redo (MacOS)
+ * Shortcut command for Redo 2
+ * Windows: N/A
+ * MacOS: Meta + Shift + Z
  */
 export const ShortcutRedoMacOS: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: true,
-    key: 'z',
-    onCommand: editor => redo(editor),
-    isDisabled: editor => !editor.getEnvironment().isMac,
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: true,
+        key: 'z',
+    },
+    onClick: editor => redo(editor),
+    environment: 'mac',
 };
 
 /**
  * Shortcut command for Bullet List
+ * Windows: Ctrl + . (Period)
+ * MacOS: Meta + . (Period)
  */
 export const ShortcutBullet: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: false,
-    key: '.',
-    onCommand: editor => toggleBullet(editor),
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: false,
+        key: '.',
+    },
+    onClick: editor => toggleBullet(editor),
 };
 
 /**
  * Shortcut command for Numbering List
+ * Windows: Ctrl + / (Forward slash)
+ * MacOS: Meta + / (Forward slash)
  */
 export const ShortcutNumbering: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: false,
-    key: '/',
-    onCommand: editor => toggleNumbering(editor),
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: false,
+        key: '/',
+    },
+    onClick: editor => toggleNumbering(editor),
 };
 
 /**
  * Shortcut command for Increase Font
+ * Windows: Ctrl + Shift + . (Period)
+ * MacOS: Meta + Shift + . (Period)
  */
 export const ShortcutIncreaseFont: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: true,
-    key: '>',
-    onCommand: editor => changeFontSize(editor, 'increase'),
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: true,
+        key: '>',
+    },
+    onClick: editor => changeFontSize(editor, 'increase'),
 };
 
 /**
  * Shortcut command for Decrease Font
+ * Windows: Ctrl + Shift + , (Comma)
+ * MacOS: Meta + Shift + , (Comma)
  */
 export const ShortcutDecreaseFont: ShortcutCommand = {
-    modifierKey: 'ctrl',
-    shiftKey: true,
-    key: '<',
-    onCommand: editor => changeFontSize(editor, 'decrease'),
+    shortcutKey: {
+        modifierKey: 'ctrl',
+        shiftKey: true,
+        key: '<',
+    },
+    onClick: editor => changeFontSize(editor, 'decrease'),
 };

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
@@ -10,6 +10,19 @@ import {
 } from 'roosterjs-content-model-api';
 import type { ShortcutCommand } from './ShortcutCommand';
 
+const enum Keys {
+    BACKSPACE = 8,
+    SPACE = 32,
+    B = 66,
+    I = 73,
+    U = 85,
+    Y = 89,
+    Z = 90,
+    COMMA = 188,
+    PERIOD = 190,
+    FORWARD_SLASH = 191,
+}
+
 /**
  * Shortcut command for Bold
  * Windows: Ctrl + B
@@ -19,7 +32,7 @@ export const ShortcutBold: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: false,
-        key: 'b',
+        which: Keys.B,
     },
     onClick: editor => toggleBold(editor),
 };
@@ -33,7 +46,7 @@ export const ShortcutItalic: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: false,
-        key: 'i',
+        which: Keys.I,
     },
     onClick: editor => toggleItalic(editor),
 };
@@ -47,7 +60,7 @@ export const ShortcutUnderline: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: false,
-        key: 'u',
+        which: Keys.U,
     },
     onClick: editor => toggleUnderline(editor),
 };
@@ -61,7 +74,7 @@ export const ShortcutClearFormat: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: false,
-        key: ' ',
+        which: Keys.SPACE,
     },
     onClick: editor => clearFormat(editor),
 };
@@ -75,7 +88,7 @@ export const ShortcutUndo: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: false,
-        key: 'z',
+        which: Keys.Z,
     },
     onClick: editor => undo(editor),
 };
@@ -89,7 +102,7 @@ export const ShortcutUndo2: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'alt',
         shiftKey: false,
-        key: 'Backspace',
+        which: Keys.BACKSPACE,
     },
     onClick: editor => undo(editor),
     environment: 'nonMac',
@@ -104,7 +117,7 @@ export const ShortcutRedo: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: false,
-        key: 'y',
+        which: Keys.Y,
     },
     onClick: editor => redo(editor),
     environment: 'nonMac',
@@ -119,7 +132,7 @@ export const ShortcutRedoMacOS: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: true,
-        key: 'z',
+        which: Keys.Z,
     },
     onClick: editor => redo(editor),
     environment: 'mac',
@@ -134,7 +147,7 @@ export const ShortcutBullet: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: false,
-        key: '.',
+        which: Keys.PERIOD,
     },
     onClick: editor => toggleBullet(editor),
 };
@@ -148,7 +161,7 @@ export const ShortcutNumbering: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: false,
-        key: '/',
+        which: Keys.FORWARD_SLASH,
     },
     onClick: editor => toggleNumbering(editor),
 };
@@ -162,7 +175,7 @@ export const ShortcutIncreaseFont: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: true,
-        key: '>',
+        which: Keys.PERIOD,
     },
     onClick: editor => changeFontSize(editor, 'increase'),
 };
@@ -176,7 +189,7 @@ export const ShortcutDecreaseFont: ShortcutCommand = {
     shortcutKey: {
         modifierKey: 'ctrl',
         shiftKey: true,
-        key: '<',
+        which: Keys.COMMA,
     },
     onClick: editor => changeFontSize(editor, 'decrease'),
 };

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
@@ -1,4 +1,4 @@
-import { redo, undo } from 'roosterjs-content-model-core/lib';
+import { redo, undo } from 'roosterjs-content-model-core';
 import {
     changeFontSize,
     clearFormat,

--- a/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
@@ -1,0 +1,133 @@
+import { redo, undo } from 'roosterjs-content-model-core/lib';
+import {
+    changeFontSize,
+    clearFormat,
+    toggleBold,
+    toggleBullet,
+    toggleItalic,
+    toggleNumbering,
+    toggleUnderline,
+} from 'roosterjs-content-model-api';
+import type { ShortcutCommand } from './ShortcutCommand';
+
+/**
+ * Shortcut command for Bold
+ */
+export const ShortcutBold: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: false,
+    key: 'b',
+    onCommand: toggleBold,
+};
+
+/**
+ * Shortcut command for Italic
+ */
+export const ShortcutItalic: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: false,
+    key: 'i',
+    onCommand: toggleItalic,
+};
+
+/**
+ * Shortcut command for Underline
+ */
+export const ShortcutUnderline: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: false,
+    key: 'u',
+    onCommand: toggleUnderline,
+};
+
+/**
+ * Shortcut command for Clear Format
+ */
+export const ShortcutClearFormat: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: false,
+    key: ' ',
+    onCommand: clearFormat,
+};
+
+/**
+ * Shortcut command for Undo
+ */
+export const ShortcutUndo: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: false,
+    key: 'z',
+    onCommand: undo,
+};
+
+/**
+ * Shortcut command for Undo (Alt+Backspace, non-MacOS)
+ */
+export const ShortcutUndo2: ShortcutCommand = {
+    modifierKey: 'alt',
+    shiftKey: false,
+    key: 'Backspace',
+    onCommand: undo,
+    isDisabled: editor => !!editor.getEnvironment().isMac,
+};
+
+/**
+ * Shortcut command for Redo (Non-MacOS)
+ */
+export const ShortcutRedo: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: false,
+    key: 'y',
+    onCommand: redo,
+};
+
+/**
+ * Shortcut command for Redo (MacOS)
+ */
+export const ShortcutRedoMacOS: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: true,
+    key: 'z',
+    onCommand: redo,
+    isDisabled: editor => !editor.getEnvironment().isMac,
+};
+
+/**
+ * Shortcut command for Bullet List
+ */
+export const ShortcutBullet: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: false,
+    key: '.',
+    onCommand: toggleBullet,
+};
+
+/**
+ * Shortcut command for Numbering List
+ */
+export const ShortcutNumbering: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: false,
+    key: '/',
+    onCommand: toggleNumbering,
+};
+
+/**
+ * Shortcut command for Increase Font
+ */
+export const ShortcutIncreaseFont: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: true,
+    key: '>',
+    onCommand: editor => changeFontSize(editor, 'increase'),
+};
+
+/**
+ * Shortcut command for Decrease Font
+ */
+export const ShortcutDecreaseFont: ShortcutCommand = {
+    modifierKey: 'ctrl',
+    shiftKey: true,
+    key: '<',
+    onCommand: editor => changeFontSize(editor, 'decrease'),
+};

--- a/packages-content-model/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
@@ -10,6 +10,20 @@ import * as undo from 'roosterjs-content-model-core/lib/publicApi/undo/undo';
 import { EditorEnvironment, IEditor, PluginEvent } from 'roosterjs-content-model-types';
 import { ShortcutPlugin } from '../../lib/shortcut/ShortcutPlugin';
 
+const enum Keys {
+    BACKSPACE = 8,
+    SPACE = 32,
+    A = 65,
+    B = 66,
+    I = 73,
+    U = 85,
+    Y = 89,
+    Z = 90,
+    COMMA = 188,
+    PERIOD = 190,
+    FORWARD_SLASH = 191,
+}
+
 describe('ShortcutPlugin', () => {
     let preventDefaultSpy: jasmine.Spy;
     let mockedEditor: IEditor;
@@ -24,14 +38,14 @@ describe('ShortcutPlugin', () => {
     });
 
     function createMockedEvent(
-        key: string,
+        which: number,
         ctrlKey: boolean,
         altKey: boolean,
         shiftKey: boolean,
         metaKey: boolean
     ): KeyboardEvent {
         return {
-            key,
+            which,
             ctrlKey,
             shiftKey,
             altKey,
@@ -46,7 +60,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('a', true, false, false, false),
+                rawEvent: createMockedEvent(Keys.A, true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -66,7 +80,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('b', true, false, false, false),
+                rawEvent: createMockedEvent(Keys.B, true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -87,7 +101,7 @@ describe('ShortcutPlugin', () => {
 
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('i', true, false, false, false),
+                rawEvent: createMockedEvent(Keys.I, true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -107,7 +121,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('u', true, false, false, false),
+                rawEvent: createMockedEvent(Keys.U, true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -127,7 +141,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent(' ', true, false, false, false),
+                rawEvent: createMockedEvent(Keys.SPACE, true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -147,7 +161,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('z', true, false, false, false),
+                rawEvent: createMockedEvent(Keys.Z, true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -167,7 +181,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('Backspace', false, true, false, false),
+                rawEvent: createMockedEvent(Keys.BACKSPACE, false, true, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -187,7 +201,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('y', true, false, false, false),
+                rawEvent: createMockedEvent(Keys.Y, true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -207,7 +221,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('z', true, false, true, false),
+                rawEvent: createMockedEvent(Keys.Z, true, false, true, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -227,7 +241,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('.', true, false, false, false),
+                rawEvent: createMockedEvent(Keys.PERIOD, true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -247,7 +261,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('/', true, false, false, false),
+                rawEvent: createMockedEvent(Keys.FORWARD_SLASH, true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -267,7 +281,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('>', true, false, true, false),
+                rawEvent: createMockedEvent(Keys.PERIOD, true, false, true, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -287,7 +301,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('<', true, false, true, false),
+                rawEvent: createMockedEvent(Keys.COMMA, true, false, true, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -313,7 +327,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('a', false, false, false, true),
+                rawEvent: createMockedEvent(Keys.A, false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -333,7 +347,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('b', false, false, false, true),
+                rawEvent: createMockedEvent(Keys.B, false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -354,7 +368,7 @@ describe('ShortcutPlugin', () => {
 
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('i', false, false, false, true),
+                rawEvent: createMockedEvent(Keys.I, false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -374,7 +388,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('u', false, false, false, true),
+                rawEvent: createMockedEvent(Keys.U, false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -394,7 +408,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent(' ', false, false, false, true),
+                rawEvent: createMockedEvent(Keys.SPACE, false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -414,7 +428,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('z', false, false, false, true),
+                rawEvent: createMockedEvent(Keys.Z, false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -435,7 +449,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('Backspace', false, true, false, false),
+                rawEvent: createMockedEvent(Keys.BACKSPACE, false, true, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -456,7 +470,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('y', false, false, false, true),
+                rawEvent: createMockedEvent(Keys.Y, false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -477,7 +491,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('z', false, false, true, true),
+                rawEvent: createMockedEvent(Keys.Z, false, false, true, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -497,7 +511,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('.', false, false, false, true),
+                rawEvent: createMockedEvent(Keys.PERIOD, false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -517,7 +531,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('/', false, false, false, true),
+                rawEvent: createMockedEvent(Keys.FORWARD_SLASH, false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -537,7 +551,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('>', false, false, true, true),
+                rawEvent: createMockedEvent(Keys.PERIOD, false, false, true, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -557,7 +571,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('<', false, false, true, true),
+                rawEvent: createMockedEvent(Keys.COMMA, false, false, true, true),
             };
 
             plugin.initialize(mockedEditor);

--- a/packages-content-model/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
@@ -1,5 +1,13 @@
+import * as changeFontSize from 'roosterjs-content-model-api/lib/publicApi/segment/changeFontSize';
+import * as clearFormat from 'roosterjs-content-model-api/lib/publicApi/format/clearFormat';
+import * as redo from 'roosterjs-content-model-core/lib/publicApi/undo/redo';
 import * as toggleBold from 'roosterjs-content-model-api/lib/publicApi/segment/toggleBold';
-import { EditorEnvironment, IEditor } from 'roosterjs-content-model-types';
+import * as toggleBullet from 'roosterjs-content-model-api/lib/publicApi/list/toggleBullet';
+import * as toggleItalic from 'roosterjs-content-model-api/lib/publicApi/segment/toggleItalic';
+import * as toggleNumbering from 'roosterjs-content-model-api/lib/publicApi/list/toggleNumbering';
+import * as toggleUnderline from 'roosterjs-content-model-api/lib/publicApi/segment/toggleUnderline';
+import * as undo from 'roosterjs-content-model-core/lib/publicApi/undo/undo';
+import { EditorEnvironment, IEditor, PluginEvent } from 'roosterjs-content-model-types';
 import { ShortcutPlugin } from '../../lib/shortcut/ShortcutPlugin';
 
 describe('ShortcutPlugin', () => {
@@ -21,26 +29,539 @@ describe('ShortcutPlugin', () => {
         altKey: boolean,
         shiftKey: boolean
     ): KeyboardEvent {
-        return {
-            key: 'b',
-            ctrlKey: true,
-            shiftKey: false,
-            altKey: false,
-            preventDefault: preventDefaultSpy,
-        } as any;
+        return { key, ctrlKey, shiftKey, altKey, preventDefault: preventDefaultSpy } as any;
     }
 
-    it('bold', () => {
-        const toggleBoldSpy = spyOn(toggleBold, 'default');
+    describe('Windows', () => {
+        it('not a shortcut', () => {
+            const apiSpy = spyOn(toggleBold, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('a', true, false, false),
+            };
 
-        const plugin = new ShortcutPlugin();
-        plugin.initialize(mockedEditor);
+            plugin.initialize(mockedEditor);
 
-        plugin.onPluginEvent({
-            eventType: 'keyDown',
-            rawEvent: createMockedEvent('b', true, false, false),
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeFalse();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeUndefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).not.toHaveBeenCalled();
         });
 
-        expect(toggleBoldSpy).toHaveBeenCalledWith(mockedEditor);
+        it('bold', () => {
+            const apiSpy = spyOn(toggleBold, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('b', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('italic', () => {
+            const apiSpy = spyOn(toggleItalic, 'default');
+            const plugin = new ShortcutPlugin();
+
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('i', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('underline', () => {
+            const apiSpy = spyOn(toggleUnderline, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('u', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('clear format', () => {
+            const apiSpy = spyOn(clearFormat, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent(' ', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('undo 1', () => {
+            const apiSpy = spyOn(undo, 'undo');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('z', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('undo 2', () => {
+            const apiSpy = spyOn(undo, 'undo');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('Backspace', false, true, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('redo 1', () => {
+            const apiSpy = spyOn(redo, 'redo');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('y', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('redo 2', () => {
+            const apiSpy = spyOn(redo, 'redo');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('z', true, false, true),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeFalse();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeUndefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).not.toHaveBeenCalled();
+        });
+
+        it('bullet list', () => {
+            const apiSpy = spyOn(toggleBullet, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('.', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('numbering list', () => {
+            const apiSpy = spyOn(toggleNumbering, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('/', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('increase font', () => {
+            const apiSpy = spyOn(changeFontSize, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('>', true, false, true),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor, 'increase');
+        });
+
+        it('decrease font', () => {
+            const apiSpy = spyOn(changeFontSize, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('<', true, false, true),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor, 'decrease');
+        });
+    });
+
+    describe('Mac', () => {
+        beforeEach(() => {
+            mockedEnvironment.isMac = true;
+        });
+
+        it('not a shortcut', () => {
+            const apiSpy = spyOn(toggleBold, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('a', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeFalse();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeUndefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).not.toHaveBeenCalled();
+        });
+
+        it('bold', () => {
+            const apiSpy = spyOn(toggleBold, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('b', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('italic', () => {
+            const apiSpy = spyOn(toggleItalic, 'default');
+            const plugin = new ShortcutPlugin();
+
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('i', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('underline', () => {
+            const apiSpy = spyOn(toggleUnderline, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('u', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('clear format', () => {
+            const apiSpy = spyOn(clearFormat, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent(' ', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('undo 1', () => {
+            const apiSpy = spyOn(undo, 'undo');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('z', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('undo 2', () => {
+            const apiSpy = spyOn(undo, 'undo');
+
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('Backspace', false, true, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeFalse();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeUndefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).not.toHaveBeenCalled();
+        });
+
+        it('redo 1', () => {
+            const apiSpy = spyOn(redo, 'redo');
+
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('y', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeFalse();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeUndefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).not.toHaveBeenCalled();
+        });
+
+        it('redo 2', () => {
+            const apiSpy = spyOn(redo, 'redo');
+
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('z', true, false, true),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('bullet list', () => {
+            const apiSpy = spyOn(toggleBullet, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('.', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('numbering list', () => {
+            const apiSpy = spyOn(toggleNumbering, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('/', true, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
+        it('increase font', () => {
+            const apiSpy = spyOn(changeFontSize, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('>', true, false, true),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor, 'increase');
+        });
+
+        it('decrease font', () => {
+            const apiSpy = spyOn(changeFontSize, 'default');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent('<', true, false, true),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor, 'decrease');
+        });
     });
 });

--- a/packages-content-model/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
@@ -1,0 +1,46 @@
+import * as toggleBold from 'roosterjs-content-model-api/lib/publicApi/segment/toggleBold';
+import { EditorEnvironment, IEditor } from 'roosterjs-content-model-types';
+import { ShortcutPlugin } from '../../lib/shortcut/ShortcutPlugin';
+
+describe('ShortcutPlugin', () => {
+    let preventDefaultSpy: jasmine.Spy;
+    let mockedEditor: IEditor;
+    let mockedEnvironment: EditorEnvironment;
+
+    beforeEach(() => {
+        preventDefaultSpy = jasmine.createSpy('preventDefault');
+        mockedEnvironment = {};
+        mockedEditor = {
+            getEnvironment: () => mockedEnvironment,
+        } as any;
+    });
+
+    function createMockedEvent(
+        key: string,
+        ctrlKey: boolean,
+        altKey: boolean,
+        shiftKey: boolean
+    ): KeyboardEvent {
+        return {
+            key: 'b',
+            ctrlKey: true,
+            shiftKey: false,
+            altKey: false,
+            preventDefault: preventDefaultSpy,
+        } as any;
+    }
+
+    it('bold', () => {
+        const toggleBoldSpy = spyOn(toggleBold, 'default');
+
+        const plugin = new ShortcutPlugin();
+        plugin.initialize(mockedEditor);
+
+        plugin.onPluginEvent({
+            eventType: 'keyDown',
+            rawEvent: createMockedEvent('b', true, false, false),
+        });
+
+        expect(toggleBoldSpy).toHaveBeenCalledWith(mockedEditor);
+    });
+});

--- a/packages-content-model/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
@@ -27,9 +27,17 @@ describe('ShortcutPlugin', () => {
         key: string,
         ctrlKey: boolean,
         altKey: boolean,
-        shiftKey: boolean
+        shiftKey: boolean,
+        metaKey: boolean
     ): KeyboardEvent {
-        return { key, ctrlKey, shiftKey, altKey, preventDefault: preventDefaultSpy } as any;
+        return {
+            key,
+            ctrlKey,
+            shiftKey,
+            altKey,
+            metaKey,
+            preventDefault: preventDefaultSpy,
+        } as any;
     }
 
     describe('Windows', () => {
@@ -38,7 +46,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('a', true, false, false),
+                rawEvent: createMockedEvent('a', true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -58,7 +66,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('b', true, false, false),
+                rawEvent: createMockedEvent('b', true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -79,7 +87,7 @@ describe('ShortcutPlugin', () => {
 
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('i', true, false, false),
+                rawEvent: createMockedEvent('i', true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -99,7 +107,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('u', true, false, false),
+                rawEvent: createMockedEvent('u', true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -119,7 +127,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent(' ', true, false, false),
+                rawEvent: createMockedEvent(' ', true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -139,7 +147,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('z', true, false, false),
+                rawEvent: createMockedEvent('z', true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -159,7 +167,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('Backspace', false, true, false),
+                rawEvent: createMockedEvent('Backspace', false, true, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -179,7 +187,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('y', true, false, false),
+                rawEvent: createMockedEvent('y', true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -199,7 +207,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('z', true, false, true),
+                rawEvent: createMockedEvent('z', true, false, true, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -219,7 +227,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('.', true, false, false),
+                rawEvent: createMockedEvent('.', true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -239,7 +247,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('/', true, false, false),
+                rawEvent: createMockedEvent('/', true, false, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -259,7 +267,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('>', true, false, true),
+                rawEvent: createMockedEvent('>', true, false, true, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -279,7 +287,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('<', true, false, true),
+                rawEvent: createMockedEvent('<', true, false, true, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -305,7 +313,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('a', true, false, false),
+                rawEvent: createMockedEvent('a', false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -325,7 +333,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('b', true, false, false),
+                rawEvent: createMockedEvent('b', false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -346,7 +354,7 @@ describe('ShortcutPlugin', () => {
 
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('i', true, false, false),
+                rawEvent: createMockedEvent('i', false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -366,7 +374,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('u', true, false, false),
+                rawEvent: createMockedEvent('u', false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -386,7 +394,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent(' ', true, false, false),
+                rawEvent: createMockedEvent(' ', false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -406,7 +414,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('z', true, false, false),
+                rawEvent: createMockedEvent('z', false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -427,7 +435,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('Backspace', false, true, false),
+                rawEvent: createMockedEvent('Backspace', false, true, false, false),
             };
 
             plugin.initialize(mockedEditor);
@@ -448,7 +456,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('y', true, false, false),
+                rawEvent: createMockedEvent('y', false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -469,7 +477,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('z', true, false, true),
+                rawEvent: createMockedEvent('z', false, false, true, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -489,7 +497,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('.', true, false, false),
+                rawEvent: createMockedEvent('.', false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -509,7 +517,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('/', true, false, false),
+                rawEvent: createMockedEvent('/', false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -529,7 +537,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('>', true, false, true),
+                rawEvent: createMockedEvent('>', false, false, true, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -549,7 +557,7 @@ describe('ShortcutPlugin', () => {
             const plugin = new ShortcutPlugin();
             const event: PluginEvent = {
                 eventType: 'keyDown',
-                rawEvent: createMockedEvent('<', true, false, true),
+                rawEvent: createMockedEvent('<', false, false, true, true),
             };
 
             plugin.initialize(mockedEditor);

--- a/packages/roosterjs-editor-adapter/lib/corePlugins/BridgePlugin.ts
+++ b/packages/roosterjs-editor-adapter/lib/corePlugins/BridgePlugin.ts
@@ -15,6 +15,7 @@ import type {
 import type { ContextMenuProvider, IEditor, PluginEvent } from 'roosterjs-content-model-types';
 
 const ExclusivelyHandleEventPluginKey = '__ExclusivelyHandleEventPlugin';
+const OldEventKey = '__OldEventFromNewEvent';
 
 /**
  * @internal
@@ -111,7 +112,7 @@ export class BridgePlugin implements ContextMenuProvider<any> {
     }
 
     onPluginEvent(event: PluginEvent) {
-        const oldEvent = newEventToOldEvent(event);
+        const oldEvent = this.cacheGetOldEvent(event);
 
         if (oldEvent) {
             const exclusivelyHandleEventPlugin = this.cacheGetExclusivelyHandlePlugin(event);
@@ -150,7 +151,7 @@ export class BridgePlugin implements ContextMenuProvider<any> {
 
     private cacheGetExclusivelyHandlePlugin(event: PluginEvent) {
         return cacheGetEventData(event, ExclusivelyHandleEventPluginKey, event => {
-            const oldEvent = newEventToOldEvent(event);
+            const oldEvent = this.cacheGetOldEvent(event);
 
             if (oldEvent) {
                 for (let i = 0; i < this.legacyPlugins.length; i++) {
@@ -164,6 +165,10 @@ export class BridgePlugin implements ContextMenuProvider<any> {
 
             return null;
         });
+    }
+
+    private cacheGetOldEvent(event: PluginEvent) {
+        return cacheGetEventData(event, OldEventKey, newEventToOldEvent);
     }
 
     private createEditorCore(editor: IEditor): EditorAdapterCore {

--- a/packages/roosterjs-editor-adapter/test/corePlugins/BridgePluginTest.ts
+++ b/packages/roosterjs-editor-adapter/test/corePlugins/BridgePluginTest.ts
@@ -223,6 +223,7 @@ describe('BridgePlugin', () => {
         expect(mockedEvent).toEqual({
             eventDataCache: {
                 __ExclusivelyHandleEventPlugin: mockedPlugin2,
+                __OldEventFromNewEvent: 'NEW_[object Object]',
             },
         });
         expect(eventConverter.newEventToOldEvent).toHaveBeenCalledTimes(1);
@@ -298,12 +299,20 @@ describe('BridgePlugin', () => {
             {
                 eventType: 'new_old_newEvent' as any,
                 data: 'plugin2',
+                eventDataCache: {
+                    __ExclusivelyHandleEventPlugin: null,
+                    __OldEventFromNewEvent: { eventType: 'old_newEvent', data: 'plugin2' },
+                },
             }
         );
 
         expect(mockedEvent).toEqual({
             eventType: 'new_old_newEvent',
             data: 'plugin2',
+            eventDataCache: {
+                __ExclusivelyHandleEventPlugin: null,
+                __OldEventFromNewEvent: { eventType: 'old_newEvent', data: 'plugin2' },
+            },
         });
 
         plugin.dispose();
@@ -343,7 +352,7 @@ describe('BridgePlugin', () => {
         const mockedEvent = {
             eventType: 'newEvent',
             eventDataCache: {
-                ['__ExclusivelyHandleEventPlugin']: mockedPlugin2,
+                __ExclusivelyHandleEventPlugin: mockedPlugin2,
             },
         } as any;
 
@@ -354,7 +363,8 @@ describe('BridgePlugin', () => {
         expect(onPluginEventSpy2).toHaveBeenCalledWith({
             eventType: 'old_newEvent',
             eventDataCache: {
-                ['__ExclusivelyHandleEventPlugin']: mockedPlugin2,
+                __ExclusivelyHandleEventPlugin: mockedPlugin2,
+                __OldEventFromNewEvent: jasmine.anything(),
             },
         });
         expect(eventConverter.newEventToOldEvent).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Port the `shortcutFeatures` of original `ContentEdit` plugin to be a separate plugin `ShortcutPlugin`. So that the standalone new editor can work with shortcut support.