### PR TITLE
Add a ID to the TempDiv, to be able to identify on blur was caused for copy/cut

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/copyPaste/CopyPastePlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/copyPaste/CopyPastePlugin.ts
@@ -33,6 +33,8 @@ import type {
     ReadonlyTableSelectionContext,
 } from 'roosterjs-content-model-types';
 
+const TEMP_DIV_ID = 'roosterJS_copyCutTempDiv';
+
 /**
  * Copy and paste plugin for handling onCopy and onPaste event
  */
@@ -235,6 +237,7 @@ class CopyPastePlugin implements PluginWithState<CopyPastePluginState> {
         div.childNodes.forEach(node => div.removeChild(node));
 
         div.style.display = '';
+        div.id = TEMP_DIV_ID;
         div.focus();
 
         return div;


### PR DESCRIPTION
This PR adds an ID to the TempDiv, so when we handle copy/cut consumers of RoosterJS can verify if the focus is being removed from the editor or if the focus is moving the the tempDiv as part of the copy/cut operation.