### PR TITLE
Add function to check if the node given is the editor node

### DIFF
--- a/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
@@ -12,12 +12,8 @@ class DOMHelperImpl implements DOMHelper {
         return this.contentDiv.textContent || '';
     }
 
-    isNodeInEditor(node: Node): boolean {
-        return this.contentDiv.contains(node);
-    }
-
-    isNodeEditor(node: Node): boolean {
-        return node == this.contentDiv;
+    isNodeInEditor(node: Node, excludeRoot?: boolean): boolean {
+        return this.contentDiv.contains(node) && (excludeRoot ? node != this.contentDiv : true);
     }
 
     calculateZoomScale(): number {

--- a/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
@@ -16,6 +16,10 @@ class DOMHelperImpl implements DOMHelper {
         return this.contentDiv.contains(node);
     }
 
+    isNodeEditor(node: Node): boolean {
+        return node == this.contentDiv;
+    }
+
     calculateZoomScale(): number {
         const originalWidth = this.contentDiv.getBoundingClientRect()?.width || 0;
         const visualWidth = this.contentDiv.offsetWidth;

--- a/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
@@ -17,24 +17,19 @@ describe('DOMHelperImpl', () => {
             expect(result).toBe(mockedResult);
             expect(containsSpy).toHaveBeenCalledWith(mockedNode);
         });
-    });
 
-    describe('isNodeEditor', () => {
-        it('isNodeEditor - Node is editor', () => {
-            const div = document.createElement('div');
-            const domHelper = createDOMHelper(div);
+        it('isNodeInEditor - exclude root', () => {
+            const mockedResult = 'RESULT' as any;
+            const containsSpy = jasmine.createSpy('contains').and.returnValue(mockedResult);
+            const mockedDiv = {
+                contains: containsSpy,
+            } as any;
+            const domHelper = createDOMHelper(mockedDiv);
 
-            const result = domHelper.isNodeEditor(div);
-            expect(result).toBeTrue();
-        });
+            const result = domHelper.isNodeInEditor(mockedDiv, true);
 
-        it('isNodeEditor - Node is not editor', () => {
-            const div = document.createElement('div');
-            const div2 = document.createElement('div');
-            const domHelper = createDOMHelper(div);
-
-            const result = domHelper.isNodeEditor(div2);
             expect(result).toBeFalse();
+            expect(containsSpy).toHaveBeenCalledWith(mockedDiv);
         });
     });
 

--- a/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
@@ -19,6 +19,25 @@ describe('DOMHelperImpl', () => {
         });
     });
 
+    describe('isNodeEditor', () => {
+        it('isNodeEditor - Node is editor', () => {
+            const div = document.createElement('div');
+            const domHelper = createDOMHelper(div);
+
+            const result = domHelper.isNodeEditor(div);
+            expect(result).toBeTrue();
+        });
+
+        it('isNodeEditor - Node is not editor', () => {
+            const div = document.createElement('div');
+            const div2 = document.createElement('div');
+            const domHelper = createDOMHelper(div);
+
+            const result = domHelper.isNodeEditor(div2);
+            expect(result).toBeFalse();
+        });
+    });
+
     describe('queryElements', () => {
         it('queryElements', () => {
             const mockedResult = ['RESULT'] as any;

--- a/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
@@ -4,8 +4,7 @@ import { DOMHelper } from 'roosterjs-content-model-types';
 describe('DOMHelperImpl', () => {
     describe('isNodeInEditor', () => {
         it('isNodeInEditor', () => {
-            const mockedResult = 'RESULT' as any;
-            const containsSpy = jasmine.createSpy('contains').and.returnValue(mockedResult);
+            const containsSpy = jasmine.createSpy('contains').and.returnValue(true);
             const mockedDiv = {
                 contains: containsSpy,
             } as any;
@@ -14,7 +13,7 @@ describe('DOMHelperImpl', () => {
 
             const result = domHelper.isNodeInEditor(mockedNode);
 
-            expect(result).toBe(mockedResult);
+            expect(result).toBeTrue();
             expect(containsSpy).toHaveBeenCalledWith(mockedNode);
         });
 

--- a/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
@@ -9,6 +9,12 @@ export interface DOMHelper {
     isNodeInEditor(node: Node): boolean;
 
     /**
+     * Check if the given DOM node is the editor itself
+     * @param node The node to check
+     */
+    isNodeEditor(node: Node): boolean;
+
+    /**
      * Query HTML elements in editor by tag name.
      * Be careful of this function since it will also return element under entity.
      * @param tag Tag name of the element to query

--- a/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
@@ -5,14 +5,9 @@ export interface DOMHelper {
     /**
      * Check if the given DOM node is in editor
      * @param node The node to check
+     * @param excludeRoot True to exclude the root element of the editor
      */
-    isNodeInEditor(node: Node): boolean;
-
-    /**
-     * Check if the given DOM node is the editor itself
-     * @param node The node to check
-     */
-    isNodeEditor(node: Node): boolean;
+    isNodeInEditor(node: Node, excludeRoot?: boolean): boolean;
 
     /**
      * Query HTML elements in editor by tag name.


### PR DESCRIPTION
### Description:

Modify isNodeInEditor on DOMHelper to exclude root node from search.