### PR TITLE
Fix #2474 - Expand isDisposed check

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/features/TableResizer.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/features/TableResizer.ts
@@ -198,8 +198,10 @@ function onDragEnd(
     event: MouseEvent,
     initValue: DragAndDropInitValue | undefined
 ) {
+    if (context.editor.isDisposed()) {
+        return false;
+    }
     if (
-        !context.editor.isDisposed() &&
         isTableBottomVisible(
             context.editor,
             normalizeRect(context.table.getBoundingClientRect()),


### PR DESCRIPTION
### Description:

Tests related to the new Table resizer plugin were failing randomly due to editor methods being accessed on a disposed editor.

### Fix

Add a check for disposed editor befor all action on onDragEnd on TableResizer.

### Warnings and implications

- Replicating the behaviour is not consistent.