### PR TITLE
Dont remove the MarginTop/Bottom from lists when pasting from Word Online

### DIFF
--- a/packages/roosterjs-content-model-core/test/command/paste/pasteTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/pasteTest.ts
@@ -178,7 +178,7 @@ describe('paste with content model & paste plugin', () => {
         paste(editor!, clipboardData);
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(2);
-        expect(addParserF.addParser).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 6);
+        expect(addParserF.addParser).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 7);
         expect(WacComponents.processPastedContentWacComponents).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/roosterjs-content-model-plugins/lib/paste/WacComponents/constants.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/WacComponents/constants.ts
@@ -52,9 +52,15 @@ export const TEMP_ELEMENTS_CLASSES: string[] = [
     ...WORD_ONLINE_TABLE_TEMP_ELEMENT_CLASSES,
     'ListMarkerWrappingSpan',
 ];
+
+/**
+ * @internal
+ */
+export const REMOVE_MARGIN_ELEMENTS: string =
+    `span.${IMAGE_CONTAINER},span.${IMAGE_BORDER},.${COMMENT_HIGHLIGHT_CLASS},.${COMMENT_HIGHLIGHT_CLICKED_CLASS},` +
+    WORD_ONLINE_TABLE_TEMP_ELEMENT_CLASSES.map(c => `table div[class^="${c}"]`).join(',');
+
 /**
  * @internal
  **/
-export const WAC_IDENTIFY_SELECTOR: string =
-    `ul[class^="${BULLET_LIST_STYLE}"]>.${OUTLINE_ELEMENT},ol[class^="${NUMBER_LIST_STYLE}"]>.${OUTLINE_ELEMENT},span.${IMAGE_CONTAINER},span.${IMAGE_BORDER},.${COMMENT_HIGHLIGHT_CLASS},.${COMMENT_HIGHLIGHT_CLICKED_CLASS},` +
-    WORD_ONLINE_TABLE_TEMP_ELEMENT_CLASSES.map(c => `table div[class^="${c}"]`).join(',');
+export const WAC_IDENTIFY_SELECTOR: string = `ul[class^="${BULLET_LIST_STYLE}"]>.${OUTLINE_ELEMENT},ol[class^="${NUMBER_LIST_STYLE}"]>.${OUTLINE_ELEMENT},${REMOVE_MARGIN_ELEMENTS}`;

--- a/packages/roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents.ts
@@ -5,8 +5,8 @@ import {
     COMMENT_HIGHLIGHT_CLASS,
     COMMENT_HIGHLIGHT_CLICKED_CLASS,
     LIST_CONTAINER_ELEMENT_CLASS_NAME,
+    REMOVE_MARGIN_ELEMENTS,
     TEMP_ELEMENTS_CLASSES,
-    WAC_IDENTIFY_SELECTOR,
 } from './constants';
 import type {
     BeforePasteEvent,
@@ -67,7 +67,7 @@ const wacElementProcessor: ElementProcessor<HTMLElement> = (
 ): void => {
     const elementTag = element.tagName;
 
-    if (element.matches(WAC_IDENTIFY_SELECTOR)) {
+    if (element.matches(REMOVE_MARGIN_ELEMENTS)) {
         element.style.removeProperty('display');
         element.style.removeProperty('margin');
     }
@@ -155,6 +155,7 @@ const wacListItemParser: FormatParser<ContentModelListItemLevelFormat> = (
     }
 
     format.marginLeft = undefined;
+    format.marginRight = undefined;
 };
 
 /**
@@ -218,6 +219,7 @@ const wacCommentParser: FormatParser<ContentModelSegmentFormat> = (
 export function processPastedContentWacComponents(ev: BeforePasteEvent) {
     addParser(ev.domToModelOption, 'segment', wacSubSuperParser);
     addParser(ev.domToModelOption, 'listItemThread', wacListItemParser);
+    addParser(ev.domToModelOption, 'listItemElement', wacListItemParser);
     addParser(ev.domToModelOption, 'listLevel', wacListLevelParser);
     addParser(ev.domToModelOption, 'container', wacContainerParser);
     addParser(ev.domToModelOption, 'table', wacContainerParser);

--- a/packages/roosterjs-content-model-plugins/test/paste/ContentModelPastePluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/ContentModelPastePluginTest.ts
@@ -151,7 +151,7 @@ describe('Content Model Paste Plugin Test', () => {
             plugin.onPluginEvent(event);
 
             expect(WacFile.processPastedContentWacComponents).toHaveBeenCalledWith(event);
-            expect(addParser.addParser).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 6);
+            expect(addParser.addParser).toHaveBeenCalledTimes(DEFAULT_TIMES_ADD_PARSER_CALLED + 7);
             expect(setProcessor.setProcessor).toHaveBeenCalledTimes(2);
         });
 

--- a/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromWacTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromWacTest.ts
@@ -1930,7 +1930,7 @@ describe('wordOnlineHandler', () => {
                             {
                                 blockType: 'BlockGroup',
                                 blockGroupType: 'General',
-                                element: {},
+                                element: jasmine.anything() as any,
                                 blocks: [
                                     {
                                         blockType: 'Paragraph',
@@ -1946,7 +1946,7 @@ describe('wordOnlineHandler', () => {
                             {
                                 blockType: 'BlockGroup',
                                 blockGroupType: 'General',
-                                element: {},
+                                element: jasmine.anything() as any,
                                 blocks: [
                                     {
                                         blockType: 'Paragraph',
@@ -1962,7 +1962,7 @@ describe('wordOnlineHandler', () => {
                             {
                                 blockType: 'BlockGroup',
                                 blockGroupType: 'General',
-                                element: {},
+                                element: jasmine.anything() as any,
                                 blocks: [
                                     {
                                         blockType: 'Paragraph',
@@ -2226,7 +2226,7 @@ describe('wordOnlineHandler', () => {
                             {
                                 blockType: 'BlockGroup',
                                 blockGroupType: 'General',
-                                element: {},
+                                element: jasmine.anything() as any,
                                 blocks: [
                                     {
                                         blockType: 'Paragraph',
@@ -2242,7 +2242,7 @@ describe('wordOnlineHandler', () => {
                             {
                                 blockType: 'BlockGroup',
                                 blockGroupType: 'General',
-                                element: {},
+                                element: jasmine.anything() as any,
                                 blocks: [
                                     {
                                         blockType: 'Paragraph',
@@ -2258,7 +2258,7 @@ describe('wordOnlineHandler', () => {
                             {
                                 blockType: 'BlockGroup',
                                 blockGroupType: 'General',
-                                element: {},
+                                element: jasmine.anything() as any,
                                 blocks: [
                                     {
                                         blockType: 'Paragraph',

--- a/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromWacTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/processPastedContentFromWacTest.ts
@@ -388,11 +388,6 @@ describe('processPastedContentFromWacTest', () => {
 });
 
 describe('wordOnlineHandler', () => {
-    function runTest2(source?: string, expected?: string, expectedModel?: ContentModelDocument) {
-        const asd = runTest(source, expected, expectedModel, true);
-
-        navigator.clipboard.writeText(JSON.stringify(asd));
-    }
     function runTest(
         source?: string,
         expected?: string,


### PR DESCRIPTION
Before we were removing all margins from the list, but to resolve a layout issue, we need to keep the margin top and bottom.

See before after pics here https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/288888/

Also check the model result in some unit test where we only verified the HTML was expected.
