### PR TITLE
Use a separate experimental feature for Enter key

### DIFF
--- a/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -58,7 +58,7 @@ const initialState: OptionState = {
         handleTabKey: true,
     },
     customReplacements: emojiReplacements,
-    experimentalFeatures: new Set<ExperimentalFeature>(['PersistCache']),
+    experimentalFeatures: new Set<ExperimentalFeature>(['PersistCache', 'HandleEnterKey']),
 };
 
 export class EditorOptionsPlugin extends SidePanePluginImpl<OptionsPane, OptionPaneProps> {

--- a/demo/scripts/controlsV2/sidePane/editorOptions/ExperimentalFeatures.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/ExperimentalFeatures.tsx
@@ -9,7 +9,13 @@ export interface DefaultFormatProps {
 
 export class ExperimentalFeatures extends React.Component<DefaultFormatProps, {}> {
     render() {
-        return this.renderFeature('PersistCache');
+        return (
+            <>
+                {this.renderFeature('PersistCache')}
+                {this.renderFeature('HandleEnterKey')}
+                {this.renderFeature('LegacyImageSelection')}
+            </>
+        );
     }
 
     private renderFeature(featureName: ExperimentalFeature): JSX.Element {

--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -63,7 +63,7 @@ export class EditPlugin implements EditorPlugin {
      */
     initialize(editor: IEditor) {
         this.editor = editor;
-        this.handleNormalEnter = this.editor.isExperimentalFeatureEnabled('PersistCache');
+        this.handleNormalEnter = this.editor.isExperimentalFeatureEnabled('HandleEnterKey');
 
         if (editor.getEnvironment().isAndroid) {
             this.disposer = this.editor.attachDomEvent({

--- a/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
@@ -162,7 +162,7 @@ describe('EditPlugin', () => {
 
         it('Enter, normal enter enabled', () => {
             isExperimentalFeatureEnabledSpy.and.callFake(
-                (featureName: string) => featureName == 'PersistCache'
+                (featureName: string) => featureName == 'HandleEnterKey'
             );
             plugin = new EditPlugin();
             const rawEvent = { which: 13, key: 'Enter' } as any;

--- a/packages/roosterjs-content-model-types/lib/editor/ExperimentalFeature.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/ExperimentalFeature.ts
@@ -12,4 +12,8 @@ export type ExperimentalFeature =
     /**
      * Workaround for the Legacy Image Edit
      */
-    | 'LegacyImageSelection';
+    | 'LegacyImageSelection'
+    /**
+     * Use Content Model handle ENTER key
+     */
+    | 'HandleEnterKey';


### PR DESCRIPTION
Previously I'm using the same experimental feature "PersistCache" for new cache and ENTER key for content model.

In this change I split them into two separate features so we can enable them separately.