### PR TITLE
Let DOM Helper return a cloned root

### DIFF
--- a/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
@@ -81,6 +81,13 @@ class DOMHelperImpl implements DOMHelper {
         const paddingRight = parseValueWithUnit(style?.paddingRight);
         return this.contentDiv.clientWidth - (paddingLeft + paddingRight);
     }
+
+    /**
+     * Get a deep cloned root element
+     */
+    getClonedRoot(): HTMLElement {
+        return this.contentDiv.cloneNode(true /*deep*/) as HTMLElement;
+    }
 }
 
 /**

--- a/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
@@ -350,4 +350,20 @@ describe('DOMHelperImpl', () => {
             expect(domHelper.getClientWidth()).toBe(1000);
         });
     });
+
+    describe('getClonedRoot', () => {
+        it('getClonedRoot', () => {
+            const mockedClone = 'CLONE' as any;
+            const cloneSpy = jasmine.createSpy('cloneSpy').and.returnValue(mockedClone);
+            const mockedDiv: HTMLElement = {
+                cloneNode: cloneSpy,
+            } as any;
+            const domHelper = createDOMHelper(mockedDiv);
+
+            const result = domHelper.getClonedRoot();
+
+            expect(result).toBe(mockedClone);
+            expect(cloneSpy).toHaveBeenCalledWith(true);
+        });
+    });
 });

--- a/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
@@ -92,4 +92,9 @@ export interface DOMHelper {
      * Get the width of the editable area of the editor content div
      */
     getClientWidth(): number;
+
+    /**
+     * Get a deep cloned root element
+     */
+    getClonedRoot(): HTMLElement;
 }


### PR DESCRIPTION
Add a new function `getClonedRoot` to `DOMHelper`, so we can use it to get a cloned copy of root element of editor.

This can be used to create a customized exportContent API, for example:

```ts
export function exportContent2(editor: IEditor): string {
    const clonedRoot = editor.getDOMHelper().getClonedRoot();

    if (editor.isDarkMode()) {
        transformColor(clonedRoot, false /*includeSelf*/, 'darkToLight', editor.getColorManager());
    }

    editor.triggerEvent(
        'extractContentWithDom',
        {
            clonedRoot,
        },
        true /*broadcast*/
    );

    return clonedRoot.innerHTML;
}
```