### PR TITLE
Ensure focusNode exists when selectionChanges

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -595,7 +595,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
             //If am image selection changed to a wider range due a keyboard event, we should update the selection
             const selection = this.editor.getDocument().getSelection();
 
-            if (newSelection?.type == 'image' && selection) {
+            if (newSelection?.type == 'image' && selection && selection.focusNode) {
                 if (selection && !isSingleImageInSelection(selection)) {
                     const range = selection.getRangeAt(0);
                     this.editor.setDOMSelection({

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -595,17 +595,20 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
             //If am image selection changed to a wider range due a keyboard event, we should update the selection
             const selection = this.editor.getDocument().getSelection();
 
-            if (newSelection?.type == 'image' && selection && selection.focusNode) {
-                if (selection && !isSingleImageInSelection(selection)) {
-                    const range = selection.getRangeAt(0);
-                    this.editor.setDOMSelection({
-                        type: 'range',
-                        range,
-                        isReverted:
-                            selection.focusNode != range.endContainer ||
-                            selection.focusOffset != range.endOffset,
-                    });
-                }
+            if (
+                newSelection?.type == 'image' &&
+                selection &&
+                selection.focusNode &&
+                !isSingleImageInSelection(selection)
+            ) {
+                const range = selection.getRangeAt(0);
+                this.editor.setDOMSelection({
+                    type: 'range',
+                    range,
+                    isReverted:
+                        selection.focusNode != range.endContainer ||
+                        selection.focusOffset != range.endOffset,
+                });
             }
 
             // Safari has problem to handle onBlur event. When blur, we cannot get the original selection from editor.

--- a/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
@@ -2456,6 +2456,9 @@ describe('SelectionPlugin selectionChange on image selected', () => {
         addEventListenerSpy = jasmine.createSpy('addEventListener');
         getRangeAtSpy = jasmine.createSpy('getRangeAt');
         getSelectionSpy = jasmine.createSpy('getSelection').and.returnValue({
+            focusNode: {
+                nodeName: 'SPAN',
+            },
             getRangeAt: getRangeAtSpy,
         });
         getDocumentSpy = jasmine.createSpy('getDocument').and.returnValue({
@@ -2513,7 +2516,7 @@ describe('SelectionPlugin selectionChange on image selected', () => {
         expect(setDOMSelectionSpy).toHaveBeenCalledWith({
             type: 'range',
             range: { startContainer: {} } as Range,
-            isReverted: false,
+            isReverted: true,
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
When selectionChange event happens, ensure the focus exist before setting the selection in the new position, otherwise
getRangeSelection(0) will return an error, since nothing is selected. 