### PR TITLE
fix: on webkit-based applications, the selection will become empty after copy, and focus will cause the window to scroll to the top

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/copyPaste/CopyPastePlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/copyPaste/CopyPastePlugin.ts
@@ -160,8 +160,8 @@ class CopyPastePlugin implements PluginWithState<CopyPastePluginState> {
                     }
 
                     cleanUpAndRestoreSelection(tempDiv);
-                    this.editor.focus();
                     this.editor.setDOMSelection(selection);
+                    this.editor.focus();
 
                     if (isCut) {
                         this.editor.formatContentModel(


### PR DESCRIPTION
selection in focus() become null after this call
https://github.com/microsoft/roosterjs/blob/a4457db8c9806400b27a1567c206b2bc5bf40290/packages/roosterjs-content-model-core/lib/corePlugin/copyPaste/CopyPastePlugin.ts#L236C9-L236C21
<img width="706" alt="image" src="https://github.com/microsoft/roosterjs/assets/24806909/bb01685d-14d9-4f3b-90f6-034b63c3753b">
and focus with null selection make the window scroll to the top

Oddly enough I wasn't able to reproduce the problem in the web demo