### PR TITLE
Do not increase list number that starts from 1

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/list/listLevelThreadFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/list/listLevelThreadFormatHandler.ts
@@ -13,8 +13,9 @@ export const listLevelThreadFormatHandler: FormatHandler<ListThreadFormat> = {
             const depth = levels.length;
 
             if (
-                typeof threadItemCounts[depth] === 'number' &&
-                element.start != threadItemCounts[depth] + 1
+                element.start == 1 ||
+                (typeof threadItemCounts[depth] === 'number' &&
+                    element.start != threadItemCounts[depth] + 1)
             ) {
                 format.startNumberOverride = element.start;
             }

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/childProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/childProcessorTest.ts
@@ -453,7 +453,15 @@ describe('childProcessor', () => {
                 {
                     blockType: 'BlockGroup',
                     blockGroupType: 'ListItem',
-                    levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                            },
+                            dataset: {},
+                        },
+                    ],
                     formatHolder: { segmentType: 'SelectionMarker', isSelected: false, format: {} },
                     blocks: [
                         {

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/listProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/listProcessorTest.ts
@@ -56,7 +56,7 @@ describe('listProcessor', () => {
         childProcessor.and.callFake((group, parent, context) => {
             expect(context.listFormat.listParent).toBe(group);
             expect(context.listFormat.levels).toEqual([
-                { listType: 'OL', format: {}, dataset: {} },
+                { listType: 'OL', format: { startNumberOverride: 1 }, dataset: {} },
             ]);
             expect(context.listFormat.threadItemCounts).toEqual([0]);
             expect(context.segmentFormat).toEqual({});
@@ -88,7 +88,13 @@ describe('listProcessor', () => {
         childProcessor.and.callFake((group, parent, context) => {
             expect(context.listFormat.listParent).toBe(group);
             expect(context.listFormat.levels).toEqual([
-                { listType: 'OL', format: {}, dataset: {} },
+                {
+                    listType: 'OL',
+                    format: {
+                        startNumberOverride: 1,
+                    },
+                    dataset: {},
+                },
             ]);
             expect(context.listFormat.threadItemCounts).toEqual([0]);
             expect(context.segmentFormat).toEqual({
@@ -212,6 +218,7 @@ describe('listProcessor', () => {
                                 paddingBottom: '2px',
                                 paddingLeft: '2px',
                                 listStylePosition: 'inside',
+                                startNumberOverride: 1,
                             },
                             dataset: {},
                         },
@@ -254,6 +261,7 @@ describe('listProcessor', () => {
                                 marginBottom: '0px',
                                 marginLeft: '0px',
                                 marginRight: '0px',
+                                startNumberOverride: 1,
                             },
                             dataset: {},
                         },
@@ -468,7 +476,7 @@ describe('listProcessor process metadata', () => {
             expect(context.listFormat.levels).toEqual([
                 {
                     listType: 'OL',
-                    format: {},
+                    format: { startNumberOverride: 1 },
                     dataset: {},
                 },
             ]);
@@ -492,7 +500,7 @@ describe('listProcessor process metadata', () => {
             expect(context.listFormat.levels).toEqual([
                 {
                     listType: 'OL',
-                    format: {},
+                    format: { startNumberOverride: 1 },
                     dataset: {
                         editingInfo: JSON.stringify({ orderedStyleType: 1, unorderedStyleType: 2 }),
                     },
@@ -520,7 +528,7 @@ describe('listProcessor process metadata', () => {
             expect(context.listFormat.levels).toEqual([
                 {
                     listType: 'OL',
-                    format: {},
+                    format: { startNumberOverride: 1 },
                     dataset: { editingInfo: metadata },
                 },
             ]);
@@ -544,7 +552,7 @@ describe('listProcessor process metadata', () => {
             expect(context.listFormat.levels).toEqual([
                 {
                     listType: 'OL',
-                    format: {},
+                    format: { startNumberOverride: 1 },
                     dataset: {
                         editingInfo: JSON.stringify({
                             orderedStyleType: NumberingListType.Max,
@@ -576,7 +584,7 @@ describe('listProcessor process metadata', () => {
                 {
                     listType: 'OL',
                     dataset: { editingInfo },
-                    format: {},
+                    format: { startNumberOverride: 1 },
                 },
             ]);
         });
@@ -601,6 +609,7 @@ describe('listProcessor process metadata', () => {
                     listType: 'OL',
                     format: {
                         listStyleType: 'decimal',
+                        startNumberOverride: 1,
                     },
                     dataset: {
                         editingInfo: JSON.stringify({ orderedStyleType: NumberingListType.Max }),
@@ -640,6 +649,7 @@ describe('listProcessor process metadata', () => {
                             dataset: {},
                             format: {
                                 direction: 'rtl',
+                                startNumberOverride: 1,
                             },
                         },
                     ],

--- a/packages/roosterjs-content-model-dom/test/endToEndTest.ts
+++ b/packages/roosterjs-content-model-dom/test/endToEndTest.ts
@@ -207,7 +207,9 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                        levels: [
+                            { listType: 'OL', format: { startNumberOverride: 1 }, dataset: {} },
+                        ],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -228,7 +230,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                         ],
                         levels: [
                             { listType: 'OL', format: {}, dataset: {} },
-                            { listType: 'OL', format: {}, dataset: {} },
+                            { listType: 'OL', format: { startNumberOverride: 1 }, dataset: {} },
                         ],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
@@ -2139,12 +2141,12 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
                         levels: [
                             {
                                 listType: 'OL',
-                                format: {},
+                                format: { startNumberOverride: 1 },
                                 dataset: {},
                             },
                             {
                                 listType: 'OL',
-                                format: { listStyleType: '"1) "' },
+                                format: { listStyleType: '"1) "', startNumberOverride: 1 },
                                 dataset: {},
                             },
                         ],

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/list/listLevelThreadFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/list/listLevelThreadFormatHandlerTest.ts
@@ -22,7 +22,7 @@ describe('listLevelThreadFormatHandler.parse', () => {
 
         listLevelThreadFormatHandler.parse(format, ol, context, {});
 
-        expect(format.startNumberOverride).toBeUndefined();
+        expect(format.startNumberOverride).toBe(1);
         expect(context.listFormat).toEqual({
             threadItemCounts: [0],
             levels: [],
@@ -38,7 +38,7 @@ describe('listLevelThreadFormatHandler.parse', () => {
 
         listLevelThreadFormatHandler.parse(format, ol, context, {});
 
-        expect(format.startNumberOverride).toBeUndefined();
+        expect(format.startNumberOverride).toBe(1);
         expect(context.listFormat).toEqual({
             threadItemCounts: [0],
             levels: [],
@@ -91,7 +91,7 @@ describe('listLevelThreadFormatHandler.parse', () => {
 
         listLevelThreadFormatHandler.parse(format, ol, context, {});
 
-        expect(format.startNumberOverride).toBeUndefined();
+        expect(format.startNumberOverride).toBe(1);
         expect(context.listFormat).toEqual({
             threadItemCounts: [2, 0],
             levels: [


### PR DESCRIPTION
To repro, having a numbered list start from 1, then type something before it. Now at the beginning of the doc, type "1." and space.

Expect: Converting "1." to be a list, and the existing list is not impacted
Actual: Converting "1." to be a list, but the existing list is now starting from 2.

This is because we incorrectly connected these two list together, because we didn't set "startNumberOverride" for the existing one so it would connect to previous list if exist.

Fix: Allow setting startNumberOverride in ListLevel.format when it is 1, so it can never be auto connected.