### PR TITLE
Fix #2741 by changing Id selectors from `#{id}` to `[id="{id}"]`

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/setEditorStyle/ensureUniqueId.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setEditorStyle/ensureUniqueId.ts
@@ -7,7 +7,7 @@ export function ensureUniqueId(element: HTMLElement, idPrefix: string): string {
     const doc = element.ownerDocument;
     let i = 0;
 
-    while (!element.id || doc.querySelectorAll('#' + element.id).length > 1) {
+    while (!element.id || doc.querySelectorAll(`[id="${element.id}"]`).length > 1) {
         element.id = idPrefix + '_' + i++;
     }
 

--- a/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/setDOMSelectionTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/setDOMSelectionTest.ts
@@ -529,7 +529,7 @@ describe('setDOMSelection', () => {
             createRangeSpy.and.returnValue(mockedRange);
 
             querySelectorAllSpy.and.callFake(selector => {
-                return selector == '#image_0' ? ['', ''] : [''];
+                return selector == '[id="image_0"]' ? ['', ''] : [''];
             });
             hasFocusSpy.and.returnValue(false);
 

--- a/packages/roosterjs-content-model-core/test/coreApi/setEditorStyle/ensureUniqueIdTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setEditorStyle/ensureUniqueIdTest.ts
@@ -1,3 +1,4 @@
+import * as ensureUniqueIdFile from '../../../lib/coreApi/setEditorStyle/ensureUniqueId';
 import { ensureUniqueId } from '../../../lib/coreApi/setEditorStyle/ensureUniqueId';
 
 describe('ensureUniqueId', () => {
@@ -38,10 +39,52 @@ describe('ensureUniqueId', () => {
             id: 'dup',
         } as any;
         querySelectorAllSpy.and.callFake((selector: string) =>
-            selector == '#dup' ? [{}, {}] : []
+            selector == '[id="dup"]' ? [{}, {}] : []
         );
         const result = ensureUniqueId(element, 'prefix');
 
         expect(result).toBe('dup_0');
+    });
+
+    it('Should not throw when element id starts with number', () => {
+        const element = {
+            ownerDocument: doc,
+            id: '0',
+        } as any;
+
+        let isFirst = true;
+        querySelectorAllSpy.and.callFake((_selector: string) => {
+            if (isFirst) {
+                isFirst = false;
+                return [{}, {}];
+            }
+            return [{}];
+        });
+
+        ensureUniqueId(element, 'prefix');
+
+        expect(querySelectorAllSpy).toHaveBeenCalledWith('[id="0"]');
+        expect(element.id).toEqual('0_0');
+    });
+
+    it('Should not throw when element id starts with hyphen', () => {
+        const element = {
+            ownerDocument: doc,
+            id: '-',
+        } as any;
+
+        let isFirst = true;
+        querySelectorAllSpy.and.callFake((_selector: string) => {
+            if (isFirst) {
+                isFirst = false;
+                return [{}, {}];
+            }
+            return [{}];
+        });
+
+        ensureUniqueId(element, 'prefix');
+
+        expect(querySelectorAllSpy).toHaveBeenCalledWith('[id="-"]');
+        expect(element.id).toEqual('-_0');
     });
 });

--- a/packages/roosterjs-content-model-core/test/coreApi/setEditorStyle/ensureUniqueIdTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setEditorStyle/ensureUniqueIdTest.ts
@@ -1,4 +1,3 @@
-import * as ensureUniqueIdFile from '../../../lib/coreApi/setEditorStyle/ensureUniqueId';
 import { ensureUniqueId } from '../../../lib/coreApi/setEditorStyle/ensureUniqueId';
 
 describe('ensureUniqueId', () => {


### PR DESCRIPTION
Fix https://github.com/microsoft/roosterjs/issues/2741

querySelector() is throwing when the Id starts with a number or a hyphen so refactor the selector so it works in all scenarios.

See [this page](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id) for more details.

