### PR TITLE
Fix picker issue, allow + for mentions

### DIFF
--- a/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
+++ b/packages/roosterjs-editor-plugins/lib/plugins/Picker/PickerPlugin.ts
@@ -41,6 +41,8 @@ const UNIDENTIFIED_KEY = 'Unidentified';
 // the char code for Android keyboard events on Webview below 51.
 const UNIDENTIFIED_CODE = [0, 229];
 
+const ALLOWED_CHAR_BEFORE_TRIGGER = ['(', '+'];
+
 /**
  * PickerPlugin represents a plugin of editor which can handle picker related behaviors, including
  * - Show picker when special trigger key is pressed
@@ -347,7 +349,7 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
                         wordBeforeCursor != null &&
                         wordBeforeCursor.split(' ').length <= 4 &&
                         (wordBeforeCursor[0] == this.pickerOptions.triggerCharacter ||
-                            (wordBeforeCursor[0] == '(' &&
+                            (ALLOWED_CHAR_BEFORE_TRIGGER.indexOf(wordBeforeCursor[0]) >= 0 &&
                                 wordBeforeCursor[1] == this.pickerOptions.triggerCharacter))
                     ) {
                         this.setIsSuggesting(true);
@@ -565,7 +567,8 @@ export default class PickerPlugin<T extends PickerDataProvider = PickerDataProvi
         // so wordFromCache is what we want to return.
         if (
             wordFromRange == this.pickerOptions.triggerCharacter &&
-            wordFromRange != wordFromCache
+            wordFromRange != wordFromCache &&
+            wordFromCache?.[wordFromCache?.length - 1] != wordFromRange
         ) {
             return wordFromCache;
         }

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,7 @@
 {
     "legacy": "8.62.0",
     "react": "8.56.0",
-    "overrides": {}
+    "overrides": {
+        "roosterjs-editor-plugins": "8.62.1"
+    }
 }


### PR DESCRIPTION
https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/285727/?triage=true

This is a special fix for roosterjs v8. We got customer complain that they cannot use @ mention after "+". So make this fix specially for that case.