### PR TITLE
Bump roosterjs-editor-adapter to 0.26.1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -4,6 +4,6 @@
     "packages-content-model": "0.26.2",
     "overrides": {
         "roosterjs-editor-plugins": "8.60.2",
-        "roosterjs-editor-adapter": "0.26.0"
+        "roosterjs-editor-adapter": "0.26.1"
     }
 }


### PR DESCRIPTION
Bump roosterjs-editor-adapter to 0.26.1 to include the latest focus fix