### PR TITLE
Fix 264234: Allow passing in sanitizing options when create Content Model from HTML

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createDomToModelContextForSanitizing.ts
+++ b/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createDomToModelContextForSanitizing.ts
@@ -30,7 +30,7 @@ export function createDomToModelContextForSanitizing(
     document: Document,
     defaultFormat?: ContentModelSegmentFormat,
     defaultOption?: DomToModelOption,
-    additionalSanitizingOption?: DomToModelOptionForSanitizing
+    additionalSanitizingOption?: Partial<DomToModelOptionForSanitizing>
 ): DomToModelContext {
     const sanitizingOption: DomToModelOptionForSanitizing = {
         ...DefaultSanitizingOption,

--- a/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createModelFromHtml.ts
+++ b/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createModelFromHtml.ts
@@ -4,7 +4,7 @@ import { createEmptyModel, domToContentModel, parseFormat } from 'roosterjs-cont
 import type {
     ContentModelDocument,
     ContentModelSegmentFormat,
-    DomToModelOption,
+    DomToModelOptionForSanitizing,
     TrustedHTMLHandler,
 } from 'roosterjs-content-model-types';
 
@@ -17,7 +17,7 @@ import type {
  */
 export function createModelFromHtml(
     html: string,
-    options?: DomToModelOption,
+    options?: Partial<DomToModelOptionForSanitizing>,
     trustedHTMLHandler?: TrustedHTMLHandler,
     defaultSegmentFormat?: ContentModelSegmentFormat
 ): ContentModelDocument {
@@ -26,7 +26,12 @@ export function createModelFromHtml(
         : null;
 
     if (doc?.body) {
-        const context = createDomToModelContextForSanitizing(doc, defaultSegmentFormat, options);
+        const context = createDomToModelContextForSanitizing(
+            doc,
+            defaultSegmentFormat,
+            undefined /*defaultOptions*/,
+            options
+        );
         const cssRules = doc ? retrieveCssRules(doc) : [];
 
         convertInlineCss(doc, cssRules);

--- a/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromExcelTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromExcelTest.ts
@@ -6,7 +6,6 @@ import {
     contentModelToDom,
     createDomToModelContext,
     createModelToDomContext,
-    createTable,
     createTableCell,
     domToContentModel,
     moveChildNodes,


### PR DESCRIPTION
We now allow passing in DomToModel options for `createModelFromHtml`, but if there is general or entity model inside, it is always using the default sanitizing options to sanitize HTML. This can cause some attribute to be lost.

To fix it, change the parameter type from `DomToModelOption` to `DomToModelOptionForSanitizing` so we can pass in sanitizing options in, and use this option to build sanitizing processor for general and entity model.