### PR TITLE
Remove BgColor from General Model if the background in the format is undefined 

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/common/backgroundColorFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/common/backgroundColorFormatHandler.ts
@@ -28,14 +28,12 @@ export const backgroundColorFormatHandler: FormatHandler<BackgroundColorFormat> 
         }
     },
     apply: (format, element, context) => {
-        if (format.backgroundColor) {
-            setColor(
-                element,
-                format.backgroundColor,
-                true /*isBackground*/,
-                !!context.isDarkMode,
-                context.darkColorHandler
-            );
-        }
+        setColor(
+            element,
+            format.backgroundColor,
+            true /*isBackground*/,
+            !!context.isDarkMode,
+            context.darkColorHandler
+        );
     },
 };

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/common/backgroundColorFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/common/backgroundColorFormatHandlerTest.ts
@@ -121,4 +121,26 @@ describe('backgroundColorFormatHandler.apply', () => {
 
         expectHtml(div.outerHTML, expectedResult);
     });
+
+    it('Element with Background color and format.background is undefined', () => {
+        format.backgroundColor = undefined;
+        div.style.backgroundColor = 'red';
+
+        backgroundColorFormatHandler.apply(format, div, context);
+
+        const expectedResult = ['<div style=""></div>'];
+
+        expectHtml(div.outerHTML, expectedResult);
+    });
+
+    it('Element with Background color and format.background is undefined', () => {
+        format.backgroundColor = undefined;
+        div.setAttribute('bgColor', 'red');
+
+        backgroundColorFormatHandler.apply(format, div, context);
+
+        const expectedResult = ['<div></div>'];
+
+        expectHtml(div.outerHTML, expectedResult);
+    });
 });


### PR DESCRIPTION
General model is handled different than other models, since we reuse the element property of the model when writing back the content.

https://github.com/microsoft/roosterjs/blob/01b4f1cc69c711eacdff775e56c7fdb1b742676f/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleGeneralModel.ts#L25-L35 

https://github.com/microsoft/roosterjs/blob/01b4f1cc69c711eacdff775e56c7fdb1b742676f/packages/roosterjs-content-model-types/lib/contentModel/blockGroup/ContentModelGeneralBlock.ts#L10-L17

So, in a scenario that we processed a general model, and the element of the model contained a background color, but we parsed the Content Model format to remove the background color. 

When we do contentModelToDom for the general model, the background color applier was no-op because the background color was undefined. However, instead doing anything if the format.background is undefined we should remove the background color of the general model. 

This PR is removing the undefined check and always calling the setColor, so we can remove the background if we removed backgroundColor from the format.

(Fix for 275125)