### PR TITLE
Allow customizability for table editors

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/index.ts
+++ b/packages/roosterjs-content-model-plugins/lib/index.ts
@@ -1,4 +1,5 @@
 export { TableEditPlugin } from './tableEdit/TableEditPlugin';
+export { OnTableEditorCreatedCallback } from './tableEdit/OnTableEditorCreatedCallback';
 export { PastePlugin } from './paste/PastePlugin';
 export { EditPlugin } from './edit/EditPlugin';
 export { AutoFormatPlugin, AutoFormatOptions } from './autoFormat/AutoFormatPlugin';

--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/OnTableEditorCreatedCallback.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/OnTableEditorCreatedCallback.ts
@@ -1,0 +1,7 @@
+/**
+ * Optional callback when creating a TableEditPlugin, allows to customize the Selectors element as required.
+ */
+export type OnTableEditorCreatedCallback = (
+    editorType: 'HorizontalTableInserter' | 'VerticalTableInserter' | 'TableMover' | 'TableResizer',
+    element: HTMLElement
+) => () => void;

--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/TableEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/TableEditPlugin.ts
@@ -1,5 +1,6 @@
 import { isNodeOfType, normalizeRect } from 'roosterjs-content-model-dom';
 import { TableEditor } from './editors/TableEditor';
+import type { OnTableEditorCreatedCallback } from './OnTableEditorCreatedCallback';
 import type { EditorPlugin, IEditor, PluginEvent, Rect } from 'roosterjs-content-model-types';
 
 const TABLE_RESIZER_LENGTH = 12;
@@ -22,14 +23,7 @@ export class TableEditPlugin implements EditorPlugin {
      */
     constructor(
         private anchorContainerSelector?: string,
-        private onTableEditorCreated?: (
-            editorType:
-                | 'HorizontalTableInserter'
-                | 'VerticalTableInserter'
-                | 'TableMover'
-                | 'TableResizer',
-            element: HTMLElement
-        ) => () => void
+        private onTableEditorCreated?: OnTableEditorCreatedCallback
     ) {}
 
     /**

--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/TableEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/TableEditPlugin.ts
@@ -18,8 +18,19 @@ export class TableEditPlugin implements EditorPlugin {
      * @param anchorContainerSelector An optional selector string to specify the container to host the plugin.
      * The container must not be affected by transform: scale(), otherwise the position calculation will be wrong.
      * If not specified, the plugin will be inserted in document.body
+     * @param onTableEditorCreated An optional callback to customize the Table Editors elements when created.
      */
-    constructor(private anchorContainerSelector?: string) {}
+    constructor(
+        private anchorContainerSelector?: string,
+        private onTableEditorCreated?: (
+            editorType:
+                | 'HorizontalTableInserter'
+                | 'VerticalTableInserter'
+                | 'TableMover'
+                | 'TableResizer',
+            element: HTMLElement
+        ) => () => void
+    ) {}
 
     /**
      * Get a friendly name of this plugin
@@ -66,6 +77,7 @@ export class TableEditPlugin implements EditorPlugin {
         this.disposeTableEditor();
         this.editor = null;
         this.onMouseMoveDisposer = null;
+        this.onTableEditorCreated = undefined;
     }
 
     /**
@@ -140,7 +152,8 @@ export class TableEditPlugin implements EditorPlugin {
                 table,
                 this.invalidateTableRects,
                 isNodeOfType(container, 'ELEMENT_NODE') ? container : undefined,
-                event?.currentTarget
+                event?.currentTarget,
+                this.onTableEditorCreated
             );
         }
     }

--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/features/TableEditFeature.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/features/TableEditFeature.ts
@@ -14,9 +14,9 @@ export interface TableEditFeature {
  */
 export function disposeTableEditFeature(resizer: TableEditFeature | null) {
     if (resizer) {
-        resizer.div?.parentNode?.removeChild(resizer.div);
-        resizer.div = null;
         resizer.featureHandler?.dispose();
         resizer.featureHandler = null;
+        resizer.div?.parentNode?.removeChild(resizer.div);
+        resizer.div = null;
     }
 }

--- a/packages/roosterjs-content-model-plugins/test/tableEdit/tableInserterTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/tableEdit/tableInserterTest.ts
@@ -1,3 +1,5 @@
+import * as getIntersectedRect from '../../lib/pluginUtils/Rect/getIntersectedRect';
+import { createTableInserter } from '../../lib/tableEdit/editors/features/TableInserter';
 import { DOMEventHandlerFunction, IEditor } from 'roosterjs-content-model-types';
 import { getMergedFirstColumnTable, getMergedTopRowTable, getModelTable } from './tableData';
 import { TableEditPlugin } from '../../lib/tableEdit/TableEditPlugin';
@@ -111,5 +113,113 @@ describe('Table Inserter tests', () => {
             y: (rect.bottom - rect.top) / 2,
         });
         expect(inserterFound).toBe('not clickable');
+    });
+
+    it('Customize table inserter', () => {
+        spyOn(getIntersectedRect, 'getIntersectedRect').and.returnValue({
+            bottom: 10,
+            left: 10,
+            right: 10,
+            top: 10,
+        });
+
+        const disposer = jasmine.createSpy('disposer');
+        const changeCb = jasmine.createSpy('changeCb');
+        //Act
+        const result = createTableInserter(
+            editor,
+            <any>(<HTMLTableCellElement>{
+                getBoundingClientRect: () => {
+                    return {
+                        bottom: 10,
+                        height: 10,
+                        left: 10,
+                        right: 10,
+                        top: 10,
+                    };
+                },
+                ownerDocument: document,
+            }),
+            <any>{
+                getBoundingClientRect: () => {
+                    return {
+                        bottom: 10,
+                        height: 10,
+                        left: 10,
+                        right: 10,
+                    };
+                    ownerDocument: document;
+                },
+            },
+            false,
+            false,
+            () => {},
+            undefined,
+            (editorType, element) => {
+                if (element && editorType == 'VerticalTableInserter') {
+                    changeCb();
+                }
+                return () => disposer();
+            }
+        );
+
+        result?.featureHandler?.dispose();
+
+        expect(disposer).toHaveBeenCalled();
+        expect(changeCb).toHaveBeenCalled();
+    });
+
+    it('Customize table inserter, do not customize editortype is not in the cb', () => {
+        spyOn(getIntersectedRect, 'getIntersectedRect').and.returnValue({
+            bottom: 10,
+            left: 10,
+            right: 10,
+            top: 10,
+        });
+
+        const disposer = jasmine.createSpy('disposer');
+        const changeCb = jasmine.createSpy('changeCb');
+        //Act
+        const result = createTableInserter(
+            editor,
+            <any>(<HTMLTableCellElement>{
+                getBoundingClientRect: () => {
+                    return {
+                        bottom: 10,
+                        height: 10,
+                        left: 10,
+                        right: 10,
+                        top: 10,
+                    };
+                },
+                ownerDocument: document,
+            }),
+            <any>{
+                getBoundingClientRect: () => {
+                    return {
+                        bottom: 10,
+                        height: 10,
+                        left: 10,
+                        right: 10,
+                    };
+                    ownerDocument: document;
+                },
+            },
+            false,
+            false,
+            () => {},
+            undefined,
+            (editorType, element) => {
+                if (element && editorType == 'TableMover') {
+                    changeCb();
+                }
+                return () => disposer();
+            }
+        );
+
+        result?.featureHandler?.dispose();
+
+        expect(disposer).toHaveBeenCalled();
+        expect(changeCb).not.toHaveBeenCalled();
     });
 });

--- a/packages/roosterjs-content-model-plugins/test/tableEdit/tableMoverTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/tableEdit/tableMoverTest.ts
@@ -1,6 +1,7 @@
 import { createTableMover } from '../../lib/tableEdit/editors/features/TableMover';
 import { Editor } from 'roosterjs-content-model-core';
 import { EditorOptions, IEditor } from 'roosterjs-content-model-types';
+import { OnTableEditorCreatedCallback } from '../../lib/tableEdit/OnTableEditorCreatedCallback';
 import { TableEditor } from '../../lib/tableEdit/editors/TableEditor';
 import { TableEditPlugin } from '../../lib/tableEdit/TableEditPlugin';
 
@@ -181,6 +182,52 @@ describe('Table Mover Tests', () => {
         runTest(0, true);
     });
 
+    it('Customize component with callback', () => {
+        //Arrange
+        const scrollContainer = document.createElement('div');
+        scrollContainer.innerHTML = '<div style="height: 300px"></div>';
+        document.body.insertBefore(scrollContainer, document.body.childNodes[0]);
+        scrollContainer.append(node);
+        spyOn(editor, 'getScrollContainer').and.returnValue(scrollContainer);
+
+        const disposer = jasmine.createSpy('disposer');
+        const changeCb = jasmine.createSpy('disposer');
+        const mover = runTest(0, true, (editorType, element) => {
+            if (element && editorType == 'TableMover') {
+                changeCb();
+            }
+            return () => disposer();
+        });
+
+        mover?.featureHandler?.dispose();
+
+        expect(disposer).toHaveBeenCalled();
+        expect(changeCb).toHaveBeenCalled();
+    });
+
+    it('Dont customize component with callback, editor type not in callback', () => {
+        //Arrange
+        const scrollContainer = document.createElement('div');
+        scrollContainer.innerHTML = '<div style="height: 300px"></div>';
+        document.body.insertBefore(scrollContainer, document.body.childNodes[0]);
+        scrollContainer.append(node);
+        spyOn(editor, 'getScrollContainer').and.returnValue(scrollContainer);
+
+        const disposer = jasmine.createSpy('disposer');
+        const changeCb = jasmine.createSpy('disposer');
+        const mover = runTest(0, true, (editorType, element) => {
+            if (element && editorType == 'TableResizer') {
+                changeCb();
+            }
+            return () => disposer();
+        });
+
+        mover?.featureHandler?.dispose();
+
+        expect(disposer).toHaveBeenCalled();
+        expect(changeCb).not.toHaveBeenCalled();
+    });
+
     it('On click event', () => {
         const table = document.getElementById(targetId) as HTMLTableElement;
 
@@ -202,7 +249,11 @@ describe('Table Mover Tests', () => {
         }
     });
 
-    function runTest(scrollTop: number, isNotNull: boolean | null) {
+    function runTest(
+        scrollTop: number,
+        isNotNull: boolean | null,
+        onTableEditorCreatedCallback?: OnTableEditorCreatedCallback
+    ) {
         //Arrange
         node.style.height = '10px';
         node.style.overflowX = 'auto';
@@ -216,8 +267,9 @@ describe('Table Mover Tests', () => {
             editor,
             false,
             () => {},
-            () => () => {},
-            node
+            node,
+            undefined,
+            onTableEditorCreatedCallback
         );
 
         //Assert
@@ -226,5 +278,7 @@ describe('Table Mover Tests', () => {
         } else {
             expect(result).toBeDefined();
         }
+
+        return result;
     }
 });

--- a/packages/roosterjs-content-model-plugins/test/tableEdit/tableResizerTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/tableEdit/tableResizerTest.ts
@@ -1,5 +1,8 @@
+import * as getIntersectedRect from '../../lib/pluginUtils/Rect/getIntersectedRect';
+import { createTableResizer } from '../../lib/tableEdit/editors/features/TableResizer';
 import { getModelTable } from './tableData';
 import { TableEditPlugin } from '../../lib/tableEdit/TableEditPlugin';
+
 import {
     ContentModelTable,
     DOMEventHandlerFunction,
@@ -193,5 +196,91 @@ xdescribe('Table Resizer tests', () => {
 
     it('decreases the width and height of the table', () => {
         resizeWholeTableTest(getModelTable(), -1, 'both');
+    });
+
+    it('Customize table inserter', () => {
+        spyOn(getIntersectedRect, 'getIntersectedRect').and.returnValue({
+            bottom: 10,
+            left: 10,
+            right: 10,
+            top: 10,
+        });
+
+        const disposer = jasmine.createSpy('disposer');
+        const changeCb = jasmine.createSpy('changeCb');
+        //Act
+        const result = createTableResizer(
+            <any>{
+                getBoundingClientRect: () => {
+                    return {
+                        bottom: 10,
+                        height: 10,
+                        left: 10,
+                        right: 10,
+                    };
+                    ownerDocument: document;
+                },
+            },
+            editor,
+            false,
+            () => {},
+            () => false,
+            null,
+            undefined,
+            (editorType, element) => {
+                if (element && editorType == 'TableResizer') {
+                    changeCb();
+                }
+                return () => disposer();
+            }
+        );
+
+        result?.featureHandler?.dispose();
+
+        expect(disposer).toHaveBeenCalled();
+        expect(changeCb).toHaveBeenCalled();
+    });
+
+    it('Customize table inserter, do not customize wrong editor type', () => {
+        spyOn(getIntersectedRect, 'getIntersectedRect').and.returnValue({
+            bottom: 10,
+            left: 10,
+            right: 10,
+            top: 10,
+        });
+
+        const disposer = jasmine.createSpy('disposer');
+        const changeCb = jasmine.createSpy('changeCb');
+        //Act
+        const result = createTableResizer(
+            <any>{
+                getBoundingClientRect: () => {
+                    return {
+                        bottom: 10,
+                        height: 10,
+                        left: 10,
+                        right: 10,
+                    };
+                    ownerDocument: document;
+                },
+            },
+            editor,
+            false,
+            () => {},
+            () => false,
+            null,
+            undefined,
+            (editorType, element) => {
+                if (element && editorType == 'TableMover') {
+                    changeCb();
+                }
+                return () => disposer();
+            }
+        );
+
+        result?.featureHandler?.dispose();
+
+        expect(disposer).toHaveBeenCalled();
+        expect(changeCb).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
We want to be able to do an event handler when double clicking the table mover.
To do this, add a new optional callback to the TableEditPlugin `onTableEditorCreated`, so we can customize or add event handlers the editor.

While adding this functionality to the table mover, we might as well add customizability to other visible components, so I also added the cutomize callback to the table Resizer, Table Inserters.