### PR TITLE
Outdent indented empty paragraph when pressing Backspace.

### DIFF
--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteCollapsedSelection.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteCollapsedSelection.ts
@@ -115,8 +115,8 @@ function shouldOutdentParagraph(
         !isForward &&
         segments.length == 1 &&
         segments[0].segmentType == 'SelectionMarker' &&
-        ((paragraph.format.marginLeft && parseInt(paragraph.format.marginLeft)) ||
-            (paragraph.format.marginRight && parseInt(paragraph.format.marginRight))) &&
+        paragraph.format.marginLeft &&
+        parseInt(paragraph.format.marginLeft) &&
         getClosestAncestorBlockGroupIndex(path, ['Document', 'TableCell'], ['ListItem']) > -1
     );
 }

--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteCollapsedSelection.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteCollapsedSelection.ts
@@ -1,8 +1,19 @@
-import { deleteBlock, deleteSegment } from 'roosterjs-content-model-core';
 import { getLeafSiblingBlock } from '../utils/getLeafSiblingBlock';
+import { setModelIndentation } from 'roosterjs-content-model-api';
 import { setParagraphNotImplicit } from 'roosterjs-content-model-dom';
+import {
+    deleteBlock,
+    deleteSegment,
+    getClosestAncestorBlockGroupIndex,
+} from 'roosterjs-content-model-core';
 import type { BlockAndPath } from '../utils/getLeafSiblingBlock';
-import type { ContentModelSegment, DeleteSelectionStep } from 'roosterjs-content-model-types';
+import type {
+    ContentModelBlockGroup,
+    ContentModelDocument,
+    ContentModelParagraph,
+    ContentModelSegment,
+    DeleteSelectionStep,
+} from 'roosterjs-content-model-types';
 
 function getDeleteCollapsedSelection(direction: 'forward' | 'backward'): DeleteSelectionStep {
     return context => {
@@ -19,6 +30,7 @@ function getDeleteCollapsedSelection(direction: 'forward' | 'backward'): DeleteS
         const index = segments.indexOf(marker) + (isForward ? 1 : -1);
         const segmentToDelete = segments[index];
         let blockToDelete: BlockAndPath | null;
+        let root: ContentModelDocument | null;
 
         if (segmentToDelete) {
             if (deleteSegment(paragraph, segmentToDelete, context.formatContext, direction)) {
@@ -28,6 +40,12 @@ function getDeleteCollapsedSelection(direction: 'forward' | 'backward'): DeleteS
                 // to avoid losing its format. See https://github.com/microsoft/roosterjs/issues/1953
                 setParagraphNotImplicit(paragraph);
             }
+        } else if (
+            shouldOutdentParagraph(isForward, segments, paragraph, path) &&
+            (root = getRoot(path))
+        ) {
+            setModelIndentation(root, 'outdent');
+            context.deleteResult = 'range';
         } else if ((blockToDelete = getLeafSiblingBlock(path, paragraph, isForward))) {
             const { block, path, siblingSegment } = blockToDelete;
 
@@ -80,6 +98,27 @@ function getDeleteCollapsedSelection(direction: 'forward' | 'backward'): DeleteS
             context.deleteResult = 'nothingToDelete';
         }
     };
+}
+
+function getRoot(path: ContentModelBlockGroup[]): ContentModelDocument | null {
+    const lastInPath = path[path.length - 1];
+    return lastInPath.blockGroupType == 'Document' ? lastInPath : null;
+}
+
+function shouldOutdentParagraph(
+    isForward: boolean,
+    segments: ContentModelSegment[],
+    paragraph: ContentModelParagraph,
+    path: ContentModelBlockGroup[]
+) {
+    return (
+        !isForward &&
+        segments.length == 1 &&
+        segments[0].segmentType == 'SelectionMarker' &&
+        ((paragraph.format.marginLeft && parseInt(paragraph.format.marginLeft)) ||
+            (paragraph.format.marginRight && parseInt(paragraph.format.marginRight))) &&
+        getClosestAncestorBlockGroupIndex(path, ['Document', 'TableCell'], ['ListItem']) > -1
+    );
 }
 
 /**

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/deleteSteps/deleteCollapsedSelectionTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/deleteSteps/deleteCollapsedSelectionTest.ts
@@ -1,6 +1,5 @@
 import { deleteSelection } from 'roosterjs-content-model-core';
 import {
-    ContentModelDocument,
     ContentModelEntity,
     ContentModelSelectionMarker,
     DeletedEntity,


### PR DESCRIPTION
If the paragraph was indented, when pressing backspace on the paragraph we are not reducing the indentation margins.

This PR adds the functionality when backspacing on a empty paragraph that have margins to outdent just like before in the original editor. By adding some code to the deleteCollapsedSelection and calling the setModelIndentation outdent to the currently selected model.

Gif:
![outdentBcksp](https://github.com/microsoft/roosterjs/assets/8291124/ee85bc24-24d0-4103-a1ff-695eb6c5ee05)

https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/238611/
