### PR TITLE
Port AnnouncePlugin step 1: refactor list number code

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/index.ts
+++ b/packages/roosterjs-content-model-dom/lib/index.ts
@@ -67,6 +67,8 @@ export { isEmpty } from './modelApi/common/isEmpty';
 export { normalizeSingleSegment } from './modelApi/common/normalizeSegment';
 
 export { setParagraphNotImplicit } from './modelApi/block/setParagraphNotImplicit';
+export { getOrderedListNumberStr } from './modelApi/list/getOrderedListNumberStr';
+export { getAutoListStyleType } from './modelApi/list/getAutoListStyleType';
 
 export { parseValueWithUnit } from './formatHandlers/utils/parseValueWithUnit';
 export { BorderKeys } from './formatHandlers/common/borderFormatHandler';

--- a/packages/roosterjs-content-model-dom/lib/modelApi/list/getAutoListStyleType.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/list/getAutoListStyleType.ts
@@ -1,0 +1,67 @@
+import { BulletListType } from '../../constants/BulletListType';
+import { NumberingListType } from '../../constants/NumberingListType';
+import type { ListMetadataFormat } from 'roosterjs-content-model-types';
+
+const DefaultOrderedListStyles = [
+    NumberingListType.Decimal,
+    NumberingListType.LowerAlpha,
+    NumberingListType.LowerRoman,
+];
+const DefaultUnorderedListStyles = [
+    BulletListType.Disc,
+    BulletListType.Circle,
+    BulletListType.Square,
+];
+const OrderedListStyleRevertMap: Record<string, number> = {
+    'lower-alpha': NumberingListType.LowerAlpha,
+    'lower-latin': NumberingListType.LowerAlpha,
+    'upper-alpha': NumberingListType.UpperAlpha,
+    'upper-latin': NumberingListType.UpperAlpha,
+    'lower-roman': NumberingListType.LowerRoman,
+    'upper-roman': NumberingListType.UpperRoman,
+};
+const UnorderedListStyleRevertMap: Record<string, number> = {
+    disc: BulletListType.Disc,
+    circle: BulletListType.Circle,
+    square: BulletListType.Square,
+};
+
+/**
+ * Get automatic list style of a list item according to its lis type and metadata.
+ * @param listType The list type, either OL or UL
+ * @param metadata Metadata of this list item from list item model
+ * @param depth Depth of list level, start from 0
+ * @param existingStyleType Existing list style type in format, if any
+ * @returns A number to represent list style type.
+ * This will be the value of either NumberingListType (when listType is OL) or BulletListType (when listType is UL).
+ * When there is a specified list style in its metadata, return this value, otherwise
+ * When specified "applyListStyleFromLevel" in metadata, calculate auto list type from its depth, otherwise
+ * When there is already listStyleType in list level format, find a related style type index, otherwise
+ * return undefined
+ */
+export function getAutoListStyleType(
+    listType: 'OL' | 'UL',
+    metadata: ListMetadataFormat,
+    depth: number,
+    existingStyleType?: string
+): number | undefined {
+    const { orderedStyleType, unorderedStyleType, applyListStyleFromLevel } = metadata;
+
+    if (listType == 'OL') {
+        return typeof orderedStyleType == 'number'
+            ? orderedStyleType
+            : applyListStyleFromLevel
+            ? DefaultOrderedListStyles[depth % DefaultOrderedListStyles.length]
+            : existingStyleType
+            ? OrderedListStyleRevertMap[existingStyleType]
+            : undefined;
+    } else {
+        return typeof unorderedStyleType == 'number'
+            ? unorderedStyleType
+            : applyListStyleFromLevel
+            ? DefaultUnorderedListStyles[depth % DefaultUnorderedListStyles.length]
+            : existingStyleType
+            ? UnorderedListStyleRevertMap[existingStyleType]
+            : undefined;
+    }
+}

--- a/packages/roosterjs-content-model-dom/lib/modelApi/list/getOrderedListNumberStr.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/list/getOrderedListNumberStr.ts
@@ -1,0 +1,78 @@
+import { getObjectKeys } from '../../domUtils/getObjectKeys';
+import { NumberingListType } from '../../constants/NumberingListType';
+
+const CharCodeOfA = 65;
+const RomanValues: Record<string, number> = {
+    M: 1000,
+    CM: 900,
+    D: 500,
+    CD: 400,
+    C: 100,
+    XC: 90,
+    L: 50,
+    XL: 40,
+    X: 10,
+    IX: 9,
+    V: 5,
+    IV: 4,
+    I: 1,
+};
+
+/**
+ * Get the list number for a list item according to list style type and its index number
+ * @param styleType The list style number, should be a value of NumberingListType type
+ * @param listNumber List number, start from 1
+ * @returns A string for this list item. For example, when pass in NumberingListType.LowerAlpha and 2, it returns "b"
+ */
+export function getOrderedListNumberStr(styleType: number, listNumber: number): string {
+    switch (styleType) {
+        case NumberingListType.LowerAlpha:
+        case NumberingListType.LowerAlphaDash:
+        case NumberingListType.LowerAlphaDoubleParenthesis:
+        case NumberingListType.LowerAlphaParenthesis:
+            return convertDecimalsToAlpha(listNumber, true /*isLowerCase*/);
+
+        case NumberingListType.UpperAlpha:
+        case NumberingListType.UpperAlphaDash:
+        case NumberingListType.UpperAlphaDoubleParenthesis:
+        case NumberingListType.UpperAlphaParenthesis:
+            return convertDecimalsToAlpha(listNumber, false /*isLowerCase*/);
+
+        case NumberingListType.LowerRoman:
+        case NumberingListType.LowerRomanDash:
+        case NumberingListType.LowerRomanDoubleParenthesis:
+        case NumberingListType.LowerRomanParenthesis:
+            return convertDecimalsToRoman(listNumber, true /*isLowerCase*/);
+
+        case NumberingListType.UpperRoman:
+        case NumberingListType.UpperRomanDash:
+        case NumberingListType.UpperRomanDoubleParenthesis:
+        case NumberingListType.UpperRomanParenthesis:
+            return convertDecimalsToRoman(listNumber, false /*isLowerCase*/);
+
+        default:
+            return listNumber + '';
+    }
+}
+
+function convertDecimalsToAlpha(decimal: number, isLowerCase?: boolean): string {
+    let alpha = '';
+    decimal--;
+
+    while (decimal >= 0) {
+        alpha = String.fromCharCode((decimal % 26) + CharCodeOfA) + alpha;
+        decimal = Math.floor(decimal / 26) - 1;
+    }
+    return isLowerCase ? alpha.toLowerCase() : alpha;
+}
+
+function convertDecimalsToRoman(decimal: number, isLowerCase?: boolean) {
+    let romanValue = '';
+
+    for (const i of getObjectKeys(RomanValues)) {
+        const timesRomanCharAppear = Math.floor(decimal / RomanValues[i]);
+        decimal = decimal - timesRomanCharAppear * RomanValues[i];
+        romanValue = romanValue + i.repeat(timesRomanCharAppear);
+    }
+    return isLowerCase ? romanValue.toLocaleLowerCase() : romanValue;
+}

--- a/packages/roosterjs-content-model-dom/test/modelApi/list/getAutoListStyleTypeTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/list/getAutoListStyleTypeTest.ts
@@ -1,0 +1,117 @@
+import { BulletListType } from '../../../lib/constants/BulletListType';
+import { getAutoListStyleType } from '../../../lib/modelApi/list/getAutoListStyleType';
+import { NumberingListType } from '../../../lib/constants/NumberingListType';
+
+describe('getAutoListStyleType', () => {
+    it('ul, no styleType, no auto apply, no existing style', () => {
+        expect(getAutoListStyleType('UL', {}, 0)).toBe(undefined);
+        expect(getAutoListStyleType('UL', {}, 1)).toBe(undefined);
+        expect(getAutoListStyleType('UL', {}, 2)).toBe(undefined);
+    });
+
+    it('ul, no styleType, no auto apply, has existing style', () => {
+        expect(getAutoListStyleType('UL', {}, 0, 'disc')).toBe(BulletListType.Disc);
+        expect(getAutoListStyleType('UL', {}, 0, 'circle')).toBe(BulletListType.Circle);
+        expect(getAutoListStyleType('UL', {}, 0, 'square')).toBe(BulletListType.Square);
+        expect(getAutoListStyleType('UL', {}, 0, 'other')).toBe(undefined);
+    });
+
+    it('ul, no styleType, has auto apply', () => {
+        expect(getAutoListStyleType('UL', { applyListStyleFromLevel: true }, 0)).toBe(
+            BulletListType.Disc
+        );
+        expect(getAutoListStyleType('UL', { applyListStyleFromLevel: true }, 1)).toBe(
+            BulletListType.Circle
+        );
+        expect(getAutoListStyleType('UL', { applyListStyleFromLevel: true }, 2)).toBe(
+            BulletListType.Square
+        );
+        expect(getAutoListStyleType('UL', { applyListStyleFromLevel: true }, 3)).toBe(
+            BulletListType.Disc
+        );
+        expect(getAutoListStyleType('UL', { applyListStyleFromLevel: true }, 2, 'other')).toBe(
+            BulletListType.Square
+        );
+    });
+
+    it('ul, has styleType', () => {
+        expect(getAutoListStyleType('UL', { unorderedStyleType: BulletListType.Circle }, 0)).toBe(
+            BulletListType.Circle
+        );
+        expect(getAutoListStyleType('UL', { unorderedStyleType: BulletListType.Dash }, 0)).toBe(
+            BulletListType.Dash
+        );
+        expect(
+            getAutoListStyleType('UL', { unorderedStyleType: BulletListType.LongArrow }, 0)
+        ).toBe(BulletListType.LongArrow);
+
+        expect(
+            getAutoListStyleType(
+                'UL',
+                { unorderedStyleType: BulletListType.LongArrow, applyListStyleFromLevel: true },
+                2
+            )
+        ).toBe(BulletListType.LongArrow);
+    });
+
+    it('ol, no styleType, no auto apply, no existing style', () => {
+        expect(getAutoListStyleType('OL', {}, 0)).toBe(undefined);
+        expect(getAutoListStyleType('OL', {}, 1)).toBe(undefined);
+        expect(getAutoListStyleType('OL', {}, 2)).toBe(undefined);
+    });
+
+    it('ol, no styleType, no auto apply, has existing style', () => {
+        expect(getAutoListStyleType('OL', {}, 0, 'lower-alpha')).toBe(NumberingListType.LowerAlpha);
+        expect(getAutoListStyleType('OL', {}, 0, 'lower-latin')).toBe(NumberingListType.LowerAlpha);
+        expect(getAutoListStyleType('OL', {}, 0, 'upper-alpha')).toBe(NumberingListType.UpperAlpha);
+        expect(getAutoListStyleType('OL', {}, 0, 'upper-latin')).toBe(NumberingListType.UpperAlpha);
+        expect(getAutoListStyleType('OL', {}, 0, 'lower-roman')).toBe(NumberingListType.LowerRoman);
+        expect(getAutoListStyleType('OL', {}, 0, 'upper-roman')).toBe(NumberingListType.UpperRoman);
+        expect(getAutoListStyleType('OL', {}, 0, 'other')).toBe(undefined);
+    });
+
+    it('ol, no styleType, has auto apply', () => {
+        expect(getAutoListStyleType('OL', { applyListStyleFromLevel: true }, 0)).toBe(
+            NumberingListType.Decimal
+        );
+        expect(getAutoListStyleType('OL', { applyListStyleFromLevel: true }, 1)).toBe(
+            NumberingListType.LowerAlpha
+        );
+        expect(getAutoListStyleType('OL', { applyListStyleFromLevel: true }, 2)).toBe(
+            NumberingListType.LowerRoman
+        );
+        expect(getAutoListStyleType('OL', { applyListStyleFromLevel: true }, 3)).toBe(
+            NumberingListType.Decimal
+        );
+        expect(getAutoListStyleType('OL', { applyListStyleFromLevel: true }, 2, 'other')).toBe(
+            NumberingListType.LowerRoman
+        );
+    });
+
+    it('ol, has styleType', () => {
+        expect(
+            getAutoListStyleType('OL', { orderedStyleType: NumberingListType.LowerAlphaDash }, 0)
+        ).toBe(NumberingListType.LowerAlphaDash);
+        expect(
+            getAutoListStyleType('OL', { orderedStyleType: NumberingListType.LowerAlpha }, 0)
+        ).toBe(NumberingListType.LowerAlpha);
+        expect(
+            getAutoListStyleType(
+                'OL',
+                { orderedStyleType: NumberingListType.LowerRomanParenthesis },
+                0
+            )
+        ).toBe(NumberingListType.LowerRomanParenthesis);
+
+        expect(
+            getAutoListStyleType(
+                'OL',
+                {
+                    orderedStyleType: NumberingListType.LowerRomanParenthesis,
+                    applyListStyleFromLevel: true,
+                },
+                2
+            )
+        ).toBe(NumberingListType.LowerRomanParenthesis);
+    });
+});

--- a/packages/roosterjs-content-model-dom/test/modelApi/list/getOrderedListNumberStrTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/list/getOrderedListNumberStrTest.ts
@@ -1,0 +1,281 @@
+import { getOrderedListNumberStr } from '../../../lib/modelApi/list/getOrderedListNumberStr';
+import { NumberingListType } from '../../../lib/constants/NumberingListType';
+
+describe('getOrderedListNumberStr', () => {
+    it('Decimal', () => {
+        expect(getOrderedListNumberStr(NumberingListType.Decimal, 1)).toBe('1');
+        expect(getOrderedListNumberStr(NumberingListType.Decimal, 2)).toBe('2');
+        expect(getOrderedListNumberStr(NumberingListType.Decimal, 5)).toBe('5');
+        expect(getOrderedListNumberStr(NumberingListType.Decimal, 10)).toBe('10');
+        expect(getOrderedListNumberStr(NumberingListType.Decimal, 20)).toBe('20');
+        expect(getOrderedListNumberStr(NumberingListType.Decimal, 50)).toBe('50');
+        expect(getOrderedListNumberStr(NumberingListType.Decimal, 100)).toBe('100');
+        expect(getOrderedListNumberStr(NumberingListType.Decimal, 1000)).toBe('1000');
+        expect(getOrderedListNumberStr(NumberingListType.Decimal, 10000)).toBe('10000');
+        expect(getOrderedListNumberStr(NumberingListType.Decimal, 0)).toBe('0');
+    });
+
+    it('LowerAlpha', () => {
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlpha, 1)).toBe('a');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlpha, 2)).toBe('b');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlpha, 5)).toBe('e');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlpha, 10)).toBe('j');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlpha, 20)).toBe('t');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlpha, 50)).toBe('ax');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlpha, 100)).toBe('cv');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlpha, 1000)).toBe('all');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlpha, 10000)).toBe('ntp');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlpha, 0)).toBe('');
+    });
+
+    it('LowerAlphaDash', () => {
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDash, 1)).toBe('a');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDash, 2)).toBe('b');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDash, 5)).toBe('e');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDash, 10)).toBe('j');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDash, 20)).toBe('t');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDash, 50)).toBe('ax');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDash, 100)).toBe('cv');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDash, 1000)).toBe('all');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDash, 10000)).toBe('ntp');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDash, 0)).toBe('');
+    });
+
+    it('LowerAlphaDoubleParenthesis', () => {
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDoubleParenthesis, 1)).toBe('a');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDoubleParenthesis, 2)).toBe('b');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDoubleParenthesis, 5)).toBe('e');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDoubleParenthesis, 10)).toBe(
+            'j'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDoubleParenthesis, 20)).toBe(
+            't'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDoubleParenthesis, 50)).toBe(
+            'ax'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDoubleParenthesis, 100)).toBe(
+            'cv'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDoubleParenthesis, 1000)).toBe(
+            'all'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDoubleParenthesis, 10000)).toBe(
+            'ntp'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaDoubleParenthesis, 0)).toBe('');
+    });
+
+    it('LowerAlphaParenthesis', () => {
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaParenthesis, 1)).toBe('a');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaParenthesis, 2)).toBe('b');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaParenthesis, 5)).toBe('e');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaParenthesis, 10)).toBe('j');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaParenthesis, 20)).toBe('t');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaParenthesis, 50)).toBe('ax');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaParenthesis, 100)).toBe('cv');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaParenthesis, 1000)).toBe('all');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaParenthesis, 10000)).toBe('ntp');
+        expect(getOrderedListNumberStr(NumberingListType.LowerAlphaParenthesis, 0)).toBe('');
+    });
+
+    it('UpperAlpha', () => {
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlpha, 1)).toBe('A');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlpha, 2)).toBe('B');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlpha, 5)).toBe('E');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlpha, 10)).toBe('J');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlpha, 20)).toBe('T');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlpha, 50)).toBe('AX');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlpha, 100)).toBe('CV');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlpha, 1000)).toBe('ALL');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlpha, 10000)).toBe('NTP');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlpha, 0)).toBe('');
+    });
+
+    it('UpperAlphaDash', () => {
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDash, 1)).toBe('A');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDash, 2)).toBe('B');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDash, 5)).toBe('E');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDash, 10)).toBe('J');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDash, 20)).toBe('T');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDash, 50)).toBe('AX');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDash, 100)).toBe('CV');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDash, 1000)).toBe('ALL');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDash, 10000)).toBe('NTP');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDash, 0)).toBe('');
+    });
+
+    it('UpperAlphaDoubleParenthesis', () => {
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDoubleParenthesis, 1)).toBe('A');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDoubleParenthesis, 2)).toBe('B');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDoubleParenthesis, 5)).toBe('E');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDoubleParenthesis, 10)).toBe(
+            'J'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDoubleParenthesis, 20)).toBe(
+            'T'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDoubleParenthesis, 50)).toBe(
+            'AX'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDoubleParenthesis, 100)).toBe(
+            'CV'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDoubleParenthesis, 1000)).toBe(
+            'ALL'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDoubleParenthesis, 10000)).toBe(
+            'NTP'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaDoubleParenthesis, 0)).toBe('');
+    });
+
+    it('UpperAlphaParenthesis', () => {
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaParenthesis, 1)).toBe('A');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaParenthesis, 2)).toBe('B');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaParenthesis, 5)).toBe('E');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaParenthesis, 10)).toBe('J');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaParenthesis, 20)).toBe('T');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaParenthesis, 50)).toBe('AX');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaParenthesis, 100)).toBe('CV');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaParenthesis, 1000)).toBe('ALL');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaParenthesis, 10000)).toBe('NTP');
+        expect(getOrderedListNumberStr(NumberingListType.UpperAlphaParenthesis, 0)).toBe('');
+    });
+
+    it('LowerRoman', () => {
+        expect(getOrderedListNumberStr(NumberingListType.LowerRoman, 1)).toBe('i');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRoman, 2)).toBe('ii');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRoman, 5)).toBe('v');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRoman, 10)).toBe('x');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRoman, 20)).toBe('xx');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRoman, 50)).toBe('l');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRoman, 100)).toBe('c');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRoman, 1000)).toBe('m');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRoman, 10000)).toBe('mmmmmmmmmm');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRoman, 0)).toBe('');
+    });
+
+    it('LowerRomanDash', () => {
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDash, 1)).toBe('i');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDash, 2)).toBe('ii');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDash, 5)).toBe('v');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDash, 10)).toBe('x');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDash, 20)).toBe('xx');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDash, 50)).toBe('l');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDash, 100)).toBe('c');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDash, 1000)).toBe('m');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDash, 10000)).toBe('mmmmmmmmmm');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDash, 0)).toBe('');
+    });
+
+    it('LowerRomanDoubleParenthesis', () => {
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDoubleParenthesis, 1)).toBe('i');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDoubleParenthesis, 2)).toBe(
+            'ii'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDoubleParenthesis, 5)).toBe('v');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDoubleParenthesis, 10)).toBe(
+            'x'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDoubleParenthesis, 20)).toBe(
+            'xx'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDoubleParenthesis, 50)).toBe(
+            'l'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDoubleParenthesis, 100)).toBe(
+            'c'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDoubleParenthesis, 1000)).toBe(
+            'm'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDoubleParenthesis, 10000)).toBe(
+            'mmmmmmmmmm'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanDoubleParenthesis, 0)).toBe('');
+    });
+
+    it('LowerRomanParenthesis', () => {
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanParenthesis, 1)).toBe('i');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanParenthesis, 2)).toBe('ii');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanParenthesis, 5)).toBe('v');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanParenthesis, 10)).toBe('x');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanParenthesis, 20)).toBe('xx');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanParenthesis, 50)).toBe('l');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanParenthesis, 100)).toBe('c');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanParenthesis, 1000)).toBe('m');
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanParenthesis, 10000)).toBe(
+            'mmmmmmmmmm'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.LowerRomanParenthesis, 0)).toBe('');
+    });
+
+    it('UpperRoman', () => {
+        expect(getOrderedListNumberStr(NumberingListType.UpperRoman, 1)).toBe('I');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRoman, 2)).toBe('II');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRoman, 5)).toBe('V');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRoman, 10)).toBe('X');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRoman, 20)).toBe('XX');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRoman, 50)).toBe('L');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRoman, 100)).toBe('C');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRoman, 1000)).toBe('M');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRoman, 10000)).toBe('MMMMMMMMMM');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRoman, 0)).toBe('');
+    });
+
+    it('UpperRomanDash', () => {
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDash, 1)).toBe('I');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDash, 2)).toBe('II');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDash, 5)).toBe('V');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDash, 10)).toBe('X');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDash, 20)).toBe('XX');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDash, 50)).toBe('L');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDash, 100)).toBe('C');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDash, 1000)).toBe('M');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDash, 10000)).toBe('MMMMMMMMMM');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDash, 0)).toBe('');
+    });
+
+    it('UpperRomanDoubleParenthesis', () => {
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDoubleParenthesis, 1)).toBe('I');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDoubleParenthesis, 2)).toBe(
+            'II'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDoubleParenthesis, 5)).toBe('V');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDoubleParenthesis, 10)).toBe(
+            'X'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDoubleParenthesis, 20)).toBe(
+            'XX'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDoubleParenthesis, 50)).toBe(
+            'L'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDoubleParenthesis, 100)).toBe(
+            'C'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDoubleParenthesis, 1000)).toBe(
+            'M'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDoubleParenthesis, 10000)).toBe(
+            'MMMMMMMMMM'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanDoubleParenthesis, 0)).toBe('');
+    });
+
+    it('UpperRomanParenthesis', () => {
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanParenthesis, 1)).toBe('I');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanParenthesis, 2)).toBe('II');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanParenthesis, 5)).toBe('V');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanParenthesis, 10)).toBe('X');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanParenthesis, 20)).toBe('XX');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanParenthesis, 50)).toBe('L');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanParenthesis, 100)).toBe('C');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanParenthesis, 1000)).toBe('M');
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanParenthesis, 10000)).toBe(
+            'MMMMMMMMMM'
+        );
+        expect(getOrderedListNumberStr(NumberingListType.UpperRomanParenthesis, 0)).toBe('');
+    });
+});


### PR DESCRIPTION
Move out the code for calculating list style type and number string, so that they can be easily reused.
