### PR TITLE
Fix empty text in markdown plugin  

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/markdown/utils/setFormat.ts
+++ b/packages/roosterjs-content-model-plugins/lib/markdown/utils/setFormat.ts
@@ -32,27 +32,28 @@ export function setFormat(
                     const firstCharIndex = previousSegment.text
                         .substring(0, lastCharIndex - 1)
                         .lastIndexOf(character);
+                    if (lastCharIndex - firstCharIndex > 2) {
+                        const formattedText = splitTextSegment(
+                            previousSegment,
+                            paragraph,
+                            firstCharIndex,
+                            lastCharIndex
+                        );
 
-                    const formattedText = splitTextSegment(
-                        previousSegment,
-                        paragraph,
-                        firstCharIndex,
-                        lastCharIndex
-                    );
-
-                    formattedText.text = formattedText.text.replace(character, '').slice(0, -1);
-                    formattedText.format = {
-                        ...formattedText.format,
-                        ...format,
-                    };
-                    if (codeFormat) {
-                        formattedText.code = {
-                            format: codeFormat,
+                        formattedText.text = formattedText.text.replace(character, '').slice(0, -1);
+                        formattedText.format = {
+                            ...formattedText.format,
+                            ...format,
                         };
-                    }
+                        if (codeFormat) {
+                            formattedText.code = {
+                                format: codeFormat,
+                            };
+                        }
 
-                    context.canUndoByBackspace = true;
-                    return true;
+                        context.canUndoByBackspace = true;
+                        return true;
+                    }
                 }
             }
             return false;

--- a/packages/roosterjs-content-model-plugins/test/markdown/utils/setFormatTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/markdown/utils/setFormatTest.ts
@@ -465,4 +465,31 @@ describe('setFormat', () => {
 
         runTest(input, '*', { fontWeight: 'bold' }, input, false);
     });
+
+    it('should not set bold -  **', () => {
+        const input: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: '**',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+
+        runTest(input, '*', { fontWeight: 'bold' }, input, false);
+    });
 });


### PR DESCRIPTION
If there is no text between ** or other characters that trigger markdown, do not apply setFormat function. 