### PR TITLE
[Content Model] Add skipKnownColorsWhenGetDarkColor in DarkColorHandler

### DIFF
--- a/packages/roosterjs-content-model-core/lib/editor/core/DarkColorHandlerImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/DarkColorHandlerImpl.ts
@@ -8,7 +8,8 @@ class DarkColorHandlerImpl implements DarkColorHandler {
     constructor(
         private readonly root: HTMLElement,
         public getDarkColor: ColorTransformFunction,
-        public readonly knownColors: Record<string, Colors>
+        public readonly knownColors: Record<string, Colors>,
+        public readonly skipKnownColorsWhenGetDarkColor: boolean
     ) {}
 
     updateKnownColor(isDarkMode: boolean, key?: string, colorPair?: Colors): void {
@@ -46,9 +47,15 @@ class DarkColorHandlerImpl implements DarkColorHandler {
  * @internal
  */
 export function createDarkColorHandler(
-    root: HTMLElement,
-    getDarkColor: ColorTransformFunction,
-    knownColors: Record<string, Colors> = {}
-): DarkColorHandler {
-    return new DarkColorHandlerImpl(root, getDarkColor, knownColors);
-}
+           root: HTMLElement,
+           getDarkColor: ColorTransformFunction,
+           knownColors: Record<string, Colors> = {},
+           skipKnownColorsWhenGetDarkColor: boolean = false
+       ): DarkColorHandler {
+           return new DarkColorHandlerImpl(
+               root,
+               getDarkColor,
+               knownColors,
+               skipKnownColorsWhenGetDarkColor
+           );
+       }

--- a/packages/roosterjs-content-model-core/lib/editor/core/createEditorCore.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/createEditorCore.ts
@@ -40,7 +40,8 @@ export function createEditorCore(contentDiv: HTMLDivElement, options: EditorOpti
         darkColorHandler: createDarkColorHandler(
             contentDiv,
             options.getDarkColor ?? getDarkColorFallback,
-            options.knownColors
+            options.knownColors,
+            options.skipKnownColorsWhenGetDarkColor
         ),
         trustedHTMLHandler: options.trustedHTMLHandler || defaultTrustHtmlHandler,
         domHelper: createDOMHelper(contentDiv),

--- a/packages/roosterjs-content-model-core/test/editor/core/createEditorCoreTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/createEditorCoreTest.ts
@@ -129,6 +129,7 @@ describe('createEditorCore', () => {
         expect(DarkColorHandlerImpl.createDarkColorHandler).toHaveBeenCalledWith(
             mockedDiv,
             getDarkColorFallback,
+            undefined,
             undefined
         );
     });
@@ -180,6 +181,7 @@ describe('createEditorCore', () => {
         expect(DarkColorHandlerImpl.createDarkColorHandler).toHaveBeenCalledWith(
             mockedDiv,
             mockedGetDarkColor,
+            undefined,
             undefined
         );
     });
@@ -213,6 +215,7 @@ describe('createEditorCore', () => {
         expect(DarkColorHandlerImpl.createDarkColorHandler).toHaveBeenCalledWith(
             mockedDiv,
             getDarkColorFallback,
+            undefined,
             undefined
         );
     });
@@ -246,6 +249,7 @@ describe('createEditorCore', () => {
         expect(DarkColorHandlerImpl.createDarkColorHandler).toHaveBeenCalledWith(
             mockedDiv,
             getDarkColorFallback,
+            undefined,
             undefined
         );
     });
@@ -279,6 +283,7 @@ describe('createEditorCore', () => {
         expect(DarkColorHandlerImpl.createDarkColorHandler).toHaveBeenCalledWith(
             mockedDiv,
             getDarkColorFallback,
+            undefined,
             undefined
         );
     });
@@ -312,6 +317,7 @@ describe('createEditorCore', () => {
         expect(DarkColorHandlerImpl.createDarkColorHandler).toHaveBeenCalledWith(
             mockedDiv,
             getDarkColorFallback,
+            undefined,
             undefined
         );
     });
@@ -345,6 +351,7 @@ describe('createEditorCore', () => {
         expect(DarkColorHandlerImpl.createDarkColorHandler).toHaveBeenCalledWith(
             mockedDiv,
             getDarkColorFallback,
+            undefined,
             undefined
         );
     });

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/utils/color.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/utils/color.ts
@@ -39,7 +39,7 @@ const VARIABLE_REGEX = /^\s*var\(\s*(\-\-[a-zA-Z0-9\-_]+)\s*(?:,\s*(.*))?\)\s*$/
 const VARIABLE_PREFIX = 'var(';
 const VARIABLE_POSTFIX = ')';
 const COLOR_VAR_PREFIX = '--darkColor';
-const COLOR_VAR_ENFORCE_FALLBACK_KEY = 'fallback-color';
+const COLOR_VAR_ENFORCE_FALLBACK_KEY = `${COLOR_VAR_PREFIX}_fallback-color`;
 
 /**
  * Get color from given HTML element

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
@@ -122,6 +122,7 @@ describe('getColor with darkColorHandler', () => {
             getDarkColor: getDarkColorSpy,
             updateKnownColor: updateKnownColorSpy,
             reset: null!,
+            skipKnownColorsWhenGetDarkColor: false,
         };
     });
 
@@ -351,6 +352,7 @@ describe('setColor with darkColorHandler', () => {
             getDarkColor: getDarkColorSpy,
             updateKnownColor: updateKnownColorSpy,
             reset: null!,
+            skipKnownColorsWhenGetDarkColor: false,
         };
     });
 

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
@@ -491,6 +491,41 @@ describe('setColor with darkColorHandler', () => {
             darkModeColor: '--dark_green',
         });
     });
+
+    it('no existing color, set valid color, skip known colors, getDarkColor return null', () => {
+        knownColors = {
+            white: {
+                lightModeColor: 'white',
+                darkModeColor: 'black',
+            },
+        };
+        getDarkColorSpy = jasmine.createSpy('getDarkColor').and.callFake((color: string) => null);
+
+        darkColorHandler = {
+            knownColors,
+            getDarkColor: getDarkColorSpy,
+            updateKnownColor: updateKnownColorSpy,
+            reset: null!,
+            skipKnownColorsWhenGetDarkColor: true,
+        };
+
+        const lightDiv = document.createElement('div');
+        const darkDiv = document.createElement('div');
+
+        setColor(lightDiv, 'white', true, false, darkColorHandler);
+        setColor(lightDiv, 'white', false, false, darkColorHandler);
+        setColor(darkDiv, 'white', true, true, darkColorHandler);
+        setColor(darkDiv, 'white', false, true, darkColorHandler);
+
+        expect(lightDiv.outerHTML).toBe(
+            '<div style="color: white; background-color: white;"></div>'
+        );
+        expect(darkDiv.outerHTML).toBe(
+            '<div style="color: var(--darkColor_fallback-color, white); background-color: var(--darkColor_fallback-color, white);"></div>'
+        );
+        expect(getDarkColorSpy).toHaveBeenCalledTimes(4);
+        expect(updateKnownColorSpy).toHaveBeenCalledTimes(0);
+    });
 });
 
 describe('parseColor', () => {

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
@@ -494,7 +494,7 @@ describe('setColor with darkColorHandler', () => {
 
     it('no existing color, set valid color, skip known colors, getDarkColor return null', () => {
         knownColors = {
-            white: {
+            '--darkColor_white': {
                 lightModeColor: 'white',
                 darkModeColor: 'black',
             },
@@ -518,10 +518,10 @@ describe('setColor with darkColorHandler', () => {
         setColor(darkDiv, 'white', false, true, darkColorHandler);
 
         expect(lightDiv.outerHTML).toBe(
-            '<div style="color: white; background-color: white;"></div>'
+            '<div style="background-color: white; color: white;"></div>'
         );
         expect(darkDiv.outerHTML).toBe(
-            '<div style="color: var(--darkColor_fallback-color, white); background-color: var(--darkColor_fallback-color, white);"></div>'
+            '<div style="background-color: var(--darkColor_fallback-color, white); color: var(--darkColor_fallback-color, white);"></div>'
         );
         expect(getDarkColorSpy).toHaveBeenCalledTimes(4);
         expect(updateKnownColorSpy).toHaveBeenCalledTimes(0);

--- a/packages/roosterjs-content-model-types/lib/context/DarkColorHandler.ts
+++ b/packages/roosterjs-content-model-types/lib/context/DarkColorHandler.ts
@@ -20,13 +20,17 @@ export interface Colors {
  * @param baseLValue Base value of light used for dark value calculation
  * @param colorType @optional Type of color, can be text, background, or border
  * @param element @optional Source HTML element of the color
+ * @returns Dark mode color string, or null if this element should not be transformed
  */
-export type ColorTransformFunction = (
-    lightColor: string,
-    baseLValue?: number,
-    colorType?: 'text' | 'background' | 'border',
-    element?: HTMLElement
-) => string;
+export interface ColorTransformFunction {
+    (lightColor: string, baseLValue?: number, colorType?: 'text' | 'background' | 'border'): string;
+    (
+        lightColor: string,
+        baseLValue?: number,
+        colorType?: 'text' | 'background' | 'border',
+        element?: HTMLElement
+    ): string | null;
+}
 
 /**
  * A handler object for dark color, used for variable-based dark color solution
@@ -36,6 +40,12 @@ export interface DarkColorHandler {
      * Map of known colors
      */
     readonly knownColors: Record<string, Colors>;
+
+    /**
+     * Whether to use cached known colors for dark mode
+     * If false, the getDarkColor function will be called every time when color is needed
+     */
+    readonly skipKnownColorsWhenGetDarkColor: boolean;
 
     /**
      * Update all known colors to root container.

--- a/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
@@ -70,6 +70,12 @@ export interface EditorOptions {
     knownColors?: Record<string, Colors>;
 
     /**
+     * Whether to use cached known colors for dark mode
+     * If false, the getDarkColor function will be called every time when color is needed
+     */
+    skipKnownColorsWhenGetDarkColor?: boolean;
+
+    /**
      * Customized trusted type handler used for sanitizing HTML string before assign to DOM tree
      * This is required when trusted-type Content-Security-Policy (CSP) is enabled.
      * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types

--- a/packages/roosterjs-editor-adapter/lib/editor/DarkColorHandlerImpl.ts
+++ b/packages/roosterjs-editor-adapter/lib/editor/DarkColorHandlerImpl.ts
@@ -35,12 +35,17 @@ class DarkColorHandlerImpl implements DarkColorHandler {
         }
 
         if (isDarkMode && lightModeColor) {
+            darkModeColor = darkModeColor || this.innerHandler.getDarkColor(lightModeColor);
+
+            if (!darkModeColor) {
+                return lightModeColor;
+            }
+
             colorKey =
                 colorKey || `--${COLOR_VAR_PREFIX}_${lightModeColor.replace(/[^\d\w]/g, '_')}`;
-
             this.innerHandler.updateKnownColor(isDarkMode, colorKey, {
                 lightModeColor,
-                darkModeColor: darkModeColor || this.innerHandler.getDarkColor(lightModeColor),
+                darkModeColor,
             });
 
             return `var(${colorKey}, ${lightModeColor})`;


### PR DESCRIPTION
We need an approach to allow `DarkColorHandler` to skip some elemnets and let clients decide its color. I added two changes in this PR.

1. Added a new option `skipKnownColorsWhenGetDarkColor`, when it's enabled, we will always skip the color in `knownColors` and call `getDarkColor`.
2. Allow `getDarkColor` to return `null`, when it return `null`, we won't update the color in `knownColors` and use the current color for the element.

I'm trying to not break the existing CSS variable logic, so we still update the `knownColors` but won't use it when we need a color for dark mode. It'll be useful when we need a light color for a dark mode color sometimes.
I also use a `COLOR_VAR_ENFORCE_FALLBACK_KEY` to construct those CSS variables of elements' color which we want to skip handling its dark mode, so the CSS variables will be always undefined and fallback to its light color.