### PR TITLE
Fix findEditingImage

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/findEditingImage.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/findEditingImage.ts
@@ -29,8 +29,8 @@ export function findEditingImage(
                     switch (segment.segmentType) {
                         case 'Image':
                             if (
-                                (segment.dataset.isEditing && !imageId) ||
-                                segment.format.id == imageId
+                                (imageId && segment.format.id == imageId) ||
+                                segment.dataset.isEditing
                             ) {
                                 return {
                                     paragraph: block,

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/utils/findEditingImageTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/utils/findEditingImageTest.ts
@@ -449,4 +449,281 @@ describe('findEditingImage', () => {
             },
         });
     });
+
+    it('editing image - no id - no editing image | by Id', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Image',
+                            src: 'test',
+                            format: {
+                                fontFamily: 'Calibri',
+                                fontSize: '11pt',
+                                textColor: 'rgb(0, 0, 0)',
+                                maxWidth: '1800px',
+                            },
+                            dataset: {},
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+            ],
+            format: {
+                fontFamily: 'Calibri',
+                fontSize: '11pt',
+                textColor: '#000000',
+            },
+        };
+
+        const image = findEditingImage(model);
+        expect(image).toEqual(null);
+    });
+
+    it('editing image - no id - editing image', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Image',
+                            src: 'test',
+                            format: {
+                                fontFamily: 'Calibri',
+                                fontSize: '11pt',
+                                textColor: 'rgb(0, 0, 0)',
+                                maxWidth: '1800px',
+                            },
+                            dataset: {},
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'second line',
+                            format: {
+                                fontFamily: 'Calibri',
+                                fontSize: '11pt',
+                                textColor: 'rgb(0, 0, 0)',
+                            },
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Image',
+                            src: 'second-Image',
+                            format: {
+                                fontFamily: 'Calibri',
+                                fontSize: '11pt',
+                                textColor: 'rgb(0, 0, 0)',
+                                maxWidth: '1800px',
+                            },
+                            dataset: {
+                                isEditing: 'true',
+                            },
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+            ],
+            format: {
+                fontFamily: 'Calibri',
+                fontSize: '11pt',
+                textColor: '#000000',
+            },
+        };
+
+        const image = findEditingImage(model);
+        expect(image).toEqual({
+            image: {
+                segmentType: 'Image',
+                src: 'second-Image',
+                format: {
+                    fontFamily: 'Calibri',
+                    fontSize: '11pt',
+                    textColor: 'rgb(0, 0, 0)',
+                    maxWidth: '1800px',
+                },
+                dataset: {
+                    isEditing: 'true',
+                },
+            },
+            paragraph: {
+                blockType: 'Paragraph',
+                segments: [
+                    {
+                        segmentType: 'Image',
+                        src: 'second-Image',
+                        format: {
+                            fontFamily: 'Calibri',
+                            fontSize: '11pt',
+                            textColor: 'rgb(0, 0, 0)',
+                            maxWidth: '1800px',
+                        },
+                        dataset: {
+                            isEditing: 'true',
+                        },
+                    },
+                ],
+                format: {},
+                segmentFormat: {
+                    fontFamily: 'Calibri',
+                    fontSize: '11pt',
+                    textColor: 'rgb(0, 0, 0)',
+                },
+            },
+        });
+    });
+
+    it('editing image - with id - editing image', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Image',
+                            src: 'test',
+                            format: {
+                                fontFamily: 'Calibri',
+                                fontSize: '11pt',
+                                textColor: 'rgb(0, 0, 0)',
+                                maxWidth: '1800px',
+                                id: 'testId',
+                            },
+                            dataset: {},
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'second line',
+                            format: {
+                                fontFamily: 'Calibri',
+                                fontSize: '11pt',
+                                textColor: 'rgb(0, 0, 0)',
+                            },
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Image',
+                            src: 'second-Image',
+                            format: {
+                                fontFamily: 'Calibri',
+                                fontSize: '11pt',
+                                textColor: 'rgb(0, 0, 0)',
+                                maxWidth: '1800px',
+                            },
+                            dataset: {
+                                isEditing: 'true',
+                            },
+                        },
+                    ],
+                    format: {},
+                    segmentFormat: {
+                        fontFamily: 'Calibri',
+                        fontSize: '11pt',
+                        textColor: 'rgb(0, 0, 0)',
+                    },
+                },
+            ],
+            format: {
+                fontFamily: 'Calibri',
+                fontSize: '11pt',
+                textColor: '#000000',
+            },
+        };
+
+        const image = findEditingImage(model, 'testId');
+        expect(image).toEqual({
+            image: {
+                segmentType: 'Image',
+                src: 'test',
+                format: {
+                    fontFamily: 'Calibri',
+                    fontSize: '11pt',
+                    textColor: 'rgb(0, 0, 0)',
+                    maxWidth: '1800px',
+                    id: 'testId',
+                },
+                dataset: {},
+            },
+            paragraph: {
+                blockType: 'Paragraph',
+                segments: [
+                    {
+                        segmentType: 'Image',
+                        src: 'test',
+                        format: {
+                            fontFamily: 'Calibri',
+                            fontSize: '11pt',
+                            textColor: 'rgb(0, 0, 0)',
+                            maxWidth: '1800px',
+                            id: 'testId',
+                        },
+                        dataset: {},
+                    },
+                ],
+                format: {},
+                segmentFormat: {
+                    fontFamily: 'Calibri',
+                    fontSize: '11pt',
+                    textColor: 'rgb(0, 0, 0)',
+                },
+            },
+        });
+    });
 });


### PR DESCRIPTION
When image does not have id and the imageId parameter does not exist the `findEditingImage` was return the image as editing image, what is not correct. To avoid that issue, only compare the imageId and the image id, if imageId parameter exists. 

**To repro the bug**: 
1. Paste  two images
2. Click at the second one
3. Press a key
4. The first image will be replaced by the second. 

**Before:** 

![imageIdBug](https://github.com/user-attachments/assets/b0092516-7278-4ed7-9363-a5b85321e904)


**After:** 

![imageIdBugFix](https://github.com/user-attachments/assets/4f61e4fd-41b8-40d8-855b-32b75c941947)
