### PR TITLE
Support adding options for exportContent

### DIFF
--- a/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/exportContent.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/publicApi/model/exportContent.ts
@@ -3,7 +3,7 @@ import {
     contentModelToText,
     createModelToDomContext,
 } from 'roosterjs-content-model-dom';
-import type { ExportContentMode, IEditor } from 'roosterjs-content-model-types';
+import type { ExportContentMode, IEditor, ModelToDomOption } from 'roosterjs-content-model-types';
 
 /**
  * Export string content of editor
@@ -12,8 +12,13 @@ import type { ExportContentMode, IEditor } from 'roosterjs-content-model-types';
  * - HTML: Export HTML content. If there are entities, this will cause EntityOperation event with option = 'replaceTemporaryContent' to get a dehydrated entity
  * - PlainText: Export plain text content
  * - PlainTextFast: Export plain text using editor's textContent property directly
+ * @param options @optional Options for Model to DOM conversion
  */
-export function exportContent(editor: IEditor, mode: ExportContentMode = 'HTML'): string {
+export function exportContent(
+    editor: IEditor,
+    mode: ExportContentMode = 'HTML',
+    options?: ModelToDomOption
+): string {
     if (mode == 'PlainTextFast') {
         return editor.getDOMHelper().getTextContent();
     } else {
@@ -25,7 +30,12 @@ export function exportContent(editor: IEditor, mode: ExportContentMode = 'HTML')
             const doc = editor.getDocument();
             const div = doc.createElement('div');
 
-            contentModelToDom(doc, div, model, createModelToDomContext());
+            contentModelToDom(
+                doc,
+                div,
+                model,
+                createModelToDomContext(undefined /*editorContext*/, options)
+            );
 
             editor.triggerEvent('extractContentWithDom', { clonedRoot: div }, true /*broadcast*/);
 

--- a/packages-content-model/roosterjs-content-model-core/test/publicApi/model/exportContentTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/publicApi/model/exportContentTest.ts
@@ -72,7 +72,51 @@ describe('exportContent', () => {
 
         expect(html).toBe(mockedHTML);
         expect(getContentModelCopySpy).toHaveBeenCalledWith('disconnected');
-        expect(createModelToDomContextSpy).toHaveBeenCalledWith();
+        expect(createModelToDomContextSpy).toHaveBeenCalledWith(undefined, undefined);
+        expect(contentModelToDomSpy).toHaveBeenCalledWith(
+            mockedDoc,
+            mockedDiv,
+            mockedModel,
+            mockedContext
+        );
+        expect(triggerEventSpy).toHaveBeenCalledWith(
+            'extractContentWithDom',
+            { clonedRoot: mockedDiv },
+            true
+        );
+    });
+
+    it('HTML with options', () => {
+        const mockedModel = 'MODEL' as any;
+        const getContentModelCopySpy = jasmine
+            .createSpy('getContentModelCopy')
+            .and.returnValue(mockedModel);
+        const mockedHTML = 'HTML';
+        const mockedDiv = {
+            innerHTML: mockedHTML,
+        } as any;
+        const mockedDoc = {
+            createElement: () => mockedDiv,
+        } as any;
+        const triggerEventSpy = jasmine.createSpy('triggerEvent');
+        const editor: IEditor = {
+            getContentModelCopy: getContentModelCopySpy,
+            getDocument: () => mockedDoc,
+            triggerEvent: triggerEventSpy,
+        } as any;
+        const contentModelToDomSpy = spyOn(contentModelToDom, 'contentModelToDom');
+        const mockedContext = 'CONTEXT' as any;
+        const createModelToDomContextSpy = spyOn(
+            createModelToDomContext,
+            'createModelToDomContext'
+        ).and.returnValue(mockedContext);
+        const mockedOptions = 'OPTIONS' as any;
+
+        const html = exportContent(editor, 'HTML', mockedOptions);
+
+        expect(html).toBe(mockedHTML);
+        expect(getContentModelCopySpy).toHaveBeenCalledWith('disconnected');
+        expect(createModelToDomContextSpy).toHaveBeenCalledWith(undefined, mockedOptions);
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
             mockedDoc,
             mockedDiv,

--- a/packages/roosterjs-editor-adapter/lib/editor/EditorAdapter.ts
+++ b/packages/roosterjs-editor-adapter/lib/editor/EditorAdapter.ts
@@ -343,7 +343,11 @@ export class EditorAdapter extends Editor implements ILegacyEditor {
      * @returns HTML string representing current editor content
      */
     getContent(mode: GetContentMode | CompatibleGetContentMode = GetContentMode.CleanHTML): string {
-        return exportContent(this, GetContentModeMap[mode]);
+        return exportContent(
+            this,
+            GetContentModeMap[mode],
+            this.getCore().modelToDomSettings.customized
+        );
     }
 
     /**


### PR DESCRIPTION
While testing the latest version bump, I found an issue that when we call `EditorAdapter.getContent()`, we didn't pass in the modelToDomOption so that the generated HTML removed a lot of attributes.

To fix this, add a parameter to `exportContent` function to allow pass in options so that those attributes can be preserved.