### PR TITLE
Enable Content Model cache by default

### DIFF
--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -300,7 +300,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
                             editorCreator={this.state.editorCreator}
                             dir={this.state.isRtl ? 'rtl' : 'ltr'}
                             knownColors={this.knownColors}
-                            cacheModel={this.state.initState.cacheModel}
+                            disableCache={this.state.initState.disableCache}
                         />
                     )}
                 </div>

--- a/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -32,7 +32,7 @@ const initialState: OptionState = {
     forcePreserveRatio: false,
     applyChangesOnMouseUp: false,
     isRtl: false,
-    cacheModel: true,
+    disableCache: false,
     tableFeaturesContainerSelector: '#' + 'EditorContainer',
     allowExcelNoBorderTable: false,
     imageMenu: true,

--- a/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
@@ -45,7 +45,7 @@ export interface OptionState {
 
     // Editor options
     isRtl: boolean;
-    cacheModel: boolean;
+    disableCache: boolean;
     applyChangesOnMouseUp: boolean;
 }
 

--- a/demo/scripts/controlsV2/sidePane/editorOptions/OptionsPane.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/OptionsPane.tsx
@@ -31,7 +31,7 @@ export class OptionsPane extends React.Component<OptionPaneProps, OptionState> {
     private exportForm = React.createRef<HTMLFormElement>();
     private exportData = React.createRef<HTMLInputElement>();
     private rtl = React.createRef<HTMLInputElement>();
-    private cacheModel = React.createRef<HTMLInputElement>();
+    private disableCache = React.createRef<HTMLInputElement>();
 
     constructor(props: OptionPaneProps) {
         super(props);
@@ -79,13 +79,13 @@ export class OptionsPane extends React.Component<OptionPaneProps, OptionState> {
                 </div>
                 <div>
                     <input
-                        id="cacheModel"
+                        id="disableCache"
                         type="checkbox"
-                        checked={this.state.cacheModel}
+                        checked={this.state.disableCache}
                         onChange={this.onToggleCacheModel}
-                        ref={this.cacheModel}
+                        ref={this.disableCache}
                     />
-                    <label htmlFor="cacheModel">Use Content Model Cache</label>
+                    <label htmlFor="disableCache">Disable Content Model Cache</label>
                 </div>
                 <hr />
                 <div>
@@ -133,7 +133,7 @@ export class OptionsPane extends React.Component<OptionPaneProps, OptionState> {
             forcePreserveRatio: this.state.forcePreserveRatio,
             applyChangesOnMouseUp: this.state.applyChangesOnMouseUp,
             isRtl: this.state.isRtl,
-            cacheModel: this.state.cacheModel,
+            disableCache: this.state.disableCache,
             tableFeaturesContainerSelector: this.state.tableFeaturesContainerSelector,
             allowExcelNoBorderTable: this.state.allowExcelNoBorderTable,
             listMenu: this.state.listMenu,
@@ -175,7 +175,7 @@ export class OptionsPane extends React.Component<OptionPaneProps, OptionState> {
 
     private onToggleCacheModel = () => {
         this.resetState(state => {
-            state.cacheModel = this.cacheModel.current.checked;
+            state.disableCache = this.disableCache.current.checked;
         }, true);
     };
 

--- a/packages/roosterjs-content-model-core/lib/corePlugin/CachePlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/CachePlugin.ts
@@ -22,12 +22,12 @@ class CachePlugin implements PluginWithState<CachePluginState> {
      * @param contentDiv The editor content DIV
      */
     constructor(option: EditorOptions, contentDiv: HTMLDivElement) {
-        this.state = option.cacheModel
-            ? {
+        this.state = option.disableCache
+            ? {}
+            : {
                   domIndexer: domIndexerImpl,
                   textMutationObserver: createTextMutationObserver(contentDiv, this.onMutation),
-              }
-            : {};
+              };
     }
 
     /**

--- a/packages/roosterjs-content-model-core/test/corePlugin/CachePluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/CachePluginTest.ts
@@ -55,7 +55,7 @@ describe('CachePlugin', () => {
         });
 
         it('initialize', () => {
-            init({});
+            init({ disableCache: true });
             expect(addEventListenerSpy).toHaveBeenCalledWith('selectionchange', jasmine.anything());
             expect(plugin.getState()).toEqual({});
         });
@@ -71,7 +71,7 @@ describe('CachePlugin', () => {
                 mockedObserver
             );
             init({
-                cacheModel: true,
+                disableCache: false,
             });
             expect(addEventListenerSpy).toHaveBeenCalledWith('selectionchange', jasmine.anything());
             expect(plugin.getState()).toEqual({
@@ -84,7 +84,7 @@ describe('CachePlugin', () => {
 
     describe('KeyDown event', () => {
         beforeEach(() => {
-            init({});
+            init({ disableCache: true });
         });
         afterEach(() => {
             plugin.dispose();
@@ -177,7 +177,9 @@ describe('CachePlugin', () => {
 
     describe('Input event', () => {
         beforeEach(() => {
-            init({});
+            init({
+                disableCache: true,
+            });
         });
         afterEach(() => {
             plugin.dispose();
@@ -203,7 +205,7 @@ describe('CachePlugin', () => {
 
     describe('SelectionChanged', () => {
         beforeEach(() => {
-            init({});
+            init({ disableCache: true });
         });
         afterEach(() => {
             plugin.dispose();
@@ -289,7 +291,7 @@ describe('CachePlugin', () => {
 
     describe('ContentChanged', () => {
         beforeEach(() => {
-            init({});
+            init({ disableCache: true });
         });
         afterEach(() => {
             plugin.dispose();

--- a/packages/roosterjs-content-model-plugins/test/paste/e2e/testUtils.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/e2e/testUtils.ts
@@ -9,6 +9,7 @@ export function initEditor(id: string): IEditor {
 
     let options: EditorOptions = {
         plugins: [new PastePlugin()],
+        disableCache: true,
         coreApiOverride: {
             getVisibleViewport: () => {
                 return {

--- a/packages/roosterjs-content-model-plugins/test/tableEdit/tableResizerTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/tableEdit/tableResizerTest.ts
@@ -1,4 +1,3 @@
-import * as TestHelper from '../TestHelper';
 import { getModelTable } from './tableData';
 import { TableEditPlugin } from '../../lib/tableEdit/TableEditPlugin';
 import {

--- a/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
@@ -24,9 +24,11 @@ export interface EditorOptions {
     defaultModelToDomOptions?: ModelToDomOption;
 
     /**
-     * Reuse existing DOM structure if possible, and update the model when content or selection is changed
+     * Whether content model should be cached in order to improve editing performance.
+     * Pass true to disable the cache.
+     * @default false
      */
-    cacheModel?: boolean;
+    disableCache?: boolean;
 
     /**
      * List of plugins.

--- a/packages/roosterjs-editor-adapter/test/editor/EditorAdapterTest.ts
+++ b/packages/roosterjs-editor-adapter/test/editor/EditorAdapterTest.ts
@@ -1,9 +1,9 @@
 import * as createDomToModelContext from 'roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext';
 import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
 import * as findAllEntities from 'roosterjs-content-model-core/lib/corePlugin/utils/findAllEntities';
+import { ContentModelDocument, EditorContext, EditorCore } from 'roosterjs-content-model-types';
 import { EditorAdapter } from '../../lib/editor/EditorAdapter';
 import { EditorPlugin, PluginEventType } from 'roosterjs-editor-types';
-import { ContentModelDocument, EditorContext, EditorCore } from 'roosterjs-content-model-types';
 
 const editorContext: EditorContext = {
     isDarkMode: false,
@@ -105,6 +105,7 @@ describe('EditorAdapter', () => {
         };
         const editor = new EditorAdapter(div, {
             legacyPlugins: [plugin],
+            disableCache: true,
         });
         editor.dispose();
 


### PR DESCRIPTION
To prepare for next release, I'm changing Editor Option `cacheModel` to be `disableCache` so that by default cache will be allowed.