### PR TITLE
Auto link for link preview

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
@@ -249,7 +249,7 @@ export class AutoFormatPlugin implements EditorPlugin {
     private handleContentChangedEvent(editor: IEditor, event: ContentChangedEvent) {
         const { autoLink } = this.options;
         if (event.source == 'Paste' && autoLink) {
-            createLink(editor);
+            createLink(editor, event);
         }
     }
 }

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
@@ -220,13 +220,9 @@ export class AutoFormatPlugin implements EditorPlugin {
                                 shouldFraction ||
                                 shouldOrdinals
                             );
-                        }
+                        },
+                        formatOptions
                     );
-
-                    editor.triggerEvent('contentChanged', {
-                        source: formatOptions.changeSource ?? ChangeSource.Format,
-                        formatApiName: formatOptions.apiName,
-                    });
 
                     break;
             }
@@ -249,7 +245,7 @@ export class AutoFormatPlugin implements EditorPlugin {
     private handleContentChangedEvent(editor: IEditor, event: ContentChangedEvent) {
         const { autoLink } = this.options;
         if (event.source == 'Paste' && autoLink) {
-            createLink(editor, event);
+            createLink(editor);
         }
     }
 }

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
@@ -220,9 +220,13 @@ export class AutoFormatPlugin implements EditorPlugin {
                                 shouldFraction ||
                                 shouldOrdinals
                             );
-                        },
-                        formatOptions
+                        }
                     );
+
+                    editor.triggerEvent('contentChanged', {
+                        source: formatOptions.changeSource ?? ChangeSource.Format,
+                        formatApiName: formatOptions.apiName,
+                    });
 
                     break;
             }

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/link/createLink.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/link/createLink.ts
@@ -9,6 +9,9 @@ export function createLink(editor: IEditor) {
     formatTextSegmentBeforeSelectionMarker(
         editor,
         (_model, linkSegment, _paragraph) => {
+            if (linkSegment.link) {
+                return true;
+            }
             let linkData: LinkData | null = null;
             if (!linkSegment.link && (linkData = matchLink(linkSegment.text))) {
                 addLink(linkSegment, {
@@ -20,6 +23,7 @@ export function createLink(editor: IEditor) {
                 });
                 return true;
             }
+
             return false;
         },
         {

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/link/createLink.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/link/createLink.ts
@@ -1,11 +1,12 @@
 import { addLink, ChangeSource } from 'roosterjs-content-model-dom';
 import { formatTextSegmentBeforeSelectionMarker, matchLink } from 'roosterjs-content-model-api';
-import type { ContentChangedEvent, IEditor, LinkData } from 'roosterjs-content-model-types';
+import type { IEditor, LinkData } from 'roosterjs-content-model-types';
 
 /**
  * @internal
  */
-export function createLink(editor: IEditor, event: ContentChangedEvent) {
+export function createLink(editor: IEditor) {
+    let anchorNode: Node | null = null;
     formatTextSegmentBeforeSelectionMarker(
         editor,
         (_model, linkSegment, _paragraph) => {
@@ -28,9 +29,12 @@ export function createLink(editor: IEditor, event: ContentChangedEvent) {
         },
         {
             changeSource: ChangeSource.AutoLink,
-            getChangeData: () => {
-                return event.data;
+            onNodeCreated: (_modelElement, node) => {
+                if (!anchorNode) {
+                    anchorNode = node;
+                }
             },
+            getChangeData: () => anchorNode,
         }
     );
 }

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/link/createLink.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/link/createLink.ts
@@ -1,11 +1,11 @@
 import { addLink, ChangeSource } from 'roosterjs-content-model-dom';
 import { formatTextSegmentBeforeSelectionMarker, matchLink } from 'roosterjs-content-model-api';
-import type { IEditor, LinkData } from 'roosterjs-content-model-types';
+import type { ContentChangedEvent, IEditor, LinkData } from 'roosterjs-content-model-types';
 
 /**
  * @internal
  */
-export function createLink(editor: IEditor) {
+export function createLink(editor: IEditor, event: ContentChangedEvent) {
     formatTextSegmentBeforeSelectionMarker(
         editor,
         (_model, linkSegment, _paragraph) => {
@@ -28,6 +28,9 @@ export function createLink(editor: IEditor) {
         },
         {
             changeSource: ChangeSource.AutoLink,
+            getChangeData: () => {
+                return event.data;
+            },
         }
     );
 }

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/link/createLinkTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/link/createLinkTest.ts
@@ -163,6 +163,6 @@ describe('createLink', () => {
             format: {},
         };
 
-        runTest(input, input, false);
+        runTest(input, input, true);
     });
 });


### PR DESCRIPTION
When the paste segment already has a link, trigger the auto link event. Also add the anchor element to the event data object. 
![autoLinkPreview](https://github.com/microsoft/roosterjs/assets/87443959/260a50a1-4a80-4ab2-ad07-c8bcf10bace9)
 