### PR TITLE
Add dark color handling for image and table cells selection

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
@@ -22,7 +22,7 @@ const HIDE_SELECTION_CSS_KEY = '_DOMSelectionHideSelection';
 const IMAGE_ID = 'image';
 const TABLE_ID = 'table';
 const DEFAULT_SELECTION_BORDER_COLOR = '#DB626C';
-const TABLE_CSS_RULE = 'background-color:#C6C6C6!important;';
+const DEFAULT_TABLE_CELL_SELECTION_BACKGROUND_COLOR = '#C6C6C6';
 const CARET_CSS_RULE = 'caret-color: transparent';
 const TRANSPARENT_SELECTION_CSS_RULE = 'background-color: transparent !important;';
 const SELECTION_SELECTOR = '*::selection';
@@ -115,7 +115,10 @@ export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionC
                 core.api.setEditorStyle(
                     core,
                     DOM_SELECTION_CSS_KEY,
-                    TABLE_CSS_RULE,
+                    `background-color:${
+                        core.selection.tableCellSelectionBackgroundColor ||
+                        DEFAULT_TABLE_CELL_SELECTION_BACKGROUND_COLOR
+                    }!important;`,
                     tableSelectors
                 );
                 core.api.setEditorStyle(core, HIDE_CURSOR_CSS_KEY, CARET_CSS_RULE);

--- a/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
@@ -36,7 +36,7 @@ export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionC
     const skipReselectOnFocus = core.selection.skipReselectOnFocus;
 
     const doc = core.physicalRoot.ownerDocument;
-
+    const isDarkMode = core.lifecycle.isDarkMode;
     core.selection.skipReselectOnFocus = true;
     core.api.setEditorStyle(core, DOM_SELECTION_CSS_KEY, null /*cssRule*/);
     core.api.setEditorStyle(core, HIDE_CURSOR_CSS_KEY, null /*cssRule*/);
@@ -51,12 +51,20 @@ export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionC
                     type: 'image',
                     image,
                 };
+                let imageSelectionColor =
+                    core.selection.imageSelectionBorderColor || DEFAULT_SELECTION_BORDER_COLOR;
+                if (imageSelectionColor !== DEFAULT_SELECTION_BORDER_COLOR && isDarkMode === true) {
+                    imageSelectionColor = core.darkColorHandler.getDarkColor(
+                        imageSelectionColor,
+                        undefined,
+                        'border',
+                        image
+                    );
+                }
                 core.api.setEditorStyle(
                     core,
                     DOM_SELECTION_CSS_KEY,
-                    `outline-style:auto!important; outline-color:${
-                        core.selection.imageSelectionBorderColor || DEFAULT_SELECTION_BORDER_COLOR
-                    }!important;`,
+                    `outline-style:auto!important; outline-color:${imageSelectionColor}!important;`,
                     [`span:has(>img#${ensureUniqueId(image, IMAGE_ID)})`]
                 );
                 core.api.setEditorStyle(
@@ -112,13 +120,24 @@ export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionC
                         : handleTableSelected(parsedTable, tableId, table, firstCell, lastCell);
 
                 core.selection.selection = selection;
+                let tableSelectionColor =
+                    core.selection.tableCellSelectionBackgroundColor ||
+                    DEFAULT_TABLE_CELL_SELECTION_BACKGROUND_COLOR;
+                if (
+                    tableSelectionColor !== DEFAULT_TABLE_CELL_SELECTION_BACKGROUND_COLOR &&
+                    isDarkMode === true
+                ) {
+                    tableSelectionColor = core.darkColorHandler.getDarkColor(
+                        tableSelectionColor,
+                        undefined,
+                        'background',
+                        table
+                    );
+                }
                 core.api.setEditorStyle(
                     core,
                     DOM_SELECTION_CSS_KEY,
-                    `background-color:${
-                        core.selection.tableCellSelectionBackgroundColor ||
-                        DEFAULT_TABLE_CELL_SELECTION_BACKGROUND_COLOR
-                    }!important;`,
+                    `background-color:${tableSelectionColor}!important;`,
                     tableSelectors
                 );
                 core.api.setEditorStyle(core, HIDE_CURSOR_CSS_KEY, CARET_CSS_RULE);

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -47,6 +47,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
             selection: null,
             tableSelection: null,
             imageSelectionBorderColor: options.imageSelectionBorderColor,
+            tableCellSelectionBackgroundColor: options.tableCellSelectionBackgroundColor,
         };
     }
 

--- a/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/setDOMSelectionTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/setDOMSelectionTest.ts
@@ -549,7 +549,7 @@ describe('setDOMSelection', () => {
             };
             const defaultSelectionColor = '#C6C6C6';
             if (selectionColor) {
-                core.selection.imageSelectionBorderColor = selectionColor;
+                core.selection.tableCellSelectionBackgroundColor = selectionColor;
             }
 
             createRangeSpy.and.returnValue(mockedRange);

--- a/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/setDOMSelectionTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/setDOMSelectionTest.ts
@@ -530,7 +530,8 @@ describe('setDOMSelection', () => {
             firstRow: number,
             lastColumn: number,
             lastRow: number,
-            result: string[]
+            result: string[],
+            selectionColor?: string
         ) {
             const mockedSelection = {
                 type: 'table',
@@ -546,6 +547,10 @@ describe('setDOMSelection', () => {
                 selectNode: selectNodeSpy,
                 collapse: collapseSpy,
             };
+            const defaultSelectionColor = '#C6C6C6';
+            if (selectionColor) {
+                core.selection.imageSelectionBorderColor = selectionColor;
+            }
 
             createRangeSpy.and.returnValue(mockedRange);
 
@@ -578,7 +583,7 @@ describe('setDOMSelection', () => {
             expect(setEditorStyleSpy).toHaveBeenCalledWith(
                 core,
                 '_DOMSelection',
-                'background-color:#C6C6C6!important;',
+                `background-color:${selectionColor ?? defaultSelectionColor}!important;`,
                 result
             );
             expect(setEditorStyleSpy).toHaveBeenCalledWith(
@@ -773,6 +778,18 @@ describe('setDOMSelection', () => {
                 '#table_0',
                 '#table_0 *',
             ]);
+        });
+
+        it('Select All with custom selection color', () => {
+            runTest(
+                buildTable(true /* tbody */, false, false),
+                0,
+                0,
+                1,
+                1,
+                ['#table_0', '#table_0 *'],
+                'red'
+            );
         });
     });
 });

--- a/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/setDOMSelectionTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/setDOMSelectionTest.ts
@@ -55,6 +55,12 @@ describe('setDOMSelection', () => {
             domHelper: {
                 hasFocus: hasFocusSpy,
             },
+            lifecycle: {
+                isDarkMode: false,
+            },
+            darkColorHandler: {
+                getDarkColor: (lightColor: string) => `DarkColorMock-${lightColor}`,
+            },
         } as any;
     });
 
@@ -350,6 +356,70 @@ describe('setDOMSelection', () => {
             );
             expect(setEditorStyleSpy).toHaveBeenCalledWith(
                 core,
+                '_DOMSelectionHideSelection',
+                'background-color: transparent !important;',
+                ['*::selection']
+            );
+        });
+
+        it('image selection with customized selection border color and dark mode', () => {
+            const mockedSelection = {
+                type: 'image',
+                image: mockedImage,
+            } as any;
+            const selectNodeSpy = jasmine.createSpy('selectNode');
+            const collapseSpy = jasmine.createSpy('collapse');
+            const mockedRange = {
+                selectNode: selectNodeSpy,
+                collapse: collapseSpy,
+            };
+            const coreValue = { ...core, lifecycle: { isDarkMode: true } as any };
+
+            coreValue.selection.imageSelectionBorderColor = 'red';
+
+            createRangeSpy.and.returnValue(mockedRange);
+
+            querySelectorAllSpy.and.returnValue([]);
+            hasFocusSpy.and.returnValue(false);
+
+            setDOMSelection(coreValue, mockedSelection);
+
+            expect(coreValue.selection).toEqual({
+                skipReselectOnFocus: undefined,
+                selection: mockedSelection,
+                imageSelectionBorderColor: 'red',
+            } as any);
+            expect(triggerEventSpy).toHaveBeenCalledWith(
+                coreValue,
+                {
+                    eventType: 'selectionChanged',
+                    newSelection: mockedSelection,
+                },
+                true
+            );
+            expect(selectNodeSpy).toHaveBeenCalledWith(mockedImage);
+            expect(collapseSpy).not.toHaveBeenCalledWith();
+            expect(addRangeToSelectionSpy).toHaveBeenCalledWith(doc, mockedRange, undefined);
+            expect(setEditorStyleSpy).toHaveBeenCalledTimes(5);
+            expect(setEditorStyleSpy).toHaveBeenCalledWith(coreValue, '_DOMSelection', null);
+            expect(setEditorStyleSpy).toHaveBeenCalledWith(
+                coreValue,
+                '_DOMSelectionHideCursor',
+                null
+            );
+            expect(setEditorStyleSpy).toHaveBeenCalledWith(
+                coreValue,
+                '_DOMSelectionHideSelection',
+                null
+            );
+            expect(setEditorStyleSpy).toHaveBeenCalledWith(
+                coreValue,
+                '_DOMSelection',
+                'outline-style:auto!important; outline-color:DarkColorMock-red!important;',
+                ['span:has(>img#image_0)']
+            );
+            expect(setEditorStyleSpy).toHaveBeenCalledWith(
+                coreValue,
                 '_DOMSelectionHideSelection',
                 'background-color: transparent !important;',
                 ['*::selection']

--- a/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/setDOMSelectionTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/setDOMSelectionTest.ts
@@ -562,6 +562,7 @@ describe('setDOMSelection', () => {
             expect(core.selection).toEqual({
                 skipReselectOnFocus: undefined,
                 selection: mockedSelection,
+                tableCellSelectionBackgroundColor: selectionColor,
             } as any);
             expect(triggerEventSpy).toHaveBeenCalledWith(
                 core,

--- a/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
@@ -33,6 +33,7 @@ describe('SelectionPlugin', () => {
         expect(state).toEqual({
             selection: null,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
             tableSelection: null,
         });
         expect(attachDomEvent).toHaveBeenCalled();
@@ -48,6 +49,7 @@ describe('SelectionPlugin', () => {
     it('init with different options', () => {
         const plugin = createSelectionPlugin({
             imageSelectionBorderColor: 'red',
+            tableCellSelectionBackgroundColor: 'blue',
         });
         const state = plugin.getState();
         const addEventListenerSpy = jasmine.createSpy('addEventListener');
@@ -69,6 +71,7 @@ describe('SelectionPlugin', () => {
         expect(state).toEqual({
             selection: null,
             imageSelectionBorderColor: 'red',
+            tableCellSelectionBackgroundColor: 'blue',
             tableSelection: null,
         });
 
@@ -135,6 +138,7 @@ describe('SelectionPlugin handle onFocus and onBlur event', () => {
         expect(plugin.getState()).toEqual({
             selection: mockedRange,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
             skipReselectOnFocus: false,
             tableSelection: null,
         });
@@ -151,6 +155,7 @@ describe('SelectionPlugin handle onFocus and onBlur event', () => {
         expect(plugin.getState()).toEqual({
             selection: mockedRange,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
             skipReselectOnFocus: true,
             tableSelection: null,
         });
@@ -768,6 +773,7 @@ describe('SelectionPlugin handle table selection', () => {
             selection: null,
             tableSelection: mockedTableSelection,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
         });
 
         plugin.onPluginEvent!({
@@ -781,6 +787,7 @@ describe('SelectionPlugin handle table selection', () => {
             selection: null,
             tableSelection: null,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
         });
         expect(mouseDispatcher).toBeUndefined();
     });
@@ -814,6 +821,7 @@ describe('SelectionPlugin handle table selection', () => {
             selection: null,
             tableSelection: null,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
         });
 
         plugin.onPluginEvent!({
@@ -834,6 +842,7 @@ describe('SelectionPlugin handle table selection', () => {
             },
             mouseDisposer: mouseMoveDisposer,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
         });
         expect(mouseDispatcher).toBeDefined();
     });
@@ -867,6 +876,7 @@ describe('SelectionPlugin handle table selection', () => {
             selection: null,
             tableSelection: null,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
         });
 
         plugin.onPluginEvent!({
@@ -881,6 +891,7 @@ describe('SelectionPlugin handle table selection', () => {
             selection: null,
             tableSelection: null,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
         });
         expect(mouseDispatcher).toBeUndefined();
     });
@@ -919,6 +930,7 @@ describe('SelectionPlugin handle table selection', () => {
             },
             mouseDisposer: mouseMoveDisposer,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
         });
         expect(mouseDispatcher).toBeDefined();
         expect(preventDefaultSpy).toHaveBeenCalled();
@@ -1259,6 +1271,7 @@ describe('SelectionPlugin handle table selection', () => {
                 selection: null,
                 tableSelection: null,
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).not.toHaveBeenCalled();
             expect(announceSpy).not.toHaveBeenCalled();
@@ -1300,6 +1313,7 @@ describe('SelectionPlugin handle table selection', () => {
                 selection: null,
                 tableSelection: null,
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(0);
             expect(announceSpy).not.toHaveBeenCalled();
@@ -1356,6 +1370,7 @@ describe('SelectionPlugin handle table selection', () => {
                 selection: null,
                 tableSelection: null,
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith({
@@ -1419,6 +1434,7 @@ describe('SelectionPlugin handle table selection', () => {
                 selection: null,
                 tableSelection: null,
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith({
@@ -1481,6 +1497,7 @@ describe('SelectionPlugin handle table selection', () => {
                 selection: null,
                 tableSelection: null,
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith({
@@ -1544,6 +1561,7 @@ describe('SelectionPlugin handle table selection', () => {
                 selection: null,
                 tableSelection: null,
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith({
@@ -1606,6 +1624,7 @@ describe('SelectionPlugin handle table selection', () => {
                 selection: null,
                 tableSelection: null,
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith({
@@ -1668,6 +1687,7 @@ describe('SelectionPlugin handle table selection', () => {
                 selection: null,
                 tableSelection: null,
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith({
@@ -1733,6 +1753,7 @@ describe('SelectionPlugin handle table selection', () => {
                     startNode: td4,
                 },
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith({
@@ -1798,6 +1819,7 @@ describe('SelectionPlugin handle table selection', () => {
                     startNode: td2,
                 },
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith({
@@ -1862,6 +1884,7 @@ describe('SelectionPlugin handle table selection', () => {
                     startNode: td2,
                 },
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(0);
             expect(announceSpy).not.toHaveBeenCalled();
@@ -1906,6 +1929,7 @@ describe('SelectionPlugin handle table selection', () => {
                     startNode: td2,
                 },
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).not.toHaveBeenCalled();
             expect(preventDefaultSpy).not.toHaveBeenCalled();
@@ -1959,6 +1983,7 @@ describe('SelectionPlugin handle table selection', () => {
                 selection: null,
                 tableSelection: null,
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith(null);
@@ -2008,6 +2033,7 @@ describe('SelectionPlugin handle table selection', () => {
                     startNode: td2,
                 },
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith({
@@ -2064,6 +2090,7 @@ describe('SelectionPlugin handle table selection', () => {
                     startNode: td3,
                 },
                 imageSelectionBorderColor: undefined,
+                tableCellSelectionBackgroundColor: undefined,
             });
             expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
             expect(setDOMSelectionSpy).toHaveBeenCalledWith({
@@ -2133,6 +2160,7 @@ describe('SelectionPlugin on Safari', () => {
         expect(state).toEqual({
             selection: null,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
             tableSelection: null,
         });
         expect(attachDomEvent).toHaveBeenCalled();
@@ -2168,6 +2196,7 @@ describe('SelectionPlugin on Safari', () => {
         expect(state).toEqual({
             selection: mockedOldSelection,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
             tableSelection: null,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
@@ -2199,6 +2228,7 @@ describe('SelectionPlugin on Safari', () => {
         expect(state).toEqual({
             selection: mockedNewSelection,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
             tableSelection: null,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
@@ -2227,6 +2257,7 @@ describe('SelectionPlugin on Safari', () => {
         expect(state).toEqual({
             selection: mockedOldSelection,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
             tableSelection: null,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
@@ -2255,6 +2286,7 @@ describe('SelectionPlugin on Safari', () => {
         expect(state).toEqual({
             selection: mockedOldSelection,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
             tableSelection: null,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
@@ -2283,6 +2315,7 @@ describe('SelectionPlugin on Safari', () => {
         expect(state).toEqual({
             selection: mockedOldSelection,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
             tableSelection: null,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(0);
@@ -2311,6 +2344,7 @@ describe('SelectionPlugin on Safari', () => {
         expect(state).toEqual({
             selection: mockedOldSelection,
             imageSelectionBorderColor: undefined,
+            tableCellSelectionBackgroundColor: undefined,
             tableSelection: null,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(0);

--- a/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
@@ -88,6 +88,11 @@ export interface EditorOptions {
     imageSelectionBorderColor?: string;
 
     /**
+     * Background color of a selected table cell. Default color: '#C6C6C6'
+     */
+    tableCellSelectionBackgroundColor?: string;
+
+    /**
      * Initial Content Model
      */
     initialModel?: ContentModelDocument;

--- a/packages/roosterjs-content-model-types/lib/pluginState/SelectionPluginState.ts
+++ b/packages/roosterjs-content-model-types/lib/pluginState/SelectionPluginState.ts
@@ -74,4 +74,9 @@ export interface SelectionPluginState {
      * Color of the border of a selectedImage. Default color: '#DB626C'
      */
     imageSelectionBorderColor?: string;
+
+    /**
+     * Background color of a selected table cell. Default color: '#C6C6C6'
+     */
+    tableCellSelectionBackgroundColor?: string;
 }


### PR DESCRIPTION
When setting s selection color, add a check if in dark mode and use a color for dark mode instead of light one. 