### PR TITLE
Fix dark mode button in demo site

### DIFF
--- a/demo/scripts/controlsV2/demoButtons/darkModeButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/darkModeButton.ts
@@ -1,4 +1,4 @@
-import MainPaneBase from '../../controls/MainPaneBase';
+import { MainPane } from '../mainPane/MainPane';
 import type { RibbonButton } from '../roosterjsReact/ribbon';
 
 /**
@@ -18,7 +18,7 @@ export const darkModeButton: RibbonButton<DarkModeButtonStringKey> = {
         editor.focus();
 
         // Let main pane know this state change so that it can be persisted when pop out/pop in
-        MainPaneBase.getInstance().toggleDarkMode();
+        MainPane.getInstance().toggleDarkMode();
         return true;
     },
 };


### PR DESCRIPTION
The dark mode button in demo site is broken, so fix it.

It is calling old main pane to toggle dark mode, so it is not working