### PR TITLE
Fix #2578:  Cannot cut tables

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelApi/selection/setSelection.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/selection/setSelection.ts
@@ -141,7 +141,13 @@ function setSelectionToTable(
     } else {
         table.rows.forEach(row =>
             row.cells.forEach(cell => {
+                const wasInSelection = isInSelection;
+
                 isInSelection = setSelectionToBlockGroup(cell, isInSelection, start, end);
+
+                if (wasInSelection && isInSelection) {
+                    mutateBlock(cell).isSelected = true;
+                }
             })
         );
     }

--- a/packages/roosterjs-content-model-dom/test/modelApi/selection/setSelectionTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/selection/setSelectionTest.ts
@@ -838,4 +838,103 @@ describe('setSelection', () => {
         expect(cell.isSelected).toBeFalsy();
         expect(segment.isSelected).toBeTrue();
     });
+
+    it('Table inside range selection', () => {
+        const model = createContentModelDocument();
+        const table = createTable(1);
+        const cell1 = createTableCell();
+        const cell2 = createTableCell();
+        const para0 = createParagraph();
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const para3 = createParagraph();
+        const segment0 = createBr();
+        const segment1 = createBr();
+        const segment2 = createBr();
+        const segment3 = createBr();
+        const segment4 = createBr();
+
+        para0.segments.push(segment0);
+        para1.segments.push(segment1);
+        para2.segments.push(segment2);
+        para3.segments.push(segment3, segment4);
+
+        cell1.blocks.push(para1);
+        cell2.blocks.push(para2);
+
+        table.rows[0].cells.push(cell1, cell2);
+
+        model.blocks.push(para0, table, para3);
+
+        setSelection(model, segment0, segment3);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Br', format: {}, isSelected: true }],
+                    format: {},
+                },
+                {
+                    blockType: 'Table',
+                    rows: [
+                        {
+                            height: 0,
+                            format: {},
+                            cells: [
+                                {
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                { segmentType: 'Br', format: {}, isSelected: true },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    spanLeft: false,
+                                    spanAbove: false,
+                                    isHeader: false,
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                                {
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            blockType: 'Paragraph',
+                                            segments: [
+                                                { segmentType: 'Br', format: {}, isSelected: true },
+                                            ],
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    spanLeft: false,
+                                    spanAbove: false,
+                                    isHeader: false,
+                                    dataset: {},
+                                    isSelected: true,
+                                },
+                            ],
+                        },
+                    ],
+                    format: {},
+                    widths: [],
+                    dataset: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        { segmentType: 'Br', format: {}, isSelected: true },
+                        { segmentType: 'Br', format: {} },
+                    ],
+                    format: {},
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
 #2578 Cannot cut tables

Root cause: When call `setSelection`, even whole table is selected, we didn't set `isSelected` to true to table cell.

Fix: set cell.isSelected=true if context.isSelected == true before and after a table cell in `setSelection`.