### PR TITLE
Patch Fixes for Content Model Core and Plugins 

### DIFF
--- a/packages/roosterjs-content-model-core/lib/publicApi/paste/paste.ts
+++ b/packages/roosterjs-content-model-core/lib/publicApi/paste/paste.ts
@@ -1,7 +1,7 @@
+import { cloneModelForPaste, mergePasteContent } from '../../utils/paste/mergePasteContent';
 import { convertInlineCss } from '../../utils/convertInlineCss';
 import { createPasteFragment } from '../../utils/paste/createPasteFragment';
 import { generatePasteOptionFromPlugins } from '../../utils/paste/generatePasteOptionFromPlugins';
-import { mergePasteContent } from '../../utils/paste/mergePasteContent';
 import { retrieveHtmlInfo } from '../../utils/paste/retrieveHtmlInfo';
 import type {
     PasteType,
@@ -26,7 +26,9 @@ export function paste(
     const trustedHTMLHandler = editor.getTrustedHTMLHandler();
 
     if (!clipboardData.modelBeforePaste) {
-        clipboardData.modelBeforePaste = editor.getContentModelCopy('connected');
+        clipboardData.modelBeforePaste = cloneModelForPaste(
+            editor.getContentModelCopy('connected')
+        );
     }
 
     // 1. Prepare variables

--- a/packages/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/utils/paste/mergePasteContent.ts
@@ -28,9 +28,17 @@ const EmptySegmentFormat: Required<ContentModelSegmentFormat> = {
     textColor: '',
     underline: false,
 };
+
 const CloneOption: CloneModelOptions = {
     includeCachedElement: (node, type) => (type == 'cache' ? undefined : node),
 };
+
+/**
+ * @internal
+ */
+export function cloneModelForPaste(model: ContentModelDocument) {
+    return cloneModel(model, CloneOption);
+}
 
 /**
  * @internal
@@ -45,7 +53,7 @@ export function mergePasteContent(
     editor.formatContentModel(
         (model, context) => {
             if (clipboardData.modelBeforePaste) {
-                const clonedModel = cloneModel(clipboardData.modelBeforePaste, CloneOption);
+                const clonedModel = cloneModelForPaste(clipboardData.modelBeforePaste);
                 model.blocks = clonedModel.blocks;
             }
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnParagraph.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnParagraph.ts
@@ -30,6 +30,15 @@ export function handleTabOnParagraph(
         selectedSegments.length === 1 && selectedSegments[0].segmentType === 'SelectionMarker';
     const isAllSelected = paragraph.segments.every(segment => segment.isSelected);
     if ((paragraph.segments[0].segmentType === 'SelectionMarker' && isCollapsed) || isAllSelected) {
+        const { marginLeft, marginRight, direction } = paragraph.format;
+        const isRtl = direction === 'rtl';
+        if (
+            rawEvent.shiftKey &&
+            ((!isRtl && (!marginLeft || marginLeft == '0px')) ||
+                (isRtl && (!marginRight || marginRight == '0px')))
+        ) {
+            return false;
+        }
         setModelIndentation(model, rawEvent.shiftKey ? 'outdent' : 'indent');
     } else {
         if (!isCollapsed) {
@@ -84,7 +93,6 @@ export function handleTabOnParagraph(
             }
         }
     }
-
     rawEvent.preventDefault();
     return true;
 }

--- a/packages/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnParagraphTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnParagraphTest.ts
@@ -131,7 +131,7 @@ describe('handleTabOnParagraph', () => {
         runTest(model, paragraph, rawEvent, selection, true);
     });
 
-    it('Outdent - collapsed range should return true when cursor is at the start', () => {
+    it('Outdent - collapsed range should return false when cursor is at the start', () => {
         const model: ContentModelDocument = {
             blockGroupType: 'Document',
             blocks: [
@@ -150,6 +150,45 @@ describe('handleTabOnParagraph', () => {
                         },
                     ],
                     format: {},
+                },
+            ],
+            format: {},
+        };
+        const paragraph = model.blocks[0] as ContentModelParagraph;
+        const rawEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: true,
+        });
+        const selection = {
+            type: 'range',
+            range: {
+                collapsed: true,
+            },
+        } as RangeSelection;
+        runTest(model, paragraph, rawEvent, selection, false);
+    });
+
+    it('Outdent - collapsed range should return true when cursor is at the start and exist indentation', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    format: {
+                        marginLeft: '4px',
+                    },
                 },
             ],
             format: {},

--- a/versions.json
+++ b/versions.json
@@ -3,5 +3,8 @@
     "react": "8.55.0",
     "main": "0.28.0",
     "legacyAdapter": "0.28.0",
-    "overrides": {}
+    "overrides": {
+        "roosterjs-content-model-core": "0.28.1",
+        "roosterjs-content-model-plugins": "0.28.1"
+    }
 }


### PR DESCRIPTION
Add this patch fixes:
[Do not prevent Shift+ Tab behavior #2514](https://github.com/microsoft/roosterjs/pull/2514)
[Patch: Fix paste issue for repaste #2516](https://github.com/microsoft/roosterjs/pull/2516)
Versions: {
    "legacy": "8.61.0",
    "react": "8.55.0",
    "main": "0.28.0",
    "legacyAdapter": "0.28.0",
    "overrides": {
        "roosterjs-content-model-core": "0.28.1",
        "roosterjs-content-model-plugins": "0.28.1"
    }
}