### PR TITLE
Using Tab key on table selects the whole next cell

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -411,6 +411,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
             }
 
             let lastCo = findCoordinate(tableSel?.parsedTable, end, domHelper);
+            let tabMove = false;
             const { parsedTable, firstCo: oldCo, table } = this.state.tableSelection;
 
             if (lastCo && tableSel.table == table) {
@@ -465,7 +466,8 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                         const cell = parsedTable[row][col];
 
                         if (typeof cell != 'string') {
-                            this.setRangeSelectionInTable(cell, 0, this.editor);
+                            tabMove = true;
+                            this.setRangeSelectionInTable(cell, 0, this.editor, true);
                             lastCo.row = row;
                             lastCo.col = col;
                             break;
@@ -486,20 +488,29 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                 }
             }
 
-            if (!collapsed && lastCo) {
+            if (!collapsed && lastCo && tabMove == false) {
                 this.state.tableSelection = tableSel;
                 this.updateTableSelection(lastCo);
             }
         }
     }
 
-    private setRangeSelectionInTable(cell: Node, nodeOffset: number, editor: IEditor) {
-        // Get deepest editable position in the cell
-        const { node, offset } = normalizePos(cell, nodeOffset);
-
+    private setRangeSelectionInTable(
+        cell: Node,
+        nodeOffset: number,
+        editor: IEditor,
+        selectAll?: boolean
+    ) {
         const range = editor.getDocument().createRange();
-        range.setStart(node, offset);
-        range.collapse(true /*toStart*/);
+        if (selectAll) {
+            range.selectNodeContents(cell);
+        } else {
+            // Get deepest editable position in the cell
+            const { node, offset } = normalizePos(cell, nodeOffset);
+
+            range.setStart(node, offset);
+            range.collapse(true /* toStart */);
+        }
 
         this.setDOMSelection(
             {

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -467,7 +467,12 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
 
                         if (typeof cell != 'string') {
                             tabMove = true;
-                            this.setRangeSelectionInTable(cell, 0, this.editor, true);
+                            this.setRangeSelectionInTable(
+                                cell,
+                                0,
+                                this.editor,
+                                true /* selectAll */
+                            );
                             lastCo.row = row;
                             lastCo.col = col;
                             break;
@@ -488,7 +493,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                 }
             }
 
-            if (!collapsed && lastCo && tabMove == false) {
+            if (!collapsed && lastCo && !tabMove) {
                 this.state.tableSelection = tableSel;
                 this.updateTableSelection(lastCo);
             }

--- a/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
@@ -1436,11 +1436,11 @@ describe('SelectionPlugin handle table selection', () => {
                       };
             });
 
-            const setStartSpy = jasmine.createSpy('setStart');
+            const selectNodeContentsSpy = jasmine.createSpy('selectNodeContents');
             const collapseSpy = jasmine.createSpy('collapse');
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
             const mockedRange = {
-                setStart: setStartSpy,
+                selectNodeContents: selectNodeContentsSpy,
                 collapse: collapseSpy,
             } as any;
 
@@ -1469,7 +1469,8 @@ describe('SelectionPlugin handle table selection', () => {
                 range: mockedRange,
                 isReverted: false,
             });
-            expect(setStartSpy).toHaveBeenCalledWith(td2, 0);
+            expect(selectNodeContentsSpy).toHaveBeenCalledWith(td2);
+            expect(collapseSpy).not.toHaveBeenCalled();
             expect(announceSpy).not.toHaveBeenCalled();
             expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
             expect(time).toBe(2);
@@ -1506,11 +1507,11 @@ describe('SelectionPlugin handle table selection', () => {
                       };
             });
 
-            const setStartSpy = jasmine.createSpy('setStart');
+            const selectNodeContentsSpy = jasmine.createSpy('selectNodeContents');
             const collapseSpy = jasmine.createSpy('collapse');
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
             const mockedRange = {
-                setStart: setStartSpy,
+                selectNodeContents: selectNodeContentsSpy,
                 collapse: collapseSpy,
             } as any;
 
@@ -1540,7 +1541,8 @@ describe('SelectionPlugin handle table selection', () => {
                 range: mockedRange,
                 isReverted: false,
             });
-            expect(setStartSpy).toHaveBeenCalledWith(td1, 0);
+            expect(selectNodeContentsSpy).toHaveBeenCalledWith(td1);
+            expect(collapseSpy).not.toHaveBeenCalled();
             expect(announceSpy).not.toHaveBeenCalled();
             expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
             expect(time).toBe(2);
@@ -1577,11 +1579,11 @@ describe('SelectionPlugin handle table selection', () => {
                       };
             });
 
-            const setStartSpy = jasmine.createSpy('setStart');
+            const selectNodeContentsSpy = jasmine.createSpy('selectNodeContents');
             const collapseSpy = jasmine.createSpy('collapse');
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
             const mockedRange = {
-                setStart: setStartSpy,
+                selectNodeContents: selectNodeContentsSpy,
                 collapse: collapseSpy,
             } as any;
 
@@ -1610,7 +1612,8 @@ describe('SelectionPlugin handle table selection', () => {
                 range: mockedRange,
                 isReverted: false,
             });
-            expect(setStartSpy).toHaveBeenCalledWith(td3, 0);
+            expect(selectNodeContentsSpy).toHaveBeenCalledWith(td3);
+            expect(collapseSpy).not.toHaveBeenCalled();
             expect(announceSpy).not.toHaveBeenCalled();
             expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
             expect(time).toBe(2);


### PR DESCRIPTION
### Description:

Using the Tab key (or Shift+Tab) moves the selection marker to an adjacent cell, or the previous/next row. The position is always at the start of the cell.

### Fix

Modify the behaviour of using the Tab key in a table so that instead of collapsing the selection at the start, it selects the whole contents of the cell.

### Cases tested:

1. Create a Table and populate it with content
2. Use the tab key to move across cells

**Before:** After movement, the selection is always at the start of the cell

**After:** After movement, the selection encompasses all the contents of the cell