### PR TITLE
Allow Shift+Delete to Cut

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -80,12 +80,15 @@ export class EditPlugin implements EditorPlugin {
         if (!rawEvent.defaultPrevented && !event.handledByEditFeature) {
             switch (rawEvent.key) {
                 case 'Backspace':
+                    // Use our API to handle BACKSPACE/DELETE key.
+                    // No need to clear cache here since if we rely on browser's behavior, there will be Input event and its handler will reconcile cache
                     keyboardDelete(editor, rawEvent);
                     break;
 
                 case 'Delete':
                     // Use our API to handle BACKSPACE/DELETE key.
                     // No need to clear cache here since if we rely on browser's behavior, there will be Input event and its handler will reconcile cache
+                    // And leave it to browser when shift key is pressed so that browser will trigger cut event
                     if (!event.rawEvent.shiftKey) {
                         keyboardDelete(editor, rawEvent);
                     }

--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -80,10 +80,15 @@ export class EditPlugin implements EditorPlugin {
         if (!rawEvent.defaultPrevented && !event.handledByEditFeature) {
             switch (rawEvent.key) {
                 case 'Backspace':
+                    keyboardDelete(editor, rawEvent);
+                    break;
+
                 case 'Delete':
                     // Use our API to handle BACKSPACE/DELETE key.
                     // No need to clear cache here since if we rely on browser's behavior, there will be Input event and its handler will reconcile cache
-                    keyboardDelete(editor, rawEvent);
+                    if (!event.rawEvent.shiftKey) {
+                        keyboardDelete(editor, rawEvent);
+                    }
                     break;
 
                 case 'Tab':

--- a/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
@@ -77,6 +77,21 @@ describe('EditPlugin', () => {
             expect(keyboardInputSpy).not.toHaveBeenCalled();
         });
 
+        it('Shift+Delete', () => {
+            plugin = new EditPlugin();
+            const rawEvent = { key: 'Delete', shiftKey: true } as any;
+
+            plugin.initialize(editor);
+
+            plugin.onPluginEvent({
+                eventType: 'keyDown',
+                rawEvent,
+            });
+
+            expect(keyboardDeleteSpy).not.toHaveBeenCalled();
+            expect(keyboardInputSpy).not.toHaveBeenCalled();
+        });
+
         it('Tab', () => {
             plugin = new EditPlugin();
             const rawEvent = { key: 'Tab' } as any;


### PR DESCRIPTION
Browser has native support for Cut when press Shift+Delete, we should not intercept this behavior.