### PR TITLE
Patch: Fix paste issue for repaste

### DIFF
--- a/packages/roosterjs-content-model-core/lib/publicApi/paste/paste.ts
+++ b/packages/roosterjs-content-model-core/lib/publicApi/paste/paste.ts
@@ -1,7 +1,7 @@
+import { cloneModelForPaste, mergePasteContent } from '../../utils/paste/mergePasteContent';
 import { convertInlineCss } from '../../utils/convertInlineCss';
 import { createPasteFragment } from '../../utils/paste/createPasteFragment';
 import { generatePasteOptionFromPlugins } from '../../utils/paste/generatePasteOptionFromPlugins';
-import { mergePasteContent } from '../../utils/paste/mergePasteContent';
 import { retrieveHtmlInfo } from '../../utils/paste/retrieveHtmlInfo';
 import type {
     PasteType,
@@ -26,7 +26,9 @@ export function paste(
     const trustedHTMLHandler = editor.getTrustedHTMLHandler();
 
     if (!clipboardData.modelBeforePaste) {
-        clipboardData.modelBeforePaste = editor.getContentModelCopy('connected');
+        clipboardData.modelBeforePaste = cloneModelForPaste(
+            editor.getContentModelCopy('connected')
+        );
     }
 
     // 1. Prepare variables

--- a/packages/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
@@ -28,9 +28,17 @@ const EmptySegmentFormat: Required<ContentModelSegmentFormat> = {
     textColor: '',
     underline: false,
 };
+
 const CloneOption: CloneModelOptions = {
     includeCachedElement: (node, type) => (type == 'cache' ? undefined : node),
 };
+
+/**
+ * @internal
+ */
+export function cloneModelForPaste(model: ContentModelDocument) {
+    return cloneModel(model, CloneOption);
+}
 
 /**
  * @internal
@@ -45,7 +53,7 @@ export function mergePasteContent(
     editor.formatContentModel(
         (model, context) => {
             if (clipboardData.modelBeforePaste) {
-                const clonedModel = cloneModel(clipboardData.modelBeforePaste, CloneOption);
+                const clonedModel = cloneModelForPaste(clipboardData.modelBeforePaste);
                 model.blocks = clonedModel.blocks;
             }
 


### PR DESCRIPTION
To repro:
Copy some text, paste. Then from the "Paste Options" bar, choose an option to repaste.

Expect: pasted content is removed and replaced with new content with new option
Actual: Both old pasted content and new pasted content are existing together

Reason: When paste, we first get a content model and save into ClipboardData. When repaste, we first use this content model, clone it to overwrite existing content then paste again into the cloned content model. However, in https://github.com/microsoft/roosterjs/pull/2481, I removed the code to clone content model when first paste, so the saved model is the same one in editor so any change to editor will also impact this saved one, which causes when repaste we are pasting on top of current model, not the original one.

Fix: Clone the model when initial paste.