### PR TITLE
Fix insertNode: Do not reselect if updateCursor is false

### DIFF
--- a/packages/roosterjs-editor-adapter/lib/editor/EditorAdapter.ts
+++ b/packages/roosterjs-editor-adapter/lib/editor/EditorAdapter.ts
@@ -219,7 +219,7 @@ export class EditorAdapter extends Editor implements ILegacyEditor {
 
                 const selection = insertNode(contentDiv, this.getDOMSelection(), node, option);
 
-                if (selection) {
+                if (selection && option.updateCursor) {
                     this.setDOMSelection(selection);
                 }
             }


### PR DESCRIPTION
For API `insertNode`, if the parameter `updateCursor` is false, we don't need to reselect the selection after insert, so that we can avoid accidentally putting focus into editor.