### PR TITLE
Add LegacyImageSelection

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
@@ -27,7 +27,12 @@ const DEFAULT_SELECTION_BORDER_COLOR = '#DB626C';
 export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionChangedEvent) => {
     const existingSelection = core.api.getDOMSelection(core);
 
-    if (existingSelection && selection && areSameSelections(existingSelection, selection)) {
+    if (
+        !core.experimentalFeatures.indexOf('PreserveImageSelections') &&
+        existingSelection &&
+        selection &&
+        areSameSelections(existingSelection, selection)
+    ) {
         return;
     }
 

--- a/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
@@ -27,12 +27,7 @@ const DEFAULT_SELECTION_BORDER_COLOR = '#DB626C';
 export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionChangedEvent) => {
     const existingSelection = core.api.getDOMSelection(core);
 
-    if (
-        existingSelection?.type !== 'image' &&
-        existingSelection &&
-        selection &&
-        areSameSelections(existingSelection, selection)
-    ) {
+    if (existingSelection && selection && areSameSelections(existingSelection, selection)) {
         return;
     }
 

--- a/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
@@ -27,12 +27,7 @@ const DEFAULT_SELECTION_BORDER_COLOR = '#DB626C';
 export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionChangedEvent) => {
     const existingSelection = core.api.getDOMSelection(core);
 
-    if (
-        !core.experimentalFeatures.indexOf('PreserveImageSelections') &&
-        existingSelection &&
-        selection &&
-        areSameSelections(existingSelection, selection)
-    ) {
+    if (existingSelection && selection && areSameSelections(existingSelection, selection)) {
         return;
     }
 

--- a/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setDOMSelection.ts
@@ -27,7 +27,12 @@ const DEFAULT_SELECTION_BORDER_COLOR = '#DB626C';
 export const setDOMSelection: SetDOMSelection = (core, selection, skipSelectionChangedEvent) => {
     const existingSelection = core.api.getDOMSelection(core);
 
-    if (existingSelection && selection && areSameSelections(existingSelection, selection)) {
+    if (
+        existingSelection?.type !== 'image' &&
+        existingSelection &&
+        selection &&
+        areSameSelections(existingSelection, selection)
+    ) {
         return;
     }
 

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -181,7 +181,13 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                 return;
             }
         } else {
-            if (selection?.type == 'image' && rawEvent.button == MouseLeftButton) {
+            if (
+                selection?.type == 'image' &&
+                (rawEvent.button == MouseLeftButton ||
+                    (rawEvent.button == MouseRightButton &&
+                        !this.getClickingImage(rawEvent) &&
+                        !this.getContainedTargetImage(rawEvent, selection)))
+            ) {
                 this.setDOMSelection(null /*domSelection*/, null /*tableSelection*/);
             }
 
@@ -199,16 +205,6 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                     null
                 );
                 return;
-            }
-
-            if (
-                selection?.type == 'image' &&
-                (rawEvent.button == MouseLeftButton ||
-                    (rawEvent.button == MouseRightButton &&
-                        !this.getClickingImage(rawEvent) &&
-                        !this.getContainedTargetImage(rawEvent, selection)))
-            ) {
-                this.setDOMSelection(null /*domSelection*/, null /*tableSelection*/);
             }
         }
 

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -22,9 +22,11 @@ import type {
     TableSelectionInfo,
     TableCellCoordinate,
     RangeSelection,
+    MouseUpEvent,
 } from 'roosterjs-content-model-types';
 
 const MouseLeftButton = 0;
+const MouseMiddleButton = 1;
 const MouseRightButton = 2;
 const Up = 'ArrowUp';
 const Down = 'ArrowDown';
@@ -140,7 +142,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                 break;
 
             case 'mouseUp':
-                this.onMouseUp();
+                this.onMouseUp(this.editor, event);
                 break;
 
             case 'keyDown':
@@ -164,8 +166,39 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         let image: HTMLImageElement | null;
 
         // Image selection
+        if (editor.isExperimentalFeatureEnabled('LegacyImageSelection')) {
+            if (
+                rawEvent.button === MouseRightButton &&
+                (image =
+                    this.getClickingImage(rawEvent) ??
+                    this.getContainedTargetImage(rawEvent, selection)) &&
+                image.isContentEditable
+            ) {
+                this.selectImageWithRange(image, rawEvent);
+                return;
+            } else if (selection?.type == 'image' && selection.image !== rawEvent.target) {
+                this.selectBeforeOrAfterElement(editor, selection.image);
+                return;
+            }
+        } else {
+            if (
+                (image =
+                    this.getClickingImage(rawEvent) ??
+                    this.getContainedTargetImage(rawEvent, selection)) &&
+                image.isContentEditable
+            ) {
+                this.setDOMSelection(
+                    {
+                        type: 'image',
+                        image: image,
+                    },
+                    null
+                );
+                return;
+            }
+        }
+
         if (
-            !editor.isExperimentalFeatureEnabled('PreserveImageSelection') &&
             selection?.type == 'image' &&
             (rawEvent.button == MouseLeftButton ||
                 (rawEvent.button == MouseRightButton &&
@@ -173,22 +206,6 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                     !this.getContainedTargetImage(rawEvent, selection)))
         ) {
             this.setDOMSelection(null /*domSelection*/, null /*tableSelection*/);
-        }
-
-        if (
-            (image =
-                this.getClickingImage(rawEvent) ??
-                this.getContainedTargetImage(rawEvent, selection)) &&
-            image.isContentEditable
-        ) {
-            this.setDOMSelection(
-                {
-                    type: 'image',
-                    image: image,
-                },
-                null
-            );
-            return;
         }
 
         // Table selection
@@ -226,6 +243,25 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                     beforeDispatch: this.onMouseMove,
                 },
             });
+        }
+    }
+
+    private selectImageWithRange(image: HTMLImageElement, event: Event) {
+        const range = image.ownerDocument.createRange();
+        range.selectNode(image);
+
+        const domSelection = this.editor?.getDOMSelection();
+        if (domSelection?.type == 'image' && image == domSelection.image) {
+            event.preventDefault();
+        } else {
+            this.setDOMSelection(
+                {
+                    type: 'range',
+                    isReverted: false,
+                    range,
+                },
+                null
+            );
         }
     }
 
@@ -289,7 +325,21 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         }
     };
 
-    private onMouseUp() {
+    private onMouseUp(editor: IEditor, event: MouseUpEvent) {
+        let image: HTMLImageElement | null;
+
+        if (
+            editor.isExperimentalFeatureEnabled('LegacyImageSelection') &&
+            (image = this.getClickingImage(event.rawEvent)) &&
+            image.isContentEditable &&
+            event.rawEvent.button != MouseMiddleButton &&
+            (event.rawEvent.button ==
+                MouseRightButton /* it's not possible to drag using right click */ ||
+                event.isClicking)
+        ) {
+            this.selectImageWithRange(image, event.rawEvent);
+        }
+
         this.detachMouseEvent();
     }
 

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -165,7 +165,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
 
         // Image selection
         if (
-            editor.isExperimentalFeatureEnabled('PreserveImageSelection') &&
+            !editor.isExperimentalFeatureEnabled('PreserveImageSelection') &&
             selection?.type == 'image' &&
             (rawEvent.button == MouseLeftButton ||
                 (rawEvent.button == MouseRightButton &&

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -181,6 +181,10 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                 return;
             }
         } else {
+            if (selection?.type == 'image' && rawEvent.button == MouseLeftButton) {
+                this.setDOMSelection(null /*domSelection*/, null /*tableSelection*/);
+            }
+
             if (
                 (image =
                     this.getClickingImage(rawEvent) ??
@@ -196,16 +200,16 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                 );
                 return;
             }
-        }
 
-        if (
-            selection?.type == 'image' &&
-            (rawEvent.button == MouseLeftButton ||
-                (rawEvent.button == MouseRightButton &&
-                    !this.getClickingImage(rawEvent) &&
-                    !this.getContainedTargetImage(rawEvent, selection)))
-        ) {
-            this.setDOMSelection(null /*domSelection*/, null /*tableSelection*/);
+            if (
+                selection?.type == 'image' &&
+                (rawEvent.button == MouseLeftButton ||
+                    (rawEvent.button == MouseRightButton &&
+                        !this.getClickingImage(rawEvent) &&
+                        !this.getContainedTargetImage(rawEvent, selection)))
+            ) {
+                this.setDOMSelection(null /*domSelection*/, null /*tableSelection*/);
+            }
         }
 
         // Table selection

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -165,6 +165,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
 
         // Image selection
         if (
+            editor.isExperimentalFeatureEnabled('PreserveImageSelection') &&
             selection?.type == 'image' &&
             (rawEvent.button == MouseLeftButton ||
                 (rawEvent.button == MouseRightButton &&

--- a/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
@@ -370,6 +370,9 @@ describe('SelectionPlugin handle image selection', () => {
             getColorManager: () => ({
                 getDarkColor: (color: string) => `${DEFAULT_DARK_COLOR_SUFFIX_COLOR}${color}`,
             }),
+            isExperimentalFeatureEnabled: () => {
+                return false;
+            },
         } as any;
         plugin = createSelectionPlugin({});
         plugin.initialize(editor);
@@ -765,6 +768,9 @@ describe('SelectionPlugin handle table selection', () => {
                 }
             },
             announce: announceSpy,
+            isExperimentalFeatureEnabled: () => {
+                return false;
+            },
         } as any;
         plugin = createSelectionPlugin({});
         plugin.initialize(editor);
@@ -2246,6 +2252,9 @@ describe('SelectionPlugin on Safari', () => {
             getColorManager: () => ({
                 getDarkColor: (color: string) => `${DEFAULT_DARK_COLOR_SUFFIX_COLOR}${color}`,
             }),
+            isExperimentalFeatureEnabled: () => {
+                return false;
+            },
         } as any) as IEditor;
     });
 

--- a/packages/roosterjs-content-model-types/lib/editor/ExperimentalFeature.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/ExperimentalFeature.ts
@@ -12,4 +12,4 @@ export type ExperimentalFeature =
     /**
      * Workaround for the Legacy Image Edit
      */
-    | 'PreserveImageSelection';
+    | 'LegacyImageSelection';

--- a/packages/roosterjs-content-model-types/lib/editor/ExperimentalFeature.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/ExperimentalFeature.ts
@@ -9,3 +9,8 @@ export type ExperimentalFeature =
      * and use cached element when write back if it is not changed.
      */
     'PersistCache';
+
+/**
+ * Workaround for the Legacy Image Edit
+ */
+'PreserveImageSelection';

--- a/packages/roosterjs-content-model-types/lib/editor/ExperimentalFeature.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/ExperimentalFeature.ts
@@ -8,9 +8,8 @@ export type ExperimentalFeature =
      * When this feature is enabled, we will persist a content model in memory as long as we can,
      * and use cached element when write back if it is not changed.
      */
-    'PersistCache';
-
-/**
- * Workaround for the Legacy Image Edit
- */
-'PreserveImageSelection';
+    | 'PersistCache'
+    /**
+     * Workaround for the Legacy Image Edit
+     */
+    | 'PreserveImageSelection';


### PR DESCRIPTION
Add the LegacyImageSelection Experiemental feature as workaround to make the Legacy Image Edit Plugin work with the new content model editor, once the Legacy Image Edit is fully removed from client-web this code will be fully removed.