### PR TITLE
Clean Demo Site: Remove ContentEdit Plugin

### DIFF
--- a/demo/scripts/controlsV2/plugins/createLegacyPlugins.ts
+++ b/demo/scripts/controlsV2/plugins/createLegacyPlugins.ts
@@ -1,11 +1,5 @@
+import { Announce, CustomReplace, HyperLink, ImageEdit } from 'roosterjs-editor-plugins';
 import { EditorPlugin as LegacyEditorPlugin, KnownAnnounceStrings } from 'roosterjs-editor-types';
-import {
-    Announce,
-    ContentEdit,
-    CustomReplace,
-    HyperLink,
-    ImageEdit,
-} from 'roosterjs-editor-plugins';
 import {
     LegacyPluginList,
     OptionState,
@@ -16,7 +10,6 @@ export function createLegacyPlugins(initState: OptionState): LegacyEditorPlugin[
     const { pluginList, linkTitle } = initState;
 
     const plugins: Record<keyof LegacyPluginList, LegacyEditorPlugin | null> = {
-        contentEdit: pluginList.contentEdit ? new ContentEdit(initState.contentEditFeatures) : null,
         hyperlink: pluginList.hyperlink
             ? new HyperLink(
                   linkTitle?.indexOf(UrlPlaceholder) >= 0

--- a/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -19,7 +19,6 @@ const initialState: OptionState = {
         markdown: true,
 
         // Legacy plugins
-        contentEdit: false,
         hyperlink: false,
         imageEdit: false,
         customReplace: false,

--- a/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
@@ -4,7 +4,6 @@ import type { SidePaneElementProps } from '../SidePaneElement';
 import type { ContentModelSegmentFormat } from 'roosterjs-content-model-types';
 
 export interface LegacyPluginList {
-    contentEdit: boolean;
     hyperlink: boolean;
     imageEdit: boolean;
     customReplace: boolean;

--- a/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import ContentEditFeatures from './ContentEditFeatures';
 import { UrlPlaceholder } from './OptionState';
 import type {
     BuildInPluginList,
@@ -110,14 +109,6 @@ export class LegacyPlugins extends PluginsBase<keyof LegacyPluginList> {
         return (
             <table>
                 <tbody>
-                    {this.renderPluginItem(
-                        'contentEdit',
-                        'Content Edit',
-                        <ContentEditFeatures
-                            state={this.props.state.contentEditFeatures}
-                            resetState={this.props.resetState}
-                        />
-                    )}
                     {this.renderPluginItem(
                         'hyperlink',
                         'Hyperlink Plugin',

--- a/demo/scripts/controlsV2/sidePane/editorOptions/codes/PluginsCode.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/codes/PluginsCode.ts
@@ -1,6 +1,5 @@
 import { AutoFormatCode } from './AutoFormatCode';
 import { CodeElement } from './CodeElement';
-import { ContentEditCode } from './ContentEditCode';
 import { HyperLinkCode } from './HyperLinkCode';
 import { MarkdownCode } from './MarkdownCode';
 import { OptionState } from '../OptionState';
@@ -55,7 +54,6 @@ export class LegacyPluginCode extends PluginsCodeBase {
         const pluginList = state.pluginList;
 
         const plugins: CodeElement[] = [
-            pluginList.contentEdit && new ContentEditCode(state.contentEditFeatures),
             pluginList.hyperlink && new HyperLinkCode(state.linkTitle),
             pluginList.imageEdit && new ImageEditCode(),
             pluginList.customReplace && new CustomReplaceCode(),


### PR DESCRIPTION
Remove content edit plugin from new demo site, since this feature was ported into Content Model. 