### PR TITLE
Word Desktop LineHeight fix on paste

### DIFF
--- a/packages/roosterjs-content-model-core/test/command/paste/pasteTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/pasteTest.ts
@@ -136,7 +136,7 @@ describe('paste with content model & paste plugin', () => {
         paste(editor!, clipboardData);
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(1);
-        expect(addParserF.addParser).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 4);
+        expect(addParserF.addParser).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 5);
         expect(WordDesktopFile.processPastedContentFromWordDesktop).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop.ts
@@ -32,7 +32,7 @@ export function processPastedContentFromWordDesktop(
     const metadataMap: Map<string, WordMetadata> = getStyleMetadata(ev, trustedHTMLHandler);
 
     setProcessor(ev.domToModelOption, 'element', wordDesktopElementProcessor(metadataMap));
-    addParser(ev.domToModelOption, 'block', removeNonValidLineHeight);
+    addParser(ev.domToModelOption, 'block', adjustPercentileLineHeight);
     addParser(ev.domToModelOption, 'block', removeNegativeTextIndentParser);
     addParser(ev.domToModelOption, 'listLevel', listLevelParser);
     addParser(ev.domToModelOption, 'container', wordTableParser);
@@ -56,7 +56,7 @@ const wordDesktopElementProcessor = (
     };
 };
 
-function removeNonValidLineHeight(format: ContentModelBlockFormat, element: HTMLElement): void {
+function adjustPercentileLineHeight(format: ContentModelBlockFormat, element: HTMLElement): void {
     //If the line height is less than the browser default line height, line between the text is going to be too narrow
     let parsedLineHeight: number;
     if (

--- a/packages/roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop.ts
@@ -17,7 +17,8 @@ import type {
 } from 'roosterjs-content-model-types';
 
 const PERCENTAGE_REGEX = /%/;
-const DEFAULT_BROWSER_LINE_HEIGHT_PERCENTAGE = 120;
+// Default line height in browsers according to https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#normal
+const DEFAULT_BROWSER_LINE_HEIGHT_PERCENTAGE = 1.2;
 
 /**
  * @internal
@@ -55,20 +56,17 @@ const wordDesktopElementProcessor = (
     };
 };
 
-function removeNonValidLineHeight(
-    format: ContentModelBlockFormat,
-    element: HTMLElement,
-    context: DomToModelContext,
-    defaultStyle: Readonly<Partial<CSSStyleDeclaration>>
-): void {
+function removeNonValidLineHeight(format: ContentModelBlockFormat, element: HTMLElement): void {
     //If the line height is less than the browser default line height, line between the text is going to be too narrow
     let parsedLineHeight: number;
     if (
         PERCENTAGE_REGEX.test(element.style.lineHeight) &&
-        !isNaN((parsedLineHeight = parseInt(element.style.lineHeight))) &&
-        parsedLineHeight < DEFAULT_BROWSER_LINE_HEIGHT_PERCENTAGE
+        !isNaN((parsedLineHeight = parseInt(element.style.lineHeight)))
     ) {
-        format.lineHeight = defaultStyle.lineHeight;
+        format.lineHeight = (
+            DEFAULT_BROWSER_LINE_HEIGHT_PERCENTAGE *
+            (parsedLineHeight / 100)
+        ).toString();
     }
 }
 

--- a/packages/roosterjs-content-model-plugins/test/paste/ContentModelPastePluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/ContentModelPastePluginTest.ts
@@ -58,7 +58,7 @@ describe('Content Model Paste Plugin Test', () => {
             plugin.initialize(editor);
             plugin.onPluginEvent(event);
 
-            expect(addParser.addParser).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 4);
+            expect(addParser.addParser).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 5);
             expect(setProcessor.setProcessor).toHaveBeenCalledTimes(1);
         });
 

--- a/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromWordDesktopTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromWordDesktopTest.ts
@@ -144,7 +144,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
         runTest(source, { blockGroupType: 'Document', blocks: [] }, true);
     });
 
-    it('Dont remove Line height less than default', () => {
+    it('Remove Line height less than default', () => {
         let source = '<p style="line-height:102%">Test</p>';
         runTest(
             source,
@@ -154,7 +154,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                     {
                         segments: [{ text: 'Test', segmentType: 'Text', format: {} }],
                         blockType: 'Paragraph',
-                        format: { marginTop: '1em', marginBottom: '1em', lineHeight: '102%' },
+                        format: { marginTop: '1em', marginBottom: '1em' },
                         decorator: { tagName: 'p', format: {} },
                     },
                 ],

--- a/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromWordDesktopTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromWordDesktopTest.ts
@@ -144,7 +144,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
         runTest(source, { blockGroupType: 'Document', blocks: [] }, true);
     });
 
-    it('Remove Line height less than default', () => {
+    it('adjust Line height less than default', () => {
         let source = '<p style="line-height:102%">Test</p>';
         runTest(
             source,
@@ -154,7 +154,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                     {
                         segments: [{ text: 'Test', segmentType: 'Text', format: {} }],
                         blockType: 'Paragraph',
-                        format: { marginTop: '1em', marginBottom: '1em' },
+                        format: { marginTop: '1em', marginBottom: '1em', lineHeight: '1.224' },
                         decorator: { tagName: 'p', format: {} },
                     },
                 ],
@@ -211,7 +211,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
         });
     });
 
-    it('Remove Line height, percentage greater than default', () => {
+    it('Adjust Line height, percentage greater than default 2', () => {
         let source = '<p style="line-height:122%">Test</p>';
         runTest(source, {
             blockGroupType: 'Document',
@@ -222,7 +222,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                         format: {},
                         tagName: 'p',
                     },
-                    format: { marginTop: '1em', marginBottom: '1em', lineHeight: '122%' },
+                    format: { marginTop: '1em', marginBottom: '1em', lineHeight: '1.464' },
                     segments: [
                         {
                             segmentType: 'Text',


### PR DESCRIPTION
Word Desktop set the line lineheight as percentages based on the At least property.
For example if in Word you set 1.16 line height after paste the value is going to be 116% in the HTML clipboard.
The problem here is that in Browser the default line height is 1.2/120% (according to https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#normal) so if you set the value as 116% instead of having a bigger line height the line height in the browser is going to look smaller.

So change the way how we parse the line height when pasting from Word Desktop and use the line Height percentage value and multiply it by the Browser default line height.

Word Document used for test:
![image](https://github.com/microsoft/roosterjs/assets/8291124/3c8869e6-e8ff-4c66-a3e5-897fceb929aa)

Before (Notice how the 1.16 line height paragraph look smaller than the 1 paragraph, because of the issue)
![image](https://github.com/microsoft/roosterjs/assets/8291124/0aefa225-f477-4d28-bcf7-ad8e2b72f262)

After (1.16 now looks with bigger line height than the "1" lineheight paragraph)
![image](https://github.com/microsoft/roosterjs/assets/8291124/d33d71ae-2948-44bf-831d-eccedd680fff)
