### PR TITLE
Handle tab key for paragraph

### DIFF
--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnList.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnList.ts
@@ -1,5 +1,5 @@
-import { ContentModelDocument, ContentModelListItem } from 'roosterjs-content-model-types';
 import { setModelIndentation } from 'roosterjs-content-model-api';
+import type { ContentModelDocument, ContentModelListItem } from 'roosterjs-content-model-types';
 
 /**
  * @internal

--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnList.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnList.ts
@@ -1,7 +1,10 @@
+import { handleTabOnParagraph } from './handleTabOnParagraph';
 import { setModelIndentation } from 'roosterjs-content-model-api';
 import type { ContentModelDocument, ContentModelListItem } from 'roosterjs-content-model-types';
 
 /**
+ * 1. When the selection is collapsed and the cursor is at start of a list item, call setModelIndentation.
+ * 2. Otherwise call handleTabOnParagraph.
  * @internal
  */
 export function handleTabOnList(
@@ -9,17 +12,30 @@ export function handleTabOnList(
     listItem: ContentModelListItem,
     rawEvent: KeyboardEvent
 ) {
-    if (isMarkerAtStartOfBlock(listItem)) {
+    const selectedParagraph = findSelectedParagraph(listItem);
+    if (
+        !isMarkerAtStartOfBlock(listItem) &&
+        selectedParagraph.length == 1 &&
+        selectedParagraph[0].blockType === 'Paragraph'
+    ) {
+        return handleTabOnParagraph(model, selectedParagraph[0], rawEvent);
+    } else {
         setModelIndentation(model, rawEvent.shiftKey ? 'outdent' : 'indent');
         rawEvent.preventDefault();
         return true;
     }
-    return false;
 }
 
 function isMarkerAtStartOfBlock(listItem: ContentModelListItem) {
     return (
         listItem.blocks[0].blockType == 'Paragraph' &&
         listItem.blocks[0].segments[0].segmentType == 'SelectionMarker'
+    );
+}
+
+function findSelectedParagraph(listItem: ContentModelListItem) {
+    return listItem.blocks.filter(
+        block =>
+            block.blockType == 'Paragraph' && block.segments.some(segment => segment.isSelected)
     );
 }

--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnList.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnList.ts
@@ -1,0 +1,25 @@
+import { ContentModelDocument, ContentModelListItem } from 'roosterjs-content-model-types';
+import { setModelIndentation } from 'roosterjs-content-model-api';
+
+/**
+ * @internal
+ */
+export function handleTabOnList(
+    model: ContentModelDocument,
+    listItem: ContentModelListItem,
+    rawEvent: KeyboardEvent
+) {
+    if (isMarkerAtStartOfBlock(listItem)) {
+        setModelIndentation(model, rawEvent.shiftKey ? 'outdent' : 'indent');
+        rawEvent.preventDefault();
+        return true;
+    }
+    return false;
+}
+
+function isMarkerAtStartOfBlock(listItem: ContentModelListItem) {
+    return (
+        listItem.blocks[0].blockType == 'Paragraph' &&
+        listItem.blocks[0].segments[0].segmentType == 'SelectionMarker'
+    );
+}

--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnParagraph.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnParagraph.ts
@@ -1,0 +1,75 @@
+import { createSelectionMarker, createText } from 'roosterjs-content-model-dom/lib';
+import { setModelIndentation } from 'roosterjs-content-model-api';
+import {
+    ContentModelDocument,
+    ContentModelParagraph,
+    RangeSelection,
+} from 'roosterjs-content-model-types/lib';
+
+const tabSpaces = '    ';
+const space = ' ';
+
+/**
+ * @internal
+ */
+export function handleTabOnParagraph(
+    model: ContentModelDocument,
+    paragraph: ContentModelParagraph,
+    rawEvent: KeyboardEvent,
+    selection: RangeSelection
+) {
+    if (paragraph.segments[0].segmentType === 'SelectionMarker' && selection.range.collapsed) {
+        setModelIndentation(model, rawEvent.shiftKey ? 'outdent' : 'indent');
+    } else {
+        const markerIndex = paragraph.segments.findIndex(
+            segment => segment.segmentType === 'SelectionMarker'
+        );
+        if (!selection.range.collapsed) {
+            let firstSelectedSegmentIndex: number | undefined = undefined;
+            let lastSelectedSegmentIndex: number | undefined = undefined;
+
+            paragraph.segments.forEach((segment, index) => {
+                if (segment.isSelected) {
+                    if (!firstSelectedSegmentIndex) {
+                        firstSelectedSegmentIndex = index;
+                    }
+                    lastSelectedSegmentIndex = index;
+                }
+            });
+            if (firstSelectedSegmentIndex && lastSelectedSegmentIndex) {
+                const firstSelectedSegment = paragraph.segments[firstSelectedSegmentIndex];
+                const spaceText = createText(rawEvent.shiftKey ? tabSpaces : space);
+                const marker = createSelectionMarker(firstSelectedSegment.format);
+                paragraph.segments.splice(
+                    firstSelectedSegmentIndex,
+                    lastSelectedSegmentIndex - firstSelectedSegmentIndex + 1,
+                    spaceText,
+                    marker
+                );
+            } else {
+                return false;
+            }
+        } else {
+            if (!rawEvent.shiftKey) {
+                const tabText = createText(tabSpaces);
+                paragraph.segments.splice(markerIndex, 0, tabText);
+            } else {
+                const tabText = paragraph.segments[markerIndex - 1];
+                const tabSpacesLength = tabSpaces.length;
+                if (tabText.segmentType == 'Text') {
+                    const tabSpaceTextLength = tabText.text.length - tabSpacesLength;
+                    if (tabText.text === tabSpaces) {
+                        paragraph.segments.splice(markerIndex - 1, 1);
+                    } else if (tabText.text.substring(tabSpaceTextLength) === tabSpaces) {
+                        tabText.text = tabText.text.substring(0, tabSpaceTextLength);
+                    } else {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
+    rawEvent.preventDefault();
+    return true;
+}

--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnParagraph.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnParagraph.ts
@@ -1,4 +1,4 @@
-import { createSelectionMarker, createText } from 'roosterjs-content-model-dom/lib';
+import { createSelectionMarker, createText } from 'roosterjs-content-model-dom';
 import { setModelIndentation } from 'roosterjs-content-model-api';
 import type {
     ContentModelDocument,

--- a/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnParagraph.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnParagraph.ts
@@ -1,10 +1,10 @@
 import { createSelectionMarker, createText } from 'roosterjs-content-model-dom/lib';
 import { setModelIndentation } from 'roosterjs-content-model-api';
-import {
+import type {
     ContentModelDocument,
     ContentModelParagraph,
     RangeSelection,
-} from 'roosterjs-content-model-types/lib';
+} from 'roosterjs-content-model-types';
 
 const tabSpaces = '    ';
 const space = ' ';

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardTabTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/keyboardTabTest.ts
@@ -413,7 +413,7 @@ describe('keyboardTab', () => {
             ],
             format: {},
         };
-        runTest(model, undefined, false, false);
+        runTest(model, undefined, false, true);
     });
 
     it('tab on the start second item on the list', () => {
@@ -665,7 +665,7 @@ describe('keyboardTab', () => {
             ],
             format: {},
         };
-        runTest(model, undefined, false, false);
+        runTest(model, undefined, false, true);
     });
 
     it('shift tab on empty list item', () => {
@@ -1426,5 +1426,438 @@ describe('keyboardTab - handleTabOnParagraph -', () => {
             format: {},
         };
         runTest(input, 'Tab', false, true, expectedResult);
+    });
+
+    it('expanded range | multiple paragraphs', () => {
+        const input: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+
+        const expectedResult: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {
+                        marginLeft: '40px',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {
+                        marginLeft: '40px',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {
+                        marginLeft: '40px',
+                    },
+                },
+            ],
+            format: {},
+        };
+
+        runTest(input, 'Tab', false, false, expectedResult);
+    });
+
+    it('expanded range | outdent paragraphs', () => {
+        const input: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {
+                        marginLeft: '40px',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {
+                        marginLeft: '40px',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {
+                        marginLeft: '40px',
+                    },
+                },
+            ],
+            format: {},
+        };
+        const expectedResult: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {
+                        marginLeft: '0px',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {
+                        marginLeft: '0px',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {
+                        marginLeft: '0px',
+                    },
+                },
+            ],
+            format: {},
+        };
+        runTest(input, 'Tab', false, true, expectedResult);
+    });
+
+    it('collapsed range | middle list', () => {
+        const input: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'te',
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'SelectionMarker',
+                                    isSelected: true,
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'Text',
+                                    text: 'st',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                            },
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: {
+                        marginLeft: '0px',
+                    },
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {},
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: {
+                        marginLeft: '0px',
+                    },
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {},
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: {
+                        marginLeft: '0px',
+                    },
+                },
+            ],
+            format: {},
+        };
+        const expectedResult: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'te',
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'Text',
+                                    text: '    ',
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'SelectionMarker',
+                                    isSelected: true,
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'Text',
+                                    text: 'st',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                            },
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: {
+                        marginLeft: '0px',
+                    },
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {},
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: {
+                        marginLeft: '0px',
+                    },
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {},
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: {
+                        marginLeft: '0px',
+                    },
+                },
+            ],
+            format: {},
+        };
+        runTest(input, 'Tab', true, false, expectedResult);
     });
 });

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnListTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnListTest.ts
@@ -207,7 +207,7 @@ describe('handleTabOnList', () => {
         runTest(model, listItem, rawEvent, expectedReturnValue);
     });
 
-    it('should return false when the cursor is not at the start of the list item', () => {
+    it('should return true when the cursor is not at the start of the list item', () => {
         // Arrange
         const model: ContentModelDocument = {
             blockGroupType: 'Document',
@@ -297,9 +297,8 @@ describe('handleTabOnList', () => {
             shiftKey: false,
             preventDefault: () => {},
         } as KeyboardEvent;
-        const expectedReturnValue = false;
 
         // Act
-        runTest(model, listItem, rawEvent, expectedReturnValue);
+        runTest(model, listItem, rawEvent, true);
     });
 });

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnListTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnListTest.ts
@@ -1,0 +1,305 @@
+import { ContentModelDocument, ContentModelListItem } from 'roosterjs-content-model-types';
+import { handleTabOnList } from '../../../lib/edit/tabUtils/handleTabOnList';
+
+describe('handleTabOnList', () => {
+    function runTest(
+        model: ContentModelDocument,
+        listItem: ContentModelListItem,
+        rawEvent: KeyboardEvent,
+        expectedReturnValue: boolean
+    ) {
+        // Act
+        const result = handleTabOnList(model, listItem, rawEvent);
+
+        // Assert
+        expect(result).toBe(expectedReturnValue);
+    }
+
+    it('should return true when the cursor is at the start of the list item', () => {
+        // Arrange
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'SelectionMarker',
+                                    isSelected: true,
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo: '{"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const listItem: ContentModelListItem = {
+            blockType: 'BlockGroup',
+            blockGroupType: 'ListItem',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            levels: [
+                {
+                    listType: 'OL',
+                    format: {
+                        listStyleType: 'decimal',
+                    },
+                    dataset: {
+                        editingInfo: '{"orderedStyleType":1}',
+                    },
+                },
+            ],
+            formatHolder: {
+                segmentType: 'SelectionMarker',
+                isSelected: true,
+                format: {},
+            },
+            format: {},
+        };
+        const rawEvent = {
+            shiftKey: false,
+            preventDefault: () => {},
+        } as KeyboardEvent;
+        const expectedReturnValue = true;
+
+        // Act
+        runTest(model, listItem, rawEvent, expectedReturnValue);
+    });
+
+    it('Outdent - should return true when the cursor is at the start of the list item', () => {
+        // Arrange
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'SelectionMarker',
+                                    isSelected: true,
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo: '{"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const listItem: ContentModelListItem = {
+            blockType: 'BlockGroup',
+            blockGroupType: 'ListItem',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            levels: [
+                {
+                    listType: 'OL',
+                    format: {
+                        listStyleType: 'decimal',
+                    },
+                    dataset: {
+                        editingInfo: '{"orderedStyleType":1}',
+                    },
+                },
+            ],
+            formatHolder: {
+                segmentType: 'SelectionMarker',
+                isSelected: true,
+                format: {},
+            },
+            format: {},
+        };
+        const rawEvent = {
+            shiftKey: false,
+            preventDefault: () => {},
+        } as KeyboardEvent;
+        const expectedReturnValue = true;
+
+        // Act
+        runTest(model, listItem, rawEvent, expectedReturnValue);
+    });
+
+    it('should return false when the cursor is not at the start of the list item', () => {
+        // Arrange
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test',
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'SelectionMarker',
+                                    isSelected: true,
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo: '{"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const listItem: ContentModelListItem = {
+            blockType: 'BlockGroup',
+            blockGroupType: 'ListItem',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            levels: [
+                {
+                    listType: 'OL',
+                    format: {
+                        listStyleType: 'decimal',
+                    },
+                    dataset: {
+                        editingInfo: '{"orderedStyleType":1}',
+                    },
+                },
+            ],
+            formatHolder: {
+                segmentType: 'SelectionMarker',
+                isSelected: true,
+                format: {},
+            },
+            format: {},
+        };
+        const rawEvent = {
+            shiftKey: false,
+            preventDefault: () => {},
+        } as KeyboardEvent;
+        const expectedReturnValue = false;
+
+        // Act
+        runTest(model, listItem, rawEvent, expectedReturnValue);
+    });
+});

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnParagraphTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnParagraphTest.ts
@@ -1,0 +1,429 @@
+import { handleTabOnParagraph } from '../../../lib/edit/tabUtils/handleTabOnParagraph';
+import {
+    ContentModelDocument,
+    ContentModelParagraph,
+    RangeSelection,
+} from 'roosterjs-content-model-types';
+
+describe('handleTabOnParagraph', () => {
+    function runTest(
+        model: ContentModelDocument,
+        paragraph: ContentModelParagraph,
+        rawEvent: KeyboardEvent,
+        selection: RangeSelection,
+        expectedReturnValue: boolean
+    ) {
+        // Act
+        const result = handleTabOnParagraph(model, paragraph, rawEvent, selection);
+
+        // Assert
+        expect(result).toBe(expectedReturnValue);
+    }
+
+    it('Indent - collapsed range should return true when cursor is at the end', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: false,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: true,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, true);
+    });
+
+    it('Outdent - collapsed range should return false when cursor is at the end', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: true,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: true,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, false);
+    });
+
+    it('Indent - collapsed range should return true when cursor is at the start', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: false,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: true,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, true);
+    });
+
+    it('Outdent - collapsed range should return true when cursor is at the start', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: true,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: true,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, true);
+    });
+
+    it('Indent - collapsed range should return true when cursor is at the middle', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'te',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'st',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: false,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: true,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, true);
+    });
+
+    it('Outdent - collapsed range should return true when cursor is at the middle', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'te',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'st',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: true,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: true,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, false);
+    });
+
+    it('Outdent - Intended - collapsed range should return true when cursor is at the end', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '    ',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: true,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: true,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, true);
+    });
+
+    it('Outdent - Intended - collapsed range should return true when cursor is at the middle', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'te',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '    ',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'st',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: true,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: true,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, true);
+    });
+
+    it('Indent - expanded range should return true', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: '123',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '456',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '789',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: false,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: false,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, true);
+    });
+
+    it('outdent - expanded range should return true', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: '123',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '456',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '789',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: true,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: false,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, true);
+    });
+});

--- a/packages-content-model/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnParagraphTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnParagraphTest.ts
@@ -14,7 +14,7 @@ describe('handleTabOnParagraph', () => {
         expectedReturnValue: boolean
     ) {
         // Act
-        const result = handleTabOnParagraph(model, paragraph, rawEvent, selection);
+        const result = handleTabOnParagraph(model, paragraph, rawEvent);
 
         // Assert
         expect(result).toBe(expectedReturnValue);


### PR DESCRIPTION
Add the `handleTabOnParagraph` function in the `keyboardTab` file. Also split the `handleTabOnList` function in a separate file. 
The `handleTabOnParagraph` function will handle the tab key in following scenarios: 

1. When the selection is collapsed and the cursor is at the end of a paragraph, add 4 spaces.
2. When the selection is collapsed and the cursor is at the start of a paragraph, call `setModelIndention` function to indent the whole paragraph
3. When the selection is collapsed and the cursor is at the middle of a paragraph, add 4 spaces.
4. When the selection is not collapsed, replace the selected range with a single space.
5. When more that one paragraph is selected,  call `setModelIndention` function to indent the whole paragraph

The `handleTabOnParagraph` function will handle the shift + tab key in a indented paragraph in following scenarios: 

1. When the selection is collapsed and the cursor is at the end of a paragraph, remove 4 spaces.
2. When the selection is collapsed and the cursor is at the start of a paragraph, call `setModelIndention` function to outdent the whole paragraph
3. When the selection is collapsed and the cursor is at the middle of a paragraph, remove 4 spaces.
4. When the selection is not collapsed, replace the selected range with a 4 space.
5. 5. When more that one paragraph is selected,  call `setModelIndention` function to outdent the whole paragraph

This behavior was design based on the word online editor. 
