### PR TITLE
Resolve null sheet in convertInlineCss

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/convertInlineCss.ts
+++ b/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/convertInlineCss.ts
@@ -28,7 +28,11 @@ export function retrieveCssRules(doc: Document): CssRule[] {
     const result: CssRule[] = [];
 
     styles.forEach(styleNode => {
-        const sheet = styleNode.sheet as CSSStyleSheet;
+        const sheet = styleNode.sheet;
+
+        if (!sheet) {
+            return;
+        }
 
         for (let ruleIndex = 0; ruleIndex < sheet.cssRules.length; ruleIndex++) {
             const rule = sheet.cssRules[ruleIndex] as CSSStyleRule;

--- a/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/convertInlineCss.ts
+++ b/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/convertInlineCss.ts
@@ -30,18 +30,16 @@ export function retrieveCssRules(doc: Document): CssRule[] {
     styles.forEach(styleNode => {
         const sheet = styleNode.sheet;
 
-        if (!sheet) {
-            return;
-        }
+        if (sheet) {
+            for (let ruleIndex = 0; ruleIndex < sheet.cssRules.length; ruleIndex++) {
+                const rule = sheet.cssRules[ruleIndex] as CSSStyleRule;
 
-        for (let ruleIndex = 0; ruleIndex < sheet.cssRules.length; ruleIndex++) {
-            const rule = sheet.cssRules[ruleIndex] as CSSStyleRule;
-
-            if (rule.type == CSSRule.STYLE_RULE && rule.selectorText) {
-                result.push({
-                    selectors: splitSelectors(rule.selectorText),
-                    text: rule.style.cssText,
-                });
+                if (rule.type == CSSRule.STYLE_RULE && rule.selectorText) {
+                    result.push({
+                        selectors: splitSelectors(rule.selectorText),
+                        text: rule.style.cssText,
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
There is an error when initializing the editor, and seems to be related to a type cast in convertInlineCss, to fix add a null check so we do not have a runtime error.

Callstack
```
TypeError: Cannot read properties of null (reading 'cssRules')

roosterjs-content-model-core/lib/command/createModelFromHtml/convertInlineCss.ts cssRules 33
Native Browser Function(Array.forEach)
roosterjs-content-model-core/lib/command/createModelFromHtml/convertInlineCss.ts forEach 30
roosterjs-content-model-core/lib/command/createModelFromHtml/createModelFromHtml.ts retrieveCssRules 35
roosterjs-editor-adapter/lib/editor/EditorAdapter.ts initContent 137
```