### PR TITLE
Bump editor-adapter to 8.62.1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
     "react": "9.0.0",
     "main": "9.6.0",
-    "legacyAdapter": "8.62.0",
+    "legacyAdapter": "8.62.1",
     "overrides": {
         "roosterjs-content-model-plugins": "9.6.1"
     }


### PR DESCRIPTION
Bump `roosterjs-editor-adapter` to 8.62.1 since we changed it in PR https://github.com/microsoft/roosterjs/pull/2651