### PR TITLE
Set segmentFormat text color to black when creating the model of the clipboard content and using Keep source formatting paste type

### DIFF
--- a/packages/roosterjs-content-model-core/test/command/paste/htmlTemplates/ClipboardContent1.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/htmlTemplates/ClipboardContent1.ts
@@ -1,0 +1,160 @@
+export const template: Readonly<string> = `
+<html
+    xmlns:o="urn:schemas-microsoft-com:office:office"
+    xmlns:w="urn:schemas-microsoft-com:office:word"
+    xmlns:m="http://schemas.microsoft.com/office/2004/12/omml"
+    xmlns="http://www.w3.org/TR/REC-html40"
+>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="ProgId" content="Word.Document" />
+        <meta name="Generator" content="Microsoft Word 15" />
+        <meta name="Originator" content="Microsoft Word 15" />
+        <!--[if gte mso 9
+            ]><xml>
+                <o:OfficeDocumentSettings>
+                    <o:AllowPNG />
+                </o:OfficeDocumentSettings> </xml
+        ><![endif]-->
+        <style>
+            <!--
+             /* Font Definitions */
+             @font-face
+            	{font-family:"Cambria Math";
+            	panose-1:2 4 5 3 5 4 6 3 2 4;
+            	mso-font-charset:0;
+            	mso-generic-font-family:roman;
+            	mso-font-pitch:variable;
+            	mso-font-signature:-536869121 1107305727 33554432 0 415 0;}
+            @font-face
+            	{font-family:"Yu Gothic";
+            	panose-1:2 11 4 0 0 0 0 0 0 0;
+            	mso-font-alt:æ¸¸ã‚´ã‚·ãƒƒã‚¯;
+            	mso-font-charset:128;
+            	mso-generic-font-family:swiss;
+            	mso-font-pitch:variable;
+            	mso-font-signature:-536870145 717749759 22 0 131231 0;}
+            @font-face
+            	{font-family:Aptos;
+            	mso-font-charset:0;
+            	mso-generic-font-family:swiss;
+            	mso-font-pitch:variable;
+            	mso-font-signature:536871559 3 0 0 415 0;}
+            @font-face
+            	{font-family:"\@Yu Gothic";
+            	panose-1:2 11 4 0 0 0 0 0 0 0;
+            	mso-font-charset:128;
+            	mso-generic-font-family:swiss;
+            	mso-font-pitch:variable;
+            	mso-font-signature:-536870145 717749759 22 0 131231 0;}
+             /* Style Definitions */
+             p.MsoNormal, li.MsoNormal, div.MsoNormal
+            	{mso-style-unhide:no;
+            	mso-style-qformat:yes;
+            	mso-style-parent:"";
+            	margin-top:0in;
+            	margin-right:0in;
+            	margin-bottom:8.0pt;
+            	margin-left:0in;
+            	line-height:115%;
+            	mso-pagination:widow-orphan;
+            	font-size:12.0pt;
+            	font-family:"Aptos",sans-serif;
+            	mso-ascii-font-family:Aptos;
+            	mso-ascii-theme-font:minor-latin;
+            	mso-fareast-font-family:"Yu Gothic";
+            	mso-fareast-theme-font:minor-fareast;
+            	mso-hansi-font-family:Aptos;
+            	mso-hansi-theme-font:minor-latin;
+            	mso-bidi-font-family:"Times New Roman";
+            	mso-bidi-theme-font:minor-bidi;
+            	mso-font-kerning:1.0pt;
+            	mso-ligatures:standardcontextual;}
+            .MsoChpDefault
+            	{mso-style-type:export-only;
+            	mso-default-props:yes;
+            	font-family:"Aptos",sans-serif;
+            	mso-ascii-font-family:Aptos;
+            	mso-ascii-theme-font:minor-latin;
+            	mso-fareast-font-family:"Yu Gothic";
+            	mso-fareast-theme-font:minor-fareast;
+            	mso-hansi-font-family:Aptos;
+            	mso-hansi-theme-font:minor-latin;
+            	mso-bidi-font-family:"Times New Roman";
+            	mso-bidi-theme-font:minor-bidi;}
+            .MsoPapDefault
+            	{mso-style-type:export-only;
+            	margin-bottom:8.0pt;
+            	line-height:115%;}
+            @page WordSection1
+            	{size:8.5in 11.0in;
+            	margin:1.0in 1.0in 1.0in 1.0in;
+            	mso-header-margin:.5in;
+            	mso-footer-margin:.5in;
+            	mso-paper-source:0;}
+            div.WordSection1
+            	{page:WordSection1;}
+            -->
+        </style>
+        <!--[if gte mso 10]>
+            <style>
+                /* Style Definitions */
+                table.MsoNormalTable {
+                    mso-style-name: 'Table Normal';
+                    mso-tstyle-rowband-size: 0;
+                    mso-tstyle-colband-size: 0;
+                    mso-style-noshow: yes;
+                    mso-style-priority: 99;
+                    mso-style-parent: '';
+                    mso-padding-alt: 0in 5.4pt 0in 5.4pt;
+                    mso-para-margin-top: 0in;
+                    mso-para-margin-right: 0in;
+                    mso-para-margin-bottom: 8pt;
+                    mso-para-margin-left: 0in;
+                    line-height: 115%;
+                    mso-pagination: widow-orphan;
+                    font-size: 12pt;
+                    font-family: 'Aptos', sans-serif;
+                    mso-ascii-font-family: Aptos;
+                    mso-ascii-theme-font: minor-latin;
+                    mso-hansi-font-family: Aptos;
+                    mso-hansi-theme-font: minor-latin;
+                    mso-font-kerning: 1pt;
+                    mso-ligatures: standardcontextual;
+                }
+            </style>
+        <![endif]-->
+    </head>
+
+    <body lang="EN-US" style="tab-interval: 0.5in; word-wrap: break-word;">
+        <!--StartFragment-->
+
+        <p class="MsoNormal">
+            <b
+                ><span style="font-size: 28pt; line-height: 115%; color: #c00000;"
+                    >Red bold<o:p></o:p></span
+            ></b>
+        </p>
+
+        <p class="MsoNormal">
+            <i
+                ><span style="font-size: 28pt; line-height: 115%; color: #c00000;"
+                    >Red italic<o:p></o:p></span
+            ></i>
+        </p>
+
+        <p class="MsoNormal">
+            <u
+                ><span style="font-size: 28pt; line-height: 115%; color: #c00000;"
+                    >Red underline<o:p></o:p></span
+            ></u>
+        </p>
+
+        <p class="MsoNormal">
+            <span style="font-size: 28pt; line-height: 115%;">Unformatted line<o:p></o:p></span>
+        </p>
+
+        <!--EndFragment-->
+    </body>
+</html>
+`;

--- a/packages/roosterjs-content-model-core/test/command/paste/htmlTemplates/ClipboardContent1.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/htmlTemplates/ClipboardContent1.ts
@@ -154,6 +154,13 @@ export const template: Readonly<string> = `
             <span style="font-size: 28pt; line-height: 115%;">Unformatted line<o:p></o:p></span>
         </p>
 
+        <p class="MsoNormal">
+            <u
+                ><a href="https://github.com/microsoft/roosterjs" style="font-size: 28pt; line-height: 115%;"
+                    >Text underlink<o:p></o:p></a
+            ></u>
+        </p>
+
         <!--EndFragment-->
     </body>
 </html>

--- a/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
@@ -614,6 +614,35 @@ describe('mergePasteContent', () => {
                             format: {},
                         },
                     },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Text underlink',
+                                format: {
+                                    fontSize: '28pt',
+                                    textColor: 'rgb(0,0,0)',
+                                    underline: true,
+                                    lineHeight: '115%',
+                                },
+                                link: {
+                                    format: {
+                                        underline: true,
+                                        href: 'https://github.com/microsoft/roosterjs',
+                                    },
+                                    dataset: {},
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: '\n',
+                                format: { fontSize: 'Calibri', textColor: 'rgb(0,0,0)' },
+                            },
+                        ],
+                        format: { marginTop: '1em', marginBottom: '1em' },
+                        decorator: { tagName: 'p', format: {} },
+                    },
                 ],
             },
             {
@@ -756,14 +785,6 @@ describe('mergePasteContent', () => {
                                 textColor: 'rgb(0,0,0)',
                             },
                         },
-                        {
-                            segmentType: 'SelectionMarker',
-                            isSelected: true,
-                            format: {
-                                fontSize: 'Calibri',
-                                textColor: 'white',
-                            },
-                        },
                     ],
                     format: {
                         marginTop: '1em',
@@ -773,6 +794,40 @@ describe('mergePasteContent', () => {
                         tagName: 'p',
                         format: {},
                     },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Text underlink',
+                            format: {
+                                fontSize: '28pt',
+                                textColor: 'rgb(0,0,0)',
+                                underline: true,
+                                lineHeight: '115%',
+                            },
+                            link: {
+                                format: {
+                                    underline: true,
+                                    href: 'https://github.com/microsoft/roosterjs',
+                                },
+                                dataset: {},
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\n',
+                            format: { fontSize: 'Calibri', textColor: 'rgb(0,0,0)' },
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: { fontSize: 'Calibri', textColor: 'white' },
+                        },
+                    ],
+                    format: { marginTop: '1em', marginBottom: '1em' },
+                    decorator: { tagName: 'p', format: {} },
                 },
             ],
         });
@@ -785,14 +840,14 @@ describe('mergePasteContent', () => {
 
         spyOn(mergeModelFile, 'mergeModel').and.callThrough();
         spyOn(getSegmentTextFormatFile, 'getSegmentTextFormat').and.returnValue({
-            fontSize: 'Calibri',
+            fontSize: '14px',
             textColor: 'white',
         });
         sourceModel = createContentModelDocument();
         const para = createParagraph();
         const marker = createSelectionMarker();
         marker.format = {
-            fontSize: 'Calibri',
+            fontSize: '14px',
             textColor: 'white',
         };
         para.segments.push(marker);
@@ -820,7 +875,7 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: 'Red bold',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                     fontWeight: 'bold',
                                 },
@@ -829,7 +884,7 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: '\n',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                 },
                             },
@@ -846,7 +901,7 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: 'Red italic',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                     italic: true,
                                 },
@@ -855,7 +910,7 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: '\n',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                 },
                             },
@@ -872,7 +927,7 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: 'Red underline',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                     underline: true,
                                 },
@@ -881,7 +936,7 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: '\n',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                 },
                             },
@@ -898,7 +953,7 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: 'Unformatted line',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                 },
                             },
@@ -906,7 +961,40 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: '\n',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
+                                    textColor: 'white',
+                                },
+                            },
+                        ],
+                        format: {
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Text underlink',
+                                format: {
+                                    fontSize: '14px',
+                                    textColor: 'white',
+                                    underline: true,
+                                },
+                                link: {
+                                    format: {
+                                        href: 'https://github.com/microsoft/roosterjs',
+                                        underline: true,
+                                    },
+                                    dataset: {},
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: '\n',
+                                format: {
+                                    fontSize: '14px',
                                     textColor: 'white',
                                 },
                             },
@@ -925,7 +1013,7 @@ describe('mergePasteContent', () => {
                 newPendingFormat: {
                     backgroundColor: '',
                     fontFamily: '',
-                    fontSize: 'Calibri',
+                    fontSize: '14px',
                     fontWeight: '',
                     italic: false,
                     letterSpacing: '',
@@ -952,7 +1040,7 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: 'Red bold',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                                 fontWeight: 'bold',
                             },
@@ -961,7 +1049,7 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: '\n',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                             },
                         },
@@ -971,7 +1059,7 @@ describe('mergePasteContent', () => {
                         marginBottom: '1em',
                     },
                     segmentFormat: {
-                        fontSize: 'Calibri',
+                        fontSize: '14px',
                         textColor: 'white',
                     },
                 },
@@ -982,7 +1070,7 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: 'Red italic',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                                 italic: true,
                             },
@@ -991,7 +1079,7 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: '\n',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                             },
                         },
@@ -1001,7 +1089,7 @@ describe('mergePasteContent', () => {
                         marginBottom: '1em',
                     },
                     segmentFormat: {
-                        fontSize: 'Calibri',
+                        fontSize: '14px',
                         textColor: 'white',
                     },
                 },
@@ -1012,7 +1100,7 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: 'Red underline',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                                 underline: true,
                             },
@@ -1021,7 +1109,7 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: '\n',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                             },
                         },
@@ -1031,7 +1119,7 @@ describe('mergePasteContent', () => {
                         marginBottom: '1em',
                     },
                     segmentFormat: {
-                        fontSize: 'Calibri',
+                        fontSize: '14px',
                         textColor: 'white',
                     },
                 },
@@ -1042,7 +1130,7 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: 'Unformatted line',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                             },
                         },
@@ -1050,15 +1138,7 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: '\n',
                             format: {
-                                fontSize: 'Calibri',
-                                textColor: 'white',
-                            },
-                        },
-                        {
-                            segmentType: 'SelectionMarker',
-                            isSelected: true,
-                            format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                             },
                         },
@@ -1068,7 +1148,52 @@ describe('mergePasteContent', () => {
                         marginBottom: '1em',
                     },
                     segmentFormat: {
-                        fontSize: 'Calibri',
+                        fontSize: '14px',
+                        textColor: 'white',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Text underlink',
+                            format: {
+                                fontSize: '14px',
+                                textColor: 'white',
+                                underline: true,
+                            },
+                            link: {
+                                format: {
+                                    href: 'https://github.com/microsoft/roosterjs',
+                                    underline: true,
+                                },
+                                dataset: {},
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\n',
+                            format: {
+                                fontSize: '14px',
+                                textColor: 'white',
+                            },
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {
+                                fontSize: '14px',
+                                textColor: 'white',
+                            },
+                        },
+                    ],
+                    format: {
+                        marginTop: '1em',
+                        marginBottom: '1em',
+                    },
+                    segmentFormat: {
+                        fontSize: '14px',
                         textColor: 'white',
                     },
                 },
@@ -1086,14 +1211,14 @@ describe('mergePasteContent', () => {
 
         spyOn(mergeModelFile, 'mergeModel').and.callThrough();
         spyOn(getSegmentTextFormatFile, 'getSegmentTextFormat').and.returnValue({
-            fontSize: 'Calibri',
+            fontSize: '14px',
             textColor: 'white',
         });
         sourceModel = createContentModelDocument();
         const para = createParagraph();
         const marker = createSelectionMarker();
         marker.format = {
-            fontSize: 'Calibri',
+            fontSize: '14px',
             textColor: 'white',
         };
         para.segments.push(marker);
@@ -1121,7 +1246,7 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: 'Red bold',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                 },
                             },
@@ -1129,7 +1254,7 @@ describe('mergePasteContent', () => {
                         format: {},
                         isImplicit: true,
                         segmentFormat: {
-                            fontSize: 'Calibri',
+                            fontSize: '14px',
                             textColor: 'white',
                         },
                     },
@@ -1140,14 +1265,14 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: 'Red italic',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                 },
                             },
                         ],
                         format: {},
                         segmentFormat: {
-                            fontSize: 'Calibri',
+                            fontSize: '14px',
                             textColor: 'white',
                         },
                     },
@@ -1158,14 +1283,14 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: 'Red underline',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                 },
                             },
                         ],
                         format: {},
                         segmentFormat: {
-                            fontSize: 'Calibri',
+                            fontSize: '14px',
                             textColor: 'white',
                         },
                     },
@@ -1176,14 +1301,14 @@ describe('mergePasteContent', () => {
                                 segmentType: 'Text',
                                 text: 'Unformatted line',
                                 format: {
-                                    fontSize: 'Calibri',
+                                    fontSize: '14px',
                                     textColor: 'white',
                                 },
                             },
                         ],
                         format: {},
                         segmentFormat: {
-                            fontSize: 'Calibri',
+                            fontSize: '14px',
                             textColor: 'white',
                         },
                     },
@@ -1196,7 +1321,7 @@ describe('mergePasteContent', () => {
                 newPendingFormat: {
                     backgroundColor: '',
                     fontFamily: '',
-                    fontSize: 'Calibri',
+                    fontSize: '14px',
                     fontWeight: '',
                     italic: false,
                     letterSpacing: '',
@@ -1223,14 +1348,14 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: 'Red bold',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                             },
                         },
                     ],
                     format: {},
                     segmentFormat: {
-                        fontSize: 'Calibri',
+                        fontSize: '14px',
                         textColor: 'white',
                     },
                 },
@@ -1241,14 +1366,14 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: 'Red italic',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                             },
                         },
                     ],
                     format: {},
                     segmentFormat: {
-                        fontSize: 'Calibri',
+                        fontSize: '14px',
                         textColor: 'white',
                     },
                 },
@@ -1259,14 +1384,14 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: 'Red underline',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                             },
                         },
                     ],
                     format: {},
                     segmentFormat: {
-                        fontSize: 'Calibri',
+                        fontSize: '14px',
                         textColor: 'white',
                     },
                 },
@@ -1277,7 +1402,7 @@ describe('mergePasteContent', () => {
                             segmentType: 'Text',
                             text: 'Unformatted line',
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                             },
                         },
@@ -1285,14 +1410,14 @@ describe('mergePasteContent', () => {
                             segmentType: 'SelectionMarker',
                             isSelected: true,
                             format: {
-                                fontSize: 'Calibri',
+                                fontSize: '14px',
                                 textColor: 'white',
                             },
                         },
                     ],
                     format: {},
                     segmentFormat: {
-                        fontSize: 'Calibri',
+                        fontSize: '14px',
                         textColor: 'white',
                     },
                 },

--- a/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
@@ -1,8 +1,17 @@
 import * as createDomToModelContextForSanitizing from '../../../lib/command/createModelFromHtml/createDomToModelContextForSanitizing';
 import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
+import * as getSegmentTextFormatFile from 'roosterjs-content-model-dom/lib/modelApi/editing/getSegmentTextFormat';
 import * as mergeModelFile from 'roosterjs-content-model-dom/lib/modelApi/editing/mergeModel';
-import { createContentModelDocument } from 'roosterjs-content-model-dom';
+import { createPasteFragment } from '../../../lib/command/paste/createPasteFragment';
 import { mergePasteContent } from '../../../lib/command/paste/mergePasteContent';
+import { template } from './htmlTemplates/ClipboardContent1';
+import {
+    addBlock,
+    createContentModelDocument,
+    createParagraph,
+    createSelectionMarker,
+    moveChildNodes,
+} from 'roosterjs-content-model-dom';
 import {
     ContentModelDocument,
     ContentModelFormatter,
@@ -444,6 +453,850 @@ describe('mergePasteContent', () => {
                 textColor: '',
                 underline: false,
             },
+        });
+    });
+
+    it('Merge paste content | Paste Type = normal | Make undefined text color equal to black', () => {
+        const html = new DOMParser().parseFromString(template, 'text/html');
+        const fragment = document.createDocumentFragment();
+        moveChildNodes(fragment, html.body);
+
+        spyOn(mergeModelFile, 'mergeModel').and.callThrough();
+        spyOn(getSegmentTextFormatFile, 'getSegmentTextFormat').and.returnValue({
+            fontSize: 'Calibri',
+            textColor: 'white',
+        });
+        sourceModel = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        marker.format = {
+            fontSize: 'Calibri',
+            textColor: 'white',
+        };
+        para.segments.push(marker);
+        addBlock(sourceModel, para);
+
+        mergePasteContent(
+            editor,
+            <any>{
+                fragment,
+                domToModelOption: <any>{},
+                pasteType: 'normal',
+            },
+            mockedClipboard
+        );
+
+        expect(mergeModelFile.mergeModel).toHaveBeenCalledWith(
+            sourceModel,
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Red bold',
+                                format: {
+                                    fontSize: '28pt',
+                                    textColor: 'rgb(192, 0, 0)',
+                                    fontWeight: 'bold',
+                                    lineHeight: '115%',
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: '\n',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'rgb(0,0,0)',
+                                },
+                            },
+                        ],
+                        format: {
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                        decorator: {
+                            tagName: 'p',
+                            format: {},
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Red italic',
+                                format: {
+                                    fontSize: '28pt',
+                                    textColor: 'rgb(192, 0, 0)',
+                                    italic: true,
+                                    lineHeight: '115%',
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: '\n',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'rgb(0,0,0)',
+                                },
+                            },
+                        ],
+                        format: {
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                        decorator: {
+                            tagName: 'p',
+                            format: {},
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Red underline',
+                                format: {
+                                    fontSize: '28pt',
+                                    textColor: 'rgb(192, 0, 0)',
+                                    underline: true,
+                                    lineHeight: '115%',
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: '\n',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'rgb(0,0,0)',
+                                },
+                            },
+                        ],
+                        format: {
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                        decorator: {
+                            tagName: 'p',
+                            format: {},
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Unformatted line',
+                                format: {
+                                    fontSize: '28pt',
+                                    textColor: 'rgb(0,0,0)',
+                                    lineHeight: '115%',
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: '\n',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'rgb(0,0,0)',
+                                },
+                            },
+                        ],
+                        format: {
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                        decorator: {
+                            tagName: 'p',
+                            format: {},
+                        },
+                    },
+                ],
+            },
+            {
+                newEntities: [],
+                deletedEntities: [],
+                newImages: [],
+                newPendingFormat: {
+                    backgroundColor: '',
+                    fontFamily: '',
+                    fontSize: 'Calibri',
+                    fontWeight: '',
+                    italic: false,
+                    letterSpacing: '',
+                    lineHeight: '',
+                    strikethrough: false,
+                    superOrSubScriptSequence: '',
+                    textColor: 'white',
+                    underline: false,
+                },
+            },
+            {
+                mergeFormat: 'none',
+                mergeTable: false,
+            }
+        );
+
+        expect(sourceModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Red bold',
+                            format: {
+                                fontSize: '28pt',
+                                textColor: 'rgb(192, 0, 0)',
+                                fontWeight: 'bold',
+                                lineHeight: '115%',
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\n',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'rgb(0,0,0)',
+                            },
+                        },
+                    ],
+                    format: {
+                        marginTop: '1em',
+                        marginBottom: '1em',
+                    },
+                    decorator: {
+                        tagName: 'p',
+                        format: {},
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Red italic',
+                            format: {
+                                fontSize: '28pt',
+                                textColor: 'rgb(192, 0, 0)',
+                                italic: true,
+                                lineHeight: '115%',
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\n',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'rgb(0,0,0)',
+                            },
+                        },
+                    ],
+                    format: {
+                        marginTop: '1em',
+                        marginBottom: '1em',
+                    },
+                    decorator: {
+                        tagName: 'p',
+                        format: {},
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Red underline',
+                            format: {
+                                fontSize: '28pt',
+                                textColor: 'rgb(192, 0, 0)',
+                                underline: true,
+                                lineHeight: '115%',
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\n',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'rgb(0,0,0)',
+                            },
+                        },
+                    ],
+                    format: {
+                        marginTop: '1em',
+                        marginBottom: '1em',
+                    },
+                    decorator: {
+                        tagName: 'p',
+                        format: {},
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Unformatted line',
+                            format: {
+                                fontSize: '28pt',
+                                textColor: 'rgb(0,0,0)',
+                                lineHeight: '115%',
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\n',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'rgb(0,0,0)',
+                            },
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                    ],
+                    format: {
+                        marginTop: '1em',
+                        marginBottom: '1em',
+                    },
+                    decorator: {
+                        tagName: 'p',
+                        format: {},
+                    },
+                },
+            ],
+        });
+    });
+
+    it('Merge paste content | Paste Type = mergeFormat | Use current format', () => {
+        const html = new DOMParser().parseFromString(template, 'text/html');
+        const fragment = document.createDocumentFragment();
+        moveChildNodes(fragment, html.body);
+
+        spyOn(mergeModelFile, 'mergeModel').and.callThrough();
+        spyOn(getSegmentTextFormatFile, 'getSegmentTextFormat').and.returnValue({
+            fontSize: 'Calibri',
+            textColor: 'white',
+        });
+        sourceModel = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        marker.format = {
+            fontSize: 'Calibri',
+            textColor: 'white',
+        };
+        para.segments.push(marker);
+        sourceModel.blocks.push(para);
+
+        mergePasteContent(
+            editor,
+            {
+                fragment,
+                domToModelOption: <any>{},
+                pasteType: 'mergeFormat',
+            } as any,
+            mockedClipboard
+        );
+
+        expect(mergeModelFile.mergeModel).toHaveBeenCalledWith(
+            sourceModel,
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Red bold',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                    fontWeight: 'bold',
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: '\n',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                },
+                            },
+                        ],
+                        format: {
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Red italic',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                    italic: true,
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: '\n',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                },
+                            },
+                        ],
+                        format: {
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Red underline',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                    underline: true,
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: '\n',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                },
+                            },
+                        ],
+                        format: {
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Unformatted line',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                },
+                            },
+                            {
+                                segmentType: 'Text',
+                                text: '\n',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                },
+                            },
+                        ],
+                        format: {
+                            marginTop: '1em',
+                            marginBottom: '1em',
+                        },
+                    },
+                ],
+            },
+            {
+                newEntities: [],
+                deletedEntities: [],
+                newImages: [],
+                newPendingFormat: {
+                    backgroundColor: '',
+                    fontFamily: '',
+                    fontSize: 'Calibri',
+                    fontWeight: '',
+                    italic: false,
+                    letterSpacing: '',
+                    lineHeight: '',
+                    strikethrough: false,
+                    superOrSubScriptSequence: '',
+                    textColor: 'white',
+                    underline: false,
+                },
+            },
+            {
+                mergeFormat: 'keepSourceEmphasisFormat',
+                mergeTable: false,
+            }
+        );
+
+        expect(sourceModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Red bold',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                                fontWeight: 'bold',
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\n',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                    ],
+                    format: {
+                        marginTop: '1em',
+                        marginBottom: '1em',
+                    },
+                    segmentFormat: {
+                        fontSize: 'Calibri',
+                        textColor: 'white',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Red italic',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                                italic: true,
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\n',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                    ],
+                    format: {
+                        marginTop: '1em',
+                        marginBottom: '1em',
+                    },
+                    segmentFormat: {
+                        fontSize: 'Calibri',
+                        textColor: 'white',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Red underline',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                                underline: true,
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\n',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                    ],
+                    format: {
+                        marginTop: '1em',
+                        marginBottom: '1em',
+                    },
+                    segmentFormat: {
+                        fontSize: 'Calibri',
+                        textColor: 'white',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Unformatted line',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\n',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                    ],
+                    format: {
+                        marginTop: '1em',
+                        marginBottom: '1em',
+                    },
+                    segmentFormat: {
+                        fontSize: 'Calibri',
+                        textColor: 'white',
+                    },
+                },
+            ],
+        });
+    });
+
+    it('Merge paste content | Paste Type = asPlainText | Use current format', () => {
+        const fragment = createPasteFragment(
+            document,
+            { text: 'Red bold\r\nRed italic\r\nRed underline\r\nUnformatted line\r\n' } as any,
+            'asPlainText',
+            document.body
+        );
+
+        spyOn(mergeModelFile, 'mergeModel').and.callThrough();
+        spyOn(getSegmentTextFormatFile, 'getSegmentTextFormat').and.returnValue({
+            fontSize: 'Calibri',
+            textColor: 'white',
+        });
+        sourceModel = createContentModelDocument();
+        const para = createParagraph();
+        const marker = createSelectionMarker();
+        marker.format = {
+            fontSize: 'Calibri',
+            textColor: 'white',
+        };
+        para.segments.push(marker);
+        sourceModel.blocks.push(para);
+
+        mergePasteContent(
+            editor,
+            {
+                fragment,
+                domToModelOption: <any>{},
+                pasteType: 'asPlainText',
+            } as any,
+            mockedClipboard
+        );
+
+        expect(mergeModelFile.mergeModel).toHaveBeenCalledWith(
+            sourceModel,
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Red bold',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                },
+                            },
+                        ],
+                        format: {},
+                        isImplicit: true,
+                        segmentFormat: {
+                            fontSize: 'Calibri',
+                            textColor: 'white',
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Red italic',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                },
+                            },
+                        ],
+                        format: {},
+                        segmentFormat: {
+                            fontSize: 'Calibri',
+                            textColor: 'white',
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Red underline',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                },
+                            },
+                        ],
+                        format: {},
+                        segmentFormat: {
+                            fontSize: 'Calibri',
+                            textColor: 'white',
+                        },
+                    },
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'Unformatted line',
+                                format: {
+                                    fontSize: 'Calibri',
+                                    textColor: 'white',
+                                },
+                            },
+                        ],
+                        format: {},
+                        segmentFormat: {
+                            fontSize: 'Calibri',
+                            textColor: 'white',
+                        },
+                    },
+                ],
+            },
+            {
+                newEntities: [],
+                deletedEntities: [],
+                newImages: [],
+                newPendingFormat: {
+                    backgroundColor: '',
+                    fontFamily: '',
+                    fontSize: 'Calibri',
+                    fontWeight: '',
+                    italic: false,
+                    letterSpacing: '',
+                    lineHeight: '',
+                    strikethrough: false,
+                    superOrSubScriptSequence: '',
+                    textColor: 'white',
+                    underline: false,
+                },
+            },
+            {
+                mergeFormat: 'none',
+                mergeTable: false,
+            }
+        );
+
+        expect(sourceModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Red bold',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontSize: 'Calibri',
+                        textColor: 'white',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Red italic',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontSize: 'Calibri',
+                        textColor: 'white',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Red underline',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontSize: 'Calibri',
+                        textColor: 'white',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Unformatted line',
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {
+                                fontSize: 'Calibri',
+                                textColor: 'white',
+                            },
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontSize: 'Calibri',
+                        textColor: 'white',
+                    },
+                },
+            ],
         });
     });
 });

--- a/packages/roosterjs-content-model-core/test/command/paste/pasteTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/pasteTest.ts
@@ -398,7 +398,13 @@ describe('Paste with clipboardData', () => {
             blocks: [
                 {
                     segments: [
-                        { text: 'Link', segmentType: 'Text', format: {} },
+                        {
+                            text: 'Link',
+                            segmentType: 'Text',
+                            format: {
+                                textColor: 'rgb(0, 0, 0)',
+                            },
+                        },
                         {
                             isSelected: true,
                             segmentType: 'SelectionMarker',
@@ -418,6 +424,7 @@ describe('Paste with clipboardData', () => {
                         },
                     ],
                     blockType: 'Paragraph',
+                    segmentFormat: { textColor: 'rgb(0, 0, 0)' },
                     format: {},
                 },
             ],
@@ -441,7 +448,7 @@ describe('Paste with clipboardData', () => {
                         {
                             text: 'Link',
                             segmentType: 'Text',
-                            format: {},
+                            format: { textColor: 'rgb(0, 0, 0)' },
                             link: {
                                 format: {
                                     underline: true,
@@ -476,6 +483,7 @@ describe('Paste with clipboardData', () => {
                         },
                     ],
                     blockType: 'Paragraph',
+                    segmentFormat: { textColor: 'rgb(0, 0, 0)' },
                     format: {},
                 },
             ],


### PR DESCRIPTION
Right now, if we paste some content in the editor and we use the Keep source formatting or normal paste type. 
If the default format is different that black, that color will be set to the elements that do not have any text color in the HTML.

Which causes inconsistencies with the content.
To fix, if the paste type is of type normal or keep source formatting. Set the text color in the default format that is going to be used to generate the model from the clipboard content to black. That way if the element does not have a text color set we just default to black.

If the paste type is different than Keep source format, there is no need to do this, as we will merge all the format anyway.

Source
![image](https://github.com/user-attachments/assets/e41dd905-03bc-4f1b-9e53-5b2981cd1f9c)

Before
![image](https://github.com/user-attachments/assets/4e9e04e7-8c9d-468f-9bb8-a5430a75e274)

After
![image](https://github.com/user-attachments/assets/da068cb9-d0c6-41ac-8b76-79dbaed10aaa)

https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/288926/
