### PR TITLE
Fix selection on void element

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/normalizePos.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/normalizePos.ts
@@ -2,6 +2,31 @@ import { isNodeOfType } from 'roosterjs-content-model-dom';
 import type { DOMInsertPoint } from 'roosterjs-content-model-types';
 
 /**
+ * HTML void elements
+ * Per https://www.w3.org/TR/html/syntax.html#syntax-elements, cannot have child nodes
+ * This regex is used when we move focus to very begin of editor. We should avoid putting focus inside
+ * void elements so users don't accidentally create child nodes in them
+ */
+const HTML_VOID_ELEMENTS = [
+    'AREA',
+    'BASE',
+    'BR',
+    'COL',
+    'COMMAND',
+    'EMBED',
+    'HR',
+    'IMG',
+    'INPUT',
+    'KEYGEN',
+    'LINK',
+    'META',
+    'PARAM',
+    'SOURCE',
+    'TRACK',
+    'WBR',
+];
+
+/**
  * @internal
  */
 export function normalizePos(node: Node, offset: number): DOMInsertPoint {
@@ -17,8 +42,17 @@ export function normalizePos(node: Node, offset: number): DOMInsertPoint {
                 ? node.nodeValue?.length ?? 0
                 : node.childNodes.length;
         } else {
-            node = node.childNodes[offset];
-            offset = 0;
+            const nextNode = node.childNodes[offset];
+
+            if (
+                isNodeOfType(nextNode, 'ELEMENT_NODE') &&
+                HTML_VOID_ELEMENTS.indexOf(nextNode.tagName) >= 0
+            ) {
+                break;
+            } else {
+                node = node.childNodes[offset];
+                offset = 0;
+            }
         }
     }
 

--- a/packages/roosterjs-content-model-core/test/corePlugin/selection/normalizePosTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/selection/normalizePosTest.ts
@@ -99,4 +99,17 @@ describe('normalizePos()', () => {
     it('VOID - With offset out of range', () => {
         runTest('test1<img id=id1>test3', () => document.getElementById('id1'), 2, '', 0);
     });
+    it('VOID - from parent', () => {
+        const div = document.createElement('div');
+        const span = document.createElement('span');
+        const br = document.createElement('br');
+
+        span.appendChild(br);
+        div.appendChild(span);
+
+        const { node, offset } = normalizePos(div, 0);
+
+        expect(node).toBe(span);
+        expect(offset).toBe(0);
+    });
 });

--- a/packages/roosterjs-content-model-plugins/test/edit/keyboardTabTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/keyboardTabTest.ts
@@ -680,6 +680,8 @@ describe('keyboardTab', () => {
                             format: {},
                             cells: [
                                 {
+                                    spanLeft: false,
+                                    spanAbove: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {

--- a/packages/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnTableCellTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnTableCellTest.ts
@@ -4,6 +4,7 @@ import {
     ContentModelDocument,
     ContentModelTableCell,
     ContentModelTable,
+    ContentModelParagraph,
 } from 'roosterjs-content-model-types';
 
 describe('handleTabOnTableCell', () => {
@@ -252,9 +253,9 @@ describe('handleTabOnTableCell', () => {
             lastRow: 3,
             lastColumn: 0,
         });
-        expect(table.rows[3]?.cells[0]?.blocks[0]?.segments[0]?.segmentType).toEqual(
-            'SelectionMarker'
-        );
+        expect(
+            (table.rows[3]?.cells[0]?.blocks[0] as ContentModelParagraph)?.segments[0]?.segmentType
+        ).toEqual('SelectionMarker');
     });
 
     it('Not create new row - Shift+Tab', () => {

--- a/packages/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnTableTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnTableTest.ts
@@ -26,6 +26,8 @@ describe('handleTabOnTable', () => {
                             format: {},
                             cells: [
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -44,6 +46,8 @@ describe('handleTabOnTable', () => {
                                     isSelected: true,
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -62,66 +66,8 @@ describe('handleTabOnTable', () => {
                                     isSelected: true,
                                 },
                                 {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                    isSelected: true,
-                                },
-                            ],
-                        },
-                        {
-                            height: 22,
-                            format: {},
-                            cells: [
-                                {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                    isSelected: true,
-                                },
-                                {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                    isSelected: true,
-                                },
-                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -146,6 +92,8 @@ describe('handleTabOnTable', () => {
                             format: {},
                             cells: [
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -164,6 +112,8 @@ describe('handleTabOnTable', () => {
                                     isSelected: true,
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -182,6 +132,74 @@ describe('handleTabOnTable', () => {
                                     isSelected: true,
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                        {
+                            height: 22,
+                            format: {},
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -235,6 +253,8 @@ describe('handleTabOnTable', () => {
                             format: {},
                             cells: [
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -253,6 +273,8 @@ describe('handleTabOnTable', () => {
                                     isSelected: true,
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -271,66 +293,8 @@ describe('handleTabOnTable', () => {
                                     isSelected: true,
                                 },
                                 {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                    isSelected: true,
-                                },
-                            ],
-                        },
-                        {
-                            height: 22,
-                            format: {},
-                            cells: [
-                                {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                    isSelected: true,
-                                },
-                                {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                    isSelected: true,
-                                },
-                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -355,6 +319,8 @@ describe('handleTabOnTable', () => {
                             format: {},
                             cells: [
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -373,6 +339,8 @@ describe('handleTabOnTable', () => {
                                     isSelected: true,
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -391,6 +359,74 @@ describe('handleTabOnTable', () => {
                                     isSelected: true,
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                        {
+                            height: 22,
+                            format: {},
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -444,6 +480,8 @@ describe('handleTabOnTable', () => {
                             format: {},
                             cells: [
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -462,6 +500,8 @@ describe('handleTabOnTable', () => {
                                     isSelected: true,
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -480,66 +520,8 @@ describe('handleTabOnTable', () => {
                                     isSelected: true,
                                 },
                                 {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                    isSelected: true,
-                                },
-                            ],
-                        },
-                        {
-                            height: 22,
-                            format: {},
-                            cells: [
-                                {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                    isSelected: true,
-                                },
-                                {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                    isSelected: true,
-                                },
-                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -564,6 +546,74 @@ describe('handleTabOnTable', () => {
                             format: {},
                             cells: [
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                        {
+                            height: 22,
+                            format: {},
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -581,6 +631,8 @@ describe('handleTabOnTable', () => {
                                     dataset: {},
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -598,6 +650,8 @@ describe('handleTabOnTable', () => {
                                     dataset: {},
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -646,6 +700,8 @@ describe('handleTabOnTable', () => {
                             format: {},
                             cells: [
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -663,6 +719,8 @@ describe('handleTabOnTable', () => {
                                     dataset: {},
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -680,63 +738,8 @@ describe('handleTabOnTable', () => {
                                     dataset: {},
                                 },
                                 {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                },
-                            ],
-                        },
-                        {
-                            height: 22,
-                            format: {},
-                            cells: [
-                                {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                },
-                                {
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            blockType: 'Paragraph',
-                                            segments: [
-                                                {
-                                                    segmentType: 'Br',
-                                                    format: {},
-                                                },
-                                            ],
-                                            format: {},
-                                        },
-                                    ],
-                                    format: {},
-                                    dataset: {},
-                                },
-                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -760,6 +763,8 @@ describe('handleTabOnTable', () => {
                             format: {},
                             cells: [
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -777,6 +782,8 @@ describe('handleTabOnTable', () => {
                                     dataset: {},
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {
@@ -794,6 +801,71 @@ describe('handleTabOnTable', () => {
                                     dataset: {},
                                 },
                                 {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                },
+                            ],
+                        },
+                        {
+                            height: 22,
+                            format: {},
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                {
+                                                    segmentType: 'Br',
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
                                     blockGroupType: 'TableCell',
                                     blocks: [
                                         {

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -21,5 +21,5 @@
         "rootDir": "..",
         "lib": ["es6", "dom"]
     },
-    "include": ["./*/lib/**/*.ts", "./*/lib/**/*.tsx"]
+    "include": ["./*/test/**/*.ts", "./*/test/**/*.tsx"]
 }


### PR DESCRIPTION
When the first child of element is a void element (element that cannot have child node such as BR, IMG), `normalizePos` should not go into it, but just return the parent element and offset. So that selections on BR, IMG can be correctly handled.

Also fixed build script to help detect test code build time error, and fix the existing build error in test code.