### PR TITLE
Updated watermark property access modifier to protected

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkPlugin.ts
@@ -22,7 +22,7 @@ export class WatermarkPlugin implements EditorPlugin {
      * Create an instance of Watermark plugin
      * @param watermark The watermark string
      */
-    constructor(private watermark: string, format?: WatermarkFormat) {
+    constructor(protected watermark: string, format?: WatermarkFormat) {
         this.format = format || {
             fontSize: '14px',
             textColor: '#AAAAAA',


### PR DESCRIPTION
Updated watermark property access modifier to make it available for classes that extends WatermarkPlugin.

Fix for https://github.com/microsoft/roosterjs/issues/2612