### PR TITLE
Add AriaLiveMode to announce to let consumers change the ariaLive attribute of the announce container.

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/announce/announce.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/announce/announce.ts
@@ -10,7 +10,7 @@ const DOT_STRING = '.';
  * @param announceData Data to announce
  */
 export const announce: Announce = (core, announceData) => {
-    const { text, defaultStrings, formatStrings = [] } = announceData;
+    const { text, defaultStrings, formatStrings = [], ariaLiveMode = 'assertive' } = announceData;
     const { announcerStringGetter } = core.lifecycle;
     const template = defaultStrings && announcerStringGetter?.(defaultStrings);
     let textToAnnounce = formatString(template || text, formatStrings);
@@ -21,6 +21,10 @@ export const announce: Announce = (core, announceData) => {
 
     if (textToAnnounce && core.lifecycle.announceContainer) {
         const { announceContainer } = core.lifecycle;
+        if (announceContainer.ariaLive != ariaLiveMode) {
+            announceContainer.ariaLive = ariaLiveMode;
+        }
+
         if (textToAnnounce == announceContainer.textContent) {
             textToAnnounce += DOT_STRING;
         }

--- a/packages/roosterjs-content-model-core/test/coreApi/announce/announceTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/announce/announceTest.ts
@@ -183,10 +183,11 @@ describe('announce', () => {
             parentElement: {
                 removeChild: removeChildSpy,
             },
+            ariaLive: 'assertive',
         });
     });
 
-    it('already has div with same text', () => {
+    it('already has div with same text 2', () => {
         const mockedDiv = {
             textContent: 'test',
         } as any;
@@ -199,6 +200,61 @@ describe('announce', () => {
 
         expect(mockedDiv).toEqual({
             textContent: 'test.',
+            ariaLive: 'assertive',
+        });
+    });
+
+    it('Set AriaLive polite', () => {
+        const mockedDiv = {
+            textContent: 'test',
+        } as any;
+
+        core.lifecycle.announceContainer = mockedDiv;
+
+        announce(core, {
+            text: 'test',
+            ariaLiveMode: 'polite',
+        });
+
+        expect(mockedDiv).toEqual({
+            textContent: 'test.',
+            ariaLive: 'polite',
+        });
+    });
+
+    it('Set AriaLive off', () => {
+        const mockedDiv = {
+            textContent: 'test',
+        } as any;
+
+        core.lifecycle.announceContainer = mockedDiv;
+
+        announce(core, {
+            text: 'test',
+            ariaLiveMode: 'off',
+        });
+
+        expect(mockedDiv).toEqual({
+            textContent: 'test.',
+            ariaLive: 'off',
+        });
+    });
+
+    it('Set AriaLive off', () => {
+        const mockedDiv = {
+            textContent: 'test',
+        } as any;
+
+        core.lifecycle.announceContainer = mockedDiv;
+
+        announce(core, {
+            text: 'test',
+            ariaLiveMode: 'assertive',
+        });
+
+        expect(mockedDiv).toEqual({
+            textContent: 'test.',
+            ariaLive: 'assertive',
         });
     });
 });

--- a/packages/roosterjs-content-model-types/lib/parameter/AnnounceData.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/AnnounceData.ts
@@ -41,4 +41,10 @@ export interface AnnounceData {
      * @optional if provided, will attempt to replace {n} with each of the values inside of the array.
      */
     formatStrings?: string[];
+
+    /**
+     * @optional if provided, will set the ariaLive property of the announce container element to the provided value.
+     * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live#values
+     */
+    ariaLiveMode?: 'assertive' | 'polite' | 'off';
 }

--- a/packages/roosterjs-react/lib/ribbon/buttons/numberedListButton.ts
+++ b/packages/roosterjs-react/lib/ribbon/buttons/numberedListButton.ts
@@ -12,9 +12,5 @@ export const numberedListButton: RibbonButton<NumberedListButtonStringKey> = {
     isChecked: formatState => !!formatState.isNumbering,
     onClick: editor => {
         toggleNumbering(editor);
-        editor.announce({
-            ariaLiveMode: 'polite',
-            defaultStrings: 'announceListItemNumbering',
-        });
     },
 };

--- a/packages/roosterjs-react/lib/ribbon/buttons/numberedListButton.ts
+++ b/packages/roosterjs-react/lib/ribbon/buttons/numberedListButton.ts
@@ -12,5 +12,9 @@ export const numberedListButton: RibbonButton<NumberedListButtonStringKey> = {
     isChecked: formatState => !!formatState.isNumbering,
     onClick: editor => {
         toggleNumbering(editor);
+        editor.announce({
+            ariaLiveMode: 'polite',
+            defaultStrings: 'announceListItemNumbering',
+        });
     },
 };


### PR DESCRIPTION
Add AriaLiveMode to announce to let consumers change the ariaLive attribute of the announce container.