### PR TITLE
Do not update the segment format if it have a value when pasting from excel

### DIFF
--- a/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromExcelTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromExcelTest.ts
@@ -6,6 +6,8 @@ import {
     contentModelToDom,
     createDomToModelContext,
     createModelToDomContext,
+    createTable,
+    createTableCell,
     domToContentModel,
     moveChildNodes,
 } from 'roosterjs-content-model-dom';
@@ -374,5 +376,48 @@ describe('Do not run scenarios', () => {
             '<table><tbody><tr><td height="19" width="67" style="height:14.4pt;width:50pt">asd</td><td width="67" style="width:50pt">asd</td></tr></tbody></table>',
             source
         );
+    });
+});
+
+describe('childProcessorTest', () => {
+    it('Remove segmentFormat', () => {
+        const spy = jasmine.createSpy('childProcessor');
+
+        const element: any = {};
+        const context: any = {
+            segmentFormat: {
+                textColor: undefined,
+            },
+            defaultElementProcessors: {
+                child: spy,
+            },
+        };
+        const tableCell = createTableCell();
+        tableCell.format.textColor = 'black';
+
+        PastePluginFile.childProcessor(tableCell, element, context);
+
+        expect(tableCell.format.textColor).toBeUndefined();
+        expect(context.segmentFormat.textColor).toBeUndefined();
+    });
+    it('Dont remove segmentFormat', () => {
+        const spy = jasmine.createSpy('childProcessor');
+
+        const element: any = {};
+        const context: any = {
+            segmentFormat: {
+                textColor: 'blue',
+            },
+            defaultElementProcessors: {
+                child: spy,
+            },
+        };
+        const tableCell = createTableCell();
+        tableCell.format.textColor = 'black';
+
+        PastePluginFile.childProcessor(tableCell, element, context);
+
+        expect(tableCell.format.textColor).toBeUndefined();
+        expect(context.segmentFormat.textColor).toEqual('blue');
     });
 });


### PR DESCRIPTION
In #2121 we updated the segment format of the context to fix an issue caused to the table cells border colors.

However, we should not override the segment format when it has a value as we would override the format of the clipboard data.
This PR is adding an additional check so we do not update the segment format if it is not needed.