### PR TITLE
Adjust Image size 

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -104,16 +104,12 @@ export const formatContentModel: FormatContentModel = (
 
 function handleImages(core: EditorCore, context: FormatContentModelContext) {
     if (context.newImages.length > 0) {
-        const viewport = core.api.getVisibleViewport(core);
-
-        if (viewport) {
-            const { left, right } = viewport;
-            const minMaxImageSize = 10;
-            const maxWidth = Math.max(right - left, minMaxImageSize);
-            context.newImages.forEach(image => {
-                image.format.maxWidth = `${maxWidth}px`;
-            });
-        }
+        const width = core.domHelper.getEditorDivWidth();
+        const minMaxImageSize = 10;
+        const maxWidth = Math.max(width, minMaxImageSize);
+        context.newImages.forEach(image => {
+            image.format.maxWidth = `${maxWidth}px`;
+        });
     }
 }
 

--- a/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
@@ -70,6 +70,17 @@ class DOMHelperImpl implements DOMHelper {
 
         return style?.direction == 'rtl';
     }
+
+    /**
+     * Get the width of the editable area of the editor content div
+     */
+    getEditorDivWidth(): number {
+        const contentDiv = this.contentDiv;
+        const style = contentDiv.ownerDocument.defaultView?.getComputedStyle(contentDiv);
+        const paddingLeft = parseInt(style?.paddingLeft || '0');
+        const paddingRight = parseInt(style?.paddingRight || '0');
+        return this.contentDiv.clientWidth - (paddingLeft + paddingRight);
+    }
 }
 
 /**

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -19,6 +19,7 @@ describe('formatContentModel', () => {
     let triggerEvent: jasmine.Spy;
     let getDOMSelection: jasmine.Spy;
     let hasFocus: jasmine.Spy;
+    let getEditorDivWidth: jasmine.Spy;
 
     const apiName = 'mockedApi';
     const mockedContainer = 'C' as any;
@@ -38,6 +39,7 @@ describe('formatContentModel', () => {
         triggerEvent = jasmine.createSpy('triggerEvent');
         getDOMSelection = jasmine.createSpy('getDOMSelection').and.returnValue(null);
         hasFocus = jasmine.createSpy('hasFocus');
+        getEditorDivWidth = jasmine.createSpy('getEditorDivWidth');
 
         core = ({
             api: {
@@ -56,6 +58,7 @@ describe('formatContentModel', () => {
             },
             domHelper: {
                 hasFocus,
+                getEditorDivWidth,
             },
         } as any) as EditorCore;
     });
@@ -443,10 +446,6 @@ describe('formatContentModel', () => {
         it('Has image', () => {
             const image = createImage('test');
             const rawEvent = 'RawEvent' as any;
-            const getVisibleViewportSpy = jasmine
-                .createSpy('getVisibleViewport')
-                .and.returnValue({ top: 100, bottom: 200, left: 100, right: 200 });
-            core.api.getVisibleViewport = getVisibleViewportSpy;
 
             formatContentModel(
                 core,
@@ -460,7 +459,7 @@ describe('formatContentModel', () => {
                 }
             );
 
-            expect(getVisibleViewportSpy).toHaveBeenCalledTimes(1);
+            expect(getEditorDivWidth).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).toHaveBeenCalled();
             expect(setContentModel).toHaveBeenCalledTimes(1);
             expect(setContentModel).toHaveBeenCalledWith(core, mockedModel, undefined, undefined);

--- a/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
@@ -282,4 +282,41 @@ describe('DOMHelperImpl', () => {
             expect(result).toBeTrue();
         });
     });
+
+    describe('getEditorDivWidth', () => {
+        let div: HTMLDivElement;
+        let getComputedStyleSpy: jasmine.Spy;
+
+        beforeEach(() => {
+            getComputedStyleSpy = jasmine.createSpy('getComputedStyle');
+
+            div = {
+                ownerDocument: {
+                    defaultView: {
+                        getComputedStyle: getComputedStyleSpy,
+                    },
+                },
+                clientWidth: 1000,
+            } as any;
+        });
+
+        it('getEditorDivWidth', () => {
+            const domHelper = createDOMHelper(div);
+
+            getComputedStyleSpy.and.returnValue({
+                paddingLeft: '10px',
+                paddingRight: '10px',
+            });
+
+            expect(domHelper.getEditorDivWidth()).toBe(980);
+        });
+
+        it('getEditorDivWidth', () => {
+            const domHelper = createDOMHelper(div);
+
+            getComputedStyleSpy.and.returnValue({});
+
+            expect(domHelper.getEditorDivWidth()).toBe(1000);
+        });
+    });
 });

--- a/packages/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/e2e/cmPasteFromExcelTest.ts
@@ -56,7 +56,7 @@ describe(ID, () => {
                             segmentType: 'Image',
                             src: 'https://github.com/microsoft/roosterjs',
                             format: {
-                                maxWidth: '100px',
+                                maxWidth: '1169px',
                             },
                             dataset: {},
                         },

--- a/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
@@ -86,4 +86,9 @@ export interface DOMHelper {
      * Check if the root element is in RTL mode
      */
     isRightToLeft(): boolean;
+
+    /**
+     * Get the width of the editable area of the editor content div
+     */
+    getEditorDivWidth(): number;
 }


### PR DESCRIPTION
When inserting an image, add max-width to editable portion of the editor div, i.e the client width - ( paddings left and right). 
Use `width: 100%` can cause a scroll bar when resize large images.  