### PR TITLE
Add PasteTypeOrGetter so we can update the default paste type based on the content and clipboard items of the Paste Event

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/paste/paste.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/paste.ts
@@ -4,7 +4,7 @@ import { createPasteFragment } from './createPasteFragment';
 import { generatePasteOptionFromPlugins } from './generatePasteOptionFromPlugins';
 import { retrieveHtmlInfo } from './retrieveHtmlInfo';
 import type {
-    PasteType,
+    PasteTypeOrGetter,
     ClipboardData,
     TrustedHTMLHandler,
     IEditor,
@@ -14,12 +14,12 @@ import type {
  * Paste into editor using a clipboardData object
  * @param editor The Editor object.
  * @param clipboardData Clipboard data retrieved from clipboard
- * @param pasteType Type of content to paste. @default normal
+ * @param pasteTypeOrGetter Type of content to paste or function that returns the Paste Type to use based on the document and the clipboard Data. @default normal
  */
 export function paste(
     editor: IEditor,
     clipboardData: ClipboardData,
-    pasteType: PasteType = 'normal'
+    pasteTypeOrGetter: PasteTypeOrGetter = 'normal'
 ) {
     editor.focus();
 
@@ -35,6 +35,10 @@ export function paste(
 
     // 1. Prepare variables
     const doc = createDOMFromHtml(clipboardData.rawHtml, trustedHTMLHandler);
+    const pasteType =
+        typeof pasteTypeOrGetter == 'function'
+            ? pasteTypeOrGetter(doc, clipboardData)
+            : pasteTypeOrGetter;
 
     // 2. Handle HTML from clipboard
     const htmlFromClipboard = retrieveHtmlInfo(doc, clipboardData);

--- a/packages/roosterjs-content-model-core/test/command/paste/pasteTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/pasteTest.ts
@@ -1,6 +1,8 @@
 import * as addParserF from 'roosterjs-content-model-plugins/lib/paste/utils/addParser';
+import * as createPasteFragmentFile from '../../../lib/command/paste/createPasteFragment';
 import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
 import * as ExcelF from 'roosterjs-content-model-plugins/lib/paste/Excel/processPastedContentFromExcel';
+import * as generatePasteOptionFromPluginsFile from '../../../lib/command/paste/generatePasteOptionFromPlugins';
 import * as getPasteSourceF from 'roosterjs-content-model-plugins/lib/paste/pasteSourceValidations/getPasteSource';
 import * as getSelectedSegmentsF from 'roosterjs-content-model-dom/lib/modelApi/selection/collectSelections';
 import * as mergeModelFile from 'roosterjs-content-model-dom/lib/modelApi/editing/mergeModel';
@@ -18,6 +20,7 @@ import {
     IEditor,
     BeforePasteEvent,
     PluginEvent,
+    PasteTypeOrGetter,
 } from 'roosterjs-content-model-types';
 
 let clipboardData: ClipboardData;
@@ -97,6 +100,34 @@ describe('Paste ', () => {
         paste(editor, clipboardData, 'asPlainText');
 
         expect(mockedModel).toEqual(mockedMergeModel);
+    });
+
+    it('Execute | With callback to return paste type', () => {
+        spyOn(createPasteFragmentFile, 'createPasteFragment').and.callThrough();
+        spyOn(
+            generatePasteOptionFromPluginsFile,
+            'generatePasteOptionFromPlugins'
+        ).and.callThrough();
+
+        const cb: PasteTypeOrGetter = () => 'normal';
+        paste(editor, clipboardData, cb);
+
+        expect(mockedModel).toEqual(mockedMergeModel);
+        expect(createPasteFragmentFile.createPasteFragment).toHaveBeenCalledWith(
+            jasmine.anything(),
+            jasmine.anything(),
+            'normal',
+            jasmine.anything()
+        );
+        expect(
+            generatePasteOptionFromPluginsFile.generatePasteOptionFromPlugins
+        ).toHaveBeenCalledWith(
+            jasmine.anything(),
+            jasmine.anything(),
+            jasmine.anything(),
+            jasmine.anything(),
+            'normal'
+        );
     });
 });
 

--- a/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
@@ -1,6 +1,6 @@
+import type { PasteTypeOrGetter } from '../parameter/PasteTypeOrGetter';
 import type { ExperimentalFeature } from './ExperimentalFeature';
 import type { KnownAnnounceStrings } from '../parameter/AnnounceData';
-import type { PasteType } from '../enum/PasteType';
 import type { Colors, ColorTransformFunction } from '../context/DarkColorHandler';
 import type { EditorPlugin } from './EditorPlugin';
 import type { ContentModelSegmentFormat } from '../contentModel/format/ContentModelSegmentFormat';
@@ -100,9 +100,9 @@ export interface PasteOptions {
     allowedCustomPasteType?: string[];
 
     /**
-     * Default paste type. By default will use the normal (as-is) paste type.
+     * Default paste type or function that returns the paste type. By default will use the normal (as-is) paste type.
      */
-    defaultPasteType?: PasteType;
+    defaultPasteType?: PasteTypeOrGetter;
 }
 
 /**

--- a/packages/roosterjs-content-model-types/lib/index.ts
+++ b/packages/roosterjs-content-model-types/lib/index.ts
@@ -398,6 +398,7 @@ export {
     ContentModelFormatter,
 } from './parameter/FormatContentModelOptions';
 export { ContentModelFormatState } from './parameter/ContentModelFormatState';
+export { PasteTypeOrGetter } from './parameter/PasteTypeOrGetter';
 export { ImageFormatState } from './parameter/ImageFormatState';
 export { Border } from './parameter/Border';
 export { InsertEntityOptions } from './parameter/InsertEntityOptions';

--- a/packages/roosterjs-content-model-types/lib/parameter/PasteTypeOrGetter.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/PasteTypeOrGetter.ts
@@ -1,0 +1,10 @@
+import type { ClipboardData } from './ClipboardData';
+import type { PasteType } from '../enum/PasteType';
+
+/**
+ * Represents the PasteType parameter used to set the paste type to use.
+ * It can be either the Paste Type value or a callback that retuns the Paste Type to use.
+ */
+export type PasteTypeOrGetter =
+    | PasteType
+    | ((document: Document | null, clipboardData: ClipboardData) => PasteType);

--- a/packages/roosterjs-content-model-types/lib/pluginState/CopyPastePluginState.ts
+++ b/packages/roosterjs-content-model-types/lib/pluginState/CopyPastePluginState.ts
@@ -1,4 +1,4 @@
-import type { PasteType } from '../enum/PasteType';
+import type { PasteTypeOrGetter } from '../parameter/PasteTypeOrGetter';
 
 /**
  * The state object for CopyPastePlugin
@@ -18,5 +18,5 @@ export interface CopyPastePluginState {
     /**
      * Default paste type. By default will use the normal (as-is) paste type.
      */
-    defaultPasteType?: PasteType;
+    defaultPasteType?: PasteTypeOrGetter;
 }


### PR DESCRIPTION
Add PasteTypeOrGetter so we can update the default paste type based on the content and clipboard items by passing a callback function that returns the paste type to use.