### PR TITLE
Fix 262779: The link still exists after deleting the picture with the link

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/hyperlink/HyperlinkPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/hyperlink/HyperlinkPlugin.ts
@@ -131,6 +131,8 @@ export class HyperlinkPlugin implements EditorPlugin {
                     } catch {}
                 }
             });
+        } else if (event.eventType == 'contentChanged') {
+            this.domHelper?.setDomAttribute('title', null /*value*/);
         }
     }
 

--- a/packages/roosterjs-content-model-plugins/test/hyperlink/HyperlinkPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/hyperlink/HyperlinkPluginTest.ts
@@ -455,4 +455,15 @@ describe('HyperlinkPlugin', () => {
 
         plugin.dispose();
     });
+
+    it('ContentChanged', () => {
+        const plugin = new HyperlinkPlugin();
+        plugin.initialize(editor);
+
+        plugin.onPluginEvent({
+            eventType: 'contentChanged',
+        } as any);
+
+        expect(setDomAttributeSpy).toHaveBeenCalledWith('title', null);
+    });
 });


### PR DESCRIPTION
https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/262779/?triage=true

We need to reset title attribute of editor when contentChanged event is triggered to avoid link hint got stuck.