### PR TITLE
Improve getDOMInsertPointRect

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/domUtils/selection/getDOMInsertPointRect.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/selection/getDOMInsertPointRect.ts
@@ -8,19 +8,18 @@ import type { DOMInsertPoint, Rect } from 'roosterjs-content-model-types';
  * @param pos The input DOM insert point
  */
 export function getDOMInsertPointRect(doc: Document, pos: DOMInsertPoint): Rect | null {
-    let { node, offset } = pos;
     const range = doc.createRange();
 
-    range.setStart(node, offset);
+    return (
+        tryGetRectFromPos(pos, range) ?? // 1. try get from the pos directly using getBoundingClientRect or getClientRects
+        tryGetRectFromPos((pos = normalizeInsertPoint(pos)), range) ?? // 2. try get normalized pos, this can work when insert point is inside text node
+        tryGetRectFromNode(pos.node) // 3. fallback to node rect using getBoundingClientRect
+    );
+}
 
-    // 1) try to get rect using range.getBoundingClientRect()
-    let rect = normalizeRect(range.getBoundingClientRect());
+function normalizeInsertPoint(pos: DOMInsertPoint) {
+    let { node, offset } = pos;
 
-    if (rect) {
-        return rect;
-    }
-
-    // 2) try to get rect using range.getClientRects
     while (node.lastChild) {
         if (offset == node.childNodes.length) {
             node = node.lastChild;
@@ -31,34 +30,28 @@ export function getDOMInsertPointRect(doc: Document, pos: DOMInsertPoint): Rect 
         }
     }
 
-    const rects = range.getClientRects && range.getClientRects();
-    rect = rects && rects.length == 1 ? normalizeRect(rects[0]) : null;
+    return { node, offset };
+}
+
+function tryGetRectFromPos(pos: DOMInsertPoint, range: Range): Rect | null {
+    let { node, offset } = pos;
+
+    range.setStart(node, offset);
+    range.setEnd(node, offset);
+
+    const rect = normalizeRect(range.getBoundingClientRect());
+
     if (rect) {
         return rect;
+    } else {
+        const rects = range.getClientRects && range.getClientRects();
+
+        return rects && rects.length == 1 ? normalizeRect(rects[0]) : null;
     }
+}
 
-    // 3) if node is text node, try inserting a SPAN and get the rect of SPAN for others
-    if (isNodeOfType(node, 'TEXT_NODE')) {
-        const span = node.ownerDocument.createElement('span');
-
-        span.textContent = '\u200b';
-        range.insertNode(span);
-        rect = normalizeRect(span.getBoundingClientRect());
-        span.parentNode?.removeChild(span);
-
-        if (rect) {
-            return rect;
-        }
-    }
-
-    // 4) try getBoundingClientRect on element
-    if (isNodeOfType(node, 'ELEMENT_NODE') && node.getBoundingClientRect) {
-        rect = normalizeRect(node.getBoundingClientRect());
-
-        if (rect) {
-            return rect;
-        }
-    }
-
-    return null;
+function tryGetRectFromNode(node: Node) {
+    return isNodeOfType(node, 'ELEMENT_NODE') && node.getBoundingClientRect
+        ? normalizeRect(node.getBoundingClientRect())
+        : null;
 }

--- a/packages/roosterjs-content-model-dom/lib/domUtils/selection/getDOMInsertPointRect.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/selection/getDOMInsertPointRect.ts
@@ -34,7 +34,7 @@ function normalizeInsertPoint(pos: DOMInsertPoint) {
 }
 
 function tryGetRectFromPos(pos: DOMInsertPoint, range: Range): Rect | null {
-    let { node, offset } = pos;
+    const { node, offset } = pos;
 
     range.setStart(node, offset);
     range.setEnd(node, offset);


### PR DESCRIPTION
In order to get rect of the cursor, we have a function `getDOMInsertPointRect()`, it uses several different ways to get current rect.

However, one of them is to insert a temp SPAN then call getBoundingClientRect() of this SPAN. This causes a DOM tree change and can causes our content model cache to be cleared. 

This change is to remove this way, and use a normalized range instead. It shows that for a range inside text node, it can return the rect successfully.