### PR TITLE
Scroll caret into view when call formatContentModel

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
@@ -94,6 +94,7 @@ export function mergePasteContent(
         {
             changeSource: ChangeSource.Paste,
             getChangeData: () => clipboardData,
+            scrollCaretIntoView: true,
             apiName: 'paste',
         }
     );

--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -1,4 +1,4 @@
-import { ChangeSource } from 'roosterjs-content-model-dom';
+import { ChangeSource, getSelectionRootNode } from 'roosterjs-content-model-dom';
 import type {
     ChangedEntity,
     ContentChangedEvent,
@@ -24,8 +24,15 @@ export const formatContentModel: FormatContentModel = (
     options,
     domToModelOptions
 ) => {
-    const { apiName, onNodeCreated, getChangeData, changeSource, rawEvent, selectionOverride } =
-        options || {};
+    const {
+        apiName,
+        onNodeCreated,
+        getChangeData,
+        changeSource,
+        rawEvent,
+        selectionOverride,
+        scrollCaretIntoView,
+    } = options || {};
     const model = core.api.createContentModel(core, domToModelOptions, selectionOverride);
     const context: FormatContentModelContext = {
         newEntities: [],
@@ -62,6 +69,14 @@ export const formatContentModel: FormatContentModel = (
                 ) ?? undefined;
 
             handlePendingFormat(core, context, selection);
+
+            if (selection && scrollCaretIntoView) {
+                const selectionRoot = getSelectionRootNode(selection);
+                const rootElement =
+                    selectionRoot && core.domHelper.findClosestElementAncestor(selectionRoot);
+
+                rootElement?.scrollIntoView();
+            }
 
             const eventData: ContentChangedEvent = {
                 eventType: 'contentChanged',

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -21,6 +21,7 @@ describe('formatContentModel', () => {
     let hasFocus: jasmine.Spy;
     let getClientWidth: jasmine.Spy;
     let announce: jasmine.Spy;
+    let findClosestElementAncestor: jasmine.Spy;
 
     const apiName = 'mockedApi';
     const mockedContainer = 'C' as any;
@@ -42,6 +43,7 @@ describe('formatContentModel', () => {
         hasFocus = jasmine.createSpy('hasFocus');
         getClientWidth = jasmine.createSpy('getClientWidth');
         announce = jasmine.createSpy('announce');
+        findClosestElementAncestor = jasmine.createSpy('findClosestElementAncestor ');
 
         core = ({
             api: {
@@ -62,6 +64,7 @@ describe('formatContentModel', () => {
             domHelper: {
                 hasFocus,
                 getClientWidth,
+                findClosestElementAncestor,
             },
         } as any) as EditorCore;
     });
@@ -548,6 +551,31 @@ describe('formatContentModel', () => {
                 cachedSelection: undefined,
             });
             expect(announce).not.toHaveBeenCalled();
+        });
+
+        it('Has scrollCaretIntoView, and callback return true', () => {
+            const scrollIntoViewSpy = jasmine.createSpy('scrollIntoView');
+            const mockedImage = { scrollIntoView: scrollIntoViewSpy } as any;
+
+            findClosestElementAncestor.and.returnValue(mockedImage);
+            setContentModel.and.returnValue({
+                type: 'image',
+                image: mockedImage,
+            });
+            formatContentModel(
+                core,
+                (model, context) => {
+                    context.clearModelCache = true;
+                    return true;
+                },
+                {
+                    scrollCaretIntoView: true,
+                    apiName,
+                }
+            );
+
+            expect(findClosestElementAncestor).toHaveBeenCalledWith(mockedImage);
+            expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -49,6 +49,7 @@ export function keyboardDelete(editor: IEditor, rawEvent: KeyboardEvent) {
                 rawEvent,
                 changeSource: ChangeSource.Keyboard,
                 getChangeData: () => rawEvent.which,
+                scrollCaretIntoView: true,
                 apiName: rawEvent.key == 'Delete' ? 'handleDeleteKey' : 'handleBackspaceKey',
             }
         );

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -36,6 +36,7 @@ export function keyboardInput(editor: IEditor, rawEvent: KeyboardEvent) {
                 }
             },
             {
+                scrollCaretIntoView: true,
                 rawEvent,
             }
         );

--- a/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelOptions.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelOptions.ts
@@ -38,6 +38,11 @@ export interface FormatContentModelOptions {
      * When specified, use this selection range to override current selection inside editor
      */
     selectionOverride?: DOMSelection;
+
+    /**
+     * When pass to true, scroll the editing caret into view after write DOM tree if need
+     */
+    scrollCaretIntoView?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add a parameter `scrollCaretIntoView` to `FormatContentModelOptions`, when pass it to true, after format with content model we will scroll caret into view so that user can keep seeing latest changed content.

And set this option to true for the following scenarios:
- paste
- keyboard input
- keyboard delete