### PR TITLE
Fix insert entity issue

### DIFF
--- a/packages/roosterjs-content-model-api/lib/modelApi/entity/insertEntityModel.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/entity/insertEntityModel.ts
@@ -118,7 +118,25 @@ function getInsertPoint(
     context?: FormatContentModelContext
 ): InsertPoint | null {
     if (insertPointOverride) {
-        return insertPointOverride;
+        const { paragraph, marker, tableContext, path } = insertPointOverride;
+        const index = paragraph.segments.indexOf(marker);
+        const previousSegment = index > 0 ? paragraph.segments[index - 1] : null;
+
+        // It is possible that the real selection is right before the override selection marker.
+        // This happens when:
+        // [Override marker][Entity node to wrap][Real marker]
+        // Then we will move the entity node into entity wrapper, causes the override marker and real marker are at the same place
+        // And recreating content model causes real marker to appear before override marker.
+        // Once that happens, we need to use the real marker instead so that after insert entity, real marker can be placed
+        // after new entity (if insertPointOverride==true)
+        return previousSegment?.segmentType == 'SelectionMarker' && previousSegment.isSelected
+            ? {
+                  marker: previousSegment,
+                  paragraph,
+                  tableContext,
+                  path,
+              }
+            : insertPointOverride;
     } else {
         const deleteResult = deleteSelection(model, [], context);
         const insertPoint = deleteResult.insertPoint;

--- a/packages/roosterjs-content-model-api/test/modelApi/entity/insertEntityModelTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/entity/insertEntityModelTest.ts
@@ -2620,4 +2620,51 @@ describe('insertEntityModel, use insert point', () => {
             ],
         });
     });
+
+    it('Block entity, Has insert point override which is right after real marker', () => {
+        const model = createContentModelDocument();
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const text1 = createText('test');
+        const markerReal = createSelectionMarker();
+        const markerOverride = createSelectionMarker();
+
+        text1.isSelected = true;
+        para1.segments.push(text1);
+
+        markerOverride.isSelected = false;
+        para2.segments.push(markerReal, markerOverride);
+
+        model.blocks.push(para1, para2);
+
+        const ip: InsertPoint = {
+            path: [model],
+            paragraph: para2,
+            marker: markerOverride,
+        };
+
+        insertEntityModel(model, Entity, 'focus', false, true, undefined, ip);
+
+        console.log(JSON.stringify(model));
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Text', text: 'test', format: {}, isSelected: true }],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        Entity,
+                        { segmentType: 'SelectionMarker', isSelected: true, format: {} },
+                        { segmentType: 'SelectionMarker', isSelected: false, format: {} },
+                    ],
+                    format: {},
+                },
+            ],
+        });
+    });
 });

--- a/packages/roosterjs-content-model-api/test/modelApi/entity/insertEntityModelTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/entity/insertEntityModelTest.ts
@@ -2645,8 +2645,6 @@ describe('insertEntityModel, use insert point', () => {
 
         insertEntityModel(model, Entity, 'focus', false, true, undefined, ip);
 
-        console.log(JSON.stringify(model));
-
         expect(model).toEqual({
             blockGroupType: 'Document',
             blocks: [


### PR DESCRIPTION
This is a little bit hard to explain.

Suppose we have the DOM structure:

```html
<div><span id=entity>...</span>[CURSOR]<div>
```

Then we call `insertEntity` to insert an entity and put the existing SPAN into the new entity, we set position to be right before this SPAN so the new entity should be inserted to replace the SPAN, and cursor is not moved.

However, inside `insertEntity` we will move the SPAN into entity wrapper, then call `formatContentModel` to insert entity. Since the SPAN is removed from the DOM tree, we need to recreate a content model, and in that case the real cursor and override cursor will be at the same place. Then our code will put the real selection marker before the override selection marker, which causes the entity is inserted after focus.

To fix this, we can check if the override selection marker is right after real one, then use the real one instead in that case.