### PR TITLE
Content model: Fix the cursor jump issue after deleting an Entity on Android

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -141,6 +141,16 @@ export class EditPlugin implements EditorPlugin {
 
         if (handled) {
             rawEvent.preventDefault();
+
+            // Restore the selection to avoid the cursor jump issue
+            // See: https://issues.chromium.org/issues/330596261
+            const selection = editor.getDOMSelection();
+            const doc = this.editor?.getDocument();
+            doc?.defaultView?.requestAnimationFrame(() => {
+                if (this.editor) {
+                    this.editor.setDOMSelection(selection);
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Previously we fixed an issue where the Entity element can't be deleted on Android (https://github.com/microsoft/roosterjs/pull/2402). However, a new cursor issue appeared: the cursor jumps to the last line after removing the entity. 

After some invetigation, we found the cursor position was modified by browser, so we reported it to Chromium: https://issues.chromium.org/issues/330596261. In this PR we are going to restore the correct cursor position in next animation frame as a workaround. 