### PR TITLE
Do not change first list number automatically

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/list/listLevelThreadFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/list/listLevelThreadFormatHandler.ts
@@ -13,7 +13,7 @@ export const listLevelThreadFormatHandler: FormatHandler<ListThreadFormat> = {
             const depth = levels.length;
 
             if (
-                typeof threadItemCounts[depth] === 'number' &&
+                threadItemCounts[depth] === undefined ||
                 element.start != threadItemCounts[depth] + 1
             ) {
                 format.startNumberOverride = element.start;

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/childProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/childProcessorTest.ts
@@ -453,7 +453,7 @@ describe('childProcessor', () => {
                 {
                     blockType: 'BlockGroup',
                     blockGroupType: 'ListItem',
-                    levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                    levels: [{ listType: 'OL', format: { startNumberOverride: 1 }, dataset: {} }],
                     formatHolder: { segmentType: 'SelectionMarker', isSelected: false, format: {} },
                     blocks: [
                         {

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/listProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/listProcessorTest.ts
@@ -56,7 +56,7 @@ describe('listProcessor', () => {
         childProcessor.and.callFake((group, parent, context) => {
             expect(context.listFormat.listParent).toBe(group);
             expect(context.listFormat.levels).toEqual([
-                { listType: 'OL', format: {}, dataset: {} },
+                { listType: 'OL', format: { startNumberOverride: 1 }, dataset: {} },
             ]);
             expect(context.listFormat.threadItemCounts).toEqual([0]);
             expect(context.segmentFormat).toEqual({});
@@ -88,7 +88,7 @@ describe('listProcessor', () => {
         childProcessor.and.callFake((group, parent, context) => {
             expect(context.listFormat.listParent).toBe(group);
             expect(context.listFormat.levels).toEqual([
-                { listType: 'OL', format: {}, dataset: {} },
+                { listType: 'OL', format: { startNumberOverride: 1 }, dataset: {} },
             ]);
             expect(context.listFormat.threadItemCounts).toEqual([0]);
             expect(context.segmentFormat).toEqual({
@@ -212,6 +212,7 @@ describe('listProcessor', () => {
                                 paddingBottom: '2px',
                                 paddingLeft: '2px',
                                 listStylePosition: 'inside',
+                                startNumberOverride: 1,
                             },
                             dataset: {},
                         },
@@ -254,6 +255,7 @@ describe('listProcessor', () => {
                                 marginBottom: '0px',
                                 marginLeft: '0px',
                                 marginRight: '0px',
+                                startNumberOverride: 1,
                             },
                             dataset: {},
                         },
@@ -468,7 +470,7 @@ describe('listProcessor process metadata', () => {
             expect(context.listFormat.levels).toEqual([
                 {
                     listType: 'OL',
-                    format: {},
+                    format: { startNumberOverride: 1 },
                     dataset: {},
                 },
             ]);
@@ -492,7 +494,7 @@ describe('listProcessor process metadata', () => {
             expect(context.listFormat.levels).toEqual([
                 {
                     listType: 'OL',
-                    format: {},
+                    format: { startNumberOverride: 1 },
                     dataset: {
                         editingInfo: JSON.stringify({ orderedStyleType: 1, unorderedStyleType: 2 }),
                     },
@@ -520,7 +522,7 @@ describe('listProcessor process metadata', () => {
             expect(context.listFormat.levels).toEqual([
                 {
                     listType: 'OL',
-                    format: {},
+                    format: { startNumberOverride: 1 },
                     dataset: { editingInfo: metadata },
                 },
             ]);
@@ -544,7 +546,9 @@ describe('listProcessor process metadata', () => {
             expect(context.listFormat.levels).toEqual([
                 {
                     listType: 'OL',
-                    format: {},
+                    format: {
+                        startNumberOverride: 1,
+                    },
                     dataset: {
                         editingInfo: JSON.stringify({
                             orderedStyleType: NumberingListType.Max,
@@ -576,7 +580,7 @@ describe('listProcessor process metadata', () => {
                 {
                     listType: 'OL',
                     dataset: { editingInfo },
-                    format: {},
+                    format: { startNumberOverride: 1 },
                 },
             ]);
         });
@@ -601,6 +605,7 @@ describe('listProcessor process metadata', () => {
                     listType: 'OL',
                     format: {
                         listStyleType: 'decimal',
+                        startNumberOverride: 1,
                     },
                     dataset: {
                         editingInfo: JSON.stringify({ orderedStyleType: NumberingListType.Max }),
@@ -622,6 +627,49 @@ describe('listProcessor process metadata', () => {
         ol.appendChild(li);
 
         context.blockFormat.direction = 'rtl';
+
+        childProcessor.and.callFake(originalChildProcessor);
+
+        listProcessor(group, ol, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            dataset: {},
+                            format: {
+                                direction: 'rtl',
+                                startNumberOverride: 1,
+                            },
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('Context has list number', () => {
+        const ol = document.createElement('ol');
+        const li = document.createElement('li');
+        const group = createContentModelDocument();
+
+        ol.start = 2;
+        ol.appendChild(li);
+
+        context.blockFormat.direction = 'rtl';
+        context.listFormat.threadItemCounts[0] = 1;
 
         childProcessor.and.callFake(originalChildProcessor);
 

--- a/packages/roosterjs-content-model-dom/test/endToEndTest.ts
+++ b/packages/roosterjs-content-model-dom/test/endToEndTest.ts
@@ -156,7 +156,15 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                        levels: [
+                            {
+                                listType: 'OL',
+                                format: {
+                                    startNumberOverride: 1,
+                                },
+                                dataset: {},
+                            },
+                        ],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -177,7 +185,13 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                         ],
                         levels: [
                             { listType: 'OL', format: {}, dataset: {} },
-                            { listType: 'OL', format: {}, dataset: {} },
+                            {
+                                listType: 'OL',
+                                format: {
+                                    startNumberOverride: 1,
+                                },
+                                dataset: {},
+                            },
                         ],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
@@ -2088,12 +2102,12 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                         levels: [
                             {
                                 listType: 'OL',
-                                format: {},
+                                format: { startNumberOverride: 1 },
                                 dataset: {},
                             },
                             {
                                 listType: 'OL',
-                                format: { listStyleType: '"1) "' },
+                                format: { listStyleType: '"1) "', startNumberOverride: 1 },
                                 dataset: {},
                             },
                         ],

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/list/listLevelThreadFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/list/listLevelThreadFormatHandlerTest.ts
@@ -22,7 +22,7 @@ describe('listLevelThreadFormatHandler.parse', () => {
 
         listLevelThreadFormatHandler.parse(format, ol, context, {});
 
-        expect(format.startNumberOverride).toBeUndefined();
+        expect(format.startNumberOverride).toBe(1);
         expect(context.listFormat).toEqual({
             threadItemCounts: [0],
             levels: [],
@@ -91,7 +91,7 @@ describe('listLevelThreadFormatHandler.parse', () => {
 
         listLevelThreadFormatHandler.parse(format, ol, context, {});
 
-        expect(format.startNumberOverride).toBeUndefined();
+        expect(format.startNumberOverride).toBe(1);
         expect(context.listFormat).toEqual({
             threadItemCounts: [2, 0],
             levels: [


### PR DESCRIPTION
To repro, use 
```html
<div style="font-family: Calibri; font-size: 11pt; color: rgb(0, 0, 0);">1.a</div><ol style="list-style-type: decimal;" data-editing-info="{&quot;orderedStyleType&quot;:1}" start="1"><li style="font-family: Calibri; font-size: 11pt; color: rgb(0, 0, 0);"><div style="font-family: Calibri; font-size: 11pt; color: rgb(0, 0, 0);">b</div></li></ol><!--{"type":"range","start":[0,0,2],"end":[0,0,2],"isReverted":false,"isDarkMode":false}-->
```

Then press SPACE key, "1." will become "2."

For the first list item, if we start a new list before it, we should not change the list number.

(TBA: need to check if there is other block between the two list items)