### PR TITLE
Fix #2500 Hyperlink misses color

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/config/defaultContentModelFormatMap.ts
+++ b/packages/roosterjs-content-model-dom/lib/config/defaultContentModelFormatMap.ts
@@ -7,6 +7,7 @@ import type { DefaultImplicitFormatMap } from 'roosterjs-content-model-types';
 export const defaultContentModelFormatMap: DefaultImplicitFormatMap = {
     a: {
         underline: true,
+        textColor: undefined, // Set to undefined to force override color from parent element so we can write correct link color if any, because browser will assign a default color for link if it doesn't have one
     },
     blockquote: {
         marginTop: '1em',

--- a/packages/roosterjs-content-model-dom/test/endToEndTest.ts
+++ b/packages/roosterjs-content-model-dom/test/endToEndTest.ts
@@ -2105,4 +2105,45 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
             '<ol start="1"><ol start="1" style="list-style-type: &quot;1) &quot;;"><li>test</li></ol></ol>'
         );
     });
+
+    it('link with color', () => {
+        runTest(
+            '<div style="font-family: Calibri; font-size: 11pt; color: rgb(0, 0, 0);"><span style="color: rgb(245, 212, 39);"><a href="http://www.bing.com" style="color: rgb(245, 212, 39);">www.bing.com</a></span></div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'www.bing.com',
+                                format: {
+                                    fontFamily: 'Calibri',
+                                    fontSize: '11pt',
+                                    textColor: 'rgb(245, 212, 39)',
+                                },
+                                link: {
+                                    format: {
+                                        underline: true,
+                                        href: 'http://www.bing.com',
+                                        textColor: 'rgb(245, 212, 39)',
+                                    },
+                                    dataset: {},
+                                },
+                            },
+                        ],
+                        format: {},
+                        segmentFormat: {
+                            fontFamily: 'Calibri',
+                            fontSize: '11pt',
+                            textColor: 'rgb(245, 212, 39)',
+                        },
+                    },
+                ],
+            },
+            'www.bing.com',
+            '<div style="font-family: Calibri; font-size: 11pt; color: rgb(245, 212, 39);"><a href="http://www.bing.com" style="color: rgb(245, 212, 39);">www.bing.com</a></div>'
+        );
+    });
 });

--- a/packages/roosterjs-content-model-dom/test/modelToDom/utils/stackFormatTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/utils/stackFormatTest.ts
@@ -26,6 +26,7 @@ describe('stackFormat', () => {
         const callback = jasmine.createSpy().and.callFake(() => {
             expect(context.implicitFormat).toEqual({
                 underline: true,
+                textColor: undefined,
             });
             context.implicitFormat.fontSize = '10px';
         });
@@ -41,6 +42,7 @@ describe('stackFormat', () => {
         const callback = jasmine.createSpy().and.callFake(() => {
             expect(context.implicitFormat).toEqual({
                 underline: true,
+                textColor: undefined,
             });
             context.implicitFormat.fontSize = '10px';
             throw new Error('test');


### PR DESCRIPTION
To repro, restore the snapshot below, then rewrite with Content Model:

```html
<div style="font-family: Calibri; font-size: 11pt; color: rgb(0, 0, 0);"><span style="color: rgb(245, 212, 39);"><a href="http://www.bing.com" style="color: rgb(245, 212, 39);">www.bing.com</a></span></div><div style="font-family: Calibri; font-size: 11pt; color: rgb(0, 0, 0);"><br></div><!--{"type":"range","start":[1,0],"end":[1,0],"isReverted":false,"isDarkMode":false}-->
```

Root cause: we have an optimization when all child segments of a paragraph have the same styles, we will move the styles from segments to paragraph when rewrite. However, for hyperlink we still need to keep its color if it has since browser will always use its own color to render link unless we directly assign color to the A tag.

Fix: Add a default color "undefined" on A tag as default style so that this will override the color we got from paragraph, so Content Model will keep write link's correct color.