### PR TITLE
Trigger snapshot creation when the logical root changes

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/undo/UndoPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/undo/UndoPlugin.ts
@@ -115,6 +115,11 @@ class UndoPlugin implements PluginWithState<UndoPluginState> {
             case 'beforeKeyboardEditing':
                 this.onBeforeKeyboardEditing(event.rawEvent);
                 break;
+            case 'logicalRootChanged':
+                if (this.state.snapshotsManager.hasNewContent) {
+                    this.addUndoSnapshot();
+                }
+                break;
         }
     }
 

--- a/packages/roosterjs-content-model-core/test/corePlugin/undo/UndoPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/undo/UndoPluginTest.ts
@@ -941,5 +941,23 @@ describe('UndoPlugin', () => {
             expect(mockedSnapshotsManager.hasNewContent).toBeTrue();
             expect(clearRedoSpy).toHaveBeenCalledTimes(0);
         });
+
+        it('LogicalRootChanged addUndoSnapshot if there is new content', () => {
+            const state = plugin.getState();
+
+            plugin.onPluginEvent({
+                eventType: 'logicalRootChanged',
+            } as any);
+
+            expect(takeSnapshotSpy).toHaveBeenCalledTimes(0);
+
+            state.snapshotsManager.hasNewContent = true;
+
+            plugin.onPluginEvent({
+                eventType: 'logicalRootChanged',
+            } as any);
+
+            expect(takeSnapshotSpy).toHaveBeenCalledTimes(1);
+        });
     });
 });


### PR DESCRIPTION
Code change similar to #2605 to also create a snapshot when logical root is changed.