### PR TITLE
Fix #2525 Format button does not work in Safari when WatermarkPlugin is enabled

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/createContentModel/createContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/createContentModel/createContentModel.ts
@@ -1,3 +1,4 @@
+import { updateCachedSelection } from '../../corePlugin/cache/updateCachedSelection';
 import {
     cloneModel,
     createDomToModelContext,
@@ -46,7 +47,7 @@ export const createContentModel: CreateContentModel = (core, option, selectionOv
 
         if (saveIndex) {
             core.cache.cachedModel = model;
-            core.cache.cachedSelection = selection;
+            updateCachedSelection(core.cache, selection);
         }
 
         return model;

--- a/packages/roosterjs-content-model-core/lib/coreApi/setContentModel/setContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setContentModel/setContentModel.ts
@@ -1,3 +1,4 @@
+import { updateCachedSelection } from '../../corePlugin/cache/updateCachedSelection';
 import {
     contentModelToDom,
     createModelToDomContext,
@@ -36,7 +37,7 @@ export const setContentModel: SetContentModel = (core, model, option, onNodeCrea
     );
 
     if (!core.lifecycle.shadowEditFragment) {
-        core.cache.cachedSelection = selection || undefined;
+        updateCachedSelection(core.cache, selection || undefined);
 
         if (!option?.ignoreSelection && selection) {
             core.api.setDOMSelection(core, selection);

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/CachePlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/CachePlugin.ts
@@ -1,6 +1,7 @@
 import { areSameSelection } from './areSameSelection';
 import { createTextMutationObserver } from './textMutationObserver';
 import { domIndexerImpl } from './domIndexerImpl';
+import { updateCachedSelection } from './updateCachedSelection';
 import type {
     CachePluginState,
     IEditor,
@@ -102,7 +103,7 @@ class CachePlugin implements PluginWithState<CachePluginState> {
 
                 if (contentModel && this.state.domIndexer) {
                     this.state.cachedModel = contentModel;
-                    this.state.cachedSelection = selection;
+                    updateCachedSelection(this.state, selection);
                 } else {
                     this.invalidateCache();
                 }
@@ -154,7 +155,7 @@ class CachePlugin implements PluginWithState<CachePluginState> {
             ) {
                 this.invalidateCache();
             } else {
-                this.state.cachedSelection = newRangeEx;
+                updateCachedSelection(this.state, newRangeEx);
             }
         } else {
             this.state.cachedSelection = cachedSelection;

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/areSameSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/areSameSelection.ts
@@ -1,10 +1,10 @@
-import type { DOMSelection } from 'roosterjs-content-model-types';
+import type { CacheSelection, DOMSelection } from 'roosterjs-content-model-types';
 
 /**
  * @internal
  * Check if the given selections are the same
  */
-export function areSameSelection(sel1: DOMSelection, sel2: DOMSelection): boolean {
+export function areSameSelection(sel1: DOMSelection, sel2: CacheSelection): boolean {
     if (sel1 == sel2) {
         return true;
     }
@@ -25,17 +25,12 @@ export function areSameSelection(sel1: DOMSelection, sel2: DOMSelection): boolea
 
         case 'range':
         default:
-            return sel2.type == 'range' && areSameRanges(sel2.range, sel1.range);
+            return (
+                sel2.type == 'range' &&
+                sel1.range.startContainer == sel2.start.node &&
+                sel1.range.endContainer == sel2.end.node &&
+                sel1.range.startOffset == sel2.start.offset &&
+                sel1.range.endOffset == sel2.end.offset
+            );
     }
-}
-
-function areSameRanges(r1?: Range, r2?: Range): boolean {
-    return !!(
-        r1 &&
-        r2 &&
-        r1.startContainer == r2.startContainer &&
-        r1.startOffset == r2.startOffset &&
-        r1.endContainer == r2.endContainer &&
-        r1.endOffset == r2.endOffset
-    );
 }

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/domIndexerImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/domIndexerImpl.ts
@@ -5,6 +5,7 @@ import {
     setSelection,
 } from 'roosterjs-content-model-dom';
 import type {
+    CacheSelection,
     ContentModelDocument,
     ContentModelParagraph,
     ContentModelSegment,
@@ -14,6 +15,7 @@ import type {
     ContentModelText,
     DomIndexer,
     DOMSelection,
+    RangeSelectionForCache,
     Selectable,
 } from 'roosterjs-content-model-types';
 
@@ -92,16 +94,16 @@ function onTable(tableElement: HTMLTableElement, table: ContentModelTable) {
 function reconcileSelection(
     model: ContentModelDocument,
     newSelection: DOMSelection,
-    oldSelection?: DOMSelection
+    oldSelection?: CacheSelection
 ): boolean {
     if (oldSelection) {
         if (
             oldSelection.type == 'range' &&
-            oldSelection.range.collapsed &&
-            isNodeOfType(oldSelection.range.startContainer, 'TEXT_NODE')
+            isCollapsed(oldSelection) &&
+            isNodeOfType(oldSelection.start.node, 'TEXT_NODE')
         ) {
-            if (isIndexedSegment(oldSelection.range.startContainer)) {
-                reconcileTextSelection(oldSelection.range.startContainer);
+            if (isIndexedSegment(oldSelection.start.node)) {
+                reconcileTextSelection(oldSelection.start.node);
             }
         } else {
             setSelection(model);
@@ -152,6 +154,12 @@ function reconcileSelection(
     }
 
     return false;
+}
+
+function isCollapsed(selection: RangeSelectionForCache): boolean {
+    const { start, end } = selection;
+
+    return start.node == end.node && start.offset == end.offset;
 }
 
 function reconcileNodeSelection(node: Node, offset: number): Selectable | undefined {

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/updateCachedSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/updateCachedSelection.ts
@@ -1,0 +1,30 @@
+import type { CachePluginState, DOMSelection } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ */
+export function updateCachedSelection(
+    state: CachePluginState,
+    selection: DOMSelection | undefined
+) {
+    if (selection?.type == 'range') {
+        const {
+            range: { startContainer, startOffset, endContainer, endOffset },
+            isReverted,
+        } = selection;
+        state.cachedSelection = {
+            type: 'range',
+            isReverted: isReverted,
+            start: {
+                node: startContainer,
+                offset: startOffset,
+            },
+            end: {
+                node: endContainer,
+                offset: endOffset,
+            },
+        };
+    } else {
+        state.cachedSelection = selection;
+    }
+}

--- a/packages/roosterjs-content-model-core/test/coreApi/createContentModel/createContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/createContentModel/createContentModelTest.ts
@@ -198,9 +198,12 @@ describe('createContentModel with selection', () => {
     });
 
     it('Incorrect regular selection', () => {
+        const mockedRange = {
+            startContainer: null!,
+        } as any;
         getDOMSelectionSpy.and.returnValue({
             type: 'range',
-            range: null!,
+            range: mockedRange,
         });
 
         createContentModel(core);
@@ -211,7 +214,7 @@ describe('createContentModel with selection', () => {
             ...originalContext,
             selection: {
                 type: 'range',
-                range: null!,
+                range: mockedRange,
             } as any,
         });
     });

--- a/packages/roosterjs-content-model-core/test/coreApi/setContentModel/setContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setContentModel/setContentModelTest.ts
@@ -186,6 +186,7 @@ describe('setContentModel', () => {
     it('restore range selection ', () => {
         const mockedRange = {
             type: 'range',
+            range: document.createRange(),
         } as any;
 
         contentModelToDomSpy.and.returnValue(mockedRange);

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/CachePluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/CachePluginTest.ts
@@ -120,9 +120,12 @@ describe('CachePlugin', () => {
 
         it('Other key with collapsed selection', () => {
             const state = plugin.getState();
+            const node = 'NODE' as any;
+            const offset = 0;
             state.cachedSelection = {
                 type: 'range',
-                range: { collapsed: true } as any,
+                start: { node, offset },
+                end: { node, offset },
                 isReverted: false,
             };
 
@@ -141,9 +144,11 @@ describe('CachePlugin', () => {
 
         it('Expanded selection with arrow input', () => {
             const state = plugin.getState();
+            const node = 'NODE' as any;
             state.cachedSelection = {
                 type: 'range',
-                range: { collapsed: false } as any,
+                start: { node, offset: 0 },
+                end: { node, offset: 1 },
                 isReverted: false,
             };
 

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/areSameSelectionTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/areSameSelectionTest.ts
@@ -1,5 +1,5 @@
 import { areSameSelection } from '../../../lib/corePlugin/cache/areSameSelection';
-import { DOMSelection } from 'roosterjs-content-model-types';
+import { CacheSelection, DOMSelection } from 'roosterjs-content-model-types';
 
 describe('areSameSelection', () => {
     const startContainer = 'MockedStartContainer' as any;
@@ -9,7 +9,7 @@ describe('areSameSelection', () => {
     const table = 'MockedTable' as any;
     const image = 'MockedImage' as any;
 
-    function runTest(r1: DOMSelection, r2: DOMSelection, result: boolean) {
+    function runTest(r1: DOMSelection, r2: CacheSelection, result: boolean) {
         expect(areSameSelection(r1, r2)).toBe(result);
     }
 
@@ -32,12 +32,14 @@ describe('areSameSelection', () => {
             },
             {
                 type: 'range',
-                range: {
-                    startContainer,
-                    endContainer,
-                    startOffset,
-                    endOffset,
-                } as any,
+                start: {
+                    node: startContainer,
+                    offset: startOffset,
+                },
+                end: {
+                    node: endContainer,
+                    offset: endOffset,
+                },
                 isReverted: false,
             },
             true
@@ -156,12 +158,14 @@ describe('areSameSelection', () => {
             },
             {
                 type: 'range',
-                range: {
-                    startContainer: 'Container 2' as any,
-                    endContainer,
-                    startOffset,
-                    endOffset,
-                } as any,
+                start: {
+                    node: 'Container 2' as any,
+                    offset: startOffset,
+                },
+                end: {
+                    node: endContainer,
+                    offset: endOffset,
+                },
                 isReverted: false,
             },
             false
@@ -182,12 +186,14 @@ describe('areSameSelection', () => {
             },
             {
                 type: 'range',
-                range: {
-                    startContainer,
-                    endContainer: 'Container 2' as any,
-                    startOffset,
-                    endOffset,
-                } as any,
+                start: {
+                    node: startContainer,
+                    offset: startOffset,
+                },
+                end: {
+                    node: 'Container 2' as any,
+                    offset: endOffset,
+                },
                 isReverted: false,
             },
             false
@@ -208,12 +214,14 @@ describe('areSameSelection', () => {
             },
             {
                 type: 'range',
-                range: {
-                    startContainer,
-                    endContainer,
-                    startOffset: 3,
-                    endOffset,
-                } as any,
+                start: {
+                    node: startContainer,
+                    offset: 3,
+                },
+                end: {
+                    node: endContainer,
+                    offset: endOffset,
+                },
                 isReverted: false,
             },
             false
@@ -234,12 +242,14 @@ describe('areSameSelection', () => {
             },
             {
                 type: 'range',
-                range: {
-                    startContainer,
-                    endContainer,
-                    startOffset,
-                    endOffset: 4,
-                } as any,
+                start: {
+                    node: startContainer,
+                    offset: startOffset,
+                },
+                end: {
+                    node: endContainer,
+                    offset: 4,
+                },
                 isReverted: false,
             },
             false

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
@@ -2,6 +2,7 @@ import * as setSelection from 'roosterjs-content-model-dom/lib/modelApi/selectio
 import { createRange } from 'roosterjs-content-model-dom/test/testUtils';
 import { domIndexerImpl } from '../../../lib/corePlugin/cache/domIndexerImpl';
 import {
+    CacheSelection,
     ContentModelDocument,
     ContentModelSegment,
     DOMSelection,
@@ -551,9 +552,16 @@ describe('domIndexerImpl.reconcileSelection', () => {
 
     it('has old range - collapsed, expanded new range', () => {
         const node = document.createTextNode('test') as any;
-        const oldRangeEx: DOMSelection = {
+        const oldRangeEx: CacheSelection = {
             type: 'range',
-            range: createRange(node, 2),
+            start: {
+                node,
+                offset: 2,
+            },
+            end: {
+                node,
+                offset: 2,
+            },
             isReverted: false,
         };
         const newRangeEx: DOMSelection = {
@@ -602,9 +610,16 @@ describe('domIndexerImpl.reconcileSelection', () => {
 
     it('has old range - expanded, expanded new range', () => {
         const node = document.createTextNode('test') as any;
-        const oldRangeEx: DOMSelection = {
+        const oldRangeEx: CacheSelection = {
             type: 'range',
-            range: createRange(node, 1, node, 3),
+            start: {
+                node,
+                offset: 1,
+            },
+            end: {
+                node,
+                offset: 3,
+            },
             isReverted: false,
         };
         const newRangeEx: DOMSelection = {

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/updateCachedSelectionTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/updateCachedSelectionTest.ts
@@ -1,0 +1,71 @@
+import { CachePluginState } from 'roosterjs-content-model-types';
+import { updateCachedSelection } from '../../../lib/corePlugin/cache/updateCachedSelection';
+
+describe('updateCachedSelection', () => {
+    it('Update to undefined', () => {
+        const state: CachePluginState = {};
+
+        updateCachedSelection(state, undefined);
+
+        expect(state).toEqual({
+            cachedSelection: undefined,
+        });
+    });
+
+    it('Update to table selection', () => {
+        const state: CachePluginState = {};
+        const mockedSelection = {
+            type: 'table',
+        } as any;
+
+        updateCachedSelection(state, mockedSelection);
+
+        expect(state).toEqual({
+            cachedSelection: mockedSelection,
+        });
+    });
+
+    it('Update to image selection', () => {
+        const state: CachePluginState = {};
+        const mockedSelection = {
+            type: 'image',
+        } as any;
+
+        updateCachedSelection(state, mockedSelection);
+
+        expect(state).toEqual({
+            cachedSelection: mockedSelection,
+        });
+    });
+
+    it('Update to range selection', () => {
+        const state: CachePluginState = {};
+        const mockedSelection = {
+            type: 'range',
+            range: {
+                startContainer: 'NODE1',
+                endContainer: 'NODE2',
+                startOffset: 'OFFSET1',
+                endOffset: 'OFFSET2',
+            },
+            isReverted: false,
+        } as any;
+
+        updateCachedSelection(state, mockedSelection);
+
+        expect(state).toEqual({
+            cachedSelection: {
+                type: 'range',
+                start: {
+                    node: 'NODE1',
+                    offset: 'OFFSET1',
+                },
+                end: {
+                    node: 'NODE2',
+                    offset: 'OFFSET2',
+                },
+                isReverted: false,
+            } as any,
+        });
+    });
+});

--- a/packages/roosterjs-content-model-types/lib/context/DomIndexer.ts
+++ b/packages/roosterjs-content-model-types/lib/context/DomIndexer.ts
@@ -1,3 +1,4 @@
+import type { CacheSelection } from '../pluginState/CachePluginState';
 import type { ContentModelDocument } from '../group/ContentModelDocument';
 import type { ContentModelParagraph } from '../block/ContentModelParagraph';
 import type { ContentModelSegment } from '../segment/ContentModelSegment';
@@ -44,6 +45,6 @@ export interface DomIndexer {
     reconcileSelection: (
         model: ContentModelDocument,
         newSelection: DOMSelection,
-        oldSelection?: DOMSelection
+        oldSelection?: CacheSelection
     ) => boolean;
 }

--- a/packages/roosterjs-content-model-types/lib/index.ts
+++ b/packages/roosterjs-content-model-types/lib/index.ts
@@ -128,6 +128,7 @@ export {
     ImageSelection,
     RangeSelection,
     TableSelection,
+    DOMInsertPoint,
 } from './selection/DOMSelection';
 export { InsertPoint } from './selection/InsertPoint';
 export { TableSelectionContext } from './selection/TableSelectionContext';
@@ -227,7 +228,11 @@ export { EditorPlugin } from './editor/EditorPlugin';
 export { PluginWithState } from './editor/PluginWithState';
 export { ContextMenuProvider } from './editor/ContextMenuProvider';
 
-export { CachePluginState } from './pluginState/CachePluginState';
+export {
+    CachePluginState,
+    RangeSelectionForCache,
+    CacheSelection,
+} from './pluginState/CachePluginState';
 export { FormatPluginState, PendingFormat } from './pluginState/FormatPluginState';
 export { CopyPastePluginState } from './pluginState/CopyPastePluginState';
 export { DOMEventPluginState } from './pluginState/DOMEventPluginState';

--- a/packages/roosterjs-content-model-types/lib/pluginState/CachePluginState.ts
+++ b/packages/roosterjs-content-model-types/lib/pluginState/CachePluginState.ts
@@ -1,7 +1,39 @@
 import type { TextMutationObserver } from '../context/TextMutationObserver';
 import type { ContentModelDocument } from '../group/ContentModelDocument';
 import type { DomIndexer } from '../context/DomIndexer';
-import type { DOMSelection } from '../selection/DOMSelection';
+import type {
+    DOMInsertPoint,
+    ImageSelection,
+    SelectionBase,
+    TableSelection,
+} from '../selection/DOMSelection';
+
+/**
+ * Represents a range selection used for cache. We store the start and end insert point here instead of range itself
+ * to prevent range got automatically modified by browser
+ */
+export interface RangeSelectionForCache extends SelectionBase<'range'> {
+    /**
+     * Start insert point
+     */
+    start: DOMInsertPoint;
+
+    /**
+     * End inset point
+     */
+    end: DOMInsertPoint;
+
+    /**
+     * Whether the selection was from left to right (in document order) or
+     * right to left (reverse of document order)
+     */
+    isReverted: boolean;
+}
+
+/**
+ * Represents a selection used for cache
+ */
+export type CacheSelection = RangeSelectionForCache | ImageSelection | TableSelection;
 
 /**
  * Plugin state for CacheEditPlugin
@@ -10,7 +42,7 @@ export interface CachePluginState {
     /**
      * Cached selection
      */
-    cachedSelection?: DOMSelection | undefined;
+    cachedSelection?: CacheSelection | undefined;
 
     /**
      * When reuse Content Model is allowed, we cache the Content Model object here after created

--- a/packages/roosterjs-content-model-types/lib/selection/DOMSelection.ts
+++ b/packages/roosterjs-content-model-types/lib/selection/DOMSelection.ts
@@ -62,3 +62,18 @@ export interface TableSelection extends TableSelectionCoordinates, SelectionBase
  * The union type of 3 selection types
  */
 export type DOMSelection = RangeSelection | ImageSelection | TableSelection;
+
+/**
+ * Represents an insert point from DOM selection
+ */
+export interface DOMInsertPoint {
+    /**
+     * The container node
+     */
+    node: Node;
+
+    /**
+     * The offset under container node
+     */
+    offset: number;
+}


### PR DESCRIPTION
I realized that it is caused by the cached selection range got updated automatically when selection is changed, so when we try to update cache, it got a result that new selection and the cached one are the same, so we skip updating cache, then we always do format on a staled content model.

To fix it, we store start/end container and offset separately in CachePlugin rather than saving a range, so it will not get auto update.