### PR TITLE
Expose the `insertImageEditingWrapper` api 

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -335,11 +335,13 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                         isNodeOfType(node, 'ELEMENT_NODE') &&
                         isElementOfType(node, 'img')
                     ) {
-                        if (isCropMode) {
-                            this.startCropMode(editor, node);
-                        } else {
-                            this.startRotateAndResize(editor, node);
-                        }
+                        node.onload = () => {
+                            if (isCropMode) {
+                                this.startCropMode(editor, node);
+                            } else {
+                                this.startRotateAndResize(editor, node);
+                            }
+                        };
                     }
                 },
             },
@@ -347,6 +349,26 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                 tryGetFromCache: true,
             }
         );
+    }
+
+    /**
+     * Insert the image editing wrapper in the selected image
+     */
+    public insertImageEditingWrapper() {
+        if (this.editor) {
+            const selection = this.editor.getDOMSelection();
+            if (!this.editor.getEnvironment().isSafari) {
+                this.editor.focus(); // Safari will keep the selection when click crop, then the focus() call should not be called
+            }
+            if (this.editor && selection?.type == 'image') {
+                this.applyFormatWithContentModel(
+                    this.editor,
+                    false /* isCropMode */,
+                    false /** should selectImage */,
+                    false /* isApiOperation */
+                );
+            }
+        }
     }
 
     private startEditing(

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -430,4 +430,20 @@ describe('ImageEditPlugin', () => {
         expect(formatContentModelSpy).toHaveBeenCalledTimes(3);
         plugin.dispose();
     });
+
+    it('insertImageEditingWrapper', () => {
+        const mockedImage = {
+            id: 'image_0',
+            getAttribute: getAttributeSpy,
+        } as any;
+        const plugin = new ImageEditPlugin();
+        plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        plugin.insertImageEditingWrapper();
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        plugin.dispose();
+    });
 });


### PR DESCRIPTION
Expose the `insertImageEditingWrapper` api to insert the resize and rotate wrapper into the selected image.