### PR TITLE
Add option for Tab Key handling in EditPlugin

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -11,8 +11,25 @@ import type {
     PluginEvent,
 } from 'roosterjs-content-model-types';
 
+/**
+ * Options to customize the keyboard handling behavior of Edit plugin
+ */
+export type EditOptions = {
+    /**
+     * Whether to handle Tab key in keyboard. @default true
+     */
+    handleTabKey?: boolean;
+}
+
 const BACKSPACE_KEY = 8;
 const DELETE_KEY = 46;
+
+/**
+ * @internal
+ */
+const DefaultOptions: Partial<EditOptions> = {
+    handleTabKey: true,
+};
 
 /**
  * Edit plugins helps editor to do editing operation on top of content model.
@@ -27,6 +44,12 @@ export class EditPlugin implements EditorPlugin {
     private shouldHandleNextInputEvent = false;
     private selectionAfterDelete: DOMSelection | null = null;
     private handleNormalEnter = false;
+
+    /**
+     * @param options An optional parameter that takes in an object of type EditOptions, which includes the following properties:
+     * handleTabKey: A boolean that enables or disables Tab key handling. Defaults to true.
+     */
+    constructor(private options: EditOptions = DefaultOptions) {}
 
     /**
      * Get name of this plugin
@@ -98,6 +121,7 @@ export class EditPlugin implements EditorPlugin {
     willHandleEventExclusively(event: PluginEvent) {
         if (
             this.editor &&
+            this.options.handleTabKey &&
             event.eventType == 'keyDown' &&
             event.rawEvent.key == 'Tab' &&
             !event.rawEvent.shiftKey
@@ -148,7 +172,9 @@ export class EditPlugin implements EditorPlugin {
                     break;
 
                 case 'Tab':
-                    keyboardTab(editor, rawEvent);
+                    if (this.options.handleTabKey) {
+                        keyboardTab(editor, rawEvent);
+                    }
                     break;
                 case 'Unidentified':
                     if (editor.getEnvironment().isAndroid) {

--- a/packages/roosterjs-content-model-plugins/lib/index.ts
+++ b/packages/roosterjs-content-model-plugins/lib/index.ts
@@ -2,7 +2,7 @@ export { TableEditPlugin } from './tableEdit/TableEditPlugin';
 export { OnTableEditorCreatedCallback } from './tableEdit/OnTableEditorCreatedCallback';
 export { TableEditFeatureName } from './tableEdit/editors/features/TableEditFeatureName';
 export { PastePlugin } from './paste/PastePlugin';
-export { EditPlugin } from './edit/EditPlugin';
+export { EditPlugin, EditOptions } from './edit/EditPlugin';
 export { AutoFormatPlugin, AutoFormatOptions } from './autoFormat/AutoFormatPlugin';
 
 export {

--- a/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
@@ -122,6 +122,25 @@ describe('EditPlugin', () => {
             expect(keyboardDeleteSpy).not.toHaveBeenCalled();
             expect(keyboardEnterSpy).not.toHaveBeenCalled();
         });
+		
+		it('Tab, Tab handling not enabled', () => {
+            plugin = new EditPlugin({
+                handleTabKey: false,
+            });
+            const rawEvent = { key: 'Tab' } as any;
+
+            plugin.initialize(editor);
+
+            plugin.onPluginEvent({
+                eventType: 'keyDown',
+                rawEvent,
+            });
+
+            expect(keyboardTabSpy).not.toHaveBeenCalled();
+            expect(keyboardInputSpy).not.toHaveBeenCalled();
+            expect(keyboardDeleteSpy).not.toHaveBeenCalled();
+            expect(keyboardEnterSpy).not.toHaveBeenCalled();
+        });
 
         it('Enter, normal enter not enabled', () => {
             plugin = new EditPlugin();

--- a/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
@@ -122,11 +122,9 @@ describe('EditPlugin', () => {
             expect(keyboardDeleteSpy).not.toHaveBeenCalled();
             expect(keyboardEnterSpy).not.toHaveBeenCalled();
         });
-		
-		it('Tab, Tab handling not enabled', () => {
-            plugin = new EditPlugin({
-                handleTabKey: false,
-            });
+
+        it('Tab, Tab handling not enabled', () => {
+            plugin = new EditPlugin({ handleTabKey: false });
             const rawEvent = { key: 'Tab' } as any;
 
             plugin.initialize(editor);


### PR DESCRIPTION
EditPlugin overrides the default behavior of Tab key by increasing the margin-left value of current line. As a result, user can't navigate to next focusable element by pressing Tab key, so we need an option for disabling this behavior.  