### PR TITLE
Fix #2435: AttributeSanitizers are not applied to the child elements

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/utils/sanitizeElement.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/utils/sanitizeElement.ts
@@ -288,7 +288,13 @@ export function sanitizeElement(
     if (sanitizedElement) {
         for (let child = element.firstChild; child; child = child.nextSibling) {
             const newChild = isNodeOfType(child, 'ELEMENT_NODE')
-                ? sanitizeElement(child, allowedTags, disallowedTags, styleSanitizers)
+                ? sanitizeElement(
+                      child,
+                      allowedTags,
+                      disallowedTags,
+                      styleSanitizers,
+                      attributeSanitizers
+                  )
                 : isNodeOfType(child, 'TEXT_NODE')
                 ? child.cloneNode()
                 : null;

--- a/packages-content-model/roosterjs-content-model-core/test/utils/sanitizeElementTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/utils/sanitizeElementTest.ts
@@ -143,6 +143,7 @@ describe('sanitizeElement', () => {
         });
 
         expect(result!.outerHTML).toBe('<div id="b"></div>');
+        expect(sanitizerSpy).toHaveBeenCalledTimes(1);
         expect(sanitizerSpy).toHaveBeenCalledWith('a', 'div');
     });
 
@@ -156,6 +157,27 @@ describe('sanitizeElement', () => {
         });
 
         expect(result!.outerHTML).toBe('<div></div>');
+    });
+
+    it('attributeCallbacks with child element', () => {
+        const element = document.createElement('div');
+        const child = document.createElement('span');
+        const sanitizerSpy = jasmine
+            .createSpy('sanitizer')
+            .and.callFake((value: string) => value + value);
+
+        element.id = 'a';
+        child.id = 'b';
+        element.appendChild(child);
+
+        const result = sanitizeElement(element, AllowedTags, DisallowedTags, undefined, {
+            id: sanitizerSpy,
+        });
+
+        expect(result!.outerHTML).toBe('<div id="aa"><span id="bb"></span></div>');
+        expect(sanitizerSpy).toHaveBeenCalledTimes(2);
+        expect(sanitizerSpy).toHaveBeenCalledWith('a', 'div');
+        expect(sanitizerSpy).toHaveBeenCalledWith('b', 'span');
     });
 });
 


### PR DESCRIPTION
When sanitize element and its child elements, we need to pass down attribute sanitizers together with other parameters.