### PR TITLE
Fix cache issue

### DIFF
--- a/packages/roosterjs-content-model-api/lib/publicApi/format/getFormatState.ts
+++ b/packages/roosterjs-content-model-api/lib/publicApi/format/getFormatState.ts
@@ -26,6 +26,7 @@ export function getFormatState(editor: IEditor): ContentModelFormatState {
             processorOverride: {
                 child: reducedModelChildProcessor,
             },
+            tryGetFromCache: true,
         }
     );
 

--- a/packages/roosterjs-content-model-api/lib/publicApi/utils/formatInsertPointWithContentModel.ts
+++ b/packages/roosterjs-content-model-api/lib/publicApi/utils/formatInsertPointWithContentModel.ts
@@ -52,34 +52,26 @@ export function formatInsertPointWithContentModel(
         {
             processorOverride: {
                 child: getShadowChildProcessor(bundle),
-                '#text': getShadowTextProcessor(bundle),
+                textWithSelection: getShadowTextProcessor(bundle),
             },
+            tryGetFromCache: false,
         }
     );
 }
 
-/**
- * @internal Export for test only
- */
-export interface InsertPointBundle {
+interface InsertPointBundle {
     input: DOMInsertPoint;
     result?: InsertPoint;
 }
 
-/**
- * @internal Export for test only
- */
-export interface DomToModelContextWithPath extends DomToModelContext {
+interface DomToModelContextWithPath extends DomToModelContext {
     /**
      * Block group path of this insert point, from direct parent group to the root group
      */
     path?: ContentModelBlockGroup[];
 }
 
-/**
- * @internal Export for test only
- */
-export function getShadowChildProcessor(bundle: InsertPointBundle): ElementProcessor<ParentNode> {
+function getShadowChildProcessor(bundle: InsertPointBundle): ElementProcessor<ParentNode> {
     return (group, parent, context) => {
         const contextWithPath = context as DomToModelContextWithPath;
 
@@ -147,10 +139,7 @@ function handleElementShadowSelection(
     }
 }
 
-/**
- * @internal export for test only
- */
-export const getShadowTextProcessor = (bundle: InsertPointBundle): ElementProcessor<Text> => (
+const getShadowTextProcessor = (bundle: InsertPointBundle): ElementProcessor<Text> => (
     group,
     textNode,
     context

--- a/packages/roosterjs-content-model-core/lib/coreApi/createContentModel/createContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/createContentModel/createContentModel.ts
@@ -18,7 +18,8 @@ export const createContentModel: CreateContentModel = (core, option, selectionOv
     // Flush all mutations if any, so that we can get an up-to-date Content Model
     core.cache.textMutationObserver?.flushMutations();
 
-    let cachedModel = selectionOverride || option ? null : core.cache.cachedModel;
+    let cachedModel =
+        selectionOverride || (option && !option.tryGetFromCache) ? null : core.cache.cachedModel;
 
     if (cachedModel && core.lifecycle.shadowEditFragment) {
         // When in shadow edit, use a cloned model so we won't pollute the cached one

--- a/packages/roosterjs-content-model-core/lib/coreApi/createEditorContext/createEditorContext.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/createEditorContext/createEditorContext.ts
@@ -8,6 +8,8 @@ import type { EditorContext, CreateEditorContext } from 'roosterjs-content-model
 export const createEditorContext: CreateEditorContext = (core, saveIndex) => {
     const { lifecycle, format, darkColorHandler, logicalRoot, cache, domHelper } = core;
 
+    saveIndex = saveIndex && !core.lifecycle.shadowEditFragment;
+
     const context: EditorContext = {
         isDarkMode: lifecycle.isDarkMode,
         defaultFormat: format.defaultFormat,

--- a/packages/roosterjs-content-model-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/Editor.ts
@@ -30,7 +30,7 @@ import type {
     Rect,
     EntityState,
     CachedElementHandler,
-    DomToModelOption,
+    DomToModelOptionForCreateModel,
 } from 'roosterjs-content-model-types';
 
 /**
@@ -100,7 +100,9 @@ export class Editor implements IEditor {
 
         switch (mode) {
             case 'connected':
-                return core.api.createContentModel(core);
+                return core.api.createContentModel(core, {
+                    tryGetFromCache: true, // Pass an option here to force disable save index
+                });
 
             case 'disconnected':
                 return cloneModel(
@@ -108,6 +110,7 @@ export class Editor implements IEditor {
                         processorOverride: {
                             table: tableProcessor,
                         },
+                        tryGetFromCache: false,
                     }),
                     {
                         includeCachedElement: this.cloneOptionCallback,
@@ -170,7 +173,7 @@ export class Editor implements IEditor {
     formatContentModel(
         formatter: ContentModelFormatter,
         options?: FormatContentModelOptions,
-        domToModelOptions?: DomToModelOption
+        domToModelOptions?: DomToModelOptionForCreateModel
     ): void {
         const core = this.getCore();
 

--- a/packages/roosterjs-content-model-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/Editor.ts
@@ -122,7 +122,10 @@ export class Editor implements IEditor {
                     core.environment.domToModelSettings.calculated,
                     core.api.createEditorContext(core, false /*saveIndex*/)
                 );
-                return domToContentModel(core.physicalRoot, domToModelContext);
+
+                return cloneModel(domToContentModel(core.physicalRoot, domToModelContext), {
+                    includeCachedElement: this.cloneOptionCallback,
+                });
         }
     }
 

--- a/packages/roosterjs-content-model-core/test/coreApi/createEditorContext/createEditorContextTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/createEditorContext/createEditorContextTest.ts
@@ -147,6 +147,55 @@ describe('createEditorContext', () => {
             rootFontSize: 16,
         });
     });
+
+    it('create with shadow edit', () => {
+        const isDarkMode = 'DARKMODE' as any;
+        const defaultFormat = 'DEFAULTFORMAT' as any;
+        const darkColorHandler = 'DARKHANDLER' as any;
+        const mockedPendingFormat = 'PENDINGFORMAT' as any;
+        const getComputedStyleSpy = jasmine.createSpy('getComputedStyleSpy');
+        const calculateZoomScaleSpy = jasmine.createSpy('calculateZoomScale').and.returnValue(1);
+
+        const div = {
+            ownerDocument: {
+                defaultView: {
+                    getComputedStyle: getComputedStyleSpy,
+                },
+            },
+        };
+
+        const core = ({
+            physicalRoot: div,
+            logicalRoot: div,
+            lifecycle: {
+                isDarkMode,
+                shadowEditFragment: {} as any,
+            },
+            format: {
+                defaultFormat,
+                pendingFormat: mockedPendingFormat,
+            },
+            darkColorHandler,
+            cache: {},
+            domHelper: {
+                calculateZoomScale: calculateZoomScaleSpy,
+            },
+        } as any) as EditorCore;
+
+        const context = createEditorContext(core, true);
+
+        expect(context).toEqual({
+            isDarkMode,
+            darkColorHandler,
+            defaultFormat,
+            addDelimiterForEntity: true,
+            allowCacheElement: true,
+            domIndexer: undefined,
+            pendingFormat: mockedPendingFormat,
+            zoomScale: 1,
+            rootFontSize: 16,
+        });
+    });
 });
 
 describe('createEditorContext - checkZoomScale', () => {

--- a/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
@@ -6,6 +6,7 @@ import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/d
 import * as transformColor from 'roosterjs-content-model-dom/lib/domUtils/style/transformColor';
 import { ChangeSource, tableProcessor } from 'roosterjs-content-model-dom';
 import { Editor } from '../../lib/editor/Editor';
+import { expectHtml } from 'roosterjs-content-model-dom/test/testUtils';
 import {
     CachedElementHandler,
     ContentModelDocument,
@@ -331,9 +332,11 @@ describe('Editor', () => {
                 },
             },
         });
-        expect(div.innerHTML).toBe(
-            '<div class="_Entity _EType_A _EId_B _EReadonly_1" contenteditable="false" style="color: var(--darkColor_red, red);"></div>'
-        );
+
+        expectHtml(div.innerHTML, [
+            '<div class="_Entity _EType_A _EId_B _EReadonly_1" contenteditable="false" style="color: var(--darkColor_red, red);"></div>',
+            '<div style="color: var(--darkColor_red, red);" class="_Entity _EType_A _EId_B _EReadonly_1" contenteditable="false"></div>',
+        ]);
 
         const model = editor.getContentModelCopy('clean');
 
@@ -355,12 +358,14 @@ describe('Editor', () => {
             ],
             format: {},
         });
-        expect((model.blocks[0] as ContentModelEntity).wrapper.outerHTML).toBe(
-            '<div class="_Entity _EType_A _EId_B _EReadonly_1" contenteditable="false" style="color: red; background-color: inherit;"></div>'
-        );
-        expect(div.innerHTML).toBe(
-            '<div class="_Entity _EType_A _EId_B _EReadonly_1" contenteditable="false" style="color: var(--darkColor_red, red);"></div>'
-        );
+        expectHtml((model.blocks[0] as ContentModelEntity).wrapper.outerHTML, [
+            '<div class="_Entity _EType_A _EId_B _EReadonly_1" contenteditable="false" style="color: red; background-color: inherit;"></div>',
+            '<div style="color: red; background-color: inherit;" class="_Entity _EType_A _EId_B _EReadonly_1" contenteditable="false"></div>',
+        ]);
+        expectHtml(div.innerHTML, [
+            '<div class="_Entity _EType_A _EId_B _EReadonly_1" contenteditable="false" style="color: var(--darkColor_red, red);"></div>',
+            '<div style="color: var(--darkColor_red, red);" class="_Entity _EType_A _EId_B _EReadonly_1" contenteditable="false"></div>',
+        ]);
     });
 
     it('getEnvironment', () => {

--- a/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
@@ -131,7 +131,7 @@ describe('Editor', () => {
         const model1 = editor.getContentModelCopy('connected');
 
         expect(model1).toBe(mockedModel);
-        expect(createContentModelSpy).toHaveBeenCalledWith(mockedCore);
+        expect(createContentModelSpy).toHaveBeenCalledWith(mockedCore, { tryGetFromCache: true });
 
         editor.dispose();
         expect(() => editor.getContentModelCopy('connected')).toThrow();
@@ -199,6 +199,7 @@ describe('Editor', () => {
             processorOverride: {
                 table: tableProcessor,
             },
+            tryGetFromCache: false,
         });
         expect(transformColorSpy).not.toHaveBeenCalled();
 
@@ -212,6 +213,7 @@ describe('Editor', () => {
             processorOverride: {
                 table: tableProcessor,
             },
+            tryGetFromCache: false,
         });
         expect(transformColorSpy).toHaveBeenCalledWith(
             clonedNode,

--- a/packages/roosterjs-content-model-types/lib/context/DomToModelOption.ts
+++ b/packages/roosterjs-content-model-types/lib/context/DomToModelOption.ts
@@ -26,6 +26,16 @@ export interface DomToModelOption {
 }
 
 /**
+ * Options for creating DomToModelContext, used by formatContentModel and createContentModel API
+ */
+export interface DomToModelOptionForCreateModel extends DomToModelOption {
+    /**
+     * When set to true, it will try to reuse cached content model if any
+     */
+    tryGetFromCache: boolean;
+}
+
+/**
  * Options for DOM to Content Model conversion for paste only
  */
 export interface DomToModelOptionForSanitizing extends Required<DomToModelOption> {

--- a/packages/roosterjs-content-model-types/lib/editor/EditorCore.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/EditorCore.ts
@@ -8,7 +8,7 @@ import type { EntityState } from '../parameter/FormatContentModelContext';
 import type { DarkColorHandler } from '../context/DarkColorHandler';
 import type { ContentModelDocument } from '../group/ContentModelDocument';
 import type { DOMSelection } from '../selection/DOMSelection';
-import type { DomToModelOption } from '../context/DomToModelOption';
+import type { DomToModelOptionForCreateModel } from '../context/DomToModelOption';
 import type { EditorContext } from '../context/EditorContext';
 import type { EditorEnvironment } from '../parameter/EditorEnvironment';
 import type { ModelToDomOption } from '../context/ModelToDomOption';
@@ -36,7 +36,7 @@ export type CreateEditorContext = (core: EditorCore, saveIndex: boolean) => Edit
  */
 export type CreateContentModel = (
     core: EditorCore,
-    option?: DomToModelOption,
+    option?: DomToModelOptionForCreateModel,
     selectionOverride?: DOMSelection | 'none'
 ) => ContentModelDocument;
 
@@ -92,7 +92,7 @@ export type FormatContentModel = (
     core: EditorCore,
     formatter: ContentModelFormatter,
     options?: FormatContentModelOptions,
-    domToModelOptions?: DomToModelOption
+    domToModelOptions?: DomToModelOptionForCreateModel
 ) => void;
 
 /**

--- a/packages/roosterjs-content-model-types/lib/editor/IEditor.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/IEditor.ts
@@ -1,4 +1,4 @@
-import type { DomToModelOption } from '../context/DomToModelOption';
+import type { DomToModelOptionForCreateModel } from '../context/DomToModelOption';
 import type { DOMHelper } from '../parameter/DOMHelper';
 import type { PluginEventData, PluginEventFromType } from '../event/PluginEventData';
 import type { PluginEventType } from '../event/PluginEventType';
@@ -72,7 +72,7 @@ export interface IEditor {
     formatContentModel(
         formatter: ContentModelFormatter,
         options?: FormatContentModelOptions,
-        domToModelOption?: DomToModelOption
+        domToModelOption?: DomToModelOptionForCreateModel
     ): void;
 
     /**

--- a/packages/roosterjs-content-model-types/lib/index.ts
+++ b/packages/roosterjs-content-model-types/lib/index.ts
@@ -183,7 +183,11 @@ export {
     ContentModelSegmentHandler,
     ContentModelBlockHandler,
 } from './context/ContentModelHandler';
-export { DomToModelOption, DomToModelOptionForSanitizing } from './context/DomToModelOption';
+export {
+    DomToModelOption,
+    DomToModelOptionForSanitizing,
+    DomToModelOptionForCreateModel,
+} from './context/DomToModelOption';
 export { ModelToDomOption } from './context/ModelToDomOption';
 export { DomIndexer } from './context/DomIndexer';
 export { TextMutationObserver } from './context/TextMutationObserver';


### PR DESCRIPTION
To repro:
1. Open demo site, turn on side pane
2. Type "abc"
3. Type ENTER
4. Type BACKSPACE, keep doing it until everything is gone
5. Keep typing BACKSPACE

Expect: nothing happens
Actual, "ab" reappears

The root cause is demo site will always update content model by calling getContentModelCopy() which will update model cache before our formatContentModel() API write cache back, it is triggered when backspace. So the result is cached model in DOM tree is updated by demo site, but cached model in editor is updated by formatContentModel(), so the two models don't match. Later when we keep editing, it will edit on a staled cache.

To fix it, we should not update cache when create model from demo site. Furthermore, we should not update cache at all from API `getContentModelCopy`. It should be a "readonly" operation, to create model only, but not touch cache at all.

In this change I explicitly specified if a API call should reuse cache, and as long as any option is passed in, we should not update cache. For more detailed summary:

| Scenarios                         | can use cache | can write cache | comment                                                                                                        |
|-----------------------------------|---------------|-----------------|----------------------------------------------------------------------------------------------------------------|
| getContentModelCopy: connected    | true          | false           | Mostly used by demo site, we can use existing model but this should not impact cache                           |
| getContentModelCopy: disconnected | false         | false           | Used by plugins and test code to read current model. We will return a cloned model, and do not impact cache    |
| getContentModelCopy: clean        | false         | false           | Used by export HTML, do not use cache to make sure the model is up to date                                     |
| formatInsertPointWithContentModel | false         | false           | Used by insertEntity (recent change), do not use cache since we need to add shadow insert point                |
| getFormatState                    | true          | false           | We can reuse cache if we have, but when there is no cache, we will create reduced model so do not impact cache |
| other formatContentModel cases    | true          | true            | Normal case, we can reuse cache, and should update cache                                                       |

I added test cases to ensure the result of this table.


Also fix another recent regression in Editor.getContentModelCopy() with parameter "clean", we need to clone the content model to avoid removing entity DOM element when write back to DOM. Related test cases added.
