### PR TITLE
Make the imageEditInfo protected

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -66,7 +66,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
     private shadowSpan: HTMLSpanElement | null = null;
     private selectedImage: HTMLImageElement | null = null;
     protected wrapper: HTMLSpanElement | null = null;
-    private imageEditInfo: ImageMetadataFormat | null = null;
+    protected imageEditInfo: ImageMetadataFormat | null = null;
     private imageHTMLOptions: ImageHtmlOptions | null = null;
     private dndHelpers: DragAndDropHelper<DragAndDropContext, any>[] = [];
     private clonedImage: HTMLImageElement | null = null;


### PR DESCRIPTION
Make the image edit info protected in the `ImageEditPlugin` class, so the if class is extended, the `imageEditInfo` property can be accessed by the subclass and changed. 