### PR TITLE
Move public type definitions into roosterjs-content-model-type package

### DIFF
--- a/packages/roosterjs-content-model-api/lib/modelApi/block/toggleModelBlockQuote.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/block/toggleModelBlockQuote.ts
@@ -1,7 +1,6 @@
 import { areSameFormats, createFormatContainer, unwrapBlock } from 'roosterjs-content-model-dom';
 import { getOperationalBlocks, isBlockGroupOfType } from 'roosterjs-content-model-core';
 import { wrapBlockStep1, wrapBlockStep2 } from '../common/wrapBlock';
-import type { OperationalBlocks } from 'roosterjs-content-model-core';
 import type { WrapBlockStep1Result } from '../common/wrapBlock';
 import type {
     ContentModelBlock,
@@ -10,6 +9,7 @@ import type {
     ContentModelFormatContainer,
     ContentModelFormatContainerFormat,
     ContentModelListItem,
+    OperationalBlocks,
 } from 'roosterjs-content-model-types';
 
 /**

--- a/packages/roosterjs-content-model-core/lib/index.ts
+++ b/packages/roosterjs-content-model-core/lib/index.ts
@@ -1,19 +1,12 @@
 export { cloneModel } from './publicApi/model/cloneModel';
-export { mergeModel, MergeModelOption } from './publicApi/model/mergeModel';
+export { mergeModel } from './publicApi/model/mergeModel';
 export { isBlockGroupOfType } from './publicApi/model/isBlockGroupOfType';
-export {
-    getClosestAncestorBlockGroupIndex,
-    TypeOfBlockGroup,
-} from './publicApi/model/getClosestAncestorBlockGroupIndex';
+export { getClosestAncestorBlockGroupIndex } from './publicApi/model/getClosestAncestorBlockGroupIndex';
 export { isBold } from './publicApi/model/isBold';
 export { createModelFromHtml } from './publicApi/model/createModelFromHtml';
 export { exportContent } from './publicApi/model/exportContent';
 
-export {
-    iterateSelections,
-    IterateSelectionsCallback,
-    IterateSelectionsOption,
-} from './publicApi/selection/iterateSelections';
+export { iterateSelections } from './publicApi/selection/iterateSelections';
 export { getSelectionRootNode } from './publicApi/selection/getSelectionRootNode';
 export { deleteSelection } from './publicApi/selection/deleteSelection';
 export { deleteSegment } from './publicApi/selection/deleteSegment';
@@ -22,7 +15,6 @@ export { hasSelectionInBlock } from './publicApi/selection/hasSelectionInBlock';
 export { hasSelectionInSegment } from './publicApi/selection/hasSelectionInSegment';
 export { hasSelectionInBlockGroup } from './publicApi/selection/hasSelectionInBlockGroup';
 export {
-    OperationalBlocks,
     getFirstSelectedListItem,
     getFirstSelectedTable,
     getOperationalBlocks,

--- a/packages/roosterjs-content-model-core/lib/modelApi/edit/deleteExpandedSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/modelApi/edit/deleteExpandedSelection.ts
@@ -2,7 +2,6 @@ import { deleteBlock } from '../../publicApi/selection/deleteBlock';
 import { deleteSegment } from '../../publicApi/selection/deleteSegment';
 import { getSegmentTextFormat } from '../../publicApi/domUtils/getSegmentTextFormat';
 import { iterateSelections } from '../../publicApi/selection/iterateSelections';
-import type { IterateSelectionsOption } from '../../publicApi/selection/iterateSelections';
 import type {
     ContentModelBlockGroup,
     ContentModelDocument,
@@ -11,6 +10,7 @@ import type {
     DeleteSelectionContext,
     FormatContentModelContext,
     InsertPoint,
+    IterateSelectionsOption,
     TableSelectionContext,
 } from 'roosterjs-content-model-types';
 import {

--- a/packages/roosterjs-content-model-core/lib/publicApi/model/getClosestAncestorBlockGroupIndex.ts
+++ b/packages/roosterjs-content-model-core/lib/publicApi/model/getClosestAncestorBlockGroupIndex.ts
@@ -1,15 +1,8 @@
 import type {
     ContentModelBlockGroup,
-    ContentModelBlockGroupBase,
     ContentModelBlockGroupType,
+    TypeOfBlockGroup,
 } from 'roosterjs-content-model-types';
-
-/**
- * Retrieve block group type string from a given block group
- */
-export type TypeOfBlockGroup<
-    T extends ContentModelBlockGroup
-> = T extends ContentModelBlockGroupBase<infer U> ? U : never;
 
 /**
  * Get index of closest ancestor block group of the expected block group type. If not found, return -1

--- a/packages/roosterjs-content-model-core/lib/publicApi/model/isBlockGroupOfType.ts
+++ b/packages/roosterjs-content-model-core/lib/publicApi/model/isBlockGroupOfType.ts
@@ -1,5 +1,8 @@
-import type { ContentModelBlock, ContentModelBlockGroup } from 'roosterjs-content-model-types';
-import type { TypeOfBlockGroup } from './getClosestAncestorBlockGroupIndex';
+import type {
+    ContentModelBlock,
+    ContentModelBlockGroup,
+    TypeOfBlockGroup,
+} from 'roosterjs-content-model-types';
 
 /**
  * Check if the given content model block or block group is of the expected block group type

--- a/packages/roosterjs-content-model-core/lib/publicApi/model/mergeModel.ts
+++ b/packages/roosterjs-content-model-core/lib/publicApi/model/mergeModel.ts
@@ -22,38 +22,10 @@ import type {
     ContentModelTable,
     FormatContentModelContext,
     InsertPoint,
+    MergeModelOption,
 } from 'roosterjs-content-model-types';
 
 const HeadingTags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
-
-/**
- * Options to specify how to merge models
- */
-export interface MergeModelOption {
-    /**
-     * When there is only a table to merge, whether merge this table into current table (if any), or just directly insert (nested table).
-     * This is usually used when paste table inside a table
-     * @default false
-     */
-    mergeTable?: boolean;
-
-    /**
-     * Use this insert position to merge instead of querying selection from target model
-     * @default undefined
-     */
-    insertPosition?: InsertPoint;
-
-    /**
-     * Use this to decide whether to change the source model format when doing the merge.
-     * 'mergeAll': segment format of the insert position will be merged into the content that is merged into current model.
-     * If the source model already has some format, it will not be overwritten.
-     * 'keepSourceEmphasisFormat': format of the insert position will be set into the content that is merged into current model.
-     * If the source model already has emphasis format, such as, fontWeight, Italic or underline different than the default style, it will not be overwritten.
-     * 'none' the source segment format will not be modified.
-     * @default undefined
-     */
-    mergeFormat?: 'mergeAll' | 'keepSourceEmphasisFormat' | 'none';
-}
 
 /**
  * Merge source model into target mode

--- a/packages/roosterjs-content-model-core/lib/publicApi/selection/collectSelections.ts
+++ b/packages/roosterjs-content-model-core/lib/publicApi/selection/collectSelections.ts
@@ -1,7 +1,6 @@
 import { getClosestAncestorBlockGroupIndex } from '../model/getClosestAncestorBlockGroupIndex';
 import { isBlockGroupOfType } from '../model/isBlockGroupOfType';
 import { iterateSelections } from './iterateSelections';
-import type { IterateSelectionsOption } from './iterateSelections';
 import type {
     ContentModelBlock,
     ContentModelBlockGroup,
@@ -11,29 +10,11 @@ import type {
     ContentModelParagraph,
     ContentModelSegment,
     ContentModelTable,
+    IterateSelectionsOption,
+    OperationalBlocks,
     TableSelectionContext,
+    TypeOfBlockGroup,
 } from 'roosterjs-content-model-types';
-import type { TypeOfBlockGroup } from '../model/getClosestAncestorBlockGroupIndex';
-
-/**
- * Represent a pair of parent block group and child block
- */
-export type OperationalBlocks<T extends ContentModelBlockGroup> = {
-    /**
-     * The parent block group
-     */
-    parent: ContentModelBlockGroup;
-
-    /**
-     * The child block
-     */
-    block: ContentModelBlock | T;
-
-    /**
-     * Selection path of this block
-     */
-    path: ContentModelBlockGroup[];
-};
 
 /**
  * Get an array of selected parent paragraph and child segment pair

--- a/packages/roosterjs-content-model-core/lib/publicApi/selection/iterateSelections.ts
+++ b/packages/roosterjs-content-model-core/lib/publicApi/selection/iterateSelections.ts
@@ -1,59 +1,11 @@
 import type {
-    ContentModelBlock,
     ContentModelBlockGroup,
     ContentModelBlockWithCache,
     ContentModelSegment,
+    IterateSelectionsCallback,
+    IterateSelectionsOption,
     TableSelectionContext,
 } from 'roosterjs-content-model-types';
-
-/**
- * Options for iterateSelections API
- */
-export interface IterateSelectionsOption {
-    /**
-     * For selected table cell, this property determines how do we handle its content.
-     * include: No matter if table cell is selected, always invoke callback function for selected content (default value)
-     * ignoreForTable: When the whole table is selected we invoke callback for the table (using block parameter) but skip
-     * all its cells and content, otherwise keep invoking callback for table cell and content
-     * ignoreForTableOrCell: If whole table is selected, same with ignoreForTable, or if a table cell is selected, only
-     * invoke callback for the table cell itself but not for its content, otherwise keep invoking callback for content.
-     * @default include
-     */
-    contentUnderSelectedTableCell?: 'include' | 'ignoreForTable' | 'ignoreForTableOrCell';
-
-    /**
-     * For a selected general element, this property determines how do we handle its content.
-     * contentOnly: (Default) When the whole general element is selected, we only invoke callback for its selected content
-     * generalElementOnly: When the whole general element is selected, we only invoke callback for the general element (using block or
-     * segment parameter depends on if it is a block or segment), but skip all its content.
-     * both: When general element is selected, we invoke callback first for its content, then for general element itself
-     */
-    contentUnderSelectedGeneralElement?: 'contentOnly' | 'generalElementOnly' | 'both';
-
-    /**
-     * Whether call the callback for the list item format holder segment
-     * anySegment: call the callback if any segment is selected under a list item
-     * allSegments: call the callback only when all segments under the list item are selected
-     * never: never call the callback for list item format holder
-     * @default allSegments
-     */
-    includeListFormatHolder?: 'anySegment' | 'allSegments' | 'never';
-}
-
-/**
- * The callback function type for iterateSelections
- * @param path The block group path of current selection
- * @param tableContext Table context of current selection
- * @param block Block of current selection
- * @param segments Segments of current selection
- * @returns True to stop iterating, otherwise keep going
- */
-export type IterateSelectionsCallback = (
-    path: ContentModelBlockGroup[],
-    tableContext?: TableSelectionContext,
-    block?: ContentModelBlock,
-    segments?: ContentModelSegment[]
-) => void | boolean;
 
 /**
  * Iterate all selected elements in a given model

--- a/packages/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
@@ -5,7 +5,6 @@ import { domToContentModel } from 'roosterjs-content-model-dom';
 import { getSegmentTextFormat } from '../../publicApi/domUtils/getSegmentTextFormat';
 import { getSelectedSegments } from '../../publicApi/selection/collectSelections';
 import { mergeModel } from '../../publicApi/model/mergeModel';
-import type { MergeModelOption } from '../../publicApi/model/mergeModel';
 import type {
     BeforePasteEvent,
     ClipboardData,
@@ -13,6 +12,7 @@ import type {
     ContentModelDocument,
     ContentModelSegmentFormat,
     IEditor,
+    MergeModelOption,
 } from 'roosterjs-content-model-types';
 
 const EmptySegmentFormat: Required<ContentModelSegmentFormat> = {

--- a/packages/roosterjs-content-model-core/test/publicApi/selection/collectSelectionsTest.ts
+++ b/packages/roosterjs-content-model-core/test/publicApi/selection/collectSelectionsTest.ts
@@ -6,6 +6,7 @@ import {
     ContentModelParagraph,
     ContentModelSegment,
     ContentModelTable,
+    OperationalBlocks,
     TableSelectionContext,
 } from 'roosterjs-content-model-types';
 import {
@@ -26,7 +27,6 @@ import {
     getFirstSelectedListItem,
     getFirstSelectedTable,
     getOperationalBlocks,
-    OperationalBlocks,
     getSelectedSegmentsAndParagraphs,
 } from '../../../lib/publicApi/selection/collectSelections';
 

--- a/packages/roosterjs-content-model-core/test/publicApi/selection/iterateSelectionsTest.ts
+++ b/packages/roosterjs-content-model-core/test/publicApi/selection/iterateSelectionsTest.ts
@@ -1,3 +1,5 @@
+import { iterateSelections } from '../../../lib/publicApi/selection/iterateSelections';
+import { IterateSelectionsCallback } from 'roosterjs-content-model-types';
 import {
     addSegment,
     createContentModelDocument,
@@ -14,10 +16,6 @@ import {
     createTableCell,
     createText,
 } from 'roosterjs-content-model-dom';
-import {
-    iterateSelections,
-    IterateSelectionsCallback,
-} from '../../../lib/publicApi/selection/iterateSelections';
 
 describe('iterateSelections', () => {
     let callback: jasmine.Spy<IterateSelectionsCallback>;

--- a/packages/roosterjs-content-model-dom/lib/domUtils/isNodeOfType.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/isNodeOfType.ts
@@ -1,47 +1,4 @@
-/**
- * A type map from node type number to its type declaration. This is used by utility function isNodeOfType()
- */
-export interface NodeTypeMap {
-    /**
-     * Attribute node
-     */
-    ATTRIBUTE_NODE: Attr;
-
-    /**
-     * Comment node
-     */
-    COMMENT_NODE: Comment;
-
-    /**
-     * DocumentFragment node
-     */
-    DOCUMENT_FRAGMENT_NODE: DocumentFragment;
-
-    /**
-     * Document node
-     */
-    DOCUMENT_NODE: Document;
-
-    /**
-     * DocumentType node
-     */
-    DOCUMENT_TYPE_NODE: DocumentType;
-
-    /**
-     * HTMLElement node
-     */
-    ELEMENT_NODE: HTMLElement;
-
-    /**
-     * ProcessingInstruction node
-     */
-    PROCESSING_INSTRUCTION_NODE: ProcessingInstruction;
-
-    /**
-     * Text node
-     */
-    TEXT_NODE: Text;
-}
+import type { NodeTypeMap } from 'roosterjs-content-model-types';
 
 /**
  * Type checker for Node. Return true if it of the specified node type

--- a/packages/roosterjs-content-model-dom/lib/index.ts
+++ b/packages/roosterjs-content-model-dom/lib/index.ts
@@ -15,7 +15,7 @@ export { areSameFormats } from './domToModel/utils/areSameFormats';
 export { isBlockElement } from './domToModel/utils/isBlockElement';
 
 export { updateMetadata, hasMetadata } from './domUtils/metadata/updateMetadata';
-export { isNodeOfType, NodeTypeMap } from './domUtils/isNodeOfType';
+export { isNodeOfType } from './domUtils/isNodeOfType';
 export { isElementOfType } from './domUtils/isElementOfType';
 export { getObjectKeys } from './domUtils/getObjectKeys';
 export { toArray } from './domUtils/toArray';

--- a/packages/roosterjs-content-model-plugins/test/tableEdit/tableEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/tableEdit/tableEditPluginTest.ts
@@ -1,6 +1,6 @@
 import * as TestHelper from '../TestHelper';
 import { createElement } from '../../lib/pluginUtils/CreateElement/createElement';
-import { DOMEventHandlerFunction, IEditor } from 'roosterjs-editor-types';
+import { DOMEventHandlerFunction, IEditor } from 'roosterjs-content-model-types';
 import { getModelTable } from './tableData';
 import { TableEditPlugin } from '../../lib/tableEdit/TableEditPlugin';
 import {

--- a/packages/roosterjs-content-model-plugins/test/tableEdit/tableResizerTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/tableEdit/tableResizerTest.ts
@@ -1,4 +1,3 @@
-import * as TestHelper from '../TestHelper';
 import { getModelTable } from './tableData';
 import { TableEditPlugin } from '../../lib/tableEdit/TableEditPlugin';
 import {

--- a/packages/roosterjs-content-model-types/lib/index.ts
+++ b/packages/roosterjs-content-model-types/lib/index.ts
@@ -284,6 +284,14 @@ export { DOMHelper } from './parameter/DOMHelper';
 export { ImageEditOperation, ImageEditor } from './parameter/ImageEditor';
 export { CachedElementHandler, CloneModelOptions } from './parameter/CloneModelOptions';
 export { LinkData } from './parameter/LinkData';
+export { MergeModelOption } from './parameter/MergeModelOption';
+export {
+    IterateSelectionsCallback,
+    IterateSelectionsOption,
+} from './parameter/IterateSelectionsOption';
+export { NodeTypeMap } from './parameter/NodeTypeMap';
+export { TypeOfBlockGroup } from './parameter/TypeOfBlockGroup';
+export { OperationalBlocks } from './parameter/OperationalBlocks';
 
 export { BasePluginEvent, BasePluginDomEvent } from './event/BasePluginEvent';
 export { BeforeCutCopyEvent } from './event/BeforeCutCopyEvent';

--- a/packages/roosterjs-content-model-types/lib/parameter/IterateSelectionsOption.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/IterateSelectionsOption.ts
@@ -1,0 +1,53 @@
+import type { ContentModelBlock } from '../block/ContentModelBlock';
+import type { ContentModelBlockGroup } from '../group/ContentModelBlockGroup';
+import type { ContentModelSegment } from '../segment/ContentModelSegment';
+import type { TableSelectionContext } from '../selection/TableSelectionContext';
+
+/**
+ * Options for iterateSelections API
+ */
+export interface IterateSelectionsOption {
+    /**
+     * For selected table cell, this property determines how do we handle its content.
+     * include: No matter if table cell is selected, always invoke callback function for selected content (default value)
+     * ignoreForTable: When the whole table is selected we invoke callback for the table (using block parameter) but skip
+     * all its cells and content, otherwise keep invoking callback for table cell and content
+     * ignoreForTableOrCell: If whole table is selected, same with ignoreForTable, or if a table cell is selected, only
+     * invoke callback for the table cell itself but not for its content, otherwise keep invoking callback for content.
+     * @default include
+     */
+    contentUnderSelectedTableCell?: 'include' | 'ignoreForTable' | 'ignoreForTableOrCell';
+
+    /**
+     * For a selected general element, this property determines how do we handle its content.
+     * contentOnly: (Default) When the whole general element is selected, we only invoke callback for its selected content
+     * generalElementOnly: When the whole general element is selected, we only invoke callback for the general element (using block or
+     * segment parameter depends on if it is a block or segment), but skip all its content.
+     * both: When general element is selected, we invoke callback first for its content, then for general element itself
+     */
+    contentUnderSelectedGeneralElement?: 'contentOnly' | 'generalElementOnly' | 'both';
+
+    /**
+     * Whether call the callback for the list item format holder segment
+     * anySegment: call the callback if any segment is selected under a list item
+     * allSegments: call the callback only when all segments under the list item are selected
+     * never: never call the callback for list item format holder
+     * @default allSegments
+     */
+    includeListFormatHolder?: 'anySegment' | 'allSegments' | 'never';
+}
+
+/**
+ * The callback function type for iterateSelections
+ * @param path The block group path of current selection
+ * @param tableContext Table context of current selection
+ * @param block Block of current selection
+ * @param segments Segments of current selection
+ * @returns True to stop iterating, otherwise keep going
+ */
+export type IterateSelectionsCallback = (
+    path: ContentModelBlockGroup[],
+    tableContext?: TableSelectionContext,
+    block?: ContentModelBlock,
+    segments?: ContentModelSegment[]
+) => void | boolean;

--- a/packages/roosterjs-content-model-types/lib/parameter/MergeModelOption.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/MergeModelOption.ts
@@ -1,0 +1,30 @@
+import type { InsertPoint } from '../selection/InsertPoint';
+
+/**
+ * Options to specify how to merge models
+ */
+export interface MergeModelOption {
+    /**
+     * When there is only a table to merge, whether merge this table into current table (if any), or just directly insert (nested table).
+     * This is usually used when paste table inside a table
+     * @default false
+     */
+    mergeTable?: boolean;
+
+    /**
+     * Use this insert position to merge instead of querying selection from target model
+     * @default undefined
+     */
+    insertPosition?: InsertPoint;
+
+    /**
+     * Use this to decide whether to change the source model format when doing the merge.
+     * 'mergeAll': segment format of the insert position will be merged into the content that is merged into current model.
+     * If the source model already has some format, it will not be overwritten.
+     * 'keepSourceEmphasisFormat': format of the insert position will be set into the content that is merged into current model.
+     * If the source model already has emphasis format, such as, fontWeight, Italic or underline different than the default style, it will not be overwritten.
+     * 'none' the source segment format will not be modified.
+     * @default undefined
+     */
+    mergeFormat?: 'mergeAll' | 'keepSourceEmphasisFormat' | 'none';
+}

--- a/packages/roosterjs-content-model-types/lib/parameter/NodeTypeMap.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/NodeTypeMap.ts
@@ -1,0 +1,44 @@
+/**
+ * A type map from node type number to its type declaration. This is used by utility function isNodeOfType()
+ */
+export interface NodeTypeMap {
+    /**
+     * Attribute node
+     */
+    ATTRIBUTE_NODE: Attr;
+
+    /**
+     * Comment node
+     */
+    COMMENT_NODE: Comment;
+
+    /**
+     * DocumentFragment node
+     */
+    DOCUMENT_FRAGMENT_NODE: DocumentFragment;
+
+    /**
+     * Document node
+     */
+    DOCUMENT_NODE: Document;
+
+    /**
+     * DocumentType node
+     */
+    DOCUMENT_TYPE_NODE: DocumentType;
+
+    /**
+     * HTMLElement node
+     */
+    ELEMENT_NODE: HTMLElement;
+
+    /**
+     * ProcessingInstruction node
+     */
+    PROCESSING_INSTRUCTION_NODE: ProcessingInstruction;
+
+    /**
+     * Text node
+     */
+    TEXT_NODE: Text;
+}

--- a/packages/roosterjs-content-model-types/lib/parameter/OperationalBlocks.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/OperationalBlocks.ts
@@ -1,0 +1,22 @@
+import type { ContentModelBlock } from '../block/ContentModelBlock';
+import type { ContentModelBlockGroup } from '../group/ContentModelBlockGroup';
+
+/**
+ * Represent a pair of parent block group and child block
+ */
+export type OperationalBlocks<T extends ContentModelBlockGroup> = {
+    /**
+     * The parent block group
+     */
+    parent: ContentModelBlockGroup;
+
+    /**
+     * The child block
+     */
+    block: ContentModelBlock | T;
+
+    /**
+     * Selection path of this block
+     */
+    path: ContentModelBlockGroup[];
+};

--- a/packages/roosterjs-content-model-types/lib/parameter/TypeOfBlockGroup.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/TypeOfBlockGroup.ts
@@ -1,0 +1,9 @@
+import type { ContentModelBlockGroup } from '../group/ContentModelBlockGroup';
+import type { ContentModelBlockGroupBase } from '../group/ContentModelBlockGroupBase';
+
+/**
+ * Retrieve block group type string from a given block group
+ */
+export type TypeOfBlockGroup<
+    T extends ContentModelBlockGroup
+> = T extends ContentModelBlockGroupBase<infer U> ? U : never;


### PR DESCRIPTION
Move public type definitions into roosterjs-content-model-type package

Move file only, no logic change