### PR TITLE
Fix: Setting font family/size/color of partial text in list will be applied to the whole sentence

### DIFF
--- a/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
+++ b/packages/roosterjs-editor-dom/lib/list/createVListFromRegion.ts
@@ -130,7 +130,7 @@ function createVListFromItemNode(node: Node): VList {
     // Wrap all child nodes under a single one, and put the new list under original root node
     // so that the list can carry over styles under the root node.
     const childNodes = toArray(node.childNodes);
-    const nodeForItem = childNodes.length == 1 ? childNodes[0] : wrap(childNodes, 'SPAN');
+    const nodeForItem = wrap(childNodes, 'SPAN');
 
     // Create a temporary OL root element for this list.
     const listNode = node.ownerDocument!.createElement('ol'); // Either OL or UL is ok here


### PR DESCRIPTION
### Repro Steps
1. Go to Legacy Demo Site
2. Click bullet button in toolbar, ensure there's no other content except for a \<br\> in that sentence
3. Select part of the text and setting font size
4. Check the result

[Bullet Style Bug.mov](https://microsoftapc-my.sharepoint.com/:v:/g/personal/yalinli_microsoft_com/EVzZI1v6UIxIkwJxGdovuPwBhIdWbLaZvPQQRHw39B80Hg?e=HdEZco&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D)

### Root Cause
When creating \<li\> element and there's only one child node (like \<br\>), the single child node won't be wrapped by \<span\> element.
Then when setting font family/size/color, `applyListItemStyleWrap` will apply the style of its child element to the whole \<li\> element. (code: [Add wrapper · microsoft/roosterjs@bf981b4 (github.com)](https://github.com/microsoft/roosterjs/commit/bf981b42e813f2ab24926b61d95503007198489f))

### Fix
Wrap childNode(s) with  \<span\> element anyway