### PR TITLE
Export content without selection

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/createContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/createContentModel.ts
@@ -27,7 +27,10 @@ export const createContentModel: CreateContentModel = (core, option, selectionOv
     if (cachedModel) {
         return cachedModel;
     } else {
-        const selection = selectionOverride || core.api.getDOMSelection(core) || undefined;
+        const selection =
+            selectionOverride == 'none'
+                ? undefined
+                : selectionOverride || core.api.getDOMSelection(core) || undefined;
         const saveIndex = !option && !selectionOverride;
         const editorContext = core.api.createEditorContext(core, saveIndex);
         const domToModelContext = option

--- a/packages/roosterjs-content-model-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/Editor.ts
@@ -91,8 +91,12 @@ export class Editor implements IEditor {
      * If editor is in dark mode, the cloned entity will be converted back to light mode.
      * - reduced: Returns a reduced Content Model that only contains the model of current selection. If there is already a up-to-date cached model, use it
      * instead to improve performance. This is mostly used for retrieve current format state.
+     * - clean: Similar with disconnected, this will return a disconnected model, the difference is "clean" mode will not include any selection info.
+     * This is usually used for exporting content
      */
-    getContentModelCopy(mode: 'connected' | 'disconnected' | 'reduced'): ContentModelDocument {
+    getContentModelCopy(
+        mode: 'connected' | 'disconnected' | 'reduced' | 'clean'
+    ): ContentModelDocument {
         const core = this.getCore();
 
         switch (mode) {
@@ -104,9 +108,17 @@ export class Editor implements IEditor {
                 });
 
             case 'disconnected':
-                return cloneModel(core.api.createContentModel(core), {
-                    includeCachedElement: this.cloneOptionCallback,
-                });
+            case 'clean':
+                return cloneModel(
+                    core.api.createContentModel(
+                        core,
+                        undefined /*option*/,
+                        mode == 'clean' ? 'none' : undefined /*selectionOverride*/
+                    ),
+                    {
+                        includeCachedElement: this.cloneOptionCallback,
+                    }
+                );
             case 'reduced':
                 return core.api.createContentModel(core, {
                     processorOverride: {

--- a/packages/roosterjs-content-model-core/lib/publicApi/model/exportContent.ts
+++ b/packages/roosterjs-content-model-core/lib/publicApi/model/exportContent.ts
@@ -22,7 +22,7 @@ export function exportContent(
     if (mode == 'PlainTextFast') {
         return editor.getDOMHelper().getTextContent();
     } else {
-        const model = editor.getContentModelCopy('disconnected');
+        const model = editor.getContentModelCopy('clean');
 
         if (mode == 'PlainText') {
             return contentModelToText(model);

--- a/packages/roosterjs-content-model-core/test/coreApi/createContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/createContentModelTest.ts
@@ -223,4 +223,31 @@ describe('createContentModel with selection', () => {
         expect(model).toBe(updatedModel);
         expect(flushMutationsSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('With selection override', () => {
+        const MockedContainer = 'MockedContainer';
+        const MockedRange = {
+            name: 'MockedRange',
+            commonAncestorContainer: MockedContainer,
+        } as any;
+        const mockedSelection = {
+            type: 'range',
+            range: MockedRange,
+        } as any;
+
+        createContentModel(core, undefined, mockedSelection);
+
+        expect(domToContentModelSpy).toHaveBeenCalledTimes(1);
+        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext, {
+            type: 'range',
+            range: MockedRange,
+        } as any);
+    });
+
+    it('With selection override, selection=none', () => {
+        createContentModel(core, undefined, 'none');
+
+        expect(domToContentModelSpy).toHaveBeenCalledTimes(1);
+        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext, undefined);
+    });
 });

--- a/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
@@ -209,7 +209,7 @@ describe('Editor', () => {
         expect(cloneNodeSpy).toHaveBeenCalledWith(true);
 
         expect(model).toBe(mockedClonedModel);
-        expect(createContentModelSpy).toHaveBeenCalledWith(mockedCore);
+        expect(createContentModelSpy).toHaveBeenCalledWith(mockedCore, undefined, undefined);
         expect(transformColorSpy).not.toHaveBeenCalled();
 
         // Clone in dark mode
@@ -218,7 +218,7 @@ describe('Editor', () => {
         expect(cloneNodeSpy).toHaveBeenCalledWith(true);
 
         expect(model).toBe(mockedClonedModel);
-        expect(createContentModelSpy).toHaveBeenCalledWith(mockedCore);
+        expect(createContentModelSpy).toHaveBeenCalledWith(mockedCore, undefined, undefined);
         expect(transformColorSpy).toHaveBeenCalledWith(
             clonedNode,
             true,

--- a/packages/roosterjs-content-model-core/test/publicApi/model/exportContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/publicApi/model/exportContentTest.ts
@@ -39,7 +39,7 @@ describe('exportContent', () => {
         const text = exportContent(editor, 'PlainText');
 
         expect(text).toBe(mockedText);
-        expect(getContentModelCopySpy).toHaveBeenCalledWith('disconnected');
+        expect(getContentModelCopySpy).toHaveBeenCalledWith('clean');
         expect(contentModelToTextSpy).toHaveBeenCalledWith(mockedModel);
     });
 
@@ -71,7 +71,8 @@ describe('exportContent', () => {
         const html = exportContent(editor, 'HTML');
 
         expect(html).toBe(mockedHTML);
-        expect(getContentModelCopySpy).toHaveBeenCalledWith('disconnected');
+        expect(getContentModelCopySpy).toHaveBeenCalledWith('clean');
+        1;
         expect(createModelToDomContextSpy).toHaveBeenCalledWith(undefined, undefined);
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
             mockedDoc,
@@ -115,7 +116,7 @@ describe('exportContent', () => {
         const html = exportContent(editor, 'HTML', mockedOptions);
 
         expect(html).toBe(mockedHTML);
-        expect(getContentModelCopySpy).toHaveBeenCalledWith('disconnected');
+        expect(getContentModelCopySpy).toHaveBeenCalledWith('clean');
         expect(createModelToDomContextSpy).toHaveBeenCalledWith(undefined, mockedOptions);
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
             mockedDoc,

--- a/packages/roosterjs-content-model-types/lib/editor/EditorCore.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/EditorCore.ts
@@ -34,12 +34,13 @@ export type CreateEditorContext = (core: EditorCore, saveIndex: boolean) => Edit
  * Create Content Model from DOM tree in this editor
  * @param core The EditorCore object
  * @param option The option to customize the behavior of DOM to Content Model conversion
- * @param selectionOverride When passed, use this selection range instead of current selection in editor
+ * @param selectionOverride When passed a valid selection, use this selection range instead of current selection in editor.
+ * When pass "none", it means we don't need a selection in content model
  */
 export type CreateContentModel = (
     core: EditorCore,
     option?: DomToModelOption,
-    selectionOverride?: DOMSelection
+    selectionOverride?: DOMSelection | 'none'
 ) => ContentModelDocument;
 
 /**
@@ -168,9 +169,11 @@ export type Paste = (core: EditorCore, clipboardData: ClipboardData, pasteType: 
  */
 export interface CoreApiMap {
     /**
-     * Create a EditorContext object used by ContentModel API
+     * Create Content Model from DOM tree in this editor
      * @param core The EditorCore object
-     * @param saveIndex True to allow saving index info into node using domIndexer, otherwise false
+     * @param option The option to customize the behavior of DOM to Content Model conversion
+     * @param selectionOverride When passed a valid selection, use this selection range instead of current selection in editor.
+     * When pass "none", it means we don't need a selection in content model
      */
     createEditorContext: CreateEditorContext;
 

--- a/packages/roosterjs-content-model-types/lib/editor/IEditor.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/IEditor.ts
@@ -34,8 +34,12 @@ export interface IEditor {
      * If editor is in dark mode, the cloned entity will be converted back to light mode.
      * - reduced: Returns a reduced Content Model that only contains the model of current selection. If there is already a up-to-date cached model, use it
      * instead to improve performance. This is mostly used for retrieve current format state.
+     * - clean: Similar with disconnected, this will return a disconnected model, the difference is "clean" mode will not include any selection info.
+     * This is usually used for exporting content
      */
-    getContentModelCopy(mode: 'connected' | 'disconnected' | 'reduced'): ContentModelDocument;
+    getContentModelCopy(
+        mode: 'connected' | 'disconnected' | 'reduced' | 'clean'
+    ): ContentModelDocument;
 
     /**
      * Get current running environment, such as if editor is running on Mac


### PR DESCRIPTION
When export HTML content, selection should not be included when create Content Model.

This is to avoid generating unnecessary DOM element when export, for example, when TABLE is the last element of the document and user put focus after table, Content Model will create an implicit paragraph for the selection marker. When generate HTML, this implicit paragraph can be represented as a SPAN. We can avoid this by not including selection into the model.