### PR TITLE
Improve Entity State related API

### DIFF
--- a/packages-content-model/roosterjs-content-model-api/lib/publicApi/entity/insertEntity.ts
+++ b/packages-content-model/roosterjs-content-model-api/lib/publicApi/entity/insertEntity.ts
@@ -11,6 +11,7 @@ import type {
     InsertEntityPosition,
     InsertEntityOptions,
     IEditor,
+    EntityState,
 } from 'roosterjs-content-model-types';
 
 const BlockEntityTag = 'div';
@@ -116,18 +117,23 @@ export default function insertEntity(
     );
 
     if (!skipUndoSnapshot) {
-        const format = parseEntityFormat(wrapper);
-        const { id, entityType } = format;
+        let entityState: EntityState | undefined;
 
-        editor.takeSnapshot(
-            initialEntityState && id && entityType
-                ? {
-                      id: id,
-                      type: entityType,
-                      state: initialEntityState,
-                  }
-                : undefined
-        );
+        if (initialEntityState) {
+            const format = parseEntityFormat(wrapper);
+            const { id, entityType } = format;
+
+            entityState =
+                id && entityType
+                    ? {
+                          id: id,
+                          type: entityType,
+                          state: initialEntityState,
+                      }
+                    : undefined;
+        }
+
+        editor.takeSnapshot(entityState);
     }
 
     return entityModel;

--- a/packages-content-model/roosterjs-content-model-api/test/publicApi/entity/insertEntityTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/publicApi/entity/insertEntityTest.ts
@@ -79,6 +79,9 @@ describe('insertEntity', () => {
     it('insert inline entity to top', () => {
         const entity = insertEntity(editor, type, false, 'begin');
 
+        expect(takeSnapshotSpy).toHaveBeenCalledTimes(2);
+        expect(takeSnapshotSpy).toHaveBeenCalledWith();
+        expect(takeSnapshotSpy).toHaveBeenCalledWith(undefined);
         expect(createElementSpy).toHaveBeenCalledWith('span');
         expect(setPropertySpy).toHaveBeenCalledWith('display', 'inline-block');
         expect(appendChildSpy).not.toHaveBeenCalled();
@@ -123,6 +126,9 @@ describe('insertEntity', () => {
     it('block inline entity to root', () => {
         const entity = insertEntity(editor, type, true, 'root');
 
+        expect(takeSnapshotSpy).toHaveBeenCalledTimes(2);
+        expect(takeSnapshotSpy).toHaveBeenCalledWith();
+        expect(takeSnapshotSpy).toHaveBeenCalledWith(undefined);
         expect(createElementSpy).toHaveBeenCalledWith('div');
         expect(setPropertySpy).toHaveBeenCalledWith('display', 'inline-block');
         expect(setPropertySpy).toHaveBeenCalledWith('width', '100%');
@@ -175,6 +181,7 @@ describe('insertEntity', () => {
             wrapperDisplay: 'none',
         });
 
+        expect(takeSnapshotSpy).toHaveBeenCalledTimes(0);
         expect(createElementSpy).toHaveBeenCalledWith('div');
         expect(setPropertySpy).toHaveBeenCalledWith('display', 'none');
         expect(setPropertySpy).not.toHaveBeenCalledWith('display', 'inline-block');
@@ -224,6 +231,81 @@ describe('insertEntity', () => {
 
         const entity = insertEntity(editor, type, false, 'begin');
 
+        expect(takeSnapshotSpy).toHaveBeenCalledTimes(2);
+        expect(takeSnapshotSpy).toHaveBeenCalledWith();
+        expect(takeSnapshotSpy).toHaveBeenCalledWith(undefined);
+        expect(createElementSpy).toHaveBeenCalledWith('span');
+        expect(setPropertySpy).toHaveBeenCalledWith('display', 'inline-block');
+        expect(appendChildSpy).not.toHaveBeenCalled();
+        expect(formatWithContentModelSpy.calls.argsFor(0)[1].apiName).toBe(apiName);
+        expect(formatWithContentModelSpy.calls.argsFor(0)[1].changeSource).toBe(
+            ChangeSource.InsertEntity
+        );
+        expect(insertEntityModelSpy).toHaveBeenCalledWith(
+            model,
+            {
+                segmentType: 'Entity',
+                blockType: 'Entity',
+                format: {},
+                entityFormat: {
+                    id: undefined,
+                    entityType: type,
+                    isReadonly: true,
+                },
+                wrapper: wrapper,
+            },
+            'begin',
+            false,
+            undefined,
+            context
+        );
+        expect(triggerContentChangedEventSpy).not.toHaveBeenCalled();
+        expect(normalizeContentModelSpy).toHaveBeenCalled();
+
+        expect(context.newEntities).toEqual([
+            {
+                segmentType: 'Entity',
+                blockType: 'Entity',
+                format: {},
+                entityFormat: {
+                    id: undefined,
+                    entityType: 'Entity',
+                    isReadonly: true,
+                },
+                wrapper,
+            },
+        ]);
+
+        expect(entity).toEqual({
+            segmentType: 'Entity',
+            blockType: 'Entity',
+            format: {},
+            entityFormat: {
+                id: undefined,
+                entityType: type,
+                isReadonly: true,
+            },
+            wrapper: wrapper,
+        });
+    });
+
+    it('Insert with initial state', () => {
+        spyOn(entityUtils, 'parseEntityFormat').and.returnValue({
+            id: 'A',
+            entityType: 'B',
+        });
+
+        const entity = insertEntity(editor, type, false, 'begin', {
+            initialEntityState: 'test',
+        });
+
+        expect(takeSnapshotSpy).toHaveBeenCalledTimes(2);
+        expect(takeSnapshotSpy).toHaveBeenCalledWith();
+        expect(takeSnapshotSpy).toHaveBeenCalledWith({
+            id: 'A',
+            type: 'B',
+            state: 'test',
+        });
         expect(createElementSpy).toHaveBeenCalledWith('span');
         expect(setPropertySpy).toHaveBeenCalledWith('display', 'inline-block');
         expect(appendChildSpy).not.toHaveBeenCalled();

--- a/packages-content-model/roosterjs-content-model-api/test/publicApi/entity/insertEntityTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/publicApi/entity/insertEntityTest.ts
@@ -24,6 +24,7 @@ describe('insertEntity', () => {
     let insertEntityModelSpy: jasmine.Spy;
     let isDarkModeSpy: jasmine.Spy;
     let normalizeContentModelSpy: jasmine.Spy;
+    let takeSnapshotSpy: jasmine.Spy;
 
     const type = 'Entity';
     const apiName = 'insertEntity';
@@ -39,6 +40,7 @@ describe('insertEntity', () => {
         appendChildSpy = jasmine.createSpy('appendChildSpy');
         insertEntityModelSpy = spyOn(insertEntityModel, 'insertEntityModel');
         isDarkModeSpy = jasmine.createSpy('isDarkMode');
+        takeSnapshotSpy = jasmine.createSpy('takeSnapshot');
 
         wrapper = {
             style: {
@@ -68,6 +70,7 @@ describe('insertEntity', () => {
             getDocument: getDocumentSpy,
             isDarkMode: isDarkModeSpy,
             formatContentModel: formatWithContentModelSpy,
+            takeSnapshot: takeSnapshotSpy,
         } as any;
 
         spyOn(entityUtils, 'addDelimiters').and.returnValue([]);

--- a/packages-content-model/roosterjs-content-model-core/lib/editor/Editor.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/editor/Editor.ts
@@ -27,6 +27,7 @@ import type {
     EditorOptions,
     TrustedHTMLHandler,
     Rect,
+    EntityState,
 } from 'roosterjs-content-model-types';
 
 /**
@@ -174,11 +175,16 @@ export class Editor implements IEditor {
 
     /**
      * Add a single undo snapshot to undo stack
+     * @param entityState @optional State for entity if we want to add entity state for this snapshot
      */
-    takeSnapshot(): Snapshot | null {
+    takeSnapshot(entityState?: EntityState): Snapshot | null {
         const core = this.getCore();
 
-        return core.api.addUndoSnapshot(core, false /*canUndoByBackspace*/);
+        return core.api.addUndoSnapshot(
+            core,
+            false /*canUndoByBackspace*/,
+            entityState ? [entityState] : undefined
+        );
     }
 
     /**

--- a/packages-content-model/roosterjs-content-model-core/lib/utils/restoreSnapshotHTML.ts
+++ b/packages-content-model/roosterjs-content-model-core/lib/utils/restoreSnapshotHTML.ts
@@ -1,8 +1,8 @@
-import { parseEntityFormat } from 'roosterjs-content-model-dom/lib/domUtils/entityUtils';
 import {
     getAllEntityWrappers,
     isEntityElement,
     isNodeOfType,
+    parseEntityFormat,
     reuseCachedElement,
 } from 'roosterjs-content-model-dom';
 import type { Snapshot, EditorCore, KnownEntityItem } from 'roosterjs-content-model-types';
@@ -78,18 +78,31 @@ function tryGetEntityElement(
 
             result = (format.id && entityMap[format.id]?.element) || null;
         } else if (isBlockEntityContainer(node)) {
-            const format = parseEntityFormat(node);
-            const parent = format.id ? entityMap[format.id]?.element.parentElement : null;
-
-            result =
-                isNodeOfType(parent, 'ELEMENT_NODE') && isBlockEntityContainer(parent)
-                    ? parent
-                    : null;
+            result = tryGetEntityFromContainer(node, entityMap);
         }
     }
 
     return result;
 }
+
 function isBlockEntityContainer(node: HTMLElement) {
     return node.classList.contains(BlockEntityContainer);
+}
+
+function tryGetEntityFromContainer(
+    element: HTMLElement,
+    entityMap: Record<string, KnownEntityItem>
+): HTMLElement | null {
+    for (let node = element.firstChild; node; node = node.nextSibling) {
+        if (isEntityElement(node) && isNodeOfType(node, 'ELEMENT_NODE')) {
+            const format = parseEntityFormat(node);
+            const parent = format.id ? entityMap[format.id]?.element.parentElement : null;
+
+            return isNodeOfType(parent, 'ELEMENT_NODE') && isBlockEntityContainer(parent)
+                ? parent
+                : null;
+        }
+    }
+
+    return null;
 }

--- a/packages-content-model/roosterjs-content-model-core/test/corePlugin/EntityPluginTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/corePlugin/EntityPluginTest.ts
@@ -599,7 +599,7 @@ describe('EntityPlugin', () => {
         it('Click on entity', () => {
             const mockedNode = {
                 parentNode: null as any,
-                classList: ['_ENtity', '_EType_A', '_EId_A'],
+                classList: ['_Entity', '_EType_A', '_EId_A'],
             } as any;
             const mockedEvent = {
                 target: mockedNode,
@@ -631,7 +631,7 @@ describe('EntityPlugin', () => {
         it('Click on child of entity', () => {
             const mockedNode1 = {
                 parentNode: null as any,
-                classList: ['_ENtity', '_EType_A', '_EId_A'],
+                classList: ['_Entity', '_EType_A', '_EId_A'],
             } as any;
 
             const mockedNode2 = {
@@ -667,7 +667,7 @@ describe('EntityPlugin', () => {
         it('Not clicking', () => {
             const mockedNode = {
                 parentNode: null as any,
-                classList: ['_ENtity', '_EType_A', '_EId_A'],
+                classList: ['_Entity', '_EType_A', '_EId_A'],
             } as any;
             const mockedEvent = {
                 target: mockedNode,

--- a/packages-content-model/roosterjs-content-model-core/test/editor/EditorTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/editor/EditorTest.ts
@@ -465,6 +465,38 @@ describe('Editor', () => {
         expect(() => editor.takeSnapshot()).toThrow();
     });
 
+    it('takeSnapshot', () => {
+        const div = document.createElement('div');
+        const mockedSnapshot = 'SNAPSHOT' as any;
+        const resetSpy = jasmine.createSpy('reset');
+        const addUndoSnapshotSpy = jasmine
+            .createSpy('addUndoSnapshot')
+            .and.returnValue(mockedSnapshot);
+        const mockedCore = {
+            plugins: [],
+            darkColorHandler: {
+                updateKnownColor: updateKnownColorSpy,
+                reset: resetSpy,
+            },
+            api: { addUndoSnapshot: addUndoSnapshotSpy, setContentModel: setContentModelSpy },
+        } as any;
+
+        createEditorCoreSpy.and.returnValue(mockedCore);
+
+        const editor = new Editor(div);
+        const snapshot = editor.takeSnapshot();
+
+        expect(snapshot).toEqual(mockedSnapshot);
+        expect(addUndoSnapshotSpy).toHaveBeenCalledTimes(1);
+        expect(addUndoSnapshotSpy).toHaveBeenCalledWith(mockedCore, false, undefined);
+
+        const mockedState = 'STATE' as any;
+
+        editor.takeSnapshot(mockedState);
+        expect(addUndoSnapshotSpy).toHaveBeenCalledTimes(2);
+        expect(addUndoSnapshotSpy).toHaveBeenCalledWith(mockedCore, false, [mockedState]);
+    });
+
     it('restoreSnapshot', () => {
         const div = document.createElement('div');
         const mockedSnapshot = 'SNAPSHOT' as any;

--- a/packages-content-model/roosterjs-content-model-core/test/editor/EditorTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/editor/EditorTest.ts
@@ -431,7 +431,7 @@ describe('Editor', () => {
 
         const snapshot = editor.takeSnapshot();
 
-        expect(addUndoSnapshotSpy).toHaveBeenCalledWith(mockedCore, false);
+        expect(addUndoSnapshotSpy).toHaveBeenCalledWith(mockedCore, false, undefined);
         expect(snapshot).toBe(mockedSnapshot);
 
         editor.dispose();

--- a/packages-content-model/roosterjs-content-model-dom/lib/domUtils/entityUtils.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domUtils/entityUtils.ts
@@ -33,11 +33,32 @@ export function getAllEntityWrappers(root: HTMLElement): HTMLElement[] {
 }
 
 /**
+ * Parse entity format from entity wrapper element
+ * @param wrapper The wrapper element to parse entity format from
+ * @returns Entity format
+ */
+export function parseEntityFormat(wrapper: HTMLElement): ContentModelEntityFormat {
+    let isEntity = false;
+    const format: ContentModelEntityFormat = {};
+
+    wrapper.classList.forEach(name => {
+        isEntity = parseEntityClassName(name, format) || isEntity;
+    });
+
+    if (!isEntity) {
+        format.isFakeEntity = true;
+        format.isReadonly = !wrapper.isContentEditable;
+    }
+
+    return format;
+}
+
+/**
  * Parse entity class names from entity wrapper element
  * @param className Class names of entity
  * @param format The output entity format object
  */
-export function parseEntityClassName(
+function parseEntityClassName(
     className: string,
     format: ContentModelEntityFormat
 ): boolean | undefined {

--- a/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/entity/entityFormatHandler.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/formatHandlers/entity/entityFormatHandler.ts
@@ -1,4 +1,4 @@
-import { generateEntityClassNames, parseEntityClassName } from '../../domUtils/entityUtils';
+import { generateEntityClassNames, parseEntityFormat } from '../../domUtils/entityUtils';
 import type { EntityInfoFormat, IdFormat } from 'roosterjs-content-model-types';
 import type { FormatHandler } from '../FormatHandler';
 
@@ -7,16 +7,7 @@ import type { FormatHandler } from '../FormatHandler';
  */
 export const entityFormatHandler: FormatHandler<EntityInfoFormat & IdFormat> = {
     parse: (format, element) => {
-        let isEntity = false;
-
-        element.classList.forEach(name => {
-            isEntity = parseEntityClassName(name, format) || isEntity;
-        });
-
-        if (!isEntity) {
-            format.isFakeEntity = true;
-            format.isReadonly = !element.isContentEditable;
-        }
+        Object.assign(format, parseEntityFormat(element));
     },
 
     apply: (format, element) => {

--- a/packages-content-model/roosterjs-content-model-dom/lib/index.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/index.ts
@@ -24,7 +24,7 @@ export { wrap } from './domUtils/wrap';
 export {
     isEntityElement,
     getAllEntityWrappers,
-    parseEntityClassName,
+    parseEntityFormat,
     generateEntityClassNames,
     addDelimiters,
     isEntityDelimiter,

--- a/packages-content-model/roosterjs-content-model-dom/test/domUtils/entityUtilTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domUtils/entityUtilTest.ts
@@ -5,7 +5,7 @@ import {
     getAllEntityWrappers,
     isEntityDelimiter,
     isEntityElement,
-    parseEntityClassName,
+    parseEntityFormat,
 } from '../../lib/domUtils/entityUtils';
 
 export function setEntityElementClasses(
@@ -43,69 +43,61 @@ describe('isEntityElement', () => {
     });
 });
 
-describe('parseEntityClassName', () => {
+describe('parseEntityFormat', () => {
     it('No entity class', () => {
-        const format: ContentModelEntityFormat = {};
+        const div = document.createElement('div');
 
-        const result = parseEntityClassName('test', format);
+        div.className = 'test';
 
-        expect(result).toBeFalsy();
-        expect(format).toEqual({});
-    });
+        const format = parseEntityFormat(div);
 
-    it('Entity class', () => {
-        const format: ContentModelEntityFormat = {};
-
-        const result = parseEntityClassName('_Entity', format);
-
-        expect(result).toBeTrue();
-        expect(format).toEqual({});
-    });
-
-    it('EntityId class', () => {
-        const format: ContentModelEntityFormat = {};
-
-        const result = parseEntityClassName('_EId_A', format);
-
-        expect(result).toBeFalsy();
         expect(format).toEqual({
-            id: 'A',
-        });
-    });
-
-    it('EntityType class', () => {
-        const format: ContentModelEntityFormat = {};
-
-        const result = parseEntityClassName('_EType_B', format);
-
-        expect(result).toBeFalsy();
-        expect(format).toEqual({
-            entityType: 'B',
-        });
-    });
-
-    it('Entity readonly class', () => {
-        const format: ContentModelEntityFormat = {};
-
-        const result = parseEntityClassName('_EReadonly_1', format);
-
-        expect(result).toBeFalsy();
-        expect(format).toEqual({
+            isFakeEntity: true,
             isReadonly: true,
         });
     });
 
-    it('Parse class on existing format', () => {
-        const format: ContentModelEntityFormat = {
-            id: 'A',
-        };
+    it('Entity class', () => {
+        const div = document.createElement('div');
 
-        const result = parseEntityClassName('_EType_B', format);
+        div.className = '_Entity _EId_A _EType_B _EReadonly_1';
 
-        expect(result).toBeFalsy();
+        const format = parseEntityFormat(div);
+
         expect(format).toEqual({
             id: 'A',
             entityType: 'B',
+            isReadonly: true,
+        });
+    });
+
+    it('Fake entity', () => {
+        const div = document.createElement('div');
+
+        div.contentEditable = 'true';
+
+        div.className = '_EId_A _EType_B _EReadonly_1';
+
+        const format = parseEntityFormat(div);
+
+        expect(format).toEqual({
+            isFakeEntity: true,
+            isReadonly: false,
+            id: 'A',
+            entityType: 'B',
+        });
+    });
+
+    it('Fake entity, readonly', () => {
+        const div = document.createElement('div');
+
+        div.contentEditable = 'false';
+
+        const format = parseEntityFormat(div);
+
+        expect(format).toEqual({
+            isFakeEntity: true,
+            isReadonly: true,
         });
     });
 });

--- a/packages-content-model/roosterjs-content-model-types/lib/editor/IEditor.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/editor/IEditor.ts
@@ -17,6 +17,7 @@ import type {
 import type { DarkColorHandler } from '../context/DarkColorHandler';
 import type { TrustedHTMLHandler } from '../parameter/TrustedHTMLHandler';
 import type { Rect } from '../parameter/Rect';
+import type { EntityState } from '../parameter/FormatContentModelContext';
 
 /**
  * An interface of Editor, built on top of Content Model
@@ -125,8 +126,9 @@ export interface IEditor {
 
     /**
      * Add a single undo snapshot to undo stack
+     * @param entityState @optional State for entity if we want to add entity state for this snapshot
      */
-    takeSnapshot(): Snapshot | null;
+    takeSnapshot(entityState?: EntityState): Snapshot | null;
 
     /**
      * Restore an undo snapshot into editor

--- a/packages-content-model/roosterjs-content-model-types/lib/parameter/InsertEntityOptions.ts
+++ b/packages-content-model/roosterjs-content-model-types/lib/parameter/InsertEntityOptions.ts
@@ -21,4 +21,9 @@ export interface InsertEntityOptions {
      * Whether skip adding an undo snapshot around
      */
     skipUndoSnapshot?: boolean;
+
+    /**
+     * Initial entity state, this is used when restore an undo snapshot to right after entity is inserted, this state will be used for set initial state of entity
+     */
+    initialEntityState?: string;
 }


### PR DESCRIPTION
The change does two things:
1. When insertEntity, we now allow passing in an initial entity state. So when user undo to the state right after insert entity, we can use this initial state to update entity.
2. The editor API `takeSnapshot` now accepts entity state. So if we just want to add an undo snapshot for entity state update, we can use editor.takeSnapshot() rather than `formatContentModel`.

Also add a util function `parseEntityFormat` to replace the original function `parseEntityClassName` to make it easier parsing entity information.