### PR TITLE
Fix bug in "undoByBackspace"

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -76,7 +76,7 @@ export const formatContentModel: FormatContentModel = (core, formatter, options)
             }
 
             if (shouldAddSnapshot) {
-                core.api.addUndoSnapshot(core, !!canUndoByBackspace, entityStates);
+                core.api.addUndoSnapshot(core, false /*canUndoByBackspace*/, entityStates);
             } else {
                 core.undo.snapshotsManager.hasNewContent = true;
             }

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -775,6 +775,7 @@ describe('formatContentModel', () => {
             expect(callback).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).toHaveBeenCalledTimes(2);
             expect(addUndoSnapshot).toHaveBeenCalledWith(core, true, undefined);
+            expect(addUndoSnapshot).toHaveBeenCalledWith(core, false, undefined);
             expect(setContentModel).toHaveBeenCalledTimes(1);
             expect(setContentModel).toHaveBeenCalledWith(core, mockedModel, undefined, undefined);
             expect(core.undo).toEqual({


### PR DESCRIPTION
"UndoByBackspace" is a feature to allow user use Backspace key to undo the last change. We have this behavior in several old features, such as auto list. 

However, in new editor this is now broken. When call `formatContentModel`, we will add undo snapshot before and after write back. We need to set undoByBacksapce to true for the undo snapshot before write back to mark it as the snapshot to revert to, then the snapshot after write back should not have "undobyBackspace".