### PR TITLE
Disable shortcuts in Mac 

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
+++ b/packages/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
@@ -71,7 +71,7 @@ export const ShortcutUnderline: ShortcutCommand = {
 /**
  * Shortcut command for Clear Format
  * Windows: Ctrl + Space
- * MacOS: Meta + Space
+ * MacOS: N/A
  */
 export const ShortcutClearFormat: ShortcutCommand = {
     shortcutKey: {
@@ -201,7 +201,7 @@ export const ShortcutDecreaseFont: ShortcutCommand = {
 /**
  * Shortcut command for Intent list
  * Windows: Alt + Shift + Arrow Right
- * MacOS: Option + Shift+ Arrow Right
+ * MacOS: N/A
  */
 export const ShortcutIndentList: ShortcutCommand = {
     shortcutKey: {
@@ -212,12 +212,13 @@ export const ShortcutIndentList: ShortcutCommand = {
     onClick: editor => {
         setShortcutIndentationCommand(editor, 'indent');
     },
+    environment: 'nonMac',
 };
 
 /**
  * Shortcut command for Outdent list
  * Windows: Alt + Shift + Arrow Left
- * MacOS: Option + Shift+ Arrow Left
+ * MacOS: N/A
  */
 export const ShortcutOutdentList: ShortcutCommand = {
     shortcutKey: {

--- a/packages/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
+++ b/packages/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
@@ -80,6 +80,7 @@ export const ShortcutClearFormat: ShortcutCommand = {
         which: Keys.SPACE,
     },
     onClick: editor => clearFormat(editor),
+    environment: 'nonMac',
 };
 
 /**
@@ -227,4 +228,5 @@ export const ShortcutOutdentList: ShortcutCommand = {
     onClick: editor => {
         setShortcutIndentationCommand(editor, 'outdent');
     },
+    environment: 'nonMac',
 };

--- a/packages/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
@@ -318,6 +318,48 @@ describe('ShortcutPlugin', () => {
 
             expect(apiSpy).toHaveBeenCalledWith(mockedEditor, 'decrease');
         });
+
+        it('indent list', () => {
+            const apiSpy = spyOn(setShortcutIndentationCommand, 'setShortcutIndentationCommand');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent(Keys.ArrowRight, false, true, true, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledTimes(1);
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor, 'indent');
+        });
+
+        it('outdent list', () => {
+            const apiSpy = spyOn(setShortcutIndentationCommand, 'setShortcutIndentationCommand');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent(Keys.ArrowLeft, false, true, true, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledTimes(1);
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor, 'outdent');
+        });
     });
 
     describe('Mac', () => {
@@ -392,26 +434,6 @@ describe('ShortcutPlugin', () => {
             const event: PluginEvent = {
                 eventType: 'keyDown',
                 rawEvent: createMockedEvent(Keys.U, false, false, false, true),
-            };
-
-            plugin.initialize(mockedEditor);
-
-            const exclusively = plugin.willHandleEventExclusively(event);
-
-            expect(exclusively).toBeTrue();
-            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
-
-            plugin.onPluginEvent(event);
-
-            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
-        });
-
-        it('clear format', () => {
-            const apiSpy = spyOn(clearFormat, 'clearFormat');
-            const plugin = new ShortcutPlugin();
-            const event: PluginEvent = {
-                eventType: 'keyDown',
-                rawEvent: createMockedEvent(Keys.SPACE, false, false, false, true),
             };
 
             plugin.initialize(mockedEditor);
@@ -587,48 +609,6 @@ describe('ShortcutPlugin', () => {
             plugin.onPluginEvent(event);
 
             expect(apiSpy).toHaveBeenCalledWith(mockedEditor, 'decrease');
-        });
-
-        it('indent list', () => {
-            const apiSpy = spyOn(setShortcutIndentationCommand, 'setShortcutIndentationCommand');
-            const plugin = new ShortcutPlugin();
-            const event: PluginEvent = {
-                eventType: 'keyDown',
-                rawEvent: createMockedEvent(Keys.ArrowRight, false, true, true, false),
-            };
-
-            plugin.initialize(mockedEditor);
-
-            const exclusively = plugin.willHandleEventExclusively(event);
-
-            expect(exclusively).toBeTrue();
-            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
-
-            plugin.onPluginEvent(event);
-
-            expect(apiSpy).toHaveBeenCalledTimes(1);
-            expect(apiSpy).toHaveBeenCalledWith(mockedEditor, 'indent');
-        });
-
-        it('outdent list', () => {
-            const apiSpy = spyOn(setShortcutIndentationCommand, 'setShortcutIndentationCommand');
-            const plugin = new ShortcutPlugin();
-            const event: PluginEvent = {
-                eventType: 'keyDown',
-                rawEvent: createMockedEvent(Keys.ArrowLeft, false, true, true, false),
-            };
-
-            plugin.initialize(mockedEditor);
-
-            const exclusively = plugin.willHandleEventExclusively(event);
-
-            expect(exclusively).toBeTrue();
-            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
-
-            plugin.onPluginEvent(event);
-
-            expect(apiSpy).toHaveBeenCalledTimes(1);
-            expect(apiSpy).toHaveBeenCalledWith(mockedEditor, 'outdent');
         });
     });
 });


### PR DESCRIPTION
Disable the following shortcuts in Mac, since their native behavior is very useful to the user. 

|Shortcut | Functionality |
| ---------| ---------------|
| Option + Shift+ Arrow Left | Select whole words   |
| Option + Shift+ Arrow Right | Select whole words |
| Meta + space | Open MacOS emoji keyboard |
