### PR TITLE
Disable auto format features

### DIFF
--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -475,7 +475,13 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             watermarkText,
         } = this.state.initState;
         return [
-            pluginList.autoFormat && new AutoFormatPlugin(),
+            pluginList.autoFormat &&
+                new AutoFormatPlugin({
+                    autoBullet: true,
+                    autoNumbering: true,
+                    autoUnlink: true,
+                    autoLink: true,
+                }),
             pluginList.edit && new EditPlugin(),
             pluginList.paste && new PastePlugin(allowExcelNoBorderTable),
             pluginList.shortcut && new ShortcutPlugin(),

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
@@ -40,10 +40,10 @@ export type AutoFormatOptions = {
  * @internal
  */
 const DefaultOptions: Required<AutoFormatOptions> = {
-    autoBullet: true,
-    autoNumbering: true,
+    autoBullet: false,
+    autoNumbering: false,
     autoUnlink: false,
-    autoLink: true,
+    autoLink: false,
 };
 
 /**
@@ -55,8 +55,10 @@ export class AutoFormatPlugin implements EditorPlugin {
 
     /**
      * @param options An optional parameter that takes in an object of type AutoFormatOptions, which includes the following properties:
-     *  - autoBullet: A boolean that enables or disables automatic bullet list formatting. Defaults to true.
-     *  - autoNumbering: A boolean that enables or disables automatic numbering formatting. Defaults to true.
+     *  - autoBullet: A boolean that enables or disables automatic bullet list formatting. Defaults to false.
+     *  - autoNumbering: A boolean that enables or disables automatic numbering formatting. Defaults to false.
+     *  - autoLink: A boolean that enables or disables automatic hyperlink creation when pasting or typing content. Defaults to false.
+     *  - autoUnlink: A boolean that enables or disables automatic hyperlink removal when pressing backspace. Defaults to false.
      */
     constructor(private options: AutoFormatOptions = DefaultOptions) {}
 

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/AutoFormatPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/AutoFormatPluginTest.ts
@@ -60,7 +60,10 @@ describe('Content Model Auto Format Plugin Test', () => {
                 eventType: 'input',
                 rawEvent: { data: ' ', defaultPrevented: false, inputType: 'insertText' } as any,
             };
-            runTest(event, true);
+            runTest(event, true, {
+                autoBullet: true,
+                autoNumbering: true,
+            });
         });
 
         it('should not trigger keyboardListTrigger', () => {
@@ -68,7 +71,10 @@ describe('Content Model Auto Format Plugin Test', () => {
                 eventType: 'input',
                 rawEvent: { data: '*', defaultPrevented: false, inputType: 'insertText' } as any,
             };
-            runTest(event, false);
+            runTest(event, false, {
+                autoBullet: true,
+                autoNumbering: true,
+            });
         });
 
         it('should not trigger keyboardListTrigger', () => {
@@ -135,7 +141,9 @@ describe('Content Model Auto Format Plugin Test', () => {
                 eventType: 'contentChanged',
                 source: 'Paste',
             };
-            runTest(event, true);
+            runTest(event, true, {
+                autoLink: true,
+            });
         });
 
         it('should not  call createLink - autolink disabled', () => {
@@ -151,7 +159,9 @@ describe('Content Model Auto Format Plugin Test', () => {
                 eventType: 'contentChanged',
                 source: 'Format',
             };
-            runTest(event, false);
+            runTest(event, false, {
+                autoLink: true,
+            });
         });
     });
 
@@ -241,7 +251,9 @@ describe('Content Model Auto Format Plugin Test', () => {
                 eventType: 'keyDown',
                 rawEvent: { key: ' ', preventDefault: () => {} } as any,
             };
-            runTest(event, true);
+            runTest(event, true, {
+                autoLink: true,
+            });
         });
 
         it('should not call createLinkAfterSpace - disable options', () => {
@@ -254,12 +266,14 @@ describe('Content Model Auto Format Plugin Test', () => {
             });
         });
 
-        it('should not call createLinkAfterSpace - not backspace', () => {
+        it('should not call createLinkAfterSpace - not space', () => {
             const event: KeyDownEvent = {
                 eventType: 'keyDown',
                 rawEvent: { key: 'Backspace', preventDefault: () => {} } as any,
             };
-            runTest(event, false);
+            runTest(event, false, {
+                autoLink: true,
+            });
         });
     });
 });


### PR DESCRIPTION
Let auto format feature disable by the default, because it can cause conflicts while we do not turn off the legacy ones. Enable them only for Demo site. 