### PR TITLE
Remove a redundant parameter from domToContentModel

### DIFF
--- a/packages/roosterjs-content-model-api/test/publicApi/segment/changeFontSizeTest.ts
+++ b/packages/roosterjs-content-model-api/test/publicApi/segment/changeFontSizeTest.ts
@@ -339,11 +339,15 @@ describe('changeFontSize', () => {
         div.appendChild(sub);
         div.style.fontSize = '20pt';
 
-        const model = domToContentModel(div, createDomToModelContext(undefined), {
+        const context = createDomToModelContext(undefined);
+
+        context.selection = {
             type: 'range',
             range: createRange(sub),
             isReverted: false,
-        });
+        };
+
+        const model = domToContentModel(div, context);
 
         let formatResult: boolean | undefined;
 

--- a/packages/roosterjs-content-model-core/lib/coreApi/createContentModel/createContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/createContentModel/createContentModel.ts
@@ -38,7 +38,11 @@ export const createContentModel: CreateContentModel = (core, option, selectionOv
             ? createDomToModelContext(editorContext, settings.builtIn, settings.customized, option)
             : createDomToModelContextWithConfig(settings.calculated, editorContext);
 
-        const model = domToContentModel(core.logicalRoot, domToModelContext, selection);
+        if (selection) {
+            domToModelContext.selection = selection;
+        }
+
+        const model = domToContentModel(core.logicalRoot, domToModelContext);
 
         if (saveIndex) {
             core.cache.cachedModel = model;

--- a/packages/roosterjs-content-model-core/test/coreApi/createContentModel/createContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/createContentModel/createContentModelTest.ts
@@ -2,16 +2,17 @@ import * as cloneModel from 'roosterjs-content-model-dom/lib/modelApi/editing/cl
 import * as createDomToModelContext from 'roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext';
 import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
 import { createContentModel } from '../../../lib/coreApi/createContentModel/createContentModel';
-import { EditorCore } from 'roosterjs-content-model-types';
+import { DomToModelContext, EditorCore } from 'roosterjs-content-model-types';
 
 const mockedEditorContext = 'EDITORCONTEXT' as any;
-const mockedContext = 'CONTEXT' as any;
+const originalContext = { context: 'Context' } as any;
 const mockedModel = 'MODEL' as any;
 const mockedDiv = 'DIV' as any;
 const mockedCachedMode = 'CACHEDMODEL' as any;
 const mockedClonedModel = 'CLONEDMODEL' as any;
 
 describe('createContentModel', () => {
+    let mockedContext: DomToModelContext;
     let core: EditorCore;
     let createEditorContext: jasmine.Spy;
     let getDOMSelection: jasmine.Spy;
@@ -19,6 +20,8 @@ describe('createContentModel', () => {
     let cloneModelSpy: jasmine.Spy;
 
     beforeEach(() => {
+        mockedContext = { ...originalContext } as any;
+
         createEditorContext = jasmine
             .createSpy('createEditorContext')
             .and.returnValue(mockedEditorContext);
@@ -57,7 +60,7 @@ describe('createContentModel', () => {
 
         expect(createEditorContext).toHaveBeenCalledWith(core, true);
         expect(getDOMSelection).toHaveBeenCalledWith(core);
-        expect(domToContentModelSpy).toHaveBeenCalledWith(mockedDiv, mockedContext, undefined);
+        expect(domToContentModelSpy).toHaveBeenCalledWith(mockedDiv, mockedContext);
         expect(model).toBe(mockedModel);
     });
 
@@ -86,6 +89,7 @@ describe('createContentModel', () => {
 });
 
 describe('createContentModel with selection', () => {
+    let mockedContext: DomToModelContext;
     let getDOMSelectionSpy: jasmine.Spy;
     let domToContentModelSpy: jasmine.Spy;
     let createEditorContextSpy: jasmine.Spy;
@@ -93,6 +97,7 @@ describe('createContentModel with selection', () => {
     const MockedDiv = 'CONTENT_DIV' as any;
 
     beforeEach(() => {
+        mockedContext = { ...originalContext } as any;
         getDOMSelectionSpy = jasmine.createSpy('getDOMSelection');
         domToContentModelSpy = spyOn(domToContentModel, 'domToContentModel');
         createEditorContextSpy = jasmine.createSpy('createEditorContext');
@@ -130,10 +135,14 @@ describe('createContentModel with selection', () => {
         createContentModel(core);
 
         expect(domToContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext, {
-            type: 'range',
-            range: MockedRange,
-        } as any);
+        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext);
+        expect(mockedContext).toEqual({
+            ...originalContext,
+            selection: {
+                type: 'range',
+                range: MockedRange,
+            } as any,
+        });
     });
 
     it('Table selection', () => {
@@ -153,14 +162,18 @@ describe('createContentModel with selection', () => {
         createContentModel(core);
 
         expect(domToContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext, {
-            type: 'table',
-            table: MockedContainer,
-            coordinates: {
-                firstCell: MockedFirstCell,
-                lastCell: MockedLastCell,
-            },
-        } as any);
+        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext);
+        expect(mockedContext).toEqual({
+            ...originalContext,
+            selection: {
+                type: 'table',
+                table: MockedContainer,
+                coordinates: {
+                    firstCell: MockedFirstCell,
+                    lastCell: MockedLastCell,
+                },
+            } as any,
+        });
     });
 
     it('Image selection', () => {
@@ -174,10 +187,14 @@ describe('createContentModel with selection', () => {
         createContentModel(core);
 
         expect(domToContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext, {
-            type: 'image',
-            image: MockedContainer,
-        } as any);
+        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext);
+        expect(mockedContext).toEqual({
+            ...originalContext,
+            selection: {
+                type: 'image',
+                image: MockedContainer,
+            } as any,
+        });
     });
 
     it('Incorrect regular selection', () => {
@@ -189,10 +206,14 @@ describe('createContentModel with selection', () => {
         createContentModel(core);
 
         expect(domToContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext, {
-            type: 'range',
-            range: null!,
-        } as any);
+        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext);
+        expect(mockedContext).toEqual({
+            ...originalContext,
+            selection: {
+                type: 'range',
+                range: null!,
+            } as any,
+        });
     });
 
     it('Incorrect table selection', () => {
@@ -203,9 +224,13 @@ describe('createContentModel with selection', () => {
         createContentModel(core);
 
         expect(domToContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext, {
-            type: 'table',
-        } as any);
+        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext);
+        expect(mockedContext).toEqual({
+            ...originalContext,
+            selection: {
+                type: 'table',
+            } as any,
+        });
     });
 
     it('Flush mutation before create model', () => {
@@ -242,16 +267,20 @@ describe('createContentModel with selection', () => {
         createContentModel(core, undefined, mockedSelection);
 
         expect(domToContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext, {
-            type: 'range',
-            range: MockedRange,
-        } as any);
+        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext);
+        expect(mockedContext).toEqual({
+            ...originalContext,
+            selection: {
+                type: 'range',
+                range: MockedRange,
+            } as any,
+        });
     });
 
     it('With selection override, selection=none', () => {
         createContentModel(core, undefined, 'none');
 
         expect(domToContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext, undefined);
+        expect(domToContentModelSpy).toHaveBeenCalledWith(MockedDiv, mockedContext);
     });
 });

--- a/packages/roosterjs-content-model-dom/lib/domToModel/domToContentModel.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/domToContentModel.ts
@@ -1,26 +1,19 @@
 import { createContentModelDocument } from '../modelApi/creators/createContentModelDocument';
 import { normalizeContentModel } from '../modelApi/common/normalizeContentModel';
-import type {
-    ContentModelDocument,
-    DOMSelection,
-    DomToModelContext,
-} from 'roosterjs-content-model-types';
+import type { ContentModelDocument, DomToModelContext } from 'roosterjs-content-model-types';
 
 /**
  * Create Content Model from DOM tree in this editor
  * @param root Root element of DOM tree to create Content Model from
  * @param context Context object for DOM to Content Model conversion
- * @param selection Selection that already exists in content
  * @returns A ContentModelDocument object that contains all the models created from the give root element
  */
 export function domToContentModel(
     root: HTMLElement | DocumentFragment,
-    context: DomToModelContext,
-    selection?: DOMSelection
+    context: DomToModelContext
 ): ContentModelDocument {
     const model = createContentModelDocument(context.defaultFormat);
 
-    context.selection = selection;
     context.elementProcessors.child(model, root, context);
 
     normalizeContentModel(model);

--- a/packages/roosterjs-editor-adapter/test/editor/EditorAdapterTest.ts
+++ b/packages/roosterjs-editor-adapter/test/editor/EditorAdapterTest.ts
@@ -36,11 +36,7 @@ describe('EditorAdapter', () => {
 
         expect(model).toBe(mockedResult);
         expect(domToContentModel.domToContentModel).toHaveBeenCalledTimes(1);
-        expect(domToContentModel.domToContentModel).toHaveBeenCalledWith(
-            div,
-            mockedContext,
-            undefined
-        );
+        expect(domToContentModel.domToContentModel).toHaveBeenCalledWith(div, mockedContext);
         expect(createDomToModelContext.createDomToModelContextWithConfig).toHaveBeenCalledWith(
             mockedConfig,
             editorContext
@@ -73,11 +69,7 @@ describe('EditorAdapter', () => {
 
         expect(model).toBe(mockedResult);
         expect(domToContentModel.domToContentModel).toHaveBeenCalledTimes(1);
-        expect(domToContentModel.domToContentModel).toHaveBeenCalledWith(
-            div,
-            mockedContext,
-            undefined
-        );
+        expect(domToContentModel.domToContentModel).toHaveBeenCalledWith(div, mockedContext);
         expect(createDomToModelContext.createDomToModelContextWithConfig).toHaveBeenCalledWith(
             mockedConfig,
             editorContext


### PR DESCRIPTION
There is an redundant parameter "selection" in API `domToContentModel`. It can be covered by the parameter "context" actually. So remove it.