### PR TITLE
Use a different change source for keyboard formatting event

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardEnter.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardEnter.ts
@@ -1,7 +1,12 @@
 import { deleteEmptyQuote } from './deleteSteps/deleteEmptyQuote';
-import { deleteSelection, normalizeContentModel, runEditSteps } from 'roosterjs-content-model-dom';
 import { handleEnterOnList } from './inputSteps/handleEnterOnList';
 import { handleEnterOnParagraph } from './inputSteps/handleEnterOnParagraph';
+import {
+    ChangeSource,
+    deleteSelection,
+    normalizeContentModel,
+    runEditSteps,
+} from 'roosterjs-content-model-dom';
 import type { IEditor } from 'roosterjs-content-model-types';
 
 /**
@@ -49,6 +54,7 @@ export function keyboardEnter(
         {
             rawEvent,
             scrollCaretIntoView: true,
+            changeSource: ChangeSource.Keyboard,
         }
     );
 }

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -1,4 +1,9 @@
-import { deleteSelection, isModifierKey, normalizeContentModel } from 'roosterjs-content-model-dom';
+import {
+    ChangeSource,
+    deleteSelection,
+    isModifierKey,
+    normalizeContentModel,
+} from 'roosterjs-content-model-dom';
 import type { DOMSelection, IEditor } from 'roosterjs-content-model-types';
 
 /**
@@ -32,6 +37,7 @@ export function keyboardInput(editor: IEditor, rawEvent: KeyboardEvent) {
             {
                 scrollCaretIntoView: true,
                 rawEvent,
+                changeSource: ChangeSource.Keyboard,
             }
         );
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardTab.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardTab.ts
@@ -1,9 +1,13 @@
-import { getOperationalBlocks, isBlockGroupOfType } from 'roosterjs-content-model-dom';
 import { handleTabOnList } from './tabUtils/handleTabOnList';
 import { handleTabOnParagraph } from './tabUtils/handleTabOnParagraph';
 import { handleTabOnTable } from './tabUtils/handleTabOnTable';
 import { handleTabOnTableCell } from './tabUtils/handleTabOnTableCell';
 import { setModelIndentation } from 'roosterjs-content-model-api';
+import {
+    ChangeSource,
+    getOperationalBlocks,
+    isBlockGroupOfType,
+} from 'roosterjs-content-model-dom';
 import type {
     ContentModelListItem,
     ContentModelTableCell,
@@ -37,6 +41,7 @@ export function keyboardTab(editor: IEditor, rawEvent: KeyboardEvent) {
                 },
                 {
                     apiName: 'handleTabKey',
+                    changeSource: ChangeSource.Keyboard,
                 }
             );
             return true;


### PR DESCRIPTION
For `formatContentModel` triggered from keyboard event (ENTER, TAB, DELETE, ...), we should use a different change source than the default `ChangeSource.Format`. We already have such a change source `Keyboard` so we should use it.
Then from plugins we can know if the ContentChanged event is from keyboard editing.