### PR TITLE
Word "constructor" should not trigger auto list

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/list/getListTypeStyle.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/list/getListTypeStyle.ts
@@ -46,7 +46,7 @@ export function getListTypeStyle(
         listMarkerSegment.segmentType == 'Text'
     ) {
         const listMarker = listMarkerSegment.text.trim();
-        const bulletType = bulletListType[listMarker];
+        const bulletType = bulletListType.get(listMarker);
 
         if (bulletType && shouldSearchForBullet) {
             return { listType: 'UL', styleType: bulletType };
@@ -117,16 +117,16 @@ const getPreviousListStyle = (list?: ContentModelListItem) => {
     }
 };
 
-const bulletListType: Record<string, number> = {
-    '*': BulletListType.Disc,
-    '-': BulletListType.Dash,
-    '--': BulletListType.Square,
-    '->': BulletListType.LongArrow,
-    '-->': BulletListType.DoubleLongArrow,
-    '=>': BulletListType.UnfilledArrow,
-    '>': BulletListType.ShortArrow,
-    '—': BulletListType.Hyphen,
-};
+const bulletListType: Map<string, number> = new Map<string, number>([
+    ['*', BulletListType.Disc],
+    ['-', BulletListType.Dash],
+    ['--', BulletListType.Square],
+    ['->', BulletListType.LongArrow],
+    ['-->', BulletListType.DoubleLongArrow],
+    ['=>', BulletListType.UnfilledArrow],
+    ['>', BulletListType.ShortArrow],
+    ['—', BulletListType.Hyphen],
+]);
 
 const isNewList = (listMarker: string) => {
     const marker = listMarker.replace(/[^\w\s]/g, '');

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformFraction.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformFraction.ts
@@ -5,11 +5,11 @@ import type {
     ShallowMutableContentModelParagraph,
 } from 'roosterjs-content-model-types';
 
-const FRACTIONS: Record<string, string> = {
-    '1/2': '½',
-    '1/4': '¼',
-    '3/4': '¾',
-};
+const FRACTIONS: Map<string, string> = new Map<string, string>([
+    ['1/2', '½'],
+    ['1/4', '¼'],
+    ['3/4', '¾'],
+]);
 
 /**
  * @internal
@@ -20,11 +20,13 @@ export function transformFraction(
     context: FormatContentModelContext
 ): boolean {
     const fraction = previousSegment.text.split(' ').pop()?.trim();
-    if (fraction && FRACTIONS[fraction]) {
+    const text = fraction ? FRACTIONS.get(fraction) : undefined;
+
+    if (fraction && text) {
         const textLength = previousSegment.text.length - 1;
         const textIndex = textLength - fraction.length;
         const textSegment = splitTextSegment(previousSegment, paragraph, textIndex, textLength);
-        textSegment.text = FRACTIONS[fraction];
+        textSegment.text = text;
 
         context.canUndoByBackspace = true;
         return true;

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/list/getListTypeStyleTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/list/getListTypeStyleTest.ts
@@ -1005,4 +1005,31 @@ describe('getListTypeStyle', () => {
         };
         runTest(model, undefined);
     });
+
+    it('"Constructor" should not trigger list', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'constructor',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+
+        runTest(model, undefined);
+    });
 });

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/numbers/transformFractionTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/numbers/transformFractionTest.ts
@@ -85,4 +85,18 @@ describe('transformFraction', () => {
         };
         runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
     });
+
+    it('"constructor"', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: 'constructor',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
+    });
 });


### PR DESCRIPTION
To repro:
1. type "constructor"
2. type SPACE
Expect: nothing special happens
Actual: it converts "constructor" into a list with text "function Object() { [native code] } "

This is because we have code like this:
```ts
const map = {
  key: value
};

const value =map[input];
```
If input is some predefined property name such as "constructor", "valueOf", "toString", it will return a function object which is treated as a valid result, which should not.

Fix: use Map instead of Record here.
Future work: Check all other places where Record is used. Possibly find a eslint rule to disable it at all.
