### PR TITLE
Bump roosterjs-editor-adapter to 0.26.3 to patch #2452

### DIFF
--- a/packages/roosterjs-editor-adapter/lib/editor/EditorAdapter.ts
+++ b/packages/roosterjs-editor-adapter/lib/editor/EditorAdapter.ts
@@ -152,6 +152,8 @@ export class EditorAdapter extends StandaloneEditor implements IEditor {
      * Dispose this editor, dispose all plugins and custom data
      */
     dispose(): void {
+        super.dispose();
+
         const core = this.contentModelEditorCore;
 
         if (core) {
@@ -167,8 +169,6 @@ export class EditorAdapter extends StandaloneEditor implements IEditor {
 
             this.contentModelEditorCore = undefined;
         }
-
-        super.dispose();
     }
 
     /**

--- a/versions.json
+++ b/versions.json
@@ -4,6 +4,6 @@
     "packages-content-model": "0.26.4",
     "overrides": {
         "roosterjs-editor-plugins": "8.60.2",
-        "roosterjs-editor-adapter": "0.26.2"
+        "roosterjs-editor-adapter": "0.26.3"
     }
 }


### PR DESCRIPTION
Bump `roosterjs-editor-adapter` to 0.26.3 to patch #2452 