### PR TITLE
Fix 258837 and 257626

### DIFF
--- a/packages-content-model/roosterjs-content-model-api/test/publicApi/image/insertImageTest.ts
+++ b/packages-content-model/roosterjs-content-model-api/test/publicApi/image/insertImageTest.ts
@@ -198,6 +198,7 @@ describe('insertImage', () => {
                                 isSelected: true,
                             },
                         ],
+                        segmentFormat: { fontFamily: 'Test', fontSize: '20px' },
                     },
                 ],
                 format: {

--- a/packages-content-model/roosterjs-content-model-core/test/publicApi/model/createModelFromHtmlTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/publicApi/model/createModelFromHtmlTest.ts
@@ -72,7 +72,7 @@ describe('createModelFromHtml', () => {
                             format: { fontSize: '20px', textColor: 'red', fontFamily: 'Arial' },
                         },
                     ],
-                    segmentFormat: { fontSize: '20px', fontFamily: 'Arial' },
+                    segmentFormat: { fontSize: '20px', fontFamily: 'Arial', textColor: 'red' },
                     format: {},
                 },
             ],

--- a/packages-content-model/roosterjs-content-model-core/test/publicApi/model/mergeModelTest.ts
+++ b/packages-content-model/roosterjs-content-model-core/test/publicApi/model/mergeModelTest.ts
@@ -2333,6 +2333,7 @@ describe('mergeModel', () => {
                 resultMarker,
             ],
             format: {},
+            segmentFormat: { fontFamily: 'sourceFontFamily' },
         };
 
         expect(majorModel).toEqual({
@@ -2510,6 +2511,7 @@ describe('mergeModel', () => {
                 marker,
             ],
             format: {},
+            segmentFormat: { fontFamily: 'Calibri', fontSize: '11pt', textColor: 'black' },
         };
 
         expect(majorModel).toEqual({

--- a/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/addSelectionMarker.ts
+++ b/packages-content-model/roosterjs-content-model-dom/lib/domToModel/utils/addSelectionMarker.ts
@@ -1,7 +1,11 @@
 import { addDecorators } from '../../modelApi/common/addDecorators';
 import { addSegment } from '../../modelApi/common/addSegment';
 import { createSelectionMarker } from '../../modelApi/creators/createSelectionMarker';
-import type { ContentModelBlockGroup, DomToModelContext } from 'roosterjs-content-model-types';
+import type {
+    ContentModelBlockGroup,
+    ContentModelSegmentFormat,
+    DomToModelContext,
+} from 'roosterjs-content-model-types';
 
 /**
  * @internal
@@ -12,6 +16,22 @@ export function addSelectionMarker(
     container?: Node,
     offset?: number
 ) {
+    const lastPara = group.blocks[group.blocks.length - 1];
+    const formatFromParagraph: ContentModelSegmentFormat =
+        !lastPara || lastPara.blockType != 'Paragraph'
+            ? {}
+            : lastPara.decorator
+            ? {
+                  fontFamily: lastPara.decorator.format.fontFamily,
+                  fontSize: lastPara.decorator.format.fontSize,
+              }
+            : lastPara.segmentFormat
+            ? {
+                  fontFamily: lastPara.segmentFormat.fontFamily,
+                  fontSize: lastPara.segmentFormat.fontSize,
+              }
+            : {};
+
     const pendingFormat =
         context.pendingFormat &&
         context.pendingFormat.posContainer === container &&
@@ -20,6 +40,7 @@ export function addSelectionMarker(
             : undefined;
     const segmentFormat = {
         ...context.defaultFormat,
+        ...formatFromParagraph,
         ...context.segmentFormat,
         ...pendingFormat,
     };

--- a/packages-content-model/roosterjs-content-model-dom/test/domToModel/utils/addSelectionMarkerTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/domToModel/utils/addSelectionMarkerTest.ts
@@ -88,6 +88,90 @@ describe('addSelectionMarker', () => {
         });
     });
 
+    it('add marker with block format from existing block', () => {
+        const doc = createContentModelDocument();
+        const context = createDomToModelContext();
+
+        doc.blocks.push({
+            blockType: 'Paragraph',
+            segments: [],
+            format: {},
+            segmentFormat: {
+                fontFamily: 'Arial',
+            },
+        });
+
+        addSelectionMarker(doc, context);
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Arial',
+                    },
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: { fontFamily: 'Arial', fontSize: undefined },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('add marker with block format from existing block decorator', () => {
+        const doc = createContentModelDocument();
+        const context = createDomToModelContext();
+
+        doc.blocks.push({
+            blockType: 'Paragraph',
+            segments: [],
+            format: {},
+            segmentFormat: {
+                fontFamily: 'Arial',
+            },
+            decorator: {
+                tagName: 'h1',
+                format: {
+                    fontFamily: 'Tahoma',
+                },
+            },
+        });
+
+        addSelectionMarker(doc, context);
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Arial',
+                    },
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: { fontFamily: 'Tahoma', fontSize: undefined },
+                        },
+                    ],
+                    decorator: {
+                        tagName: 'h1',
+                        format: {
+                            fontFamily: 'Tahoma',
+                        },
+                    },
+                },
+            ],
+        });
+    });
+
     it('add marker with link format', () => {
         const doc = createContentModelDocument();
         const context = createDomToModelContext();

--- a/packages-content-model/roosterjs-content-model-dom/test/endToEndTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/endToEndTest.ts
@@ -57,6 +57,11 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                     },
                                 ],
                                 isImplicit: true,
+                                segmentFormat: {
+                                    fontFamily: 'Calibri, sans-serif',
+                                    fontSize: '11pt',
+                                    textColor: 'black',
+                                },
                             },
                         ],
                         levels: [
@@ -99,6 +104,11 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                     },
                                 ],
                                 isImplicit: true,
+                                segmentFormat: {
+                                    fontFamily: 'Calibri, sans-serif',
+                                    fontSize: '11pt',
+                                    textColor: 'black',
+                                },
                             },
                         ],
                         levels: [
@@ -262,6 +272,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                 ],
                                 format: { whiteSpace: 'pre' },
                                 isImplicit: true,
+                                segmentFormat: { fontFamily: 'monospace' },
                             },
                         ],
                         format: {
@@ -329,6 +340,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                     },
                                 ],
                                 isImplicit: true,
+                                segmentFormat: { fontFamily: 'monospace' },
                             },
                         ],
                     },
@@ -353,6 +365,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                     },
                                 ],
                                 isImplicit: true,
+                                segmentFormat: { fontFamily: 'monospace' },
                             },
                         ],
                     },
@@ -905,6 +918,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                     whiteSpace: 'pre',
                                 },
                                 isImplicit: true,
+                                segmentFormat: { fontFamily: 'monospace' },
                             },
                         ],
                         format: {
@@ -934,6 +948,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                     whiteSpace: 'pre',
                                 },
                                 isImplicit: true,
+                                segmentFormat: { fontFamily: 'monospace', fontSize: '20px' },
                             },
                         ],
                         format: {
@@ -945,7 +960,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                 ],
             },
             'aaa\nbbb\r\naaa\nbb',
-            '<pre><div>aaa\nbbb</div></pre><pre><div><span style="font-size: 20px;">aaa\nbb</span></div></pre>'
+            '<pre><div>aaa\nbbb</div></pre><pre><div style="font-size: 20px;">aaa\nbb</div></pre>'
         );
     });
 
@@ -1034,6 +1049,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                             },
                         ],
                         format: {},
+                        segmentFormat: { textColor: 'red' },
                     },
                     {
                         blockType: 'BlockGroup',
@@ -1054,6 +1070,11 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                     },
                                 ],
                                 format: {},
+                                segmentFormat: {
+                                    fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                                    fontSize: '12pt',
+                                    textColor: 'rgb(102, 102, 102)',
+                                },
                             },
                         ],
                         format: {
@@ -1077,6 +1098,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                             },
                         ],
                         format: {},
+                        segmentFormat: { textColor: 'red' },
                     },
                     {
                         blockType: 'Paragraph',
@@ -1090,6 +1112,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                             },
                         ],
                         format: {},
+                        segmentFormat: { textColor: 'red' },
                     },
                     {
                         blockType: 'Paragraph',
@@ -1108,6 +1131,11 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                             marginRight: '40px',
                             marginLeft: '40px',
                         },
+                        segmentFormat: {
+                            fontFamily: 'Calibri, Arial, Helvetica, sans-serif',
+                            fontSize: '12pt',
+                            textColor: 'rgb(102, 102, 102)',
+                        },
                     },
                     {
                         blockType: 'Paragraph',
@@ -1121,11 +1149,14 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                             },
                         ],
                         format: {},
+                        segmentFormat: {
+                            textColor: 'red',
+                        },
                     },
                 ],
             },
             'aaaa\r\nbbbbbb\r\ncccc\r\naaaa\r\nbbbbbb\r\ncccc',
-            '<div><span style="color: red;">aaaa</span></div><blockquote style="padding-left: 10px; border-left: 3px solid rgb(200, 200, 200);"><div><span style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(102, 102, 102);">bbbbbb</span></div></blockquote><div><span style="color: red;">cccc</span></div><div><span style="color: red;">aaaa</span></div><div style="margin-right: 40px; margin-left: 40px;"><span style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(102, 102, 102);">bbbbbb</span></div><div><span style="color: red;">cccc</span></div>'
+            '<div style="color: red;">aaaa</div><blockquote style="padding-left: 10px; border-left: 3px solid rgb(200, 200, 200);"><div style="font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(102, 102, 102);">bbbbbb</div></blockquote><div style="color: red;">cccc</div><div style="color: red;">aaaa</div><div style="margin-right: 40px; margin-left: 40px; font-family: Calibri, Arial, Helvetica, sans-serif; font-size: 12pt; color: rgb(102, 102, 102);">bbbbbb</div><div style="color: red;">cccc</div>'
         );
     });
 
@@ -1166,6 +1197,9 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                 ],
                                 format: {
                                     whiteSpace: 'pre',
+                                },
+                                segmentFormat: {
+                                    fontFamily: 'monospace',
                                 },
                             },
                         ],
@@ -1570,6 +1604,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                 },
                             },
                         ],
+                        segmentFormat: { textColor: 'red' },
                     },
                 ],
             },

--- a/packages-content-model/roosterjs-content-model-dom/test/modelApi/common/normalizeParagraphTest.ts
+++ b/packages-content-model/roosterjs-content-model-dom/test/modelApi/common/normalizeParagraphTest.ts
@@ -5,6 +5,7 @@ import { createParagraph } from '../../../lib/modelApi/creators/createParagraph'
 import { createSelectionMarker } from '../../../lib/modelApi/creators/createSelectionMarker';
 import { createText } from '../../../lib/modelApi/creators/createText';
 import { normalizeContentModel } from '../../../lib/modelApi/common/normalizeContentModel';
+import { normalizeParagraph } from '../../../lib/modelApi/common/normalizeParagraph';
 
 describe('Normalize text that contains space', () => {
     function runTest(texts: string[], expected: string[], whiteSpace?: string) {
@@ -351,6 +352,159 @@ describe('Normalize text that contains space', () => {
                     ],
                 },
             ],
+        });
+    });
+});
+
+describe('Normalize paragraph with segmentFormat', () => {
+    it('Empty paragraph', () => {
+        const paragraph = createParagraph();
+
+        normalizeParagraph(paragraph);
+
+        expect(paragraph).toEqual({
+            blockType: 'Paragraph',
+            segments: [],
+            format: {},
+        });
+    });
+
+    it('Single text segment', () => {
+        const paragraph = createParagraph();
+        const text = createText('test', {
+            fontFamily: 'Arial',
+        });
+
+        paragraph.segments.push(text);
+
+        normalizeParagraph(paragraph);
+
+        expect(paragraph).toEqual({
+            blockType: 'Paragraph',
+            segments: [
+                {
+                    segmentType: 'Text',
+                    format: { fontFamily: 'Arial' },
+                    text: 'test',
+                },
+            ],
+            format: {},
+            segmentFormat: { fontFamily: 'Arial' },
+        });
+    });
+
+    it('text + selection marker + text', () => {
+        const paragraph = createParagraph();
+        const text1 = createText('test1', {
+            fontFamily: 'Arial',
+        });
+        const text2 = createText('test2', {
+            fontFamily: 'Arial',
+        });
+        const marker = createSelectionMarker();
+
+        paragraph.segments.push(text1, marker, text2);
+
+        normalizeParagraph(paragraph);
+
+        expect(paragraph).toEqual({
+            blockType: 'Paragraph',
+            segments: [
+                {
+                    segmentType: 'Text',
+                    format: { fontFamily: 'Arial' },
+                    text: 'test1',
+                },
+                {
+                    segmentType: 'SelectionMarker',
+                    format: {},
+                    isSelected: true,
+                },
+                {
+                    segmentType: 'Text',
+                    format: { fontFamily: 'Arial' },
+                    text: 'test2',
+                },
+            ],
+            format: {},
+            segmentFormat: { fontFamily: 'Arial' },
+        });
+    });
+
+    it('text + selection marker + text, formats are different', () => {
+        const paragraph = createParagraph();
+        const text1 = createText('test1', {
+            fontFamily: 'Arial',
+        });
+        const text2 = createText('test2', {
+            fontFamily: 'Tahoma',
+        });
+        const marker = createSelectionMarker();
+
+        paragraph.segments.push(text1, marker, text2);
+
+        normalizeParagraph(paragraph);
+
+        expect(paragraph).toEqual({
+            blockType: 'Paragraph',
+            segments: [
+                {
+                    segmentType: 'Text',
+                    format: { fontFamily: 'Arial' },
+                    text: 'test1',
+                },
+                {
+                    segmentType: 'SelectionMarker',
+                    format: {},
+                    isSelected: true,
+                },
+                {
+                    segmentType: 'Text',
+                    format: { fontFamily: 'Tahoma' },
+                    text: 'test2',
+                },
+            ],
+            format: {},
+        });
+    });
+
+    it('text + selection marker + text, formats are partially different', () => {
+        const paragraph = createParagraph();
+        const text1 = createText('test1', {
+            fontFamily: 'Arial',
+            fontSize: '10px',
+        });
+        const text2 = createText('test2', {
+            fontFamily: 'Tahoma',
+            fontSize: '10px',
+        });
+        const marker = createSelectionMarker();
+
+        paragraph.segments.push(text1, marker, text2);
+
+        normalizeParagraph(paragraph);
+
+        expect(paragraph).toEqual({
+            blockType: 'Paragraph',
+            segments: [
+                {
+                    segmentType: 'Text',
+                    format: { fontFamily: 'Arial', fontSize: '10px' },
+                    text: 'test1',
+                },
+                {
+                    segmentType: 'SelectionMarker',
+                    format: {},
+                    isSelected: true,
+                },
+                {
+                    segmentType: 'Text',
+                    format: { fontFamily: 'Tahoma', fontSize: '10px' },
+                    text: 'test2',
+                },
+            ],
+            format: {},
+            segmentFormat: { fontSize: '10px' },
         });
     });
 });

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelOnlineTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelOnlineTest.ts
@@ -88,6 +88,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'black',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -131,6 +136,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'black',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -171,6 +181,11 @@ describe(ID, () => {
                                             blockType: 'Paragraph',
                                             format: {
                                                 textAlign: 'center',
+                                            },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'black',
                                             },
                                         },
                                     ],
@@ -217,6 +232,11 @@ describe(ID, () => {
                                             format: {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
+                                            },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'black',
                                             },
                                         },
                                     ],
@@ -268,6 +288,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(5, 99, 193)',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -308,6 +333,11 @@ describe(ID, () => {
                                             format: {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
+                                            },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(219, 219, 219)',
                                             },
                                         },
                                     ],
@@ -356,6 +386,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'black',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -406,6 +441,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(5, 99, 193)',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -446,6 +486,11 @@ describe(ID, () => {
                                             format: {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
+                                            },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(219, 219, 219)',
                                             },
                                         },
                                     ],
@@ -494,6 +539,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'black',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -544,6 +594,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(5, 99, 193)',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -584,6 +639,11 @@ describe(ID, () => {
                                             format: {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
+                                            },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(219, 219, 219)',
                                             },
                                         },
                                     ],
@@ -632,6 +692,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'black',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -682,6 +747,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(5, 99, 193)',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -722,6 +792,11 @@ describe(ID, () => {
                                             format: {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
+                                            },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(219, 219, 219)',
                                             },
                                         },
                                     ],
@@ -770,6 +845,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'black',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -820,6 +900,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(5, 99, 193)',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -860,6 +945,11 @@ describe(ID, () => {
                                             format: {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
+                                            },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(219, 219, 219)',
                                             },
                                         },
                                     ],
@@ -908,6 +998,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'black',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -958,6 +1053,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(5, 99, 193)',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -998,6 +1098,11 @@ describe(ID, () => {
                                             format: {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
+                                            },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(219, 219, 219)',
                                             },
                                         },
                                     ],
@@ -1046,6 +1151,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'black',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -1096,6 +1206,11 @@ describe(ID, () => {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
                                             },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(5, 99, 193)',
+                                            },
                                         },
                                     ],
                                     format: {
@@ -1136,6 +1251,11 @@ describe(ID, () => {
                                             format: {
                                                 textAlign: 'center',
                                                 whiteSpace: 'nowrap',
+                                            },
+                                            segmentFormat: {
+                                                fontFamily: 'Calibri, sans-serif',
+                                                fontSize: '11pt',
+                                                textColor: 'rgb(219, 219, 219)',
                                             },
                                         },
                                     ],

--- a/packages-content-model/roosterjs-content-model-plugins/test/paste/processPastedContentFromWordDesktopTest.ts
+++ b/packages-content-model/roosterjs-content-model-plugins/test/paste/processPastedContentFromWordDesktopTest.ts
@@ -350,6 +350,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 ],
                                 format: {},
                                 isImplicit: true,
+                                segmentFormat: { fontSize: '2em' },
                             },
                         ],
                         levels: [
@@ -441,6 +442,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 ],
                                 format: {},
                                 isImplicit: true,
+                                segmentFormat: { fontSize: '2em' },
                             },
                         ],
                         levels: [
@@ -541,6 +543,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 ],
                                 format: {},
                                 isImplicit: true,
+                                segmentFormat: { fontSize: '2em' },
                             },
                         ],
                         levels: [
@@ -648,6 +651,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 ],
                                 format: {},
                                 isImplicit: true,
+                                segmentFormat: { fontSize: '2em' },
                             },
                         ],
                         levels: [
@@ -1302,6 +1306,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 ],
                                 format: {},
                                 isImplicit: true,
+                                segmentFormat: {
+                                    fontFamily: 'Calibri, sans-serif',
+                                    fontSize: '12pt',
+                                },
                             },
                         ],
                         levels: [
@@ -1372,6 +1380,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     format: {},
                                     isImplicit: true,
+                                    segmentFormat: { fontFamily: 'Arial, sans-serif' },
                                 },
                             ],
                             levels: [
@@ -1407,6 +1416,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     format: {},
                                     isImplicit: true,
+                                    segmentFormat: { fontFamily: 'Arial, sans-serif' },
                                 },
                             ],
                             levels: [
@@ -1512,6 +1522,9 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        textColor: 'rgb(70, 120, 134)',
+                                    },
                                 },
                             ],
                         },
@@ -1554,6 +1567,9 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        textColor: 'rgb(70, 120, 134)',
+                                    },
                                 },
                             ],
                         },
@@ -1596,6 +1612,9 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        textColor: 'rgb(70, 120, 134)',
+                                    },
                                 },
                             ],
                         },
@@ -1660,6 +1679,9 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        textColor: 'rgb(70, 120, 134)',
+                                    },
                                 },
                             ],
                         },
@@ -1702,6 +1724,9 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        textColor: 'rgb(70, 120, 134)',
+                                    },
                                 },
                             ],
                         },
@@ -2516,6 +2541,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -2579,6 +2608,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -2654,6 +2687,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -2741,6 +2778,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -2840,6 +2881,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -2951,6 +2996,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -3074,6 +3123,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -3209,6 +3262,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -3356,6 +3413,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -3490,6 +3551,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -3612,6 +3677,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -3722,6 +3791,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -3820,6 +3893,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -3906,6 +3983,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -3980,6 +4061,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -4042,6 +4127,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },
@@ -4092,6 +4181,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     ],
                                     blockType: 'Paragraph',
                                     format: {},
+                                    segmentFormat: {
+                                        fontFamily: 'Aptos, sans-serif',
+                                        fontSize: '12pt',
+                                    },
                                 },
                             ],
                         },


### PR DESCRIPTION
https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/257626/?triage=true

When create selection marker, we didn't read format from existing block decorator, causes format specified on decorator is not shown in format state. To fix it, read format from decorator and use it.

https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/258837/?triage=true

When paste plain text, the format will be applied to SPAN element. However, if existing content applies segment format on DIV, this will cause some layout difference even their formats are the same. To fix, we try to move fontFamily/fontSize/textColor from segment to paragraph if all its child segments have the same such format.