### PR TITLE
Fix mergeTable when pasting

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/mergeModel.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/mergeModel.ts
@@ -50,20 +50,22 @@ export function mergeModel(
     const insertPosition =
         options?.insertPosition ?? deleteSelection(target, [], context).insertPoint;
 
-    if (options?.addParagraphAfterMergedContent) {
+    const { addParagraphAfterMergedContent, mergeFormat, mergeTable } = options || {};
+
+    if (addParagraphAfterMergedContent && !mergeTable) {
         const { paragraph, marker } = insertPosition || {};
         const newPara = createParagraph(false /* isImplicit */, paragraph?.format, marker?.format);
         addBlock(source, newPara);
     }
 
     if (insertPosition) {
-        if (options?.mergeFormat && options.mergeFormat != 'none') {
+        if (mergeFormat && mergeFormat != 'none') {
             const newFormat: ContentModelSegmentFormat = {
                 ...(target.format || {}),
                 ...insertPosition.marker.format,
             };
 
-            applyDefaultFormat(source, newFormat, options?.mergeFormat);
+            applyDefaultFormat(source, newFormat, mergeFormat);
         }
 
         for (let i = 0; i < source.blocks.length; i++) {
@@ -84,8 +86,8 @@ export function mergeModel(
                     break;
 
                 case 'Table':
-                    if (source.blocks.length == 1 && options?.mergeTable) {
-                        mergeTable(insertPosition, block, source);
+                    if (source.blocks.length == 1 && mergeTable) {
+                        mergeTables(insertPosition, block, source);
                     } else {
                         insertBlock(insertPosition, block);
                     }
@@ -176,7 +178,7 @@ function mergeParagraph(
     }
 }
 
-function mergeTable(
+function mergeTables(
     markerPosition: InsertPoint,
     newTable: ContentModelTable,
     source: ContentModelDocument


### PR DESCRIPTION
In https://github.com/microsoft/roosterjs/pull/2777 I implemented a way to always add a paragraph after the pasted content. This caused that if the option to mergeTable is also true. The if check to make sure that the source model only contains a single table to be false in there lines:

https://github.com/microsoft/roosterjs/blob/e3bc1f346de6d37dd801b4a57475d37d40c1a798/packages/roosterjs-content-model-dom/lib/modelApi/editing/mergeModel.ts#L87C21-L91C22

So instead of merging the tables, we would paste the table inside the table cell.

To fix, if the option addParagraphAfterMergedContent is true but the mergeTable option is also true. Do not add the extra paragraph. So the mergeTable code is executed correctly.