### PR TITLE
Fix #2633 `scrollCaretIntoView` causes unexpected scroll

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
@@ -94,7 +94,7 @@ export function mergePasteContent(
         {
             changeSource: ChangeSource.Paste,
             getChangeData: () => clipboardData,
-            scrollCaretIntoView: true,
+            scrollCaretIntoView: false,
             apiName: 'paste',
         }
     );

--- a/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
@@ -94,7 +94,7 @@ export function mergePasteContent(
         {
             changeSource: ChangeSource.Paste,
             getChangeData: () => clipboardData,
-            scrollCaretIntoView: false,
+            scrollCaretIntoView: false, // TODO #2633: Make a full fix to the scroll behavior
             apiName: 'paste',
         }
     );

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -49,7 +49,7 @@ export function keyboardDelete(editor: IEditor, rawEvent: KeyboardEvent) {
                 rawEvent,
                 changeSource: ChangeSource.Keyboard,
                 getChangeData: () => rawEvent.which,
-                scrollCaretIntoView: true,
+                scrollCaretIntoView: false,
                 apiName: rawEvent.key == 'Delete' ? 'handleDeleteKey' : 'handleBackspaceKey',
             }
         );

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -49,7 +49,7 @@ export function keyboardDelete(editor: IEditor, rawEvent: KeyboardEvent) {
                 rawEvent,
                 changeSource: ChangeSource.Keyboard,
                 getChangeData: () => rawEvent.which,
-                scrollCaretIntoView: false,
+                scrollCaretIntoView: false, // TODO #2633: Make a full fix to the scroll behavior
                 apiName: rawEvent.key == 'Delete' ? 'handleDeleteKey' : 'handleBackspaceKey',
             }
         );

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -36,7 +36,7 @@ export function keyboardInput(editor: IEditor, rawEvent: KeyboardEvent) {
                 }
             },
             {
-                scrollCaretIntoView: true,
+                scrollCaretIntoView: false,
                 rawEvent,
             }
         );

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -36,7 +36,7 @@ export function keyboardInput(editor: IEditor, rawEvent: KeyboardEvent) {
                 }
             },
             {
-                scrollCaretIntoView: false,
+                scrollCaretIntoView: false, // TODO #2633: Make a full fix to the scroll behavior
                 rawEvent,
             }
         );


### PR DESCRIPTION
This is a temp fix to #2633, just disable this scrolling behavior. We will need a full fix later.