### PR TITLE
Fix drag and drop

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -215,7 +215,6 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                     const segment = imageDropped.image;
                     const paragraph = imageDropped.paragraph;
                     mutateSegment(paragraph, segment, image => {
-                        console.log(image.format.id);
                         image.isSelected = true;
                         image.isSelectedAsImageSelection = true;
                     });

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -205,7 +205,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                 const imageDragged = findEditingImage(model, selection.image.id);
                 const imageDropped = findEditingImage(
                     model,
-                    selection.image.id.replace(DRAG_ID, '')
+                    selection.image.id.replace(DRAG_ID, '').trim()
                 );
                 if (imageDragged && imageDropped) {
                     const draggedIndex = imageDragged.paragraph.segments.indexOf(
@@ -215,6 +215,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                     const segment = imageDropped.image;
                     const paragraph = imageDropped.paragraph;
                     mutateSegment(paragraph, segment, image => {
+                        console.log(image.format.id);
                         image.isSelected = true;
                         image.isSelectedAsImageSelection = true;
                     });

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/findEditingImage.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/findEditingImage.ts
@@ -4,13 +4,16 @@ import type { ImageAndParagraph } from '../types/ImageAndParagraph';
 /**
  * @internal
  */
-export function findEditingImage(group: ReadonlyContentModelBlockGroup): ImageAndParagraph | null {
+export function findEditingImage(
+    group: ReadonlyContentModelBlockGroup,
+    imageId?: string
+): ImageAndParagraph | null {
     for (let i = 0; i < group.blocks.length; i++) {
         const block = group.blocks[i];
 
         switch (block.blockType) {
             case 'BlockGroup':
-                const result = findEditingImage(block);
+                const result = findEditingImage(block, imageId);
 
                 if (result) {
                     return result;
@@ -22,7 +25,7 @@ export function findEditingImage(group: ReadonlyContentModelBlockGroup): ImageAn
                     const segment = block.segments[j];
                     switch (segment.segmentType) {
                         case 'Image':
-                            if (segment.dataset.isEditing) {
+                            if (segment.dataset.isEditing || segment.format.id == imageId) {
                                 return {
                                     paragraph: block,
                                     image: segment,
@@ -31,7 +34,7 @@ export function findEditingImage(group: ReadonlyContentModelBlockGroup): ImageAn
                             break;
 
                         case 'General':
-                            const result = findEditingImage(segment);
+                            const result = findEditingImage(segment, imageId);
 
                             if (result) {
                                 return result;

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/findEditingImage.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/findEditingImage.ts
@@ -25,7 +25,10 @@ export function findEditingImage(
                     const segment = block.segments[j];
                     switch (segment.segmentType) {
                         case 'Image':
-                            if (segment.dataset.isEditing || segment.format.id == imageId) {
+                            if (
+                                (segment.dataset.isEditing && !imageId) ||
+                                segment.format.id == imageId
+                            ) {
                                 return {
                                     paragraph: block,
                                     image: segment,

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -1,35 +1,56 @@
-import { ContentModelDocument } from 'roosterjs-content-model-types';
+import * as findImage from '../../lib/imageEdit/utils/findEditingImage';
+import * as getSelectedImage from '../../lib/imageEdit/utils/getSelectedImage';
+import { ChangeSource, createImage, createParagraph } from 'roosterjs-content-model-dom';
 import { getSelectedImageMetadata } from '../../lib/imageEdit/utils/updateImageEditInfo';
 import { ImageEditPlugin } from '../../lib/imageEdit/ImageEditPlugin';
 import { initEditor } from '../TestHelper';
+import {
+    ContentModelDocument,
+    ContentModelFormatter,
+    EditorEnvironment,
+    FormatContentModelOptions,
+    IEditor,
+} from 'roosterjs-content-model-types';
 
 const model: ContentModelDocument = {
     blockGroupType: 'Document',
     blocks: [
         {
-            blockType: 'Paragraph',
             segments: [
                 {
+                    isSelected: true,
+                    segmentType: 'SelectionMarker',
+                    format: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+                {
+                    src:
+                        'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAsJCQcJCQcJCQkJCwkJCQkJCQsJCwsMCwsLDA0QDB...',
+                    isSelectedAsImageSelection: true,
                     segmentType: 'Image',
-                    src: 'test',
+                    isSelected: true,
                     format: {
                         fontFamily: 'Calibri',
                         fontSize: '11pt',
                         textColor: 'rgb(0, 0, 0)',
                         id: 'image_0',
-                        maxWidth: '1800px',
+                        maxWidth: '1123px',
                     },
-                    dataset: {},
-                    isSelectedAsImageSelection: true,
-                    isSelected: true,
+                    dataset: {
+                        isEditing: 'true',
+                    },
                 },
             ],
-            format: {},
             segmentFormat: {
                 fontFamily: 'Calibri',
                 fontSize: '11pt',
                 textColor: 'rgb(0, 0, 0)',
             },
+            blockType: 'Paragraph',
+            format: {},
         },
     ],
     format: {
@@ -40,209 +61,181 @@ const model: ContentModelDocument = {
 };
 
 describe('ImageEditPlugin', () => {
-    it('keyDown', () => {
-        const model: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'Paragraph',
-                    segments: [
-                        {
-                            segmentType: 'Image',
-                            src: 'test',
-                            format: {
-                                fontFamily: 'Calibri',
-                                fontSize: '11pt',
-                                textColor: 'rgb(0, 0, 0)',
-                                id: 'image_0',
-                                maxWidth: '1800px',
-                            },
-                            dataset: {
-                                isEditing: 'true',
-                            },
-                            isSelectedAsImageSelection: true,
-                            isSelected: true,
-                        },
-                    ],
-                    format: {},
-                    segmentFormat: {
-                        fontFamily: 'Calibri',
-                        fontSize: '11pt',
-                        textColor: 'rgb(0, 0, 0)',
+    let editor: IEditor;
+    let mockedEnvironment: EditorEnvironment;
+    let attachDomEventSpy: jasmine.Spy;
+    let getDOMSelectionSpy: jasmine.Spy;
+    let formatContentModelSpy: jasmine.Spy;
+    let focusSpy: jasmine.Spy;
+    let isDarkModeSpy: jasmine.Spy;
+    let setAttributeSpy: jasmine.Spy;
+    let appendChildSpy: jasmine.Spy;
+    let getDOMHelperSpy: jasmine.Spy;
+    let calculateZoomScaleSpy: jasmine.Spy;
+    let setEditorStyleSpy: jasmine.Spy;
+    let triggerEventSpy: jasmine.Spy;
+    let getAttributeSpy: jasmine.Spy;
+    beforeEach(() => {
+        attachDomEventSpy = jasmine.createSpy('attachDomEvent');
+        getDOMSelectionSpy = jasmine.createSpy('getDOMSelection');
+        mockedEnvironment = {
+            isSafari: false,
+        } as any;
+        getAttributeSpy = jasmine.createSpy('getAttribute');
+        const image = createImage('');
+        const editImage = createImage('test image');
+        image.dataset = {
+            isEditing: 'true',
+        };
+        const paragraph = createParagraph();
+        paragraph.segments.push(image);
+        paragraph.segments.push(editImage);
+        spyOn(findImage, 'findEditingImage').and.returnValue({
+            image,
+            paragraph,
+        });
+        spyOn(getSelectedImage, 'getSelectedImage').and.returnValue({
+            image: editImage,
+            paragraph,
+        });
+        formatContentModelSpy = jasmine
+            .createSpy('formatContentModel')
+            .and.callFake(
+                (callback: ContentModelFormatter, _options: FormatContentModelOptions) => {
+                    callback(model, {
+                        newEntities: [],
+                        deletedEntities: [],
+                        newImages: [],
+                    });
+                }
+            );
+        focusSpy = jasmine.createSpy('focus');
+        isDarkModeSpy = jasmine.createSpy('isDarkMode');
+        setAttributeSpy = jasmine.createSpy('setAttribute');
+        appendChildSpy = jasmine.createSpy('appendChild');
+        calculateZoomScaleSpy = jasmine.createSpy('calculateZoomScale');
+        getDOMHelperSpy = jasmine.createSpy('getDOMHelper').and.returnValue({
+            calculateZoomScale: calculateZoomScaleSpy,
+        });
+        setEditorStyleSpy = jasmine.createSpy('setEditorStyle');
+        triggerEventSpy = jasmine.createSpy('triggerEvent').and.returnValue({
+            newSrc: '',
+        });
+        editor = {
+            getEnvironment: () => mockedEnvironment,
+            attachDomEvent: attachDomEventSpy,
+            getDOMSelection: getDOMSelectionSpy,
+            formatContentModel: formatContentModelSpy,
+            focus: focusSpy,
+            isDarkMode: isDarkModeSpy,
+            getDOMHelper: getDOMHelperSpy,
+            getDocument: () => ({
+                createElement: () => ({
+                    setAttribute: setAttributeSpy,
+                    appendChild: appendChildSpy,
+                    style: {
+                        display: '',
                     },
-                },
-            ],
-            format: {
-                fontFamily: 'Calibri',
-                fontSize: '11pt',
-                textColor: '#000000',
-            },
+
+                    attachShadow: () => ({
+                        appendChild: appendChildSpy,
+                    }),
+                }),
+            }),
+            setEditorStyle: setEditorStyleSpy,
+            triggerEvent: triggerEventSpy,
+        } as any;
+    });
+
+    it('keyDown', () => {
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
         };
         const plugin = new ImageEditPlugin();
-        const editor = initEditor('image_edit', [plugin], model);
         plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        const image = createImage('');
+        const paragraph = createParagraph();
+        paragraph.segments.push(image);
         plugin.onPluginEvent({
             eventType: 'mouseUp',
-            isClicking: true,
+
             rawEvent: {
                 button: 0,
+                target: mockedImage,
             } as any,
         });
         plugin.onPluginEvent({
             eventType: 'keyDown',
             rawEvent: {
                 key: 'k',
+                target: mockedImage,
             } as any,
         });
-        expect(plugin.isEditingImage).toBeFalsy();
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
         plugin.dispose();
     });
 
     it('mouseUp', () => {
-        const model: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'Paragraph',
-                    segments: [
-                        {
-                            segmentType: 'Image',
-                            src: 'test',
-                            format: {
-                                fontFamily: 'Calibri',
-                                fontSize: '11pt',
-                                textColor: 'rgb(0, 0, 0)',
-                                id: 'image_0',
-                                maxWidth: '1800px',
-                            },
-                            dataset: {},
-                            isSelectedAsImageSelection: true,
-                            isSelected: true,
-                        },
-                    ],
-                    format: {},
-                    segmentFormat: {
-                        fontFamily: 'Calibri',
-                        fontSize: '11pt',
-                        textColor: 'rgb(0, 0, 0)',
-                    },
-                },
-            ],
-            format: {
-                fontFamily: 'Calibri',
-                fontSize: '11pt',
-                textColor: '#000000',
-            },
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
         };
         const plugin = new ImageEditPlugin();
-        const editor = initEditor('image_edit', [plugin], model);
         plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
         plugin.onPluginEvent({
             eventType: 'mouseUp',
-            isClicking: true,
+
             rawEvent: {
                 button: 0,
+                target: mockedImage,
             } as any,
         });
-
-        expect(plugin.isEditingImage).toBeTruthy();
+        expect(formatContentModelSpy).toHaveBeenCalled();
         plugin.dispose();
     });
 
     it('mouseUp - left click - remove selection', () => {
-        const model: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'Paragraph',
-                    segments: [
-                        {
-                            segmentType: 'Image',
-                            src: 'test',
-                            format: {
-                                fontFamily: 'Calibri',
-                                fontSize: '11pt',
-                                textColor: 'rgb(0, 0, 0)',
-                                id: 'image_0',
-                                maxWidth: '1800px',
-                            },
-                            dataset: {
-                                isEditing: 'true',
-                            },
-                            isSelectedAsImageSelection: false,
-                            isSelected: false,
-                        },
-                    ],
-                    format: {},
-                    segmentFormat: {
-                        fontFamily: 'Calibri',
-                        fontSize: '11pt',
-                        textColor: 'rgb(0, 0, 0)',
-                    },
-                },
-            ],
-            format: {
-                fontFamily: 'Calibri',
-                fontSize: '11pt',
-                textColor: '#000000',
-            },
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
         };
         const plugin = new ImageEditPlugin();
-        const editor = initEditor('image_edit', [plugin], model);
         plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
         plugin.onPluginEvent({
             eventType: 'mouseUp',
-            isClicking: true,
+
             rawEvent: {
                 button: 0,
             } as any,
         });
-        expect(plugin.isEditingImage).toBeFalsy();
+        expect(formatContentModelSpy).toHaveBeenCalled();
         plugin.dispose();
     });
 
     it('mouseUp - right click - remove wrapper', () => {
-        const model: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'Paragraph',
-                    segments: [
-                        {
-                            segmentType: 'Image',
-                            src: 'test',
-                            format: {
-                                fontFamily: 'Calibri',
-                                fontSize: '11pt',
-                                textColor: 'rgb(0, 0, 0)',
-                                id: 'image_0',
-                                maxWidth: '1800px',
-                            },
-                            dataset: {},
-                            isSelectedAsImageSelection: true,
-                            isSelected: true,
-                        },
-                    ],
-                    format: {},
-                    segmentFormat: {
-                        fontFamily: 'Calibri',
-                        fontSize: '11pt',
-                        textColor: 'rgb(0, 0, 0)',
-                    },
-                },
-            ],
-            format: {
-                fontFamily: 'Calibri',
-                fontSize: '11pt',
-                textColor: '#000000',
-            },
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
         };
         const plugin = new ImageEditPlugin();
-        const editor = initEditor('image_edit', [plugin], model);
         plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
         plugin.onPluginEvent({
             eventType: 'mouseUp',
-            isClicking: true,
+
             rawEvent: {
                 button: 0,
                 target: {
@@ -252,7 +245,7 @@ describe('ImageEditPlugin', () => {
         });
         plugin.onPluginEvent({
             eventType: 'mouseUp',
-            isClicking: true,
+
             rawEvent: {
                 button: 2,
                 target: {
@@ -261,27 +254,37 @@ describe('ImageEditPlugin', () => {
                 } as any,
             } as any,
         });
-
-        expect(plugin.isEditingImage).toBeFalsy();
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
         plugin.dispose();
     });
 
     it('cropImage', () => {
         const plugin = new ImageEditPlugin();
-        const editor = initEditor('image_edit', [plugin], model);
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
+        };
         plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
         plugin.cropImage();
-        expect(plugin.isEditingImage).toBeTruthy();
+        expect(formatContentModelSpy).toHaveBeenCalled();
         plugin.dispose();
     });
 
     it('flip', () => {
         const plugin = new ImageEditPlugin();
-        const editor = initEditor('image_edit', [plugin], model);
         const image = new Image();
         image.src = 'test';
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: image,
+        });
         plugin.initialize(editor);
         plugin.flipImage('horizontal');
+        expect(formatContentModelSpy).toHaveBeenCalled();
         const dataset = getSelectedImageMetadata(editor, image);
         expect(dataset).toBeTruthy();
         plugin.dispose();
@@ -289,12 +292,16 @@ describe('ImageEditPlugin', () => {
 
     it('rotate', () => {
         const plugin = new ImageEditPlugin();
-        const editor = initEditor('image_edit', [plugin], model);
         const image = new Image();
         image.src = 'test';
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: image,
+        });
         plugin.initialize(editor);
         plugin.rotateImage(Math.PI / 2);
         const dataset = getSelectedImageMetadata(editor, image);
+        expect(formatContentModelSpy).toHaveBeenCalled();
         expect(dataset).toBeTruthy();
         plugin.dispose();
     });
@@ -348,5 +355,79 @@ describe('ImageEditPlugin', () => {
             'outline-style:none!important;',
             ['span:has(>img[id="0"])']
         );
+    });
+
+    it('mouseDown on edit image', () => {
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
+        };
+        const plugin = new ImageEditPlugin();
+        plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseUp',
+            rawEvent: {
+                button: 0,
+                target: new Image(),
+            } as any,
+        });
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseDown',
+            rawEvent: {
+                button: 0,
+                target: new Image(),
+            } as any,
+        });
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
+        plugin.dispose();
+    });
+
+    it('dragImage', () => {
+        const mockedImage = {
+            id: 'image_0',
+            getAttribute: getAttributeSpy,
+        } as any;
+        const plugin = new ImageEditPlugin();
+        plugin.initialize(editor);
+        const draggedImage = mockedImage as HTMLImageElement;
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: draggedImage,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseUp',
+            rawEvent: {
+                button: 0,
+                target: new Image(),
+            } as any,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseDown',
+            rawEvent: {
+                button: 0,
+                target: new Image(),
+            } as any,
+        });
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: {
+                id: 'image_0_dragging',
+            } as any,
+        });
+        plugin.onPluginEvent({
+            eventType: 'contentChanged',
+            source: ChangeSource.Drop,
+        });
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(3);
+        plugin.dispose();
     });
 });

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/utils/findEditingImageTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/utils/findEditingImageTest.ts
@@ -106,4 +106,79 @@ describe('findEditingImage', () => {
             },
         });
     });
+
+    it('editing image | by Id', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Image',
+                            src: 'test',
+                            format: {
+                                fontFamily: 'Calibri',
+                                fontSize: '11pt',
+                                textColor: 'rgb(0, 0, 0)',
+                                id: 'image_0',
+                                maxWidth: '1800px',
+                            },
+                            dataset: {},
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+            ],
+            format: {
+                fontFamily: 'Calibri',
+                fontSize: '11pt',
+                textColor: '#000000',
+            },
+        };
+
+        const image = findEditingImage(model, 'image_0');
+        expect(image).toEqual({
+            image: {
+                segmentType: 'Image',
+                src: 'test',
+                format: {
+                    fontFamily: 'Calibri',
+                    fontSize: '11pt',
+                    textColor: 'rgb(0, 0, 0)',
+                    id: 'image_0',
+                    maxWidth: '1800px',
+                },
+                dataset: {},
+            },
+            paragraph: {
+                blockType: 'Paragraph',
+                segments: [
+                    {
+                        segmentType: 'Image',
+                        src: 'test',
+                        format: {
+                            fontFamily: 'Calibri',
+                            fontSize: '11pt',
+                            textColor: 'rgb(0, 0, 0)',
+                            id: 'image_0',
+                            maxWidth: '1800px',
+                        },
+                        dataset: {},
+                    },
+                ],
+                format: {},
+                segmentFormat: {
+                    fontFamily: 'Calibri',
+                    fontSize: '11pt',
+                    textColor: 'rgb(0, 0, 0)',
+                },
+            },
+        });
+    });
 });


### PR DESCRIPTION
Drag and drop has two issues when the Image Edit Plugin is on:
1. When drag an image that has happens on, the original image will not be selected but image wrapper causing the drop behavior to be broken. To solve the issue, remove the wrapper when mouse down an image in editing state. 
2. The drop event is not updating content model when Image Edit Plugin, this makes the dragged image not be removed in the original position. To fix this identify the image that was dragged and the one that drop, then removed the dragged one and set the selection in the one that was dropped. 

**Warning**: Drag and Drop image in Mac is broken even when Image Edit Plugin is off. This fix will only fix Drag and Drop for windows. The fix for Mac requires more investigation and will be done in another PR. 

Before:

![DragAndDropBug](https://github.com/user-attachments/assets/a9207acf-a485-43e7-847e-9bd37d09a040)


After:  

![DragAndDropFix](https://github.com/user-attachments/assets/d1b66d42-9613-4e66-9215-23ddbd57fde6)
