### PR TITLE
Hide watermark when input with IME

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkPlugin.ts
@@ -62,7 +62,10 @@ export class WatermarkPlugin implements EditorPlugin {
             return;
         }
 
-        if (event.eventType == 'input' && event.rawEvent.inputType == 'insertText') {
+        if (
+            (event.eventType == 'input' && event.rawEvent.inputType == 'insertText') ||
+            event.eventType == 'compositionEnd'
+        ) {
             // When input text, editor must not be empty, so we can do hide watermark now without checking content model
             this.showHide(editor, false /*isEmpty*/);
         } else if (


### PR DESCRIPTION
When input with IME, we need to hide watermark text since the input will finally trigger compositionEnd event rather than keydown or input event.