### PR TITLE
Provide our own implementation of `scrollCaretIntoView`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,8 @@
         "coverage": true,
         ".vscode/**": true,
         "dist/**": true,
-        "stats.json": true
+        "stats.json": true,
+        "assets/**": true
     },
     "prettier.arrowParens": "avoid",
     "prettier.singleQuote": true,

--- a/demo/scripts/controlsV2/plugins/SamplePickerPlugin.tsx
+++ b/demo/scripts/controlsV2/plugins/SamplePickerPlugin.tsx
@@ -10,12 +10,12 @@ import {
     PickerHelper,
     PickerPlugin,
     PickerSelectionChangMode,
-    getDOMInsertPointRect,
 } from 'roosterjs-content-model-plugins';
 import {
     createContentModelDocument,
     createEntity,
     createParagraph,
+    getDOMInsertPointRect,
 } from 'roosterjs-content-model-dom';
 
 const itemStyle = mergeStyles({

--- a/demo/scripts/controlsV2/roosterjsReact/pasteOptions/component/showPasteOptionPane.tsx
+++ b/demo/scripts/controlsV2/roosterjsReact/pasteOptions/component/showPasteOptionPane.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { ButtonKeys, Buttons } from '../utils/buttons';
 import { Callout, DirectionalHint } from '@fluentui/react/lib/Callout';
-import { getDOMInsertPointRect } from 'roosterjs-content-model-plugins';
+import { getDOMInsertPointRect, getObjectKeys } from 'roosterjs-content-model-dom';
 import { getLocalizedString } from '../../common/index';
-import { getObjectKeys } from 'roosterjs-content-model-dom';
 import { Icon } from '@fluentui/react/lib/Icon';
 import { IconButton } from '@fluentui/react/lib/Button';
 import { memoizeFunction } from '@fluentui/react/lib/Utilities';

--- a/demo/scripts/controlsV2/sidePane/formatState/FormatStatePlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/formatState/FormatStatePlugin.ts
@@ -1,5 +1,5 @@
 import { FormatStatePane, FormatStatePaneProps, FormatStatePaneState } from './FormatStatePane';
-import { getDOMInsertPointRect } from 'roosterjs-content-model-plugins';
+import { getDOMInsertPointRect } from 'roosterjs-content-model-dom';
 import { getFormatState } from 'roosterjs-content-model-api';
 import { PluginEvent } from 'roosterjs-content-model-types';
 import { SidePaneElementProps } from '../SidePaneElement';

--- a/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
@@ -95,7 +95,7 @@ export function mergePasteContent(
         {
             changeSource: ChangeSource.Paste,
             getChangeData: () => clipboardData,
-            scrollCaretIntoView: false, // TODO #2633: Make a full fix to the scroll behavior
+            scrollCaretIntoView: true,
             apiName: 'paste',
         }
     );

--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -1,4 +1,5 @@
-import { ChangeSource, getSelectionRootNode } from 'roosterjs-content-model-dom';
+import { ChangeSource } from 'roosterjs-content-model-dom';
+import { scrollCaretIntoView } from './scrollCaretIntoView';
 import type {
     ChangedEntity,
     ContentChangedEvent,
@@ -31,7 +32,7 @@ export const formatContentModel: FormatContentModel = (
         changeSource,
         rawEvent,
         selectionOverride,
-        scrollCaretIntoView,
+        scrollCaretIntoView: scroll,
     } = options || {};
     const model = core.api.createContentModel(core, domToModelOptions, selectionOverride);
     const context: FormatContentModelContext = {
@@ -70,12 +71,8 @@ export const formatContentModel: FormatContentModel = (
 
             handlePendingFormat(core, context, selection);
 
-            if (selection && scrollCaretIntoView) {
-                const selectionRoot = getSelectionRootNode(selection);
-                const rootElement =
-                    selectionRoot && core.domHelper.findClosestElementAncestor(selectionRoot);
-
-                rootElement?.scrollIntoView();
+            if (scroll && (selection?.type == 'range' || selection?.type == 'image')) {
+                scrollCaretIntoView(core, selection);
             }
 
             const eventData: ContentChangedEvent = {

--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/scrollCaretIntoView.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/scrollCaretIntoView.ts
@@ -1,0 +1,39 @@
+import { getDOMInsertPointRect } from 'roosterjs-content-model-dom';
+import type { EditorCore, ImageSelection, RangeSelection } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ */
+export function scrollCaretIntoView(core: EditorCore, selection: RangeSelection | ImageSelection) {
+    const rect = getDOMInsertPointRect(
+        core.physicalRoot.ownerDocument,
+        selection.type == 'image'
+            ? {
+                  node: selection.image,
+                  offset: 0,
+              }
+            : selection.isReverted
+            ? {
+                  node: selection.range.startContainer,
+                  offset: selection.range.startOffset,
+              }
+            : {
+                  node: selection.range.endContainer,
+                  offset: selection.range.endOffset,
+              }
+    );
+    const visibleRect = core.api.getVisibleViewport(core);
+    const scrollContainer = core.domEvent.scrollContainer;
+
+    if (rect && visibleRect) {
+        if (rect.bottom > visibleRect.bottom) {
+            const zoomScale = core.domHelper.calculateZoomScale();
+
+            scrollContainer.scrollTop += (rect.bottom - visibleRect.bottom) / zoomScale;
+        } else if (rect.top < visibleRect.top) {
+            const zoomScale = core.domHelper.calculateZoomScale();
+
+            scrollContainer.scrollTop += (rect.top - visibleRect.top) / zoomScale;
+        }
+    }
+}

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -1,3 +1,4 @@
+import * as scrollCaretIntoView from '../../../lib/coreApi/formatContentModel/scrollCaretIntoView';
 import * as transformColor from 'roosterjs-content-model-dom/lib/domUtils/style/transformColor';
 import { ChangeSource, createImage } from 'roosterjs-content-model-dom';
 import { formatContentModel } from '../../../lib/coreApi/formatContentModel/formatContentModel';
@@ -21,7 +22,6 @@ describe('formatContentModel', () => {
     let hasFocus: jasmine.Spy;
     let getClientWidth: jasmine.Spy;
     let announce: jasmine.Spy;
-    let findClosestElementAncestor: jasmine.Spy;
 
     const apiName = 'mockedApi';
     const mockedContainer = 'C' as any;
@@ -43,7 +43,6 @@ describe('formatContentModel', () => {
         hasFocus = jasmine.createSpy('hasFocus');
         getClientWidth = jasmine.createSpy('getClientWidth');
         announce = jasmine.createSpy('announce');
-        findClosestElementAncestor = jasmine.createSpy('findClosestElementAncestor ');
 
         core = ({
             api: {
@@ -64,7 +63,6 @@ describe('formatContentModel', () => {
             domHelper: {
                 hasFocus,
                 getClientWidth,
-                findClosestElementAncestor,
             },
         } as any) as EditorCore;
     });
@@ -554,14 +552,14 @@ describe('formatContentModel', () => {
         });
 
         it('Has scrollCaretIntoView, and callback return true', () => {
-            const scrollIntoViewSpy = jasmine.createSpy('scrollIntoView');
-            const mockedImage = { scrollIntoView: scrollIntoViewSpy } as any;
+            const scrollCaretIntoViewSpy = spyOn(scrollCaretIntoView, 'scrollCaretIntoView');
+            const mockedImage = 'IMAGE' as any;
 
-            findClosestElementAncestor.and.returnValue(mockedImage);
             setContentModel.and.returnValue({
                 type: 'image',
                 image: mockedImage,
             });
+
             formatContentModel(
                 core,
                 (model, context) => {
@@ -574,8 +572,10 @@ describe('formatContentModel', () => {
                 }
             );
 
-            expect(findClosestElementAncestor).toHaveBeenCalledWith(mockedImage);
-            expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+            expect(scrollCaretIntoViewSpy).toHaveBeenCalledWith(core, {
+                type: 'image',
+                image: mockedImage,
+            });
         });
     });
 

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/scrollCaretIntoViewTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/scrollCaretIntoViewTest.ts
@@ -1,0 +1,314 @@
+import * as getDOMInsertPointRect from 'roosterjs-content-model-dom/lib/domUtils/selection/getDOMInsertPointRect';
+import { EditorCore } from 'roosterjs-content-model-types';
+import { scrollCaretIntoView } from '../../../lib/coreApi/formatContentModel/scrollCaretIntoView';
+
+describe('scrollCaretIntoView', () => {
+    let getDOMInsertPointRectSpy: jasmine.Spy;
+    let getVisibleViewportSpy: jasmine.Spy;
+    let calculateZoomScaleSpy: jasmine.Spy;
+    let core: EditorCore;
+    let mockedScrollContainer: HTMLElement;
+    const startContainer = 'STARTCONTAINER' as any;
+    const endContainer = 'ENDCONTAINER' as any;
+    const startOffset = 'STARTOFFSET' as any;
+    const endOffset = 'ENDOFFSET' as any;
+    const mockedDocument = 'DOCUMENT' as any;
+
+    beforeEach(() => {
+        getDOMInsertPointRectSpy = spyOn(getDOMInsertPointRect, 'getDOMInsertPointRect');
+        getVisibleViewportSpy = jasmine.createSpy('getVisibleViewport');
+        calculateZoomScaleSpy = jasmine.createSpy('calculateZoomScale').and.returnValue(1);
+
+        mockedScrollContainer = {
+            scrollTop: 50,
+        } as any;
+
+        core = {
+            physicalRoot: {
+                ownerDocument: mockedDocument,
+            },
+            api: {
+                getVisibleViewport: getVisibleViewportSpy,
+            },
+            domEvent: {
+                scrollContainer: mockedScrollContainer,
+            },
+            domHelper: {
+                calculateZoomScale: calculateZoomScaleSpy,
+            },
+        } as any;
+    });
+
+    it('range selection, not reverted, caret is in view, zoom scale=1', () => {
+        getDOMInsertPointRectSpy.and.returnValue({
+            top: 30,
+            bottom: 40,
+        } as any);
+        getVisibleViewportSpy.and.returnValue({
+            top: 0,
+            bottom: 100,
+        } as any);
+
+        scrollCaretIntoView(core, {
+            type: 'range',
+            isReverted: false,
+            range: {
+                startContainer,
+                endContainer,
+                startOffset,
+                endOffset,
+            } as any,
+        });
+
+        expect(getDOMInsertPointRectSpy).toHaveBeenCalledWith(mockedDocument, {
+            node: endContainer,
+            offset: endOffset,
+        });
+        expect(getVisibleViewportSpy).toHaveBeenCalledWith(core);
+        expect(calculateZoomScaleSpy).not.toHaveBeenCalled();
+        expect(mockedScrollContainer.scrollTop).toBe(50);
+    });
+
+    it('range selection, not reverted, caret is in view, zoom scale=2', () => {
+        getDOMInsertPointRectSpy.and.returnValue({
+            top: 30,
+            bottom: 40,
+        } as any);
+        getVisibleViewportSpy.and.returnValue({
+            top: 0,
+            bottom: 100,
+        } as any);
+        calculateZoomScaleSpy.and.returnValue(2);
+
+        scrollCaretIntoView(core, {
+            type: 'range',
+            isReverted: false,
+            range: {
+                startContainer,
+                endContainer,
+                startOffset,
+                endOffset,
+            } as any,
+        });
+
+        expect(getDOMInsertPointRectSpy).toHaveBeenCalledWith(mockedDocument, {
+            node: endContainer,
+            offset: endOffset,
+        });
+        expect(getVisibleViewportSpy).toHaveBeenCalledWith(core);
+        expect(calculateZoomScaleSpy).not.toHaveBeenCalled();
+        expect(mockedScrollContainer.scrollTop).toBe(50);
+    });
+
+    it('range selection, not reverted, caret is above view, zoom scale=1', () => {
+        getDOMInsertPointRectSpy.and.returnValue({
+            top: 30,
+            bottom: 45,
+        } as any);
+        getVisibleViewportSpy.and.returnValue({
+            top: 40,
+            bottom: 100,
+        } as any);
+
+        scrollCaretIntoView(core, {
+            type: 'range',
+            isReverted: false,
+            range: {
+                startContainer,
+                endContainer,
+                startOffset,
+                endOffset,
+            } as any,
+        });
+
+        expect(getDOMInsertPointRectSpy).toHaveBeenCalledWith(mockedDocument, {
+            node: endContainer,
+            offset: endOffset,
+        });
+        expect(getVisibleViewportSpy).toHaveBeenCalledWith(core);
+        expect(calculateZoomScaleSpy).toHaveBeenCalledWith();
+        expect(mockedScrollContainer.scrollTop).toBe(40);
+    });
+
+    it('range selection, not reverted, caret is above view, zoom scale=2', () => {
+        getDOMInsertPointRectSpy.and.returnValue({
+            top: 30,
+            bottom: 45,
+        } as any);
+        getVisibleViewportSpy.and.returnValue({
+            top: 40,
+            bottom: 100,
+        } as any);
+        calculateZoomScaleSpy.and.returnValue(2);
+
+        scrollCaretIntoView(core, {
+            type: 'range',
+            isReverted: false,
+            range: {
+                startContainer,
+                endContainer,
+                startOffset,
+                endOffset,
+            } as any,
+        });
+
+        expect(getDOMInsertPointRectSpy).toHaveBeenCalledWith(mockedDocument, {
+            node: endContainer,
+            offset: endOffset,
+        });
+        expect(getVisibleViewportSpy).toHaveBeenCalledWith(core);
+        expect(calculateZoomScaleSpy).toHaveBeenCalledWith();
+        expect(mockedScrollContainer.scrollTop).toBe(45);
+    });
+
+    it('range selection, not reverted, caret is below view, zoom scale=1', () => {
+        getDOMInsertPointRectSpy.and.returnValue({
+            top: 120,
+            bottom: 140,
+        } as any);
+        getVisibleViewportSpy.and.returnValue({
+            top: 40,
+            bottom: 100,
+        } as any);
+        calculateZoomScaleSpy.and.returnValue(1);
+
+        scrollCaretIntoView(core, {
+            type: 'range',
+            isReverted: false,
+            range: {
+                startContainer,
+                endContainer,
+                startOffset,
+                endOffset,
+            } as any,
+        });
+
+        expect(getDOMInsertPointRectSpy).toHaveBeenCalledWith(mockedDocument, {
+            node: endContainer,
+            offset: endOffset,
+        });
+        expect(getVisibleViewportSpy).toHaveBeenCalledWith(core);
+        expect(calculateZoomScaleSpy).toHaveBeenCalledWith();
+        expect(mockedScrollContainer.scrollTop).toBe(90);
+    });
+
+    it('range selection, not reverted, caret is below view, zoom scale=0.5', () => {
+        getDOMInsertPointRectSpy.and.returnValue({
+            top: 120,
+            bottom: 140,
+        } as any);
+        getVisibleViewportSpy.and.returnValue({
+            top: 40,
+            bottom: 100,
+        } as any);
+        calculateZoomScaleSpy.and.returnValue(0.5);
+
+        scrollCaretIntoView(core, {
+            type: 'range',
+            isReverted: false,
+            range: {
+                startContainer,
+                endContainer,
+                startOffset,
+                endOffset,
+            } as any,
+        });
+
+        expect(getDOMInsertPointRectSpy).toHaveBeenCalledWith(mockedDocument, {
+            node: endContainer,
+            offset: endOffset,
+        });
+        expect(getVisibleViewportSpy).toHaveBeenCalledWith(core);
+        expect(calculateZoomScaleSpy).toHaveBeenCalledWith();
+        expect(mockedScrollContainer.scrollTop).toBe(130);
+    });
+
+    it('range selection, not reverted, caret is above and below view, zoom scale=1', () => {
+        getDOMInsertPointRectSpy.and.returnValue({
+            top: 10,
+            bottom: 80,
+        } as any);
+        getVisibleViewportSpy.and.returnValue({
+            top: 30,
+            bottom: 40,
+        } as any);
+        calculateZoomScaleSpy.and.returnValue(1);
+
+        scrollCaretIntoView(core, {
+            type: 'range',
+            isReverted: false,
+            range: {
+                startContainer,
+                endContainer,
+                startOffset,
+                endOffset,
+            } as any,
+        });
+
+        expect(getDOMInsertPointRectSpy).toHaveBeenCalledWith(mockedDocument, {
+            node: endContainer,
+            offset: endOffset,
+        });
+        expect(getVisibleViewportSpy).toHaveBeenCalledWith(core);
+        expect(calculateZoomScaleSpy).toHaveBeenCalledWith();
+        expect(mockedScrollContainer.scrollTop).toBe(90);
+    });
+
+    it('range selection, reverted, caret is above, zoom scale=1', () => {
+        getDOMInsertPointRectSpy.and.returnValue({
+            top: 10,
+            bottom: 20,
+        } as any);
+        getVisibleViewportSpy.and.returnValue({
+            top: 30,
+            bottom: 40,
+        } as any);
+        calculateZoomScaleSpy.and.returnValue(1);
+
+        scrollCaretIntoView(core, {
+            type: 'range',
+            isReverted: true,
+            range: {
+                startContainer,
+                endContainer,
+                startOffset,
+                endOffset,
+            } as any,
+        });
+
+        expect(getDOMInsertPointRectSpy).toHaveBeenCalledWith(mockedDocument, {
+            node: startContainer,
+            offset: startOffset,
+        });
+        expect(getVisibleViewportSpy).toHaveBeenCalledWith(core);
+        expect(calculateZoomScaleSpy).toHaveBeenCalledWith();
+        expect(mockedScrollContainer.scrollTop).toBe(30);
+    });
+
+    it('image selection, not reverted, caret is above view, zoom scale=1', () => {
+        getDOMInsertPointRectSpy.and.returnValue({
+            top: 10,
+            bottom: 20,
+        } as any);
+        getVisibleViewportSpy.and.returnValue({
+            top: 30,
+            bottom: 40,
+        } as any);
+        calculateZoomScaleSpy.and.returnValue(1);
+
+        const mockedImage = 'IMAGE' as any;
+
+        scrollCaretIntoView(core, {
+            type: 'image',
+            image: mockedImage,
+        });
+
+        expect(getDOMInsertPointRectSpy).toHaveBeenCalledWith(mockedDocument, {
+            node: mockedImage,
+            offset: 0,
+        });
+        expect(getVisibleViewportSpy).toHaveBeenCalledWith(core);
+        expect(calculateZoomScaleSpy).toHaveBeenCalledWith();
+        expect(mockedScrollContainer.scrollTop).toBe(30);
+    });
+});

--- a/packages/roosterjs-content-model-dom/lib/domUtils/selection/getDOMInsertPointRect.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/selection/getDOMInsertPointRect.ts
@@ -1,4 +1,5 @@
-import { isNodeOfType, normalizeRect } from 'roosterjs-content-model-dom';
+import { isNodeOfType } from '../isNodeOfType';
+import { normalizeRect } from '../normalizeRect';
 import type { DOMInsertPoint, Rect } from 'roosterjs-content-model-types';
 
 /**

--- a/packages/roosterjs-content-model-dom/lib/index.ts
+++ b/packages/roosterjs-content-model-dom/lib/index.ts
@@ -92,6 +92,7 @@ export {
 
 export { isBold } from './domUtils/style/isBold';
 export { getSelectionRootNode } from './domUtils/selection/getSelectionRootNode';
+export { getDOMInsertPointRect } from './domUtils/selection/getDOMInsertPointRect';
 export { isCharacterValue, isModifierKey, isCursorMovingKey } from './domUtils/event/eventUtils';
 export { combineBorderValue, extractBorderValues } from './domUtils/style/borderValues';
 export { isPunctuation, isSpace, normalizeText } from './domUtils/stringUtil';

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -49,7 +49,7 @@ export function keyboardDelete(editor: IEditor, rawEvent: KeyboardEvent) {
                 rawEvent,
                 changeSource: ChangeSource.Keyboard,
                 getChangeData: () => rawEvent.which,
-                scrollCaretIntoView: false, // TODO #2633: Make a full fix to the scroll behavior
+                scrollCaretIntoView: true,
                 apiName: rawEvent.key == 'Delete' ? 'handleDeleteKey' : 'handleBackspaceKey',
             }
         );

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -36,7 +36,7 @@ export function keyboardInput(editor: IEditor, rawEvent: KeyboardEvent) {
                 }
             },
             {
-                scrollCaretIntoView: false, // TODO #2633: Make a full fix to the scroll behavior
+                scrollCaretIntoView: true,
                 rawEvent,
             }
         );

--- a/packages/roosterjs-content-model-plugins/lib/index.ts
+++ b/packages/roosterjs-content-model-plugins/lib/index.ts
@@ -36,5 +36,3 @@ export { PickerSelectionChangMode, PickerDirection, PickerHandler } from './pick
 export { CustomReplacePlugin, CustomReplace } from './customReplace/CustomReplacePlugin';
 export { ImageEditPlugin } from './imageEdit/ImageEditPlugin';
 export { ImageEditOptions } from './imageEdit/types/ImageEditOptions';
-
-export { getDOMInsertPointRect } from './pluginUtils/Rect/getDOMInsertPointRect';


### PR DESCRIPTION
Previously I added a feature in `formatContentModel` to allow scroll caret into view after write back with Content Model. It was using browser's `scrollIntoView` implementation which has some problem especially when caret is already visible. And we also need to handle the case when visible viewport is not the actual size of editor (`getVisibleViewport()` will give us the expected value). So in this change I created our own implementation of `scrollCreateIntoView`, and call it from existing format API