### PR TITLE
Fix context menu for Image Edit menu

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -25,6 +25,7 @@ import type {
 } from 'roosterjs-content-model-types';
 
 const MouseLeftButton = 0;
+const MouseRightButton = 2;
 const Up = 'ArrowUp';
 const Down = 'ArrowDown';
 const Left = 'ArrowLeft';
@@ -163,12 +164,17 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         let image: HTMLImageElement | null;
 
         // Image selection
-        if (selection?.type == 'image' && rawEvent.button == MouseLeftButton) {
+        if (
+            selection?.type == 'image' &&
+            (rawEvent.button == MouseLeftButton ||
+                (rawEvent.button == MouseRightButton &&
+                    !this.getClickingImage(rawEvent) &&
+                    !this.getContainedTargetImage(rawEvent, selection)))
+        ) {
             this.setDOMSelection(null /*domSelection*/, null /*tableSelection*/);
         }
 
         if (
-            rawEvent.button === MouseLeftButton &&
             (image =
                 this.getClickingImage(rawEvent) ??
                 this.getContainedTargetImage(rawEvent, selection)) &&
@@ -549,7 +555,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         if (!this.isMac || !previousSelection || previousSelection.type !== 'image') {
             return null;
         }
-
+        console.log('getContainedTargetImage', event);
         const target = event.target as Node;
         if (
             isNodeOfType(target, 'ELEMENT_NODE') &&

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -555,7 +555,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         if (!this.isMac || !previousSelection || previousSelection.type !== 'image') {
             return null;
         }
-        console.log('getContainedTargetImage', event);
+
         const target = event.target as Node;
         if (
             isNodeOfType(target, 'ELEMENT_NODE') &&

--- a/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
@@ -419,6 +419,38 @@ describe('SelectionPlugin handle image selection', () => {
         expect(setDOMSelectionSpy).toHaveBeenCalledWith(null);
     });
 
+    it('Image selection, mouse down with right click to div', () => {
+        const mockedImage = {
+            parentNode: { childNodes: [] },
+        } as any;
+
+        mockedImage.parentNode.childNodes.push(mockedImage);
+
+        const mockedRange = {
+            setStart: jasmine.createSpy('setStart'),
+            collapse: jasmine.createSpy('collapse'),
+        };
+
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+
+        createRangeSpy.and.returnValue(mockedRange);
+
+        const node = document.createElement('div');
+        plugin.onPluginEvent!({
+            eventType: 'mouseDown',
+            rawEvent: {
+                target: node,
+                button: 2,
+            } as any,
+        });
+
+        expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
+        expect(setDOMSelectionSpy).toHaveBeenCalledWith(null);
+    });
+
     it('Image selection, mouse down to div, no parent of image', () => {
         const mockedImage = {
             parentNode: { childNodes: [] },

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -201,7 +201,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                 this.applyFormatWithContentModel(
                     editor,
                     this.isCropMode,
-                    isModifierKey(event.rawEvent) && isImageSelection //if it's a modifier key over a image, the image should select the image
+                    (isModifierKey(event.rawEvent) || event.rawEvent.shiftKey) && isImageSelection //if it's a modifier key over a image, the image should select the image
                 );
             }
         }

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -98,11 +98,11 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
             blur: {
                 beforeDispatch: () => {
                     if (this.editor) {
-                        // this.applyFormatWithContentModel(
-                        //     this.editor,
-                        //     this.isCropMode,
-                        //     true /* shouldSelectImage */
-                        // );
+                        this.applyFormatWithContentModel(
+                            this.editor,
+                            this.isCropMode,
+                            true /* shouldSelectImage */
+                        );
                     }
                 },
             },

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -149,6 +149,123 @@ describe('ImageEditPlugin', () => {
         plugin.dispose();
     });
 
+    it('mouseUp - left click - remove selection', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Image',
+                            src: 'test',
+                            format: {
+                                fontFamily: 'Calibri',
+                                fontSize: '11pt',
+                                textColor: 'rgb(0, 0, 0)',
+                                id: 'image_0',
+                                maxWidth: '1800px',
+                            },
+                            dataset: {
+                                isEditing: 'true',
+                            },
+                            isSelectedAsImageSelection: false,
+                            isSelected: false,
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+            ],
+            format: {
+                fontFamily: 'Calibri',
+                fontSize: '11pt',
+                textColor: '#000000',
+            },
+        };
+        const plugin = new ImageEditPlugin();
+        const editor = initEditor('image_edit', [plugin], model);
+        plugin.initialize(editor);
+        plugin.onPluginEvent({
+            eventType: 'mouseUp',
+            isClicking: true,
+            rawEvent: {
+                button: 0,
+            } as any,
+        });
+        expect(plugin.isEditingImage).toBeFalsy();
+        plugin.dispose();
+    });
+
+    it('mouseUp - right click - remove wrapper', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Image',
+                            src: 'test',
+                            format: {
+                                fontFamily: 'Calibri',
+                                fontSize: '11pt',
+                                textColor: 'rgb(0, 0, 0)',
+                                id: 'image_0',
+                                maxWidth: '1800px',
+                            },
+                            dataset: {},
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+            ],
+            format: {
+                fontFamily: 'Calibri',
+                fontSize: '11pt',
+                textColor: '#000000',
+            },
+        };
+        const plugin = new ImageEditPlugin();
+        const editor = initEditor('image_edit', [plugin], model);
+        plugin.initialize(editor);
+        plugin.onPluginEvent({
+            eventType: 'mouseUp',
+            isClicking: true,
+            rawEvent: {
+                button: 0,
+                target: {
+                    tagName: 'IMG',
+                } as any,
+            } as any,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseUp',
+            isClicking: true,
+            rawEvent: {
+                button: 2,
+                target: {
+                    tagName: 'IMG',
+                    nodeType: 1,
+                } as any,
+            } as any,
+        });
+
+        expect(plugin.isEditingImage).toBeFalsy();
+        plugin.dispose();
+    });
+
     it('cropImage', () => {
         const plugin = new ImageEditPlugin();
         const editor = initEditor('image_edit', [plugin], model);


### PR DESCRIPTION
To make context menu work with image edit plugin, when the user right clicks on an image, the editing operations will be applied, and the image will be selected. Also, if the image was selected and right click occurs in an element that is not a image, remove image selection. 
![ContextMenuOnImages](https://github.com/microsoft/roosterjs/assets/87443959/fef07593-9624-4b43-8c47-0c52464884e9)

