### PR TITLE
Fix #2807 Handle selection in BR

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/brProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/brProcessor.ts
@@ -1,5 +1,6 @@
 import { addSegment } from '../../modelApi/common/addSegment';
 import { createBr } from '../../modelApi/creators/createBr';
+import { getRegularSelectionOffsets } from '../utils/getRegularSelectionOffsets';
 import type { ElementProcessor } from 'roosterjs-content-model-types';
 
 /**
@@ -7,11 +8,21 @@ import type { ElementProcessor } from 'roosterjs-content-model-types';
  */
 export const brProcessor: ElementProcessor<HTMLBRElement> = (group, element, context) => {
     const br = createBr(context.segmentFormat);
+    const [start, end] = getRegularSelectionOffsets(context, element);
+
+    if (start >= 0) {
+        context.isInSelection = true;
+    }
 
     if (context.isInSelection) {
         br.isSelected = true;
     }
 
     const paragraph = addSegment(group, br, context.blockFormat);
+
+    if (end >= 0) {
+        context.isInSelection = false;
+    }
+
     context.domIndexer?.onSegment(element, paragraph, [br]);
 };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/brProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/brProcessorTest.ts
@@ -100,4 +100,74 @@ describe('brProcessor', () => {
         });
         expect(onSegmentSpy).toHaveBeenCalledWith(br, paragraphModel, [brModel]);
     });
+
+    it('Selection starts in BR', () => {
+        const doc = createContentModelDocument();
+        const div = document.createElement('div');
+        const br = document.createElement('br');
+        const range = document.createRange();
+
+        div.appendChild(br);
+        range.setStart(br, 0);
+        range.setEnd(div, 1);
+        context.selection = {
+            type: 'range',
+            range: range,
+            isReverted: false,
+        };
+
+        brProcessor(doc, br, context);
+
+        const brModel: ContentModelBr = {
+            segmentType: 'Br',
+            format: {},
+            isSelected: true,
+        };
+        const paragraphModel: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            isImplicit: true,
+            segments: [brModel],
+            format: {},
+        };
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [paragraphModel],
+        });
+        expect(context.isInSelection).toBeTrue();
+    });
+
+    it('Selection ends in BR', () => {
+        const doc = createContentModelDocument();
+        const br = document.createElement('br');
+        const range = document.createRange();
+
+        range.setEnd(br, 0);
+        context.selection = {
+            type: 'range',
+            range: range,
+            isReverted: false,
+        };
+        context.isInSelection = true;
+
+        brProcessor(doc, br, context);
+
+        const brModel: ContentModelBr = {
+            segmentType: 'Br',
+            format: {},
+            isSelected: true,
+        };
+        const paragraphModel: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            isImplicit: true,
+            segments: [brModel],
+            format: {},
+        };
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [paragraphModel],
+        });
+        expect(context.isInSelection).toBeFalse();
+    });
 });


### PR DESCRIPTION
It is possible to set selection into BR element, so we also need to handle the selection in a BR.

BR should not have child nodes, so we don't need to care its offset, just always treat the BR element as selected when it has selection.