### PR TITLE
Preserve Height/Width Attributes

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/imageProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/imageProcessor.ts
@@ -41,11 +41,11 @@ export const imageProcessor: ElementProcessor<HTMLImageElement> = (group, elemen
         }
 
         if (element.width || element.clientWidth) {
-            image.format.widthAttr = element.width || element.clientWidth;
+            image.format.widthAttr = (element.width || element.clientWidth).toString();
         }
 
         if (element.height || element.clientHeight) {
-            image.format.heightAttr = element.height || element.clientHeight;
+            image.format.heightAttr = (element.height || element.clientHeight).toString();
         }
 
         const paragraph = addSegment(group, image);

--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/imageProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/imageProcessor.ts
@@ -40,8 +40,13 @@ export const imageProcessor: ElementProcessor<HTMLImageElement> = (group, elemen
             image.isSelected = true;
         }
 
-        image.format.width = (element.width || element.clientWidth) + 'px';
-        image.format.height = (element.height || element.clientHeight) + 'px';
+        if (element.width || element.clientWidth) {
+            image.format.width = (element.width || element.clientWidth) + 'px';
+        }
+
+        if (element.height || element.clientHeight) {
+            image.format.height = (element.height || element.clientHeight) + 'px';
+        }
 
         const paragraph = addSegment(group, image);
         context.domIndexer?.onSegment(element, paragraph, [image]);

--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/imageProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/imageProcessor.ts
@@ -41,11 +41,11 @@ export const imageProcessor: ElementProcessor<HTMLImageElement> = (group, elemen
         }
 
         if (element.width || element.clientWidth) {
-            image.format.width = (element.width || element.clientWidth) + 'px';
+            image.format.widthAttr = element.width || element.clientWidth;
         }
 
         if (element.height || element.clientHeight) {
-            image.format.height = (element.height || element.clientHeight) + 'px';
+            image.format.heightAttr = element.height || element.clientHeight;
         }
 
         const paragraph = addSegment(group, image);

--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/imageProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/imageProcessor.ts
@@ -40,6 +40,9 @@ export const imageProcessor: ElementProcessor<HTMLImageElement> = (group, elemen
             image.isSelected = true;
         }
 
+        image.format.width = (element.width || element.clientWidth) + 'px';
+        image.format.height = (element.height || element.clientHeight) + 'px';
+
         const paragraph = addSegment(group, image);
         context.domIndexer?.onSegment(element, paragraph, [image]);
     });

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
@@ -41,7 +41,6 @@ export const sizeFormatHandler: FormatHandler<SizeFormat> = {
         if (format.height) {
             element.style.height = format.height;
         }
-
         if (format.maxWidth) {
             element.style.maxWidth = format.maxWidth;
         }

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
@@ -15,8 +15,14 @@ export const sizeFormatHandler: FormatHandler<SizeFormat> = {
         const maxHeight = element.style.maxHeight;
         const minWidth = element.style.minWidth;
         const minHeight = element.style.minHeight;
-        const widthAttr = element.getAttribute('width') || element.clientWidth.toString();
-        const heightAttr = element.getAttribute('height') || element.clientHeight.toString();
+        const widthAttr = isElementOfType(element, 'img')
+            ? tryParseSize(element, 'width', false /* addPixels */) ||
+              tryParseSize(element, 'clientWidth', false /* addPixels */)
+            : undefined;
+        const heightAttr = isElementOfType(element, 'img')
+            ? tryParseSize(element, 'height', false /* addPixels */) ||
+              tryParseSize(element, 'clientHeight', false /* addPixels */)
+            : undefined;
 
         if (width) {
             format.width = width;
@@ -62,16 +68,22 @@ export const sizeFormatHandler: FormatHandler<SizeFormat> = {
         if (format.minHeight) {
             element.style.minHeight = format.minHeight;
         }
-        if (format.widthAttr && isElementOfType(element, 'img')) {
-            element.width = parseInt(format.widthAttr);
+        const widthAttr = format.widthAttr ? parseInt(format.widthAttr) : 0;
+        if (widthAttr > 0 && isElementOfType(element, 'img')) {
+            element.width = widthAttr;
         }
-        if (format.heightAttr && isElementOfType(element, 'img')) {
-            element.height = parseInt(format.heightAttr);
+        const heightAttr = format.heightAttr ? parseInt(format.heightAttr) : 0;
+        if (heightAttr > 0 && isElementOfType(element, 'img')) {
+            element.height = heightAttr;
         }
     },
 };
 
-function tryParseSize(element: HTMLElement, attrName: 'width' | 'height'): string | undefined {
+function tryParseSize(
+    element: HTMLElement,
+    attrName: 'width' | 'height' | 'clientWidth' | 'clientHeight',
+    addPixels: boolean = true
+): string | undefined {
     const attrValue = element.getAttribute(attrName);
     const value = parseInt(attrValue || '');
 
@@ -79,5 +91,5 @@ function tryParseSize(element: HTMLElement, attrName: 'width' | 'height'): strin
         ? attrValue
         : Number.isNaN(value) || value == 0
         ? undefined
-        : value + 'px';
+        : value + (addPixels ? 'px' : '');
 }

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
@@ -41,6 +41,7 @@ export const sizeFormatHandler: FormatHandler<SizeFormat> = {
         if (format.height) {
             element.style.height = format.height;
         }
+
         if (format.maxWidth) {
             element.style.maxWidth = format.maxWidth;
         }

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
@@ -14,6 +14,8 @@ export const sizeFormatHandler: FormatHandler<SizeFormat> = {
         const maxHeight = element.style.maxHeight;
         const minWidth = element.style.minWidth;
         const minHeight = element.style.minHeight;
+        const widthAttr = parseInt(element.getAttribute('width') || '') || element.clientWidth;
+        const heightAttr = parseInt(element.getAttribute('height') || '') || element.clientHeight;
 
         if (width) {
             format.width = width;
@@ -32,6 +34,14 @@ export const sizeFormatHandler: FormatHandler<SizeFormat> = {
         }
         if (minHeight) {
             format.minHeight = minHeight;
+        }
+
+        if (widthAttr) {
+            format.widthAttr = widthAttr;
+        }
+
+        if (heightAttr) {
+            format.heightAttr = heightAttr;
         }
     },
     apply: (format, element) => {

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/common/sizeFormatHandler.ts
@@ -1,3 +1,4 @@
+import { isElementOfType } from '../../domUtils/isElementOfType';
 import type { FormatHandler } from '../FormatHandler';
 import type { SizeFormat } from 'roosterjs-content-model-types';
 
@@ -14,8 +15,8 @@ export const sizeFormatHandler: FormatHandler<SizeFormat> = {
         const maxHeight = element.style.maxHeight;
         const minWidth = element.style.minWidth;
         const minHeight = element.style.minHeight;
-        const widthAttr = parseInt(element.getAttribute('width') || '') || element.clientWidth;
-        const heightAttr = parseInt(element.getAttribute('height') || '') || element.clientHeight;
+        const widthAttr = element.getAttribute('width') || element.clientWidth.toString();
+        const heightAttr = element.getAttribute('height') || element.clientHeight.toString();
 
         if (width) {
             format.width = width;
@@ -35,11 +36,9 @@ export const sizeFormatHandler: FormatHandler<SizeFormat> = {
         if (minHeight) {
             format.minHeight = minHeight;
         }
-
         if (widthAttr) {
             format.widthAttr = widthAttr;
         }
-
         if (heightAttr) {
             format.heightAttr = heightAttr;
         }
@@ -62,6 +61,12 @@ export const sizeFormatHandler: FormatHandler<SizeFormat> = {
         }
         if (format.minHeight) {
             element.style.minHeight = format.minHeight;
+        }
+        if (format.widthAttr && isElementOfType(element, 'img')) {
+            element.width = parseInt(format.widthAttr);
+        }
+        if (format.heightAttr && isElementOfType(element, 'img')) {
+            element.height = parseInt(format.heightAttr);
         }
     },
 };

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleImage.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleImage.ts
@@ -1,6 +1,5 @@
 import { applyFormat } from '../utils/applyFormat';
 import { handleSegmentCommon } from '../utils/handleSegmentCommon';
-import { parseValueWithUnit } from '../../formatHandlers/utils/parseValueWithUnit';
 import type { ContentModelImage, ContentModelSegmentHandler } from 'roosterjs-content-model-types';
 
 /**
@@ -33,15 +32,21 @@ export const handleImage: ContentModelSegmentHandler<ContentModelImage> = (
     applyFormat(img, context.formatAppliers.dataset, imageModel.dataset, context);
 
     const { width, height, widthAttr, heightAttr } = imageModel.format;
-    const widthNum = width ? parseValueWithUnit(width) : widthAttr || 0;
-    const heightNum = height ? parseValueWithUnit(height) : heightAttr || 0;
 
-    if (widthNum > 0) {
-        img.width = widthNum;
+    if (width) {
+        img.style.width = width;
     }
 
-    if (heightNum > 0) {
-        img.height = heightNum;
+    if (height) {
+        img.style.height = height;
+    }
+
+    if (widthAttr) {
+        img.width = parseInt(widthAttr);
+    }
+
+    if (heightAttr) {
+        img.height = parseInt(heightAttr);
     }
 
     if (imageModel.isSelectedAsImageSelection) {

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleImage.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleImage.ts
@@ -32,9 +32,9 @@ export const handleImage: ContentModelSegmentHandler<ContentModelImage> = (
     applyFormat(img, context.formatAppliers.image, imageModel.format, context);
     applyFormat(img, context.formatAppliers.dataset, imageModel.dataset, context);
 
-    const { width, height } = imageModel.format;
-    const widthNum = width ? parseValueWithUnit(width) : 0;
-    const heightNum = height ? parseValueWithUnit(height) : 0;
+    const { width, height, widthAttr, heightAttr } = imageModel.format;
+    const widthNum = width ? parseValueWithUnit(width) : widthAttr || 0;
+    const heightNum = height ? parseValueWithUnit(height) : heightAttr || 0;
 
     if (widthNum > 0) {
         img.width = widthNum;

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleImage.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleImage.ts
@@ -41,12 +41,14 @@ export const handleImage: ContentModelSegmentHandler<ContentModelImage> = (
         img.style.height = height;
     }
 
-    if (widthAttr) {
-        img.width = parseInt(widthAttr);
+    const widthNum = widthAttr ? parseInt(widthAttr) : 0;
+    if (widthNum > 0) {
+        img.width = widthNum;
     }
 
-    if (heightAttr) {
-        img.height = parseInt(heightAttr);
+    const heightNum = heightAttr ? parseInt(heightAttr) : 0;
+    if (heightNum > 0) {
+        img.height = heightNum;
     }
 
     if (imageModel.isSelectedAsImageSelection) {

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/imageProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/imageProcessorTest.ts
@@ -351,4 +351,37 @@ describe('imageProcessor', () => {
         });
         expect(onSegmentSpy).toHaveBeenCalledWith(img, paragraph, [segment]);
     });
+
+    it('Image with size', () => {
+        const doc = createContentModelDocument();
+        const img = document.createElement('img');
+        img.height = 50;
+        img.width = 100;
+
+        imageProcessor(doc, img, context);
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    isImplicit: true,
+                    segments: [
+                        {
+                            segmentType: 'Image',
+                            format: {
+                                widthAttr: '100',
+                                heightAttr: '50',
+                                width: '100px',
+                                height: '50px',
+                            },
+                            src: '',
+                            dataset: {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/common/sizeFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/common/sizeFormatHandlerTest.ts
@@ -1,6 +1,7 @@
 import { createDomToModelContext } from '../../../lib/domToModel/context/createDomToModelContext';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { DomToModelContext, ModelToDomContext, SizeFormat } from 'roosterjs-content-model-types';
+import { itChromeOnly, itFirefoxOnly } from '../../testUtils';
 import { sizeFormatHandler } from '../../../lib/formatHandlers/common/sizeFormatHandler';
 
 describe('sizeFormatHandler.parse', () => {
@@ -208,7 +209,7 @@ describe('sizeFormatHandler.apply', () => {
         );
     });
 
-    it('Image has both width and height attribute', () => {
+    itChromeOnly('Image has both width and height attribute', () => {
         format.width = '10px';
         format.height = '20px';
         format.widthAttr = '30';
@@ -216,6 +217,17 @@ describe('sizeFormatHandler.apply', () => {
         sizeFormatHandler.apply(format, img, context);
         expect(img.outerHTML).toBe(
             '<img width="30" height="40" style="width: 10px; height: 20px;">'
+        );
+    });
+
+    itFirefoxOnly('Image has both width and height attribute', () => {
+        format.width = '10px';
+        format.height = '20px';
+        format.widthAttr = '30';
+        format.heightAttr = '40';
+        sizeFormatHandler.apply(format, img, context);
+        expect(img.outerHTML).toBe(
+            '<img style="width: 10px; height: 20px;" width="30" height="40">'
         );
     });
 });

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/common/sizeFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/common/sizeFormatHandlerTest.ts
@@ -31,6 +31,17 @@ describe('sizeFormatHandler.parse', () => {
         expect(format).toEqual({ width: '10px', height: '20px' });
     });
 
+    it('Image with width and height in style', () => {
+        const element = document.createElement('img');
+
+        element.style.width = '10px';
+        element.style.height = '20px';
+
+        sizeFormatHandler.parse(format, element, context, {});
+
+        expect(format).toEqual({ width: '10px', height: '20px' });
+    });
+
     it('Element with width and height in attribute', () => {
         const element = document.createElement('div');
 
@@ -39,7 +50,26 @@ describe('sizeFormatHandler.parse', () => {
 
         sizeFormatHandler.parse(format, element, context, {});
 
-        expect(format).toEqual({ width: '10px', height: '20px' });
+        expect(format).toEqual({
+            width: '10px',
+            height: '20px',
+        });
+    });
+
+    it('Image with width and height in attribute', () => {
+        const element = document.createElement('img');
+
+        element.setAttribute('width', '10');
+        element.setAttribute('height', '20');
+
+        sizeFormatHandler.parse(format, element, context, {});
+
+        expect(format).toEqual({
+            width: '10px',
+            height: '20px',
+            widthAttr: '10',
+            heightAttr: '20',
+        });
     });
 
     it('Element with width and height in both style and attribute', () => {
@@ -53,11 +83,44 @@ describe('sizeFormatHandler.parse', () => {
 
         sizeFormatHandler.parse(format, element, context, {});
 
-        expect(format).toEqual({ width: '10px', height: '20px' });
+        expect(format).toEqual({
+            width: '10px',
+            height: '20px',
+        });
+    });
+
+    it('Image with width and height in both style and attribute', () => {
+        const element = document.createElement('img');
+
+        element.style.width = '10px';
+        element.style.height = '20px';
+
+        element.setAttribute('width', '30');
+        element.setAttribute('height', '40');
+
+        sizeFormatHandler.parse(format, element, context, {});
+
+        expect(format).toEqual({
+            width: '10px',
+            height: '20px',
+            widthAttr: '30',
+            heightAttr: '40',
+        });
     });
 
     it('Element with width and height attributes equal to 0', () => {
         const element = document.createElement('div');
+
+        element.setAttribute('width', '0');
+        element.setAttribute('height', '0');
+
+        sizeFormatHandler.parse(format, element, context, {});
+
+        expect(format).toEqual({});
+    });
+
+    it('image with width and height attributes equal to 0', () => {
+        const element = document.createElement('img');
 
         element.setAttribute('width', '0');
         element.setAttribute('height', '0');
@@ -99,11 +162,13 @@ describe('sizeFormatHandler.parse', () => {
 
 describe('sizeFormatHandler.apply', () => {
     let div: HTMLElement;
+    let img: HTMLImageElement;
     let format: SizeFormat;
     let context: ModelToDomContext;
 
     beforeEach(() => {
         div = document.createElement('div');
+        img = document.createElement('img');
         format = {};
         context = createModelToDomContext();
     });
@@ -140,6 +205,17 @@ describe('sizeFormatHandler.apply', () => {
         sizeFormatHandler.apply(format, div, context);
         expect(div.outerHTML).toBe(
             '<div style="max-width: 20px; max-height: 40px; min-width: 10px; min-height: 30px;"></div>'
+        );
+    });
+
+    it('Image has both width and height attribute', () => {
+        format.width = '10px';
+        format.height = '20px';
+        format.widthAttr = '30';
+        format.heightAttr = '40';
+        sizeFormatHandler.apply(format, img, context);
+        expect(img.outerHTML).toBe(
+            '<img width="30" height="40" style="width: 10px; height: 20px;">'
         );
     });
 });

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleImageTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleImageTest.ts
@@ -100,8 +100,46 @@ describe('handleSegment', () => {
         runTest(
             segment,
             [
-                '<span><a href="/test"><img src="http://test.com/test" width="100" height="200" style="width: 100px; height: 200px;"></a></span>',
-                '<span><a href="/test"><img src="http://test.com/test" style="width: 100px; height: 200px;" width="100" height="200"></a></span>',
+                '<span><a href="/test"><img src="http://test.com/test" style="width: 100px; height: 200px;"></a></span>',
+                '<span><a href="/test"><img src="http://test.com/test" style="width: 100px; height: 200px;"></a></span>',
+            ],
+            0
+        );
+    });
+
+    it('image segment with size attributes', () => {
+        const segment: ContentModelImage = {
+            segmentType: 'Image',
+            src: 'http://test.com/test',
+            format: { width: '100px', height: '200px', widthAttr: '50', heightAttr: '150' },
+            link: { format: { href: '/test', underline: true }, dataset: {} },
+            dataset: {},
+        };
+
+        runTest(
+            segment,
+            [
+                '<span><a href="/test"><img src="http://test.com/test" width="50" height="150" style="width: 100px; height: 200px;"></a></span>',
+                '<span><a href="/test"><img src="http://test.com/test" style="width: 100px; height: 200px;" width="50" height="150 ></a></span>',
+            ],
+            0
+        );
+    });
+
+    it('image segment with size attributes only', () => {
+        const segment: ContentModelImage = {
+            segmentType: 'Image',
+            src: 'http://test.com/test',
+            format: { widthAttr: '50', heightAttr: '150' },
+            link: { format: { href: '/test', underline: true }, dataset: {} },
+            dataset: {},
+        };
+
+        runTest(
+            segment,
+            [
+                '<span><a href="/test"><img src="http://test.com/test" width="50" height="150"></a></span>',
+                '<span><a href="/test"><img src="http://test.com/test" width="50" height="150 ></a></span>',
             ],
             0
         );

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleImageTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleImageTest.ts
@@ -120,7 +120,7 @@ describe('handleSegment', () => {
             segment,
             [
                 '<span><a href="/test"><img src="http://test.com/test" width="50" height="150" style="width: 100px; height: 200px;"></a></span>',
-                '<span><a href="/test"><img src="http://test.com/test" style="width: 100px; height: 200px;" width="50" height="150 ></a></span>',
+                '<span><a href="/test"><img src="http://test.com/test" style="width: 100px; height: 200px;" width="50" height="150"></a></span>',
             ],
             0
         );

--- a/packages/roosterjs-content-model-dom/test/testUtils.ts
+++ b/packages/roosterjs-content-model-dom/test/testUtils.ts
@@ -29,3 +29,12 @@ export function itChromeOnly(
     const func = __karma__.config.browser == 'Chrome' ? it : xit;
     return func(expectation, assertion, timeout);
 }
+
+export function itFirefoxOnly(
+    expectation: string,
+    assertion?: jasmine.ImplementationCallback,
+    timeout?: number
+) {
+    const func = __karma__.config.browser == 'Firefox' ? it : xit;
+    return func(expectation, assertion, timeout);
+}

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/applyChange.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/applyChange.ts
@@ -83,5 +83,7 @@ export function applyChange(
     if (wasResizedOrCropped || state == 'FullyChanged') {
         contentModelImage.format.width = generatedImageSize.targetWidth + 'px';
         contentModelImage.format.height = generatedImageSize.targetHeight + 'px';
+        contentModelImage.format.widthAttr = undefined;
+        contentModelImage.format.heightAttr = undefined;
     }
 }

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/formatParts/SizeFormat.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/formatParts/SizeFormat.ts
@@ -13,6 +13,16 @@ export type SizeFormat = {
     height?: string;
 
     /**
+     * Width attribute of the element
+     */
+    widthAttr?: number;
+
+    /**
+     * Heigh attribute of the element
+     */
+    heightAttr?: number;
+
+    /**
      * Maximum width of the element
      */
     maxWidth?: string;

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/formatParts/SizeFormat.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/formatParts/SizeFormat.ts
@@ -18,7 +18,7 @@ export type SizeFormat = {
     widthAttr?: string;
 
     /**
-     * Heigh attribute of the element
+     * Height attribute of the element
      */
     heightAttr?: string;
 

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/formatParts/SizeFormat.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/formatParts/SizeFormat.ts
@@ -15,12 +15,12 @@ export type SizeFormat = {
     /**
      * Width attribute of the element
      */
-    widthAttr?: number;
+    widthAttr?: string;
 
     /**
      * Heigh attribute of the element
      */
-    heightAttr?: number;
+    heightAttr?: string;
 
     /**
      * Maximum width of the element


### PR DESCRIPTION
To ensure the integrity of content, it's important to include both the widthAttr and heightAttr. This is to accurately maintain the values of the height and width attributes, which may differ from the width and height style properties. Previously, the content model format's width property was used to store values for both width and height from attributes and style properties, with a preference for the style property. However, in cases where the width or height style is set to auto, the image handler fails to interpret the width or height attribute correctly. To prevent this and to keep the attribute values intact without overriding the style properties, these values should be stored in separate properties within the size format.