### PR TITLE
Fix dispose plugin issus in EditorAdapter

### DIFF
--- a/packages/roosterjs-editor-adapter/lib/editor/EditorAdapter.ts
+++ b/packages/roosterjs-editor-adapter/lib/editor/EditorAdapter.ts
@@ -152,6 +152,8 @@ export class EditorAdapter extends Editor implements ILegacyEditor {
      * Dispose this editor, dispose all plugins and custom data
      */
     dispose(): void {
+        super.dispose();
+
         const core = this.contentModelEditorCore;
 
         if (core) {
@@ -167,8 +169,6 @@ export class EditorAdapter extends Editor implements ILegacyEditor {
 
             this.contentModelEditorCore = undefined;
         }
-
-        super.dispose();
     }
 
     /**


### PR DESCRIPTION
This is a recent regression in EditorAdapter.

When we dispose EditorAdapter, we should dispose its plugins first (via super.dispose()), then finally we dispose the core object. Otherwise if any plugin needs the core object during disposing, there will be exception.

