### PR TITLE
Do not trigger markdown inside a word. 

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
@@ -21,7 +21,8 @@ const ORDINAL_LENGTH = 2;
 
 /**
  * @internal
- */ export function transformOrdinals(
+ */
+export function transformOrdinals(
     previousSegment: ContentModelText,
     paragraph: ShallowMutableContentModelParagraph,
     context: FormatContentModelContext

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
@@ -21,8 +21,7 @@ const ORDINAL_LENGTH = 2;
 
 /**
  * @internal
- */
-export function transformOrdinals(
+ */ export function transformOrdinals(
     previousSegment: ContentModelText,
     paragraph: ShallowMutableContentModelParagraph,
     context: FormatContentModelContext

--- a/packages/roosterjs-content-model-plugins/lib/markdown/utils/setFormat.ts
+++ b/packages/roosterjs-content-model-plugins/lib/markdown/utils/setFormat.ts
@@ -29,7 +29,6 @@ export function setFormat(
                     italic: !!markerFormat.italic,
                     fontWeight: markerFormat?.fontWeight ? 'bold' : undefined,
                 };
-                console.log(textBeforeMarker);
                 if (textBeforeMarker.indexOf(character) > -1) {
                     const lastCharIndex = textSegment.length;
                     const firstCharIndex = textSegment

--- a/packages/roosterjs-content-model-plugins/lib/markdown/utils/setFormat.ts
+++ b/packages/roosterjs-content-model-plugins/lib/markdown/utils/setFormat.ts
@@ -21,19 +21,25 @@ export function setFormat(
         editor,
         (_model, previousSegment, paragraph, markerFormat, context) => {
             if (previousSegment.text[previousSegment.text.length - 1] == character) {
-                const textBeforeMarker = previousSegment.text.slice(0, -1);
+                const textSegment = previousSegment.text;
+                const textBeforeMarker = textSegment.slice(0, -1);
                 context.newPendingFormat = {
                     ...markerFormat,
                     strikethrough: !!markerFormat.strikethrough,
                     italic: !!markerFormat.italic,
                     fontWeight: markerFormat?.fontWeight ? 'bold' : undefined,
                 };
+                console.log(textBeforeMarker);
                 if (textBeforeMarker.indexOf(character) > -1) {
-                    const lastCharIndex = previousSegment.text.length;
-                    const firstCharIndex = previousSegment.text
+                    const lastCharIndex = textSegment.length;
+                    const firstCharIndex = textSegment
                         .substring(0, lastCharIndex - 1)
                         .lastIndexOf(character);
-                    if (lastCharIndex - firstCharIndex > 2) {
+
+                    if (
+                        hasSpaceBeforeFirstCharacter(textSegment, firstCharIndex) &&
+                        lastCharIndex - firstCharIndex > 2
+                    ) {
                         const formattedText = splitTextSegment(
                             previousSegment,
                             paragraph,
@@ -60,4 +66,13 @@ export function setFormat(
             return false;
         }
     );
+}
+
+/**
+ * The markdown should not be trigger inside a word, so whe check if exist a space before the trigger character
+ * Should trigger markdown example: _one two_
+ * Should not trigger markdown example: one_two_
+ */
+function hasSpaceBeforeFirstCharacter(text: string, index: number) {
+    return !text[index - 1] || text[index - 1].trim().length == 0;
 }

--- a/packages/roosterjs-content-model-plugins/lib/markdown/utils/setFormat.ts
+++ b/packages/roosterjs-content-model-plugins/lib/markdown/utils/setFormat.ts
@@ -68,7 +68,7 @@ export function setFormat(
 }
 
 /**
- * The markdown should not be trigger inside a word, so whe check if exist a space before the trigger character
+ * The markdown should not be trigger inside a word, then check if exist a space before the trigger character
  * Should trigger markdown example: _one two_
  * Should not trigger markdown example: one_two_
  */

--- a/packages/roosterjs-content-model-plugins/test/markdown/utils/setFormatTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/markdown/utils/setFormatTest.ts
@@ -492,4 +492,31 @@ describe('setFormat', () => {
 
         runTest(input, '*', { fontWeight: 'bold' }, input, false);
     });
+
+    it('should not set italic - one_two_', () => {
+        const input: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'one_two_',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+
+        runTest(input, '_', { italic: true }, input, false);
+    });
 });


### PR DESCRIPTION
The markdown should not be trigger inside a word, so we check if exist a space before the trigger character
 * Should trigger markdown example: _one two_
 * Should not trigger markdown example: one_two_

Before:
![MarkdownBug](https://github.com/user-attachments/assets/b08fc592-0274-4649-b318-506a09134c7a)

After:
![MarkdownFixed](https://github.com/user-attachments/assets/518b2358-4d92-4447-9a9d-2c9b70b7f0e7)
