### PR TITLE
FHL: Port WatermarkPlugin

### DIFF
--- a/demo/scripts/controlsV2/demoButtons/formatPainterButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/formatPainterButton.ts
@@ -1,15 +1,19 @@
-import { FormatPainterPlugin } from '../plugins/FormatPainterPlugin';
+import { FormatPainterHandler } from '../plugins/FormatPainterPlugin';
 import type { RibbonButton } from '../roosterjsReact/ribbon';
 
 /**
  * @internal
  * "Format Painter" button on the format ribbon
  */
-export const formatPainterButton: RibbonButton<'formatPainter'> = {
-    key: 'formatPainter',
-    unlocalizedText: 'Format painter',
-    iconName: 'Brush',
-    onClick: () => {
-        FormatPainterPlugin.startFormatPainter();
-    },
-};
+export function createFormatPainterButton(
+    handler: FormatPainterHandler
+): RibbonButton<'formatPainter'> {
+    return {
+        key: 'formatPainter',
+        unlocalizedText: 'Format painter',
+        iconName: 'Brush',
+        onClick: () => {
+            handler.startFormatPainter();
+        },
+    };
+}

--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -7,11 +7,12 @@ import { buttons, buttonsWithPopout } from './ribbonButtons';
 import { Colors, EditorPlugin, IEditor, Snapshots } from 'roosterjs-content-model-types';
 import { ContentModelPanePlugin } from '../sidePane/contentModel/ContentModelPanePlugin';
 import { createEmojiPlugin } from '../roosterjsReact/emoji';
+import { createFormatPainterButton } from '../demoButtons/formatPainterButton';
 import { createImageEditMenuProvider } from '../roosterjsReact/contextMenu/menus/createImageEditMenuProvider';
 import { createLegacyPlugins } from '../plugins/createLegacyPlugins';
 import { createListEditMenuProvider } from '../roosterjsReact/contextMenu/menus/createListEditMenuProvider';
 import { createPasteOptionPlugin } from '../roosterjsReact/pasteOptions';
-import { createRibbonPlugin, Ribbon, RibbonPlugin } from '../roosterjsReact/ribbon';
+import { createRibbonPlugin, Ribbon, RibbonButton, RibbonPlugin } from '../roosterjsReact/ribbon';
 import { Editor } from 'roosterjs-content-model-core';
 import { EditorAdapter } from 'roosterjs-editor-adapter';
 import { EditorOptionsPlugin } from '../sidePane/editorOptions/EditorOptionsPlugin';
@@ -41,6 +42,7 @@ import {
     PastePlugin,
     ShortcutPlugin,
     TableEditPlugin,
+    WatermarkPlugin,
 } from 'roosterjs-content-model-plugins';
 
 const styles = require('./MainPane.scss');
@@ -75,6 +77,8 @@ export class MainPane extends React.Component<{}, MainPaneState> {
     private snapshotPlugin: SnapshotPlugin;
     private formatPainterPlugin: FormatPainterPlugin;
     private snapshots: Snapshots;
+    private buttons: RibbonButton<any>[];
+    private buttonsWithPopout: RibbonButton<any>[];
 
     protected sidePane = React.createRef<SidePane>();
     protected updateContentPlugin: UpdateContentPlugin;
@@ -110,6 +114,10 @@ export class MainPane extends React.Component<{}, MainPaneState> {
         this.contentModelPanePlugin = new ContentModelPanePlugin();
         this.ribbonPlugin = createRibbonPlugin();
         this.formatPainterPlugin = new FormatPainterPlugin();
+
+        const baseButtons = [createFormatPainterButton(this.formatPainterPlugin)];
+        this.buttons = baseButtons.concat(buttons);
+        this.buttonsWithPopout = baseButtons.concat(buttonsWithPopout);
         this.state = {
             showSidePane: window.location.hash != '',
             popoutWindow: null,
@@ -228,7 +236,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
     private renderRibbon(isPopout: boolean) {
         return (
             <Ribbon
-                buttons={isPopout ? buttons : buttonsWithPopout}
+                buttons={isPopout ? this.buttons : this.buttonsWithPopout}
                 plugin={this.ribbonPlugin}
                 dir={this.state.isRtl ? 'rtl' : 'ltr'}
             />
@@ -417,6 +425,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             listMenu,
             tableMenu,
             imageMenu,
+            watermarkText,
         } = this.state.initState;
         return [
             pluginList.autoFormat && new AutoFormatPlugin(),
@@ -424,6 +433,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             pluginList.paste && new PastePlugin(allowExcelNoBorderTable),
             pluginList.shortcut && new ShortcutPlugin(),
             pluginList.tableEdit && new TableEditPlugin(),
+            pluginList.watermark && new WatermarkPlugin(watermarkText),
             pluginList.emoji && createEmojiPlugin(),
             pluginList.pasteOption && createPasteOptionPlugin(),
             pluginList.sampleEntity && new SampleEntityPlugin(),

--- a/demo/scripts/controlsV2/mainPane/ribbonButtons.ts
+++ b/demo/scripts/controlsV2/mainPane/ribbonButtons.ts
@@ -15,7 +15,6 @@ import { decreaseIndentButton } from '../roosterjsReact/ribbon/buttons/decreaseI
 import { exportContentButton } from '../demoButtons/exportContentButton';
 import { fontButton } from '../roosterjsReact/ribbon/buttons/fontButton';
 import { fontSizeButton } from '../roosterjsReact/ribbon/buttons/fontSizeButton';
-import { formatPainterButton } from '../demoButtons/formatPainterButton';
 import { formatTableButton } from '../demoButtons/formatTableButton';
 import { imageBorderColorButton } from '../demoButtons/imageBorderColorButton';
 import { imageBorderRemoveButton } from '../demoButtons/imageBorderRemoveButton';
@@ -65,7 +64,6 @@ import {
 import type { RibbonButton } from '../roosterjsReact/ribbon';
 
 export const buttons: RibbonButton<any>[] = [
-    formatPainterButton,
     boldButton,
     italicButton,
     underlineButton,

--- a/demo/scripts/controlsV2/plugins/createLegacyPlugins.ts
+++ b/demo/scripts/controlsV2/plugins/createLegacyPlugins.ts
@@ -6,7 +6,6 @@ import {
     HyperLink,
     ImageEdit,
     TableCellSelection,
-    Watermark,
 } from 'roosterjs-editor-plugins';
 import {
     LegacyPluginList,
@@ -28,7 +27,6 @@ export function createLegacyPlugins(initState: OptionState): LegacyEditorPlugin[
                       : null
               )
             : null,
-        watermark: pluginList.watermark ? new Watermark(initState.watermarkText) : null,
         imageEdit: pluginList.imageEdit
             ? new ImageEdit({
                   preserveRatio: initState.forcePreserveRatio,

--- a/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -12,6 +12,7 @@ const initialState: OptionState = {
         shortcut: true,
         tableEdit: true,
         contextMenu: true,
+        watermark: true,
         emoji: true,
         pasteOption: true,
         sampleEntity: true,
@@ -19,7 +20,6 @@ const initialState: OptionState = {
         // Legacy plugins
         contentEdit: false,
         hyperlink: false,
-        watermark: false,
         imageEdit: false,
         tableCellSelection: true,
         customReplace: false,

--- a/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
@@ -5,7 +5,6 @@ import type { ContentModelSegmentFormat } from 'roosterjs-content-model-types';
 export interface LegacyPluginList {
     contentEdit: boolean;
     hyperlink: boolean;
-    watermark: boolean;
     imageEdit: boolean;
     tableCellSelection: boolean;
     customReplace: boolean;
@@ -19,6 +18,7 @@ export interface NewPluginList {
     shortcut: boolean;
     tableEdit: boolean;
     contextMenu: boolean;
+    watermark: boolean;
     emoji: boolean;
     pasteOption: boolean;
     sampleEntity: boolean;
@@ -34,12 +34,12 @@ export interface OptionState {
     listMenu: boolean;
     tableMenu: boolean;
     imageMenu: boolean;
+    watermarkText: string;
 
     // Legacy plugin options
     contentEditFeatures: ContentEditFeatureSettings;
     defaultFormat: ContentModelSegmentFormat;
     linkTitle: string;
-    watermarkText: string;
     forcePreserveRatio: boolean;
     tableFeaturesContainerSelector: string;
 

--- a/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
@@ -104,7 +104,6 @@ abstract class PluginsBase<PluginKey extends keyof BuildInPluginList> extends Re
 
 export class LegacyPlugins extends PluginsBase<keyof LegacyPluginList> {
     private linkTitle = React.createRef<HTMLInputElement>();
-    private watermarkText = React.createRef<HTMLInputElement>();
     private forcePreserveRatio = React.createRef<HTMLInputElement>();
 
     render() {
@@ -131,17 +130,6 @@ export class LegacyPlugins extends PluginsBase<keyof LegacyPluginList> {
                         )
                     )}
                     {this.renderPluginItem(
-                        'watermark',
-                        'Watermark Plugin',
-                        this.renderInputBox(
-                            'Watermark text: ',
-                            this.watermarkText,
-                            this.props.state.watermarkText,
-                            '',
-                            (state, value) => (state.watermarkText = value)
-                        )
-                    )}
-                    {this.renderPluginItem(
                         'imageEdit',
                         'Image Edit Plugin',
                         this.renderCheckBox(
@@ -165,6 +153,7 @@ export class Plugins extends PluginsBase<keyof NewPluginList> {
     private listMenu = React.createRef<HTMLInputElement>();
     private tableMenu = React.createRef<HTMLInputElement>();
     private imageMenu = React.createRef<HTMLInputElement>();
+    private watermarkText = React.createRef<HTMLInputElement>();
 
     render(): JSX.Element {
         return (
@@ -207,6 +196,17 @@ export class Plugins extends PluginsBase<keyof NewPluginList> {
                                 (state, value) => (state.imageMenu = value)
                             )}
                         </>
+                    )}
+                    {this.renderPluginItem(
+                        'watermark',
+                        'Watermark Plugin',
+                        this.renderInputBox(
+                            'Watermark text: ',
+                            this.watermarkText,
+                            this.props.state.watermarkText,
+                            '',
+                            (state, value) => (state.watermarkText = value)
+                        )
                     )}
                     {this.renderPluginItem('emoji', 'Emoji')}
                     {this.renderPluginItem('pasteOption', 'PasteOptions')}

--- a/demo/scripts/controlsV2/sidePane/editorOptions/codes/PluginsCode.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/codes/PluginsCode.ts
@@ -44,6 +44,7 @@ export class PluginsCode extends PluginsCodeBase {
             pluginList.paste && new PastePluginCode(),
             pluginList.tableEdit && new TableEditPluginCode(),
             pluginList.shortcut && new ShortcutPluginCode(),
+            pluginList.watermark && new WatermarkCode(state.watermarkText),
         ]);
     }
 }
@@ -55,7 +56,6 @@ export class LegacyPluginCode extends PluginsCodeBase {
         const plugins: CodeElement[] = [
             pluginList.contentEdit && new ContentEditCode(state.contentEditFeatures),
             pluginList.hyperlink && new HyperLinkCode(state.linkTitle),
-            pluginList.watermark && new WatermarkCode(state.watermarkText),
             pluginList.imageEdit && new ImageEditCode(),
             pluginList.customReplace && new CustomReplaceCode(),
             pluginList.tableCellSelection && new TableCellSelectionCode(),

--- a/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection.ts
@@ -1,4 +1,5 @@
 import { addRangeToSelection } from '../corePlugin/utils/addRangeToSelection';
+import { ensureUniqueId } from './setEditorStyle/ensureUniqueId';
 import { isNodeOfType, toArray } from 'roosterjs-content-model-dom';
 import { parseTableCells } from '../publicApi/domUtils/tableCellUtils';
 import type {
@@ -7,13 +8,13 @@ import type {
     TableSelection,
 } from 'roosterjs-content-model-types';
 
+const DOM_SELECTION_CSS_KEY = '_DOMSelection';
+const HIDE_CURSOR_CSS_KEY = '_DOMSelectionHideCursor';
 const IMAGE_ID = 'image';
 const TABLE_ID = 'table';
-const CONTENT_DIV_ID = 'contentDiv';
 const DEFAULT_SELECTION_BORDER_COLOR = '#DB626C';
-const TABLE_CSS_RULE = '{background-color: rgb(198,198,198) !important;}';
-const CARET_CSS_RULE = '{caret-color: transparent}';
-const MAX_RULE_SELECTOR_LENGTH = 9000;
+const TABLE_CSS_RULE = 'background-color:#C6C6C6!important;';
+const CARET_CSS_RULE = 'caret-color: transparent';
 
 /**
  * @internal
@@ -24,36 +25,44 @@ export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionC
     const skipReselectOnFocus = core.selection.skipReselectOnFocus;
 
     const doc = core.physicalRoot.ownerDocument;
-    const sheet = core.selection.selectionStyleNode?.sheet;
 
     core.selection.skipReselectOnFocus = true;
+    core.api.setEditorStyle(core, DOM_SELECTION_CSS_KEY, null /*cssRule*/);
+    core.api.setEditorStyle(core, HIDE_CURSOR_CSS_KEY, null /*cssRule*/);
 
     try {
-        let selectionRules: string[] | undefined;
-        const rootSelector = '#' + addUniqueId(core.physicalRoot, CONTENT_DIV_ID);
-
         switch (selection?.type) {
             case 'image':
                 const image = selection.image;
 
-                selectionRules = buildImageCSS(
-                    rootSelector,
-                    addUniqueId(image, IMAGE_ID),
-                    core.selection.imageSelectionBorderColor
-                );
                 core.selection.selection = selection;
+                core.api.setEditorStyle(
+                    core,
+                    DOM_SELECTION_CSS_KEY,
+                    `outline-style:auto!important; outline-color:${
+                        core.selection.imageSelectionBorderColor || DEFAULT_SELECTION_BORDER_COLOR
+                    }!important;`,
+                    [`#${ensureUniqueId(image, IMAGE_ID)}`]
+                );
+                core.api.setEditorStyle(core, HIDE_CURSOR_CSS_KEY, CARET_CSS_RULE);
 
                 setRangeSelection(doc, image);
                 break;
             case 'table':
                 const { table, firstColumn, firstRow } = selection;
-
-                selectionRules = buildTableCss(
-                    rootSelector,
-                    addUniqueId(table, TABLE_ID),
+                const tableSelectors = buildTableSelectors(
+                    ensureUniqueId(table, TABLE_ID),
                     selection
                 );
+
                 core.selection.selection = selection;
+                core.api.setEditorStyle(
+                    core,
+                    DOM_SELECTION_CSS_KEY,
+                    TABLE_CSS_RULE,
+                    tableSelectors
+                );
+                core.api.setEditorStyle(core, HIDE_CURSOR_CSS_KEY, CARET_CSS_RULE);
 
                 setRangeSelection(doc, table.rows[firstRow]?.cells[firstColumn]);
                 break;
@@ -66,18 +75,6 @@ export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionC
             default:
                 core.selection.selection = null;
                 break;
-        }
-
-        if (sheet) {
-            for (let i = sheet.cssRules.length - 1; i >= 0; i--) {
-                sheet.deleteRule(i);
-            }
-
-            if (selectionRules) {
-                for (let i = 0; i < selectionRules.length; i++) {
-                    sheet.insertRule(selectionRules[i]);
-                }
-            }
         }
     } finally {
         core.selection.skipReselectOnFocus = skipReselectOnFocus;
@@ -93,20 +90,7 @@ export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionC
     }
 };
 
-function buildImageCSS(editorSelector: string, imageId: string, borderColor?: string): string[] {
-    const color = borderColor || DEFAULT_SELECTION_BORDER_COLOR;
-
-    return [
-        `${editorSelector} #${imageId} {outline-style:auto!important;outline-color:${color}!important;}`,
-        `${editorSelector} ${CARET_CSS_RULE}`,
-    ];
-}
-
-function buildTableCss(
-    editorSelector: string,
-    tableId: string,
-    selection: TableSelection
-): string[] {
+function buildTableSelectors(tableId: string, selection: TableSelection): string[] {
     const { firstColumn, firstRow, lastColumn, lastRow } = selection;
     const cells = parseTableCells(selection.table);
     const isAllTableSelected =
@@ -114,31 +98,13 @@ function buildTableCss(
         firstColumn == 0 &&
         lastRow == cells.length - 1 &&
         lastColumn == (cells[lastRow]?.length ?? 0) - 1;
-    const rootSelector = editorSelector + ' #' + tableId;
-    const selectors = isAllTableSelected
-        ? [rootSelector, `${rootSelector} *`]
-        : handleTableSelected(rootSelector, selection, cells);
-
-    const cssRules: string[] = [`${editorSelector} ${CARET_CSS_RULE}`];
-    let currentRules: string = '';
-
-    for (let i = 0; i < selectors.length; i++) {
-        currentRules += (currentRules.length > 0 ? ',' : '') + selectors[i] || '';
-
-        if (
-            currentRules.length + (selectors[0]?.length || 0) > MAX_RULE_SELECTOR_LENGTH ||
-            i == selectors.length - 1
-        ) {
-            cssRules.push(currentRules + ' ' + TABLE_CSS_RULE);
-            currentRules = '';
-        }
-    }
-
-    return cssRules;
+    return isAllTableSelected
+        ? [`#${tableId}`, `#${tableId} *`]
+        : handleTableSelected(tableId, selection, cells);
 }
 
 function handleTableSelected(
-    rootSelector: string,
+    tableId: string,
     selection: TableSelection,
     cells: (HTMLTableCellElement | null)[][]
 ) {
@@ -189,7 +155,7 @@ function handleTableSelected(
                     cellIndex >= firstColumn &&
                     cellIndex <= lastColumn
                 ) {
-                    const selector = `${rootSelector}${middleElSelector} tr:nth-child(${currentRow})>${cell.tagName}:nth-child(${tdCount})`;
+                    const selector = `#${tableId}${middleElSelector} tr:nth-child(${currentRow})>${cell.tagName}:nth-child(${tdCount})`;
 
                     selectors.push(selector, selector + ' *');
                 }
@@ -209,17 +175,4 @@ function setRangeSelection(doc: Document, element: HTMLElement | undefined) {
 
         addRangeToSelection(doc, range);
     }
-}
-
-function addUniqueId(element: HTMLElement, idPrefix: string): string {
-    idPrefix = element.id || idPrefix;
-
-    const doc = element.ownerDocument;
-    let i = 0;
-
-    while (!element.id || doc.querySelectorAll('#' + element.id).length > 1) {
-        element.id = idPrefix + '_' + i++;
-    }
-
-    return element.id;
 }

--- a/packages/roosterjs-content-model-core/lib/coreApi/setEditorStyle/ensureUniqueId.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setEditorStyle/ensureUniqueId.ts
@@ -1,0 +1,15 @@
+/**
+ * @internal
+ */
+export function ensureUniqueId(element: HTMLElement, idPrefix: string): string {
+    idPrefix = element.id || idPrefix;
+
+    const doc = element.ownerDocument;
+    let i = 0;
+
+    while (!element.id || doc.querySelectorAll('#' + element.id).length > 1) {
+        element.id = idPrefix + '_' + i++;
+    }
+
+    return element.id;
+}

--- a/packages/roosterjs-content-model-core/lib/coreApi/setEditorStyle/setEditorStyle.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setEditorStyle/setEditorStyle.ts
@@ -1,0 +1,77 @@
+import { ensureUniqueId } from './ensureUniqueId';
+import type { SetEditorStyle } from 'roosterjs-content-model-types';
+
+const MAX_RULE_SELECTOR_LENGTH = 9000;
+const CONTENT_DIV_ID = 'contentDiv';
+
+/**
+ * @internal
+ */
+export const setEditorStyle: SetEditorStyle = (
+    core,
+    key,
+    cssRule,
+    subSelectors,
+    maxRuleLength = MAX_RULE_SELECTOR_LENGTH
+) => {
+    let styleElement = core.lifecycle.styleElements[key];
+
+    if (!styleElement && cssRule) {
+        const doc = core.physicalRoot.ownerDocument;
+
+        styleElement = doc.createElement('style');
+        doc.head.appendChild(styleElement);
+
+        styleElement.dataset.roosterjsStyleKey = key;
+        core.lifecycle.styleElements[key] = styleElement;
+    }
+
+    const sheet = styleElement?.sheet;
+
+    if (sheet) {
+        for (let i = sheet.cssRules.length - 1; i >= 0; i--) {
+            sheet.deleteRule(i);
+        }
+
+        if (cssRule) {
+            const rootSelector = '#' + ensureUniqueId(core.physicalRoot, CONTENT_DIV_ID);
+            const selectors = !subSelectors
+                ? [rootSelector]
+                : typeof subSelectors === 'string'
+                ? [`${rootSelector}::${subSelectors}`]
+                : buildSelectors(
+                      rootSelector,
+                      subSelectors,
+                      maxRuleLength - cssRule.length - 3 // minus 3 for " {}"
+                  );
+
+            selectors.forEach(selector => {
+                sheet.insertRule(`${selector} {${cssRule}}`);
+            });
+        }
+    }
+};
+
+function buildSelectors(rootSelector: string, subSelectors: string[], maxLen: number): string[] {
+    const result: string[] = [];
+
+    let stringBuilder: string[] = [];
+    let len = 0;
+
+    subSelectors.forEach(subSelector => {
+        if (len >= maxLen) {
+            result.push(stringBuilder.join(','));
+            stringBuilder = [];
+            len = 0;
+        }
+
+        const selector = `${rootSelector} ${subSelector}`;
+
+        len += selector.length + 1; // Add 1 for potential "," between selectors
+        stringBuilder.push(selector);
+    });
+
+    result.push(stringBuilder.join(','));
+
+    return result;
+}

--- a/packages/roosterjs-content-model-core/lib/corePlugin/LifecyclePlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/LifecyclePlugin.ts
@@ -1,5 +1,5 @@
 import { ChangeSource } from '../constants/ChangeSource';
-import { setColor } from 'roosterjs-content-model-dom';
+import { getObjectKeys, setColor } from 'roosterjs-content-model-dom';
 import type {
     IEditor,
     LifecyclePluginState,
@@ -48,6 +48,7 @@ class LifecyclePlugin implements PluginWithState<LifecyclePluginState> {
         this.state = {
             isDarkMode: !!options.inDarkMode,
             shadowEditFragment: null,
+            styleElements: {},
         };
     }
 
@@ -80,6 +81,13 @@ class LifecyclePlugin implements PluginWithState<LifecyclePluginState> {
      */
     dispose() {
         this.editor?.triggerEvent('beforeDispose', {}, true /*broadcast*/);
+
+        getObjectKeys(this.state.styleElements).forEach(key => {
+            const element = this.state.styleElements[key];
+
+            element.parentElement?.removeChild(element);
+            delete this.state.styleElements[key];
+        });
 
         if (this.disposer) {
             this.disposer();

--- a/packages/roosterjs-content-model-core/lib/corePlugin/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/SelectionPlugin.ts
@@ -22,7 +22,6 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
     constructor(options: EditorOptions) {
         this.state = {
             selection: null,
-            selectionStyleNode: null,
             imageSelectionBorderColor: options.imageSelectionBorderColor,
         };
     }
@@ -33,12 +32,6 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
 
     initialize(editor: IEditor) {
         this.editor = editor;
-
-        const doc = this.editor.getDocument();
-        const styleNode = doc.createElement('style');
-
-        doc.head.appendChild(styleNode);
-        this.state.selectionStyleNode = styleNode;
 
         const env = this.editor.getEnvironment();
         const document = this.editor.getDocument();
@@ -61,11 +54,6 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         this.editor
             ?.getDocument()
             .removeEventListener('selectionchange', this.onSelectionChangeSafari);
-
-        if (this.state.selectionStyleNode) {
-            this.state.selectionStyleNode.parentNode?.removeChild(this.state.selectionStyleNode);
-            this.state.selectionStyleNode = null;
-        }
 
         if (this.disposer) {
             this.disposer();

--- a/packages/roosterjs-content-model-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/Editor.ts
@@ -372,6 +372,23 @@ export class Editor implements IEditor {
     }
 
     /**
+     * Add CSS rules for editor
+     * @param key A string to identify the CSS rule type. When set CSS rules with the same key again, existing rules with the same key will be replaced.
+     * @param cssRule The CSS rule string, must be a valid CSS rule string, or browser may throw exception. Pass null to clear existing rules
+     * @param subSelectors @optional If the rule is used for child element under editor, use this parameter to specify the child elements. Each item will be
+     * combined with root selector together to build a separate rule.
+     */
+    setEditorStyle(
+        key: string,
+        cssRule: string | null,
+        subSelectors?: 'before' | 'after' | string[]
+    ): void {
+        const core = this.getCore();
+
+        core.api.setEditorStyle(core, key, cssRule, subSelectors);
+    }
+
+    /**
      * @returns the current EditorCore object
      * @throws a standard Error if there's no core object
      */

--- a/packages/roosterjs-content-model-core/lib/editor/coreApiMap.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/coreApiMap.ts
@@ -9,6 +9,7 @@ import { getVisibleViewport } from '../coreApi/getVisibleViewport';
 import { restoreUndoSnapshot } from '../coreApi/restoreUndoSnapshot';
 import { setContentModel } from '../coreApi/setContentModel';
 import { setDOMSelection } from '../coreApi/setDOMSelection';
+import { setEditorStyle } from '../coreApi/setEditorStyle/setEditorStyle';
 import { switchShadowEdit } from '../coreApi/switchShadowEdit';
 import { triggerEvent } from '../coreApi/triggerEvent';
 import type { CoreApiMap } from 'roosterjs-content-model-types';
@@ -35,4 +36,5 @@ export const coreApiMap: CoreApiMap = {
 
     switchShadowEdit: switchShadowEdit,
     getVisibleViewport: getVisibleViewport,
+    setEditorStyle: setEditorStyle,
 };

--- a/packages/roosterjs-content-model-core/test/coreApi/setContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setContentModelTest.ts
@@ -159,7 +159,6 @@ describe('setContentModel', () => {
 
         core.selection = {
             selection: null,
-            selectionStyleNode: null,
         };
         setContentModel(core, mockedModel, {
             ignoreSelection: true,
@@ -192,7 +191,6 @@ describe('setContentModel', () => {
 
         core.selection = {
             selection: null,
-            selectionStyleNode: null,
         };
         setContentModel(core, mockedModel, {
             ignoreSelection: true,
@@ -221,7 +219,6 @@ describe('setContentModel', () => {
 
         core.selection = {
             selection: null,
-            selectionStyleNode: null,
         };
         setContentModel(core, mockedModel, {
             ignoreSelection: true,

--- a/packages/roosterjs-content-model-core/test/coreApi/setEditorStyle/ensureUniqueIdTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setEditorStyle/ensureUniqueIdTest.ts
@@ -1,0 +1,47 @@
+import { ensureUniqueId } from '../../../lib/coreApi/setEditorStyle/ensureUniqueId';
+
+describe('ensureUniqueId', () => {
+    let doc: Document;
+    let querySelectorAllSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        querySelectorAllSpy = jasmine.createSpy('querySelectorAll');
+        doc = {
+            querySelectorAll: querySelectorAllSpy,
+        } as any;
+    });
+
+    it('no id', () => {
+        const element = {
+            ownerDocument: doc,
+        } as any;
+        querySelectorAllSpy.and.returnValue([]);
+        const result = ensureUniqueId(element, 'prefix');
+
+        expect(result).toBe('prefix_0');
+    });
+
+    it('Has unique id', () => {
+        const element = {
+            ownerDocument: doc,
+            id: 'unique',
+        } as any;
+        querySelectorAllSpy.and.returnValue([{}]);
+        const result = ensureUniqueId(element, 'prefix');
+
+        expect(result).toBe('unique');
+    });
+
+    it('Has duplicated', () => {
+        const element = {
+            ownerDocument: doc,
+            id: 'dup',
+        } as any;
+        querySelectorAllSpy.and.callFake((selector: string) =>
+            selector == '#dup' ? [{}, {}] : []
+        );
+        const result = ensureUniqueId(element, 'prefix');
+
+        expect(result).toBe('dup_0');
+    });
+});

--- a/packages/roosterjs-content-model-core/test/coreApi/setEditorStyle/setEditorStyleTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setEditorStyle/setEditorStyleTest.ts
@@ -1,0 +1,214 @@
+import * as ensureUniqueId from '../../../lib/coreApi/setEditorStyle/ensureUniqueId';
+import { EditorCore } from 'roosterjs-content-model-types';
+import { setEditorStyle } from '../../../lib/coreApi/setEditorStyle/setEditorStyle';
+
+describe('setEditorStyle', () => {
+    let core: EditorCore;
+    let createElementSpy: jasmine.Spy;
+    let appendChildSpy: jasmine.Spy;
+    let insertRuleSpy: jasmine.Spy;
+    let deleteRuleSpy: jasmine.Spy;
+    let ensureUniqueIdSpy: jasmine.Spy;
+    let mockedStyle: HTMLStyleElement;
+
+    beforeEach(() => {
+        createElementSpy = jasmine.createSpy('createElement');
+        appendChildSpy = jasmine.createSpy('appendChild');
+        insertRuleSpy = jasmine.createSpy('insertRule');
+        deleteRuleSpy = jasmine.createSpy('deleteRule');
+        ensureUniqueIdSpy = spyOn(ensureUniqueId, 'ensureUniqueId').and.returnValue('uniqueId');
+        core = {
+            physicalRoot: {
+                ownerDocument: {
+                    createElement: createElementSpy,
+                    head: {
+                        appendChild: appendChildSpy,
+                    },
+                },
+            },
+            lifecycle: {
+                styleElements: {},
+            },
+        } as any;
+
+        mockedStyle = {
+            dataset: {},
+            sheet: {
+                cssRules: [],
+                insertRule: insertRuleSpy,
+                deleteRule: deleteRuleSpy,
+            },
+        } as any;
+    });
+
+    it('New key, empty rule', () => {
+        setEditorStyle(core, 'key', null);
+
+        expect(core.lifecycle.styleElements).toEqual({});
+        expect(createElementSpy).not.toHaveBeenCalled();
+        expect(appendChildSpy).not.toHaveBeenCalled();
+        expect(insertRuleSpy).not.toHaveBeenCalled();
+        expect(deleteRuleSpy).not.toHaveBeenCalled();
+        expect(ensureUniqueIdSpy).not.toHaveBeenCalled();
+        expect(core.lifecycle.styleElements).toEqual({});
+        expect(mockedStyle.dataset).toEqual({});
+    });
+
+    it('New key, valid rule, no sub selector', () => {
+        createElementSpy.and.returnValue(mockedStyle);
+
+        setEditorStyle(core, 'key0', 'rule');
+
+        expect(createElementSpy).toHaveBeenCalledWith('style');
+        expect(appendChildSpy).toHaveBeenCalledWith(mockedStyle);
+        expect(insertRuleSpy).toHaveBeenCalledTimes(1);
+        expect(insertRuleSpy).toHaveBeenCalledWith('#uniqueId {rule}');
+        expect(deleteRuleSpy).not.toHaveBeenCalled();
+        expect(ensureUniqueIdSpy).toHaveBeenCalledTimes(1);
+        expect(core.lifecycle.styleElements).toEqual({
+            key0: mockedStyle,
+        });
+        expect(mockedStyle.dataset).toEqual({ roosterjsStyleKey: 'key0' });
+    });
+
+    it('New key, valid rule, has sub selector array', () => {
+        createElementSpy.and.returnValue(mockedStyle);
+
+        setEditorStyle(core, 'key0', 'rule', ['selector1', 'selector2']);
+
+        expect(createElementSpy).toHaveBeenCalledWith('style');
+        expect(appendChildSpy).toHaveBeenCalledWith(mockedStyle);
+        expect(insertRuleSpy).toHaveBeenCalledTimes(1);
+        expect(insertRuleSpy).toHaveBeenCalledWith(
+            '#uniqueId selector1,#uniqueId selector2 {rule}'
+        );
+        expect(deleteRuleSpy).not.toHaveBeenCalled();
+        expect(ensureUniqueIdSpy).toHaveBeenCalledTimes(1);
+        expect(core.lifecycle.styleElements).toEqual({
+            key0: mockedStyle,
+        });
+        expect(mockedStyle.dataset).toEqual({ roosterjsStyleKey: 'key0' });
+    });
+
+    it('New key, valid rule, has sub selector pseudo class', () => {
+        createElementSpy.and.returnValue(mockedStyle);
+
+        setEditorStyle(core, 'key0', 'rule', 'before');
+
+        expect(createElementSpy).toHaveBeenCalledWith('style');
+        expect(appendChildSpy).toHaveBeenCalledWith(mockedStyle);
+        expect(insertRuleSpy).toHaveBeenCalledTimes(1);
+        expect(insertRuleSpy).toHaveBeenCalledWith('#uniqueId::before {rule}');
+        expect(deleteRuleSpy).not.toHaveBeenCalled();
+        expect(ensureUniqueIdSpy).toHaveBeenCalledTimes(1);
+        expect(core.lifecycle.styleElements).toEqual({
+            key0: mockedStyle,
+        });
+        expect(mockedStyle.dataset).toEqual({ roosterjsStyleKey: 'key0' });
+    });
+
+    it('Existing key, null rule', () => {
+        const existingStyle = {
+            sheet: {
+                cssRules: ['rule1', 'rule2'],
+                insertRule: insertRuleSpy,
+                deleteRule: deleteRuleSpy,
+            },
+        } as any;
+        core.lifecycle.styleElements.key0 = existingStyle;
+
+        insertRuleSpy.and.callFake((rule: string) => {
+            existingStyle.sheet.cssRules.push(rule);
+        });
+        deleteRuleSpy.and.callFake((index: number) => {
+            existingStyle.sheet.cssRules.splice(index, 1);
+        });
+
+        setEditorStyle(core, 'key0', null);
+
+        expect(createElementSpy).not.toHaveBeenCalled();
+        expect(appendChildSpy).not.toHaveBeenCalled();
+        expect(insertRuleSpy).toHaveBeenCalledTimes(0);
+        expect(deleteRuleSpy).toHaveBeenCalledTimes(2);
+        expect(deleteRuleSpy).toHaveBeenCalledWith(1);
+        expect(deleteRuleSpy).toHaveBeenCalledWith(0);
+        expect(ensureUniqueIdSpy).not.toHaveBeenCalled();
+        expect(core.lifecycle.styleElements).toEqual({
+            key0: {
+                sheet: {
+                    cssRules: [],
+                    insertRule: insertRuleSpy,
+                    deleteRule: deleteRuleSpy,
+                },
+            } as any,
+        });
+        expect(mockedStyle.dataset).toEqual({});
+    });
+
+    it('Existing key, valid rule', () => {
+        const existingStyle = {
+            sheet: {
+                cssRules: ['rule1', 'rule2'],
+                insertRule: insertRuleSpy,
+                deleteRule: deleteRuleSpy,
+            },
+        } as any;
+        core.lifecycle.styleElements.key0 = existingStyle;
+
+        insertRuleSpy.and.callFake((rule: string) => {
+            existingStyle.sheet.cssRules.push(rule);
+        });
+        deleteRuleSpy.and.callFake((index: number) => {
+            existingStyle.sheet.cssRules.splice(index, 1);
+        });
+
+        setEditorStyle(core, 'key0', 'rule3');
+
+        expect(createElementSpy).not.toHaveBeenCalled();
+        expect(appendChildSpy).not.toHaveBeenCalled();
+        expect(insertRuleSpy).toHaveBeenCalledTimes(1);
+        expect(insertRuleSpy).toHaveBeenCalledWith('#uniqueId {rule3}');
+        expect(deleteRuleSpy).toHaveBeenCalledTimes(2);
+        expect(ensureUniqueIdSpy).toHaveBeenCalledTimes(1);
+        expect(core.lifecycle.styleElements).toEqual({
+            key0: {
+                sheet: {
+                    cssRules: ['#uniqueId {rule3}'],
+                    insertRule: insertRuleSpy,
+                    deleteRule: deleteRuleSpy,
+                },
+            } as any,
+        });
+        expect(mockedStyle.dataset).toEqual({});
+    });
+
+    it('New key, valid rule, has super long sub selector array', () => {
+        createElementSpy.and.returnValue(mockedStyle);
+        const s1 = 'longSelector1';
+        const s2 = 'longSelector2';
+        const s3 = 'longSelector3';
+        const s4 = 'longSelector4';
+        const s5 = 'longSelector5';
+
+        const selectors = [s1, s2, s3, s4, s5];
+
+        setEditorStyle(core, 'key0', 'rule', selectors, 50);
+
+        expect(createElementSpy).toHaveBeenCalledWith('style');
+        expect(appendChildSpy).toHaveBeenCalledWith(mockedStyle);
+        expect(insertRuleSpy).toHaveBeenCalledTimes(3);
+        expect(insertRuleSpy).toHaveBeenCalledWith(
+            '#uniqueId longSelector1,#uniqueId longSelector2 {rule}'
+        );
+        expect(insertRuleSpy).toHaveBeenCalledWith(
+            '#uniqueId longSelector3,#uniqueId longSelector4 {rule}'
+        );
+        expect(insertRuleSpy).toHaveBeenCalledWith('#uniqueId longSelector5 {rule}');
+        expect(deleteRuleSpy).not.toHaveBeenCalled();
+        expect(ensureUniqueIdSpy).toHaveBeenCalledTimes(1);
+        expect(core.lifecycle.styleElements).toEqual({
+            key0: mockedStyle,
+        });
+        expect(mockedStyle.dataset).toEqual({ roosterjsStyleKey: 'key0' });
+    });
+});

--- a/packages/roosterjs-content-model-core/test/corePlugin/LifecyclePluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/LifecyclePluginTest.ts
@@ -20,6 +20,7 @@ describe('LifecyclePlugin', () => {
         expect(state).toEqual({
             isDarkMode: false,
             shadowEditFragment: null,
+            styleElements: {},
         });
 
         expect(div.isContentEditable).toBeTrue();
@@ -57,6 +58,7 @@ describe('LifecyclePlugin', () => {
         expect(state).toEqual({
             isDarkMode: false,
             shadowEditFragment: null,
+            styleElements: {},
         });
 
         expect(div.isContentEditable).toBeTrue();
@@ -131,6 +133,7 @@ describe('LifecyclePlugin', () => {
         expect(state).toEqual({
             isDarkMode: false,
             shadowEditFragment: null,
+            styleElements: {},
         });
 
         plugin.onPluginEvent({
@@ -161,6 +164,7 @@ describe('LifecyclePlugin', () => {
         expect(state).toEqual({
             isDarkMode: false,
             shadowEditFragment: null,
+            styleElements: {},
         });
 
         const mockedIsDarkColor = 'Dark' as any;
@@ -205,7 +209,7 @@ describe('LifecyclePlugin', () => {
 
         plugin.initialize(<IEditor>(<any>{
             triggerEvent,
-            getDarkColorHandler: () => mockedDarkColorHandler,
+            getColorManager: () => mockedDarkColorHandler,
         }));
 
         expect(setColorSpy).toHaveBeenCalledTimes(0);
@@ -213,6 +217,7 @@ describe('LifecyclePlugin', () => {
         expect(state).toEqual({
             isDarkMode: false,
             shadowEditFragment: null,
+            styleElements: {},
         });
 
         const mockedIsDarkColor = 'Dark' as any;
@@ -225,5 +230,35 @@ describe('LifecyclePlugin', () => {
         });
 
         expect(setColorSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('Dispose plugin and clean up style nodes', () => {
+        const div = document.createElement('div');
+        const plugin = createLifecyclePlugin({}, div);
+
+        plugin.initialize(<any>{
+            getColorManager: jasmine.createSpy(),
+            triggerEvent: jasmine.createSpy(),
+        });
+
+        const state = plugin.getState();
+        const removeChildSpy = jasmine.createSpy('removeChild');
+        const style = {
+            parentElement: {
+                removeChild: removeChildSpy,
+            },
+        } as any;
+
+        state.styleElements.a = style;
+
+        plugin.dispose();
+
+        expect(removeChildSpy).toHaveBeenCalledTimes(1);
+        expect(removeChildSpy).toHaveBeenCalledWith(style);
+        expect(state).toEqual({
+            styleElements: {},
+            isDarkMode: false,
+            shadowEditFragment: null,
+        });
     });
 });

--- a/packages/roosterjs-content-model-core/test/corePlugin/SelectionPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/SelectionPluginTest.ts
@@ -6,20 +6,14 @@ import {
     SelectionPluginState,
 } from 'roosterjs-content-model-types';
 
-const MockedStyleNode = 'STYLENODE' as any;
-
 describe('SelectionPlugin', () => {
     it('init and dispose', () => {
         const plugin = createSelectionPlugin({});
         const disposer = jasmine.createSpy('disposer');
-        const createElementSpy = jasmine
-            .createSpy('createElement')
-            .and.returnValue(MockedStyleNode);
         const appendChildSpy = jasmine.createSpy('appendChild');
         const attachDomEvent = jasmine.createSpy('attachDomEvent').and.returnValue(disposer);
         const removeEventListenerSpy = jasmine.createSpy('removeEventListener');
         const getDocumentSpy = jasmine.createSpy('getDocument').and.returnValue({
-            createElement: createElementSpy,
             head: {
                 appendChild: appendChildSpy,
             },
@@ -36,7 +30,6 @@ describe('SelectionPlugin', () => {
 
         expect(state).toEqual({
             selection: null,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: undefined,
         });
         expect(attachDomEvent).toHaveBeenCalled();
@@ -58,13 +51,9 @@ describe('SelectionPlugin', () => {
         const attachDomEvent = jasmine
             .createSpy('attachDomEvent')
             .and.returnValue(jasmine.createSpy('disposer'));
-        const createElementSpy = jasmine
-            .createSpy('createElement')
-            .and.returnValue(MockedStyleNode);
         const appendChildSpy = jasmine.createSpy('appendChild');
         const removeEventListenerSpy = jasmine.createSpy('removeEventListener');
         const getDocumentSpy = jasmine.createSpy('getDocument').and.returnValue({
-            createElement: createElementSpy,
             head: {
                 appendChild: appendChildSpy,
             },
@@ -79,7 +68,6 @@ describe('SelectionPlugin', () => {
 
         expect(state).toEqual({
             selection: null,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: 'red',
         });
 
@@ -94,7 +82,6 @@ describe('SelectionPlugin handle onFocus and onBlur event', () => {
     let triggerEvent: jasmine.Spy;
     let eventMap: Record<string, any>;
     let getElementAtCursorSpy: jasmine.Spy;
-    let createElementSpy: jasmine.Spy;
     let getDocumentSpy: jasmine.Spy;
     let appendChildSpy: jasmine.Spy;
     let setDOMSelectionSpy: jasmine.Spy;
@@ -105,11 +92,9 @@ describe('SelectionPlugin handle onFocus and onBlur event', () => {
     beforeEach(() => {
         triggerEvent = jasmine.createSpy('triggerEvent');
         getElementAtCursorSpy = jasmine.createSpy('getElementAtCursor');
-        createElementSpy = jasmine.createSpy('createElement').and.returnValue(MockedStyleNode);
         appendChildSpy = jasmine.createSpy('appendChild');
         removeEventListenerSpy = jasmine.createSpy('removeEventListener');
         getDocumentSpy = jasmine.createSpy('getDocument').and.returnValue({
-            createElement: createElementSpy,
             head: {
                 appendChild: appendChildSpy,
             },
@@ -147,7 +132,6 @@ describe('SelectionPlugin handle onFocus and onBlur event', () => {
         eventMap.focus.beforeDispatch();
         expect(plugin.getState()).toEqual({
             selection: mockedRange,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: undefined,
             skipReselectOnFocus: false,
         });
@@ -163,7 +147,6 @@ describe('SelectionPlugin handle onFocus and onBlur event', () => {
         eventMap.focus.beforeDispatch();
         expect(plugin.getState()).toEqual({
             selection: mockedRange,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: undefined,
             skipReselectOnFocus: true,
         });
@@ -176,16 +159,13 @@ describe('SelectionPlugin handle image selection', () => {
     let getDOMSelectionSpy: jasmine.Spy;
     let setDOMSelectionSpy: jasmine.Spy;
     let getDocumentSpy: jasmine.Spy;
-    let createElementSpy: jasmine.Spy;
     let createRangeSpy: jasmine.Spy;
 
     beforeEach(() => {
         getDOMSelectionSpy = jasmine.createSpy('getDOMSelection');
         setDOMSelectionSpy = jasmine.createSpy('setDOMSelection');
-        createElementSpy = jasmine.createSpy('createElement').and.returnValue(MockedStyleNode);
         createRangeSpy = jasmine.createSpy('createRange');
         getDocumentSpy = jasmine.createSpy('getDocument').and.returnValue({
-            createElement: createElementSpy,
             createRange: createRangeSpy,
             head: {
                 appendChild: () => {},
@@ -575,7 +555,6 @@ describe('SelectionPlugin handle image selection', () => {
 
 describe('SelectionPlugin on Safari', () => {
     let disposer: jasmine.Spy;
-    let createElementSpy: jasmine.Spy;
     let appendChildSpy: jasmine.Spy;
     let attachDomEvent: jasmine.Spy;
     let removeEventListenerSpy: jasmine.Spy;
@@ -588,13 +567,11 @@ describe('SelectionPlugin on Safari', () => {
 
     beforeEach(() => {
         disposer = jasmine.createSpy('disposer');
-        createElementSpy = jasmine.createSpy('createElement').and.returnValue(MockedStyleNode);
         appendChildSpy = jasmine.createSpy('appendChild');
         attachDomEvent = jasmine.createSpy('attachDomEvent').and.returnValue(disposer);
         removeEventListenerSpy = jasmine.createSpy('removeEventListener');
         addEventListenerSpy = jasmine.createSpy('addEventListener');
         getDocumentSpy = jasmine.createSpy('getDocument').and.returnValue({
-            createElement: createElementSpy,
             head: {
                 appendChild: appendChildSpy,
             },
@@ -625,7 +602,6 @@ describe('SelectionPlugin on Safari', () => {
 
         expect(state).toEqual({
             selection: null,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: undefined,
         });
         expect(attachDomEvent).toHaveBeenCalled();
@@ -660,7 +636,6 @@ describe('SelectionPlugin on Safari', () => {
 
         expect(state).toEqual({
             selection: mockedOldSelection,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: undefined,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
@@ -688,7 +663,6 @@ describe('SelectionPlugin on Safari', () => {
 
         expect(state).toEqual({
             selection: mockedNewSelection,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: undefined,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
@@ -716,7 +690,6 @@ describe('SelectionPlugin on Safari', () => {
 
         expect(state).toEqual({
             selection: mockedOldSelection,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: undefined,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
@@ -744,7 +717,6 @@ describe('SelectionPlugin on Safari', () => {
 
         expect(state).toEqual({
             selection: mockedOldSelection,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: undefined,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
@@ -772,7 +744,6 @@ describe('SelectionPlugin on Safari', () => {
 
         expect(state).toEqual({
             selection: mockedOldSelection,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: undefined,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(0);
@@ -800,7 +771,6 @@ describe('SelectionPlugin on Safari', () => {
 
         expect(state).toEqual({
             selection: mockedOldSelection,
-            selectionStyleNode: MockedStyleNode,
             imageSelectionBorderColor: undefined,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(0);

--- a/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
@@ -917,4 +917,38 @@ describe('Editor', () => {
         expect(resetSpy).toHaveBeenCalledWith();
         expect(() => editor.getVisibleViewport()).toThrow();
     });
+
+    it('setEditorStyle', () => {
+        const div = document.createElement('div');
+        const mockedScrollContainer: Rect = { top: 0, bottom: 100, left: 0, right: 100 };
+        const resetSpy = jasmine.createSpy('reset');
+        const setEditorStyleSpy = jasmine.createSpy('setEditorStyle');
+        const mockedCore = {
+            plugins: [],
+            darkColorHandler: {
+                updateKnownColor: updateKnownColorSpy,
+                reset: resetSpy,
+            },
+            api: {
+                setContentModel: setContentModelSpy,
+                setEditorStyle: setEditorStyleSpy,
+            },
+            domEvent: { scrollContainer: mockedScrollContainer },
+        } as any;
+
+        createEditorCoreSpy.and.returnValue(mockedCore);
+
+        const editor = new Editor(div);
+
+        editor.setEditorStyle('key', 'rule', ['rule1', 'rule2']);
+
+        expect(setEditorStyleSpy).toHaveBeenCalledWith(mockedCore, 'key', 'rule', [
+            'rule1',
+            'rule2',
+        ]);
+
+        editor.dispose();
+        expect(resetSpy).toHaveBeenCalledWith();
+        expect(() => editor.getVisibleViewport()).toThrow();
+    });
 });

--- a/packages/roosterjs-content-model-plugins/lib/index.ts
+++ b/packages/roosterjs-content-model-plugins/lib/index.ts
@@ -22,3 +22,5 @@ export {
 export { ShortcutPlugin } from './shortcut/ShortcutPlugin';
 export { ShortcutKeyDefinition, ShortcutCommand } from './shortcut/ShortcutCommand';
 export { ContextMenuPluginBase, ContextMenuOptions } from './contextMenuBase/ContextMenuPluginBase';
+export { WatermarkPlugin } from './watermark/WatermarkPlugin';
+export { WatermarkFormat } from './watermark/WatermarkFormat';

--- a/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkFormat.ts
+++ b/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkFormat.ts
@@ -1,0 +1,10 @@
+import type {
+    FontFamilyFormat,
+    FontSizeFormat,
+    TextColorFormat,
+} from 'roosterjs-content-model-types';
+
+/**
+ * Format type of watermark text
+ */
+export type WatermarkFormat = FontFamilyFormat & FontSizeFormat & TextColorFormat;

--- a/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkPlugin.ts
@@ -1,0 +1,101 @@
+import { getObjectKeys } from 'roosterjs-content-model-dom';
+import { isModelEmptyFast } from './isModelEmptyFast';
+import type { WatermarkFormat } from './WatermarkFormat';
+import type { EditorPlugin, IEditor, PluginEvent } from 'roosterjs-content-model-types';
+
+const WATERMARK_CONTENT_KEY = '_WatermarkContent';
+const styleMap: Record<keyof WatermarkFormat, string> = {
+    fontFamily: 'font-family',
+    fontSize: 'font-size',
+    textColor: 'color',
+};
+
+/**
+ * A watermark plugin to manage watermark string for roosterjs
+ */
+export class WatermarkPlugin implements EditorPlugin {
+    private editor: IEditor | null = null;
+    private format: WatermarkFormat;
+    private isShowing = false;
+
+    /**
+     * Create an instance of Watermark plugin
+     * @param watermark The watermark string
+     */
+    constructor(private watermark: string | (() => string), format?: WatermarkFormat) {
+        this.format = format || {
+            fontSize: '14px',
+            textColor: '#AAAAAA',
+        };
+    }
+
+    /**
+     * Get a friendly name of  this plugin
+     */
+    getName() {
+        return 'Watermark';
+    }
+
+    /**
+     * Initialize this plugin. This should only be called from Editor
+     * @param editor Editor instance
+     */
+    initialize(editor: IEditor) {
+        this.editor = editor;
+    }
+
+    /**
+     * Dispose this plugin
+     */
+    dispose() {
+        this.editor = null;
+    }
+
+    /**
+     * Handle events triggered from editor
+     * @param event PluginEvent object
+     */
+    onPluginEvent(event: PluginEvent) {
+        const editor = this.editor;
+
+        if (
+            editor &&
+            (event.eventType == 'editorReady' ||
+                event.eventType == 'contentChanged' ||
+                event.eventType == 'input' ||
+                event.eventType == 'beforeDispose')
+        ) {
+            editor.formatContentModel(model => {
+                const isEmpty = isModelEmptyFast(model);
+
+                if (this.isShowing && !isEmpty) {
+                    this.hide(editor);
+                } else if (!this.isShowing && isEmpty) {
+                    this.show(editor);
+                }
+                return false;
+            });
+        }
+    }
+
+    private show(editor: IEditor) {
+        let rule = `position: absolute; pointer-events: none; content: "${
+            typeof this.watermark == 'function' ? this.watermark() : this.watermark
+        }";`;
+
+        getObjectKeys(styleMap).forEach(x => {
+            if (this.format[x]) {
+                rule += `${styleMap[x]}: ${this.format[x]}!important;`;
+            }
+        });
+
+        editor.setEditorStyle(WATERMARK_CONTENT_KEY, rule, 'before');
+
+        this.isShowing = true;
+    }
+
+    private hide(editor: IEditor) {
+        editor.setEditorStyle(WATERMARK_CONTENT_KEY, null);
+        this.isShowing = false;
+    }
+}

--- a/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkPlugin.ts
@@ -22,7 +22,7 @@ export class WatermarkPlugin implements EditorPlugin {
      * Create an instance of Watermark plugin
      * @param watermark The watermark string
      */
-    constructor(private watermark: string | (() => string), format?: WatermarkFormat) {
+    constructor(private watermark: string, format?: WatermarkFormat) {
         this.format = format || {
             fontSize: '14px',
             textColor: '#AAAAAA',
@@ -78,10 +78,8 @@ export class WatermarkPlugin implements EditorPlugin {
         }
     }
 
-    private show(editor: IEditor) {
-        let rule = `position: absolute; pointer-events: none; content: "${
-            typeof this.watermark == 'function' ? this.watermark() : this.watermark
-        }";`;
+    protected show(editor: IEditor) {
+        let rule = `position: absolute; pointer-events: none; content: "${this.watermark}";`;
 
         getObjectKeys(styleMap).forEach(x => {
             if (this.format[x]) {
@@ -94,7 +92,7 @@ export class WatermarkPlugin implements EditorPlugin {
         this.isShowing = true;
     }
 
-    private hide(editor: IEditor) {
+    protected hide(editor: IEditor) {
         editor.setEditorStyle(WATERMARK_CONTENT_KEY, null);
         this.isShowing = false;
     }

--- a/packages/roosterjs-content-model-plugins/lib/watermark/isModelEmptyFast.ts
+++ b/packages/roosterjs-content-model-plugins/lib/watermark/isModelEmptyFast.ts
@@ -1,0 +1,31 @@
+import type { ContentModelDocument } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ * A fast way to check if content model is empty
+ */
+export function isModelEmptyFast(model: ContentModelDocument): boolean {
+    const firstBlock = model.blocks[0];
+
+    if (model.blocks.length > 1) {
+        return false; // Multiple blocks, treat as not empty
+    } else if (!firstBlock) {
+        return true; // No block, it is empty
+    } else if (firstBlock.blockType != 'Paragraph') {
+        return false; // First block is not paragraph, treat as not empty
+    } else if (firstBlock.segments.length == 0) {
+        return true; // No segment, it is empty
+    } else if (
+        firstBlock.segments.some(
+            x =>
+                x.segmentType == 'Entity' ||
+                x.segmentType == 'Image' ||
+                x.segmentType == 'General' ||
+                (x.segmentType == 'Text' && x.text)
+        )
+    ) {
+        return false; // Has meaningful segments, it is not empty
+    } else {
+        return firstBlock.segments.filter(x => x.segmentType == 'Br').length <= 1; // If there are more than one BR, it is not empty, otherwise it is empty
+    }
+}

--- a/packages/roosterjs-content-model-plugins/test/tableEdit/tableEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/tableEdit/tableEditPluginTest.ts
@@ -1,6 +1,6 @@
 import * as TestHelper from '../TestHelper';
 import { createElement } from '../../lib/pluginUtils/CreateElement/createElement';
-import { DOMEventHandlerFunction, IEditor } from 'roosterjs-editor-types';
+import { DOMEventHandlerFunction, IEditor } from 'roosterjs-content-model-types';
 import { getModelTable } from './tableData';
 import { TableEditPlugin } from '../../lib/tableEdit/TableEditPlugin';
 import {

--- a/packages/roosterjs-content-model-plugins/test/tableEdit/tableResizerTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/tableEdit/tableResizerTest.ts
@@ -1,4 +1,3 @@
-import * as TestHelper from '../TestHelper';
 import { getModelTable } from './tableData';
 import { TableEditPlugin } from '../../lib/tableEdit/TableEditPlugin';
 import {

--- a/packages/roosterjs-content-model-plugins/test/watermark/WatermarkPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/watermark/WatermarkPluginTest.ts
@@ -84,39 +84,6 @@ describe('WatermarkPlugin', () => {
         );
     });
 
-    it('No format, empty editor, with callback', () => {
-        isModelEmptyFastSpy.and.returnValue(true);
-
-        const watermarkCallback = jasmine.createSpy('watermark').and.returnValue('test');
-        const plugin = new WatermarkPlugin(watermarkCallback);
-
-        plugin.initialize(editor);
-
-        plugin.onPluginEvent({ eventType: 'editorReady' });
-
-        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
-        expect(setEditorStyleSpy).toHaveBeenCalledWith(
-            '_WatermarkContent',
-            'position: absolute; pointer-events: none; content: "test";font-size: 14px!important;color: #AAAAAA!important;',
-            'before'
-        );
-        expect(watermarkCallback).toHaveBeenCalledTimes(1);
-
-        plugin.onPluginEvent({ eventType: 'input' } as any);
-        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
-        expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
-        expect(watermarkCallback).toHaveBeenCalledTimes(1);
-
-        isModelEmptyFastSpy.and.returnValue(false);
-
-        plugin.onPluginEvent({ eventType: 'input' } as any);
-        expect(formatContentModelSpy).toHaveBeenCalledTimes(3);
-        expect(setEditorStyleSpy).toHaveBeenCalledTimes(2);
-        expect(setEditorStyleSpy).toHaveBeenCalledWith('_WatermarkContent', null);
-        expect(watermarkCallback).toHaveBeenCalledTimes(1);
-    });
-
     it('Has format, empty editor, with text', () => {
         isModelEmptyFastSpy.and.returnValue(true);
 

--- a/packages/roosterjs-content-model-plugins/test/watermark/WatermarkPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/watermark/WatermarkPluginTest.ts
@@ -1,0 +1,152 @@
+import * as isModelEmptyFast from '../../lib/watermark/isModelEmptyFast';
+import { IEditor } from 'roosterjs-content-model-types';
+import { WatermarkPlugin } from '../../lib/watermark/WatermarkPlugin';
+
+describe('WatermarkPlugin', () => {
+    let editor: IEditor;
+    let formatContentModelSpy: jasmine.Spy;
+    let isModelEmptyFastSpy: jasmine.Spy;
+    let setEditorStyleSpy: jasmine.Spy;
+
+    const mockedModel = 'Model' as any;
+
+    beforeEach(() => {
+        isModelEmptyFastSpy = spyOn(isModelEmptyFast, 'isModelEmptyFast');
+        setEditorStyleSpy = jasmine.createSpy('setEditorStyle');
+
+        formatContentModelSpy = jasmine
+            .createSpy('formatContentModel')
+            .and.callFake((callback: Function) => {
+                const result = callback(mockedModel);
+
+                expect(result).toBeFalse();
+            });
+        editor = {
+            formatContentModel: formatContentModelSpy,
+            setEditorStyle: setEditorStyleSpy,
+        } as any;
+    });
+
+    it('No format, empty editor, with text', () => {
+        isModelEmptyFastSpy.and.returnValue(true);
+
+        const plugin = new WatermarkPlugin('test');
+
+        plugin.initialize(editor);
+
+        plugin.onPluginEvent({ eventType: 'editorReady' });
+
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
+        expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
+        expect(setEditorStyleSpy).toHaveBeenCalledWith(
+            '_WatermarkContent',
+            'position: absolute; pointer-events: none; content: "test";font-size: 14px!important;color: #AAAAAA!important;',
+            'before'
+        );
+
+        plugin.onPluginEvent({ eventType: 'input' } as any);
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
+        expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
+
+        isModelEmptyFastSpy.and.returnValue(false);
+
+        plugin.onPluginEvent({ eventType: 'input' } as any);
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(3);
+        expect(setEditorStyleSpy).toHaveBeenCalledTimes(2);
+        expect(setEditorStyleSpy).toHaveBeenCalledWith('_WatermarkContent', null);
+    });
+
+    it('No format, not empty editor, with text', () => {
+        isModelEmptyFastSpy.and.returnValue(false);
+
+        const plugin = new WatermarkPlugin('test');
+
+        plugin.initialize(editor);
+
+        plugin.onPluginEvent({ eventType: 'editorReady' });
+
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
+        expect(setEditorStyleSpy).not.toHaveBeenCalled();
+
+        plugin.onPluginEvent({ eventType: 'input' } as any);
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
+        expect(setEditorStyleSpy).not.toHaveBeenCalled();
+
+        isModelEmptyFastSpy.and.returnValue(true);
+
+        plugin.onPluginEvent({ eventType: 'input' } as any);
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(3);
+        expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
+        expect(setEditorStyleSpy).toHaveBeenCalledWith(
+            '_WatermarkContent',
+            'position: absolute; pointer-events: none; content: "test";font-size: 14px!important;color: #AAAAAA!important;',
+            'before'
+        );
+    });
+
+    it('No format, empty editor, with callback', () => {
+        isModelEmptyFastSpy.and.returnValue(true);
+
+        const watermarkCallback = jasmine.createSpy('watermark').and.returnValue('test');
+        const plugin = new WatermarkPlugin(watermarkCallback);
+
+        plugin.initialize(editor);
+
+        plugin.onPluginEvent({ eventType: 'editorReady' });
+
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
+        expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
+        expect(setEditorStyleSpy).toHaveBeenCalledWith(
+            '_WatermarkContent',
+            'position: absolute; pointer-events: none; content: "test";font-size: 14px!important;color: #AAAAAA!important;',
+            'before'
+        );
+        expect(watermarkCallback).toHaveBeenCalledTimes(1);
+
+        plugin.onPluginEvent({ eventType: 'input' } as any);
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
+        expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
+        expect(watermarkCallback).toHaveBeenCalledTimes(1);
+
+        isModelEmptyFastSpy.and.returnValue(false);
+
+        plugin.onPluginEvent({ eventType: 'input' } as any);
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(3);
+        expect(setEditorStyleSpy).toHaveBeenCalledTimes(2);
+        expect(setEditorStyleSpy).toHaveBeenCalledWith('_WatermarkContent', null);
+        expect(watermarkCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('Has format, empty editor, with text', () => {
+        isModelEmptyFastSpy.and.returnValue(true);
+
+        const plugin = new WatermarkPlugin('test', {
+            fontFamily: 'Arial',
+            fontSize: '20pt',
+            textColor: 'red',
+        });
+
+        plugin.initialize(editor);
+
+        plugin.onPluginEvent({ eventType: 'editorReady' });
+
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
+        expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
+        expect(setEditorStyleSpy).toHaveBeenCalledWith(
+            '_WatermarkContent',
+            'position: absolute; pointer-events: none; content: "test";font-family: Arial!important;font-size: 20pt!important;color: red!important;',
+            'before'
+        );
+
+        plugin.onPluginEvent({ eventType: 'input' } as any);
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
+        expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
+
+        isModelEmptyFastSpy.and.returnValue(false);
+
+        plugin.onPluginEvent({ eventType: 'input' } as any);
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(3);
+        expect(setEditorStyleSpy).toHaveBeenCalledTimes(2);
+        expect(setEditorStyleSpy).toHaveBeenCalledWith('_WatermarkContent', null);
+    });
+});

--- a/packages/roosterjs-content-model-plugins/test/watermark/isModelEmptyFastTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/watermark/isModelEmptyFastTest.ts
@@ -1,0 +1,189 @@
+import { isModelEmptyFast } from '../../lib/watermark/isModelEmptyFast';
+import {
+    createBr,
+    createContentModelDocument,
+    createDivider,
+    createEntity,
+    createFormatContainer,
+    createImage,
+    createParagraph,
+    createSelectionMarker,
+    createText,
+} from 'roosterjs-content-model-dom';
+
+describe('isModelEmptyFast', () => {
+    it('Empty model', () => {
+        const model = createContentModelDocument();
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeTrue();
+    });
+
+    it('Single Divider block', () => {
+        const model = createContentModelDocument();
+
+        model.blocks.push(createDivider('div'));
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeFalse();
+    });
+
+    it('Single FormatContainer block', () => {
+        const model = createContentModelDocument();
+
+        model.blocks.push(createFormatContainer('div'));
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeFalse();
+    });
+
+    it('Single Entity block', () => {
+        const model = createContentModelDocument();
+
+        model.blocks.push(createEntity({} as any));
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeFalse();
+    });
+
+    it('Single Paragraph block - no segment', () => {
+        const model = createContentModelDocument();
+
+        model.blocks.push(createParagraph());
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeTrue();
+    });
+
+    it('Single Paragraph block - one selection marker segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createSelectionMarker());
+
+        model.blocks.push(para);
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeTrue();
+    });
+
+    it('Single Paragraph block - one BR segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createBr());
+
+        model.blocks.push(para);
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeTrue();
+    });
+
+    it('Single Paragraph block - one selection marker and one BR segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createSelectionMarker(), createBr());
+
+        model.blocks.push(para);
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeTrue();
+    });
+
+    it('Single Paragraph block - two BR segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createBr(), createBr());
+
+        model.blocks.push(para);
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeFalse();
+    });
+
+    it('Single Paragraph block - one empty text segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createText(''));
+
+        model.blocks.push(para);
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeTrue();
+    });
+
+    it('Single Paragraph block - two empty text segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createText(''), createText(''));
+
+        model.blocks.push(para);
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeTrue();
+    });
+
+    it('Single Paragraph block - one text segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createText('test'));
+
+        model.blocks.push(para);
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeFalse();
+    });
+
+    it('Single Paragraph block - one image segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createImage(''));
+
+        model.blocks.push(para);
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeFalse();
+    });
+
+    it('Single Paragraph block - one entity segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+
+        para.segments.push(createEntity({} as any));
+
+        model.blocks.push(para);
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeFalse();
+    });
+
+    it('Multiple blocks', () => {
+        const model = createContentModelDocument();
+
+        model.blocks.push({} as any, {} as any);
+
+        const result = isModelEmptyFast(model);
+
+        expect(result).toBeFalse();
+    });
+});

--- a/packages/roosterjs-content-model-types/lib/editor/EditorCore.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/EditorCore.ts
@@ -146,6 +146,24 @@ export type AttachDomEvent = (
 export type RestoreUndoSnapshot = (core: EditorCore, snapshot: Snapshot) => void;
 
 /**
+ * Add CSS rules for editor
+ * @param core The EditorCore object
+ * @param key A string to identify the CSS rule type. When set CSS rules with the same key again, existing rules with the same key will be replaced.
+ * @param cssRule The CSS rule string, must be a valid CSS rule string, or browser may throw exception. Pass null to remove existing rules
+ * @param subSelectors @optional If the rule is used for child element under editor, use this parameter to specify the child elements. Each item will be
+ * combined with root selector together to build a separate rule. It also accepts pseudo classes "before" and "after" to create pseudo class rule "::before"
+ * and "::after" to the editor root element itself
+ * @param maxRuleLength @optional Set maximum length for a single rule. This is used by test code only
+ */
+export type SetEditorStyle = (
+    core: EditorCore,
+    key: string,
+    cssRule: string | null,
+    subSelectors?: 'before' | 'after' | string[],
+    maxRuleLength?: number
+) => void;
+
+/**
  * The interface for the map of core API for Editor.
  * Editor can call call API from this map under EditorCore object
  */
@@ -249,6 +267,16 @@ export interface CoreApiMap {
      * @param broadcast Set to true to skip the shouldHandleEventExclusively check
      */
     triggerEvent: TriggerEvent;
+
+    /**
+     * Add CSS rules for editor
+     * @param core The EditorCore object
+     * @param key A string to identify the CSS rule type. When set CSS rules with the same key again, existing rules with the same key will be replaced.
+     * @param cssRule The CSS rule string, must be a valid CSS rule string, or browser may throw exception
+     * @param subSelectors @optional If the rule is used for child element under editor, use this parameter to specify the child elements. Each item will be
+     * combined with root selector together to build a separate rule.
+     */
+    setEditorStyle: SetEditorStyle;
 }
 
 /**

--- a/packages/roosterjs-content-model-types/lib/editor/IEditor.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/IEditor.ts
@@ -197,4 +197,17 @@ export interface IEditor {
      * Retrieves the rect of the visible viewport of the editor.
      */
     getVisibleViewport(): Rect | null;
+
+    /**
+     * Add CSS rules for editor
+     * @param key A string to identify the CSS rule type. When set CSS rules with the same key again, existing rules with the same key will be replaced.
+     * @param cssRule The CSS rule string, must be a valid CSS rule string, or browser may throw exception. Pass null to clear existing rules
+     * @param subSelectors @optional If the rule is used for child element under editor, use this parameter to specify the child elements. Each item will be
+     * combined with root selector together to build a separate rule.
+     */
+    setEditorStyle(
+        key: string,
+        cssRule: string | null,
+        subSelectors?: 'before' | 'after' | string[]
+    ): void;
 }

--- a/packages/roosterjs-content-model-types/lib/index.ts
+++ b/packages/roosterjs-content-model-types/lib/index.ts
@@ -219,6 +219,7 @@ export {
     AttachDomEvent,
     RestoreUndoSnapshot,
     GetVisibleViewport,
+    SetEditorStyle,
 } from './editor/EditorCore';
 export { EditorCorePlugins } from './editor/EditorCorePlugins';
 export { EditorPlugin } from './editor/EditorPlugin';

--- a/packages/roosterjs-content-model-types/lib/pluginState/LifecyclePluginState.ts
+++ b/packages/roosterjs-content-model-types/lib/pluginState/LifecyclePluginState.ts
@@ -11,4 +11,9 @@ export interface LifecyclePluginState {
      * Cached document fragment for original content
      */
     shadowEditFragment: DocumentFragment | null;
+
+    /**
+     * Style elements used for adding CSS rules for editor
+     */
+    readonly styleElements: Record<string, HTMLStyleElement>;
 }

--- a/packages/roosterjs-content-model-types/lib/pluginState/SelectionPluginState.ts
+++ b/packages/roosterjs-content-model-types/lib/pluginState/SelectionPluginState.ts
@@ -10,11 +10,6 @@ export interface SelectionPluginState {
     selection: DOMSelection | null;
 
     /**
-     * A style node in current document to help implement image and table selection
-     */
-    selectionStyleNode: HTMLStyleElement | null;
-
-    /**
      * When set to true, onFocus event will not trigger reselect cached range
      */
     skipReselectOnFocus?: boolean;


### PR DESCRIPTION
Port WatermarkPlugin to use Content Model editor, also change its behavior to show watermark as long as editor is empty, even editor has focus.

![image](https://github.com/microsoft/roosterjs/assets/23065085/f0aa60a5-c8ff-47b7-b121-c70f4212105d)


In order to show watermark, add a new core API `setEditorStyle`, it manages global STYLE node for editor DIV and its child nodes. We can now use this API to add/remove global CSS rule for editor. For example:

```ts
editor.setEditorStyle('StyleKey', 'color: red');
```
This will add a global style "color:red" for editor DIV

```ts
editor.setEditorStyle('StyleKey', 'color: red', ['#childNode1', '#childNode2']);
```
This will add a global style "color:red" for child node with id "childNode1" and "childNode2" under editor

```ts
editor.setEditorStyle('StyleKey', 'color: red', 'before');
```
This will add a global style "color:red" for editor DIV with pseudo class "::before".

Also change existing code `setDOMSelection` and `FormatPainterPlugin` to reuse this new API.

