### PR TITLE
Fix default format on Android

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/format/FormatPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/format/FormatPlugin.ts
@@ -21,6 +21,8 @@ import type {
 
 // During IME input, KeyDown event will have "Process" as key
 const ProcessKey = 'Process';
+// For some Android IME, KeyDown event will have "Unidentified" as key
+const UnidentifiedKey = 'Unidentified';
 const DefaultStyleKeyMap: Record<
     keyof (FontFamilyFormat & FontSizeFormat & TextColorFormat & BackgroundColorFormat),
     keyof CSSStyleDeclaration
@@ -108,7 +110,6 @@ class FormatPlugin implements PluginWithState<FormatPluginState> {
         switch (event.eventType) {
             case 'input':
                 this.checkAndApplyPendingFormat(event.rawEvent.data);
-
                 break;
 
             case 'compositionEnd':
@@ -116,12 +117,17 @@ class FormatPlugin implements PluginWithState<FormatPluginState> {
                 break;
 
             case 'keyDown':
+                // Some Android IME can't provide correct keycode in keyDown event, so skip the check
+                const isAndroidIME =
+                    this.editor.getEnvironment().isAndroid && event.rawEvent.key == UnidentifiedKey;
                 if (isCursorMovingKey(event.rawEvent)) {
                     this.clearPendingFormat();
                     this.lastCheckedNode = null;
                 } else if (
                     this.defaultFormatKeys.size > 0 &&
-                    (isCharacterValue(event.rawEvent) || event.rawEvent.key == ProcessKey) &&
+                    (isAndroidIME ||
+                        isCharacterValue(event.rawEvent) ||
+                        event.rawEvent.key == ProcessKey) &&
                     this.shouldApplyDefaultFormat(this.editor)
                 ) {
                     applyDefaultFormat(this.editor, this.state.defaultFormat);

--- a/packages/roosterjs-content-model-core/test/corePlugin/format/FormatPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/format/FormatPluginTest.ts
@@ -18,7 +18,7 @@ describe('FormatPlugin', () => {
         const editor = ({
             cacheContentModel: () => {},
             isDarkMode: () => false,
-            getEnvironment: () => {},
+            getEnvironment: () => ({}),
         } as any) as IEditor;
         const plugin = createFormatPlugin({});
         plugin.initialize(editor);
@@ -102,7 +102,7 @@ describe('FormatPlugin', () => {
         const editor = ({
             createContentModel: () => model,
             cacheContentModel: () => {},
-            getEnvironment: () => {},
+            getEnvironment: () => ({}),
         } as any) as IEditor;
 
         const plugin = createFormatPlugin({});
@@ -245,7 +245,7 @@ describe('FormatPlugin for default format', () => {
             cacheContentModel: cacheContentModelSpy,
             takeSnapshot: takeSnapshotSpy,
             formatContentModel: formatContentModelSpy,
-            getEnvironment: () => {},
+            getEnvironment: () => ({}),
         } as any) as IEditor;
     });
 

--- a/packages/roosterjs-content-model-core/test/corePlugin/format/FormatPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/format/FormatPluginTest.ts
@@ -18,6 +18,7 @@ describe('FormatPlugin', () => {
         const editor = ({
             cacheContentModel: () => {},
             isDarkMode: () => false,
+            getEnvironment: () => {},
         } as any) as IEditor;
         const plugin = createFormatPlugin({});
         plugin.initialize(editor);
@@ -101,6 +102,7 @@ describe('FormatPlugin', () => {
         const editor = ({
             createContentModel: () => model,
             cacheContentModel: () => {},
+            getEnvironment: () => {},
         } as any) as IEditor;
 
         const plugin = createFormatPlugin({});
@@ -243,6 +245,7 @@ describe('FormatPlugin for default format', () => {
             cacheContentModel: cacheContentModelSpy,
             takeSnapshot: takeSnapshotSpy,
             formatContentModel: formatContentModelSpy,
+            getEnvironment: () => {},
         } as any) as IEditor;
     });
 


### PR DESCRIPTION
On Android, the default format can't be applied to the new content because the `isCharacterValue()` check in `FormatPlugin` always fails when using Android IME. To workaround this issue, we need to disable this check on Android. 