### PR TITLE
Set default format in demo site

### DIFF
--- a/demo/scripts/controlsV2/sidePane/editorOptions/DefaultFormatPane.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/DefaultFormatPane.tsx
@@ -39,6 +39,7 @@ export class DefaultFormatPane extends React.Component<DefaultFormatProps, {}> {
                             [NOT_SET]: 'Not Set',
                             '8pt': '8',
                             '10pt': '10',
+                            '11pt': '11',
                             '12pt': '12',
                             '16pt': '16',
                             '20pt': '20',

--- a/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -26,7 +26,11 @@ const initialState: OptionState = {
         announce: false,
     },
     contentEditFeatures: getDefaultContentEditFeatureSettings(),
-    defaultFormat: {},
+    defaultFormat: {
+        fontFamily: 'Calibri',
+        fontSize: '11pt',
+        textColor: '#000000',
+    },
     linkTitle: 'Ctrl+Click to follow the link:' + UrlPlaceholder,
     watermarkText: 'Type content here ...',
     forcePreserveRatio: false,


### PR DESCRIPTION
Set the following default format in demo site, so that we can better test default format behavior.
- font family: Calibri
- font size: 11pt
- text color: black