### PR TITLE
When setDOMSelection is called with Table or image selection also call scrollIntoView

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection.ts
@@ -44,6 +44,7 @@ export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionC
                 core.selection.selection = selection;
 
                 setRangeSelection(doc, image);
+                image.scrollIntoView();
                 break;
             case 'table':
                 const { table, firstColumn, firstRow } = selection;
@@ -56,6 +57,7 @@ export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionC
                 core.selection.selection = selection;
 
                 setRangeSelection(doc, table.rows[firstRow]?.cells[firstColumn]);
+                table.scrollIntoView();
                 break;
             case 'range':
                 addRangeToSelection(doc, selection.range, selection.isReverted);

--- a/packages/roosterjs-content-model-core/test/coreApi/setDOMSelectionTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setDOMSelectionTest.ts
@@ -349,10 +349,13 @@ describe('setDOMSelection', () => {
 
     describe('Image selection', () => {
         let mockedImage: HTMLImageElement;
+        let scrollIntoViewSpy: jasmine.Spy;
 
         beforeEach(() => {
+            scrollIntoViewSpy = jasmine.createSpy('scrollIntoView');
             mockedImage = {
                 ownerDocument: doc,
+                scrollIntoView: scrollIntoViewSpy,
             } as any;
         });
 
@@ -399,6 +402,7 @@ describe('setDOMSelection', () => {
             expect(insertRuleSpy).toHaveBeenCalledWith(
                 '#contentDiv_0 #image_0 {outline-style:auto!important;outline-color:#DB626C!important;}'
             );
+            expect(scrollIntoViewSpy).toHaveBeenCalled();
         });
 
         it('image selection with duplicated id', () => {
@@ -447,6 +451,7 @@ describe('setDOMSelection', () => {
             expect(insertRuleSpy).toHaveBeenCalledWith(
                 '#contentDiv_0 #image_0_0 {outline-style:auto!important;outline-color:#DB626C!important;}'
             );
+            expect(scrollIntoViewSpy).toHaveBeenCalled();
         });
 
         it('image selection with customized selection border color', () => {
@@ -495,6 +500,7 @@ describe('setDOMSelection', () => {
             expect(insertRuleSpy).toHaveBeenCalledWith(
                 '#contentDiv_0 #image_0 {outline-style:auto!important;outline-color:red!important;}'
             );
+            expect(scrollIntoViewSpy).toHaveBeenCalled();
         });
 
         it('do not select if node is out of document', () => {
@@ -542,17 +548,21 @@ describe('setDOMSelection', () => {
             expect(insertRuleSpy).toHaveBeenCalledWith(
                 '#contentDiv_0 #image_0 {outline-style:auto!important;outline-color:#DB626C!important;}'
             );
+            expect(scrollIntoViewSpy).toHaveBeenCalled();
         });
     });
 
     describe('Table selection', () => {
         let mockedTable: HTMLTableElement;
+        let scrollIntoViewSpy: jasmine.Spy;
 
         beforeEach(() => {
+            scrollIntoViewSpy = jasmine.createSpy('scrollIntoView');
             mockedTable = {
                 ownerDocument: doc,
                 rows: [],
                 childNodes: [],
+                scrollIntoView: scrollIntoViewSpy,
             } as any;
         });
 
@@ -596,6 +606,7 @@ describe('setDOMSelection', () => {
             expect(deleteRuleSpy).not.toHaveBeenCalled();
             expect(insertRuleSpy).toHaveBeenCalledTimes(1);
             expect(insertRuleSpy).toHaveBeenCalledWith('#contentDiv_0 {caret-color: transparent}');
+            expect(scrollIntoViewSpy).toHaveBeenCalled();
         });
 
         function runTest(


### PR DESCRIPTION
When setDOMSelection is called, also call scrollIntoView HTMLelement function to scroll to the selected element. Otherwise in some scenarios, like copying a image or a table selection, the scroll is lost and returns to the top of the editor.