### PR TITLE
Add `<del>` elements to default processors and use knownElementProcessor for this type of element.

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/domToModel/context/defaultProcessors.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/context/defaultProcessors.ts
@@ -55,6 +55,7 @@ export const defaultProcessorMap: ElementProcessorMap = {
     table: tableProcessor,
     u: knownElementProcessor,
     ul: listProcessor,
+    del: knownElementProcessor,
 
     '*': generalProcessor,
     '#text': textProcessor,

--- a/packages/roosterjs-content-model-dom/lib/domToModel/context/defaultProcessors.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/context/defaultProcessors.ts
@@ -29,6 +29,7 @@ export const defaultProcessorMap: ElementProcessorMap = {
     blockquote: knownElementProcessor,
     br: brProcessor,
     code: codeProcessor,
+    del: knownElementProcessor,
     div: knownElementProcessor,
     em: knownElementProcessor,
     font: fontProcessor,
@@ -55,7 +56,6 @@ export const defaultProcessorMap: ElementProcessorMap = {
     table: tableProcessor,
     u: knownElementProcessor,
     ul: listProcessor,
-    del: knownElementProcessor,
 
     '*': generalProcessor,
     '#text': textProcessor,


### PR DESCRIPTION
When pasting content with Elements of [del ](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del)tag. Since the element is unknown we process it with generalProcessor. But this cause that the result of the paste is different. This is because when we call the [ensureParagraph.ts](https://github.com/microsoft/roosterjs/blob/024877f79ec1c3955be6796afe784fcb5149a396/packages/roosterjs-content-model-dom/lib/modelApi/common/ensureParagraph.ts#L19) function and the current group is general and not paragraph, ensure Paragraph will create a new paragraph and it will be inserted inside of the del element. Causing the issue seen in the image below for the Before,

 To fix add this type of tag that adds strikethrough style to the known element processor.

Source:
![image](https://github.com/user-attachments/assets/b7f5118d-732d-411f-978b-a7a6e07a9956)

Before
![image](https://github.com/user-attachments/assets/4444dc56-f13e-4d8c-bf72-5bc70163fe9a)

After
![image](https://github.com/user-attachments/assets/159869cc-16fa-488e-8f62-396555e71def)
