### PR TITLE
Fix image selection in range expanded selection 

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -258,7 +258,10 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         }
     }
 
-    private applyFormatWithContentModel(
+    /**
+     * EXPOSED FOR TESTING PURPOSE ONLY
+     */
+    protected applyFormatWithContentModel(
         editor: IEditor,
         isCropMode: boolean,
         shouldSelectImage: boolean,
@@ -266,6 +269,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
     ) {
         let editingImageModel: ContentModelImage | undefined;
         const selection = editor.getDOMSelection();
+
         editor.formatContentModel(
             model => {
                 const editingImage = getSelectedImage(model);
@@ -273,6 +277,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                     ? editingImage
                     : findEditingImage(model);
                 let result = false;
+
                 if (
                     shouldSelectImage ||
                     previousSelectedImage?.image != editingImage?.image ||
@@ -328,6 +333,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
 
                     this.isEditing = false;
                     this.isCropMode = false;
+
                     if (
                         editingImage &&
                         selection?.type == 'image' &&

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -14,7 +14,6 @@ import { Resizer } from './Resizer/resizerContext';
 import { Rotator } from './Rotator/rotatorContext';
 import { updateRotateHandle } from './Rotator/updateRotateHandle';
 import { updateWrapper } from './utils/updateWrapper';
-
 import {
     ChangeSource,
     getSafeIdSelector,
@@ -30,7 +29,6 @@ import type { ImageHtmlOptions } from './types/ImageHtmlOptions';
 import type { ImageEditOptions } from './types/ImageEditOptions';
 import type {
     ContentModelImage,
-    DOMInsertPoint,
     EditorPlugin,
     IEditor,
     ImageEditOperation,
@@ -192,23 +190,19 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
     }
 
     private mouseDownHandler(editor: IEditor, event: MouseDownEvent) {
-        if (this.isEditing && event.rawEvent.button !== MouseRightButton) {
-            const target = event.rawEvent.target as Node;
-            const isClickOnImage = this.shadowSpan === target;
-            let insertPoint: DOMInsertPoint | undefined = undefined;
-            if (
-                target.contains(this.shadowSpan) &&
-                !isClickOnImage &&
-                isNodeOfType(target, 'ELEMENT_NODE')
-            ) {
-                console.log('isClickOnImage', target.offsetLeft);
-            }
+        const target = event.rawEvent.relatedTarget as Node;
+        const isClickOnImage = this.shadowSpan === target;
+        if (
+            this.isEditing &&
+            event.rawEvent.button !== MouseRightButton &&
+            target?.contains(this.shadowSpan) &&
+            !isClickOnImage
+        ) {
             this.applyFormatWithContentModel(
                 editor,
                 this.isCropMode,
                 isClickOnImage,
-                false /* isApiOperation */,
-                insertPoint
+                false /* isApiOperation */
             );
         }
     }
@@ -260,8 +254,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         editor: IEditor,
         isCropMode: boolean,
         shouldSelectImage: boolean,
-        isApiOperation?: boolean,
-        newInsertPoint?: DOMInsertPoint
+        isApiOperation?: boolean
     ) {
         let editingImageModel: ContentModelImage | undefined;
         const selection = editor.getDOMSelection();

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -191,19 +191,15 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
     }
 
     private mouseDownHandler(editor: IEditor, event: MouseDownEvent) {
-        const target = event.rawEvent.target as Node;
-        const isClickOnImage = this.shadowSpan === target;
         if (
             this.isEditing &&
-            event.rawEvent.button !== MouseRightButton &&
-            !target?.contains(this.shadowSpan) &&
-            !isClickOnImage
+            this.isImageSelection(event.rawEvent.target as Node) &&
+            event.rawEvent.button !== MouseRightButton
         ) {
             this.applyFormatWithContentModel(
                 editor,
                 this.isCropMode,
-                isClickOnImage,
-                false /* isApiOperation */
+                this.shadowSpan === event.rawEvent.target
             );
         }
     }

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -195,7 +195,10 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         if (
             this.isEditing &&
             event.rawEvent.button !== MouseRightButton &&
-            !(target.contains(this.shadowSpan) || target.contains(this.wrapper))
+            !(
+                this.shadowSpan !== event.rawEvent.target &&
+                (target.contains(this.shadowSpan) || target.contains(this.wrapper))
+            )
         ) {
             this.applyFormatWithContentModel(
                 editor,

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -17,6 +17,7 @@ import { updateWrapper } from './utils/updateWrapper';
 import {
     ChangeSource,
     getSafeIdSelector,
+    getSelectedParagraphs,
     isElementOfType,
     isNodeOfType,
     mutateBlock,
@@ -190,12 +191,12 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
     }
 
     private mouseDownHandler(editor: IEditor, event: MouseDownEvent) {
-        const target = event.rawEvent.relatedTarget as Node;
+        const target = event.rawEvent.target as Node;
         const isClickOnImage = this.shadowSpan === target;
         if (
             this.isEditing &&
             event.rawEvent.button !== MouseRightButton &&
-            target?.contains(this.shadowSpan) &&
+            !target?.contains(this.shadowSpan) &&
             !isClickOnImage
         ) {
             this.applyFormatWithContentModel(
@@ -297,6 +298,16 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                                 image.isSelected = shouldSelectImage;
                                 image.isSelectedAsImageSelection = shouldSelectImage;
                                 delete image.dataset.isEditing;
+
+                                if (selection?.type == 'range' && !selection.range.collapsed) {
+                                    const selectedParagraphs = getSelectedParagraphs(model, true);
+                                    const isImageInRange = selectedParagraphs.some(paragraph =>
+                                        paragraph.segments.includes(image)
+                                    );
+                                    if (isImageInRange) {
+                                        image.isSelected = true;
+                                    }
+                                }
                             }
                         );
 

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -191,10 +191,11 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
     }
 
     private mouseDownHandler(editor: IEditor, event: MouseDownEvent) {
+        const target = event.rawEvent.target as Node;
         if (
             this.isEditing &&
-            this.isImageSelection(event.rawEvent.target as Node) &&
-            event.rawEvent.button !== MouseRightButton
+            event.rawEvent.button !== MouseRightButton &&
+            !(target.contains(this.shadowSpan) || target.contains(this.wrapper))
         ) {
             this.applyFormatWithContentModel(
                 editor,

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -475,7 +475,7 @@ describe('ImageEditPlugin', () => {
             } as any,
         });
         expect(formatContentModelSpy).toHaveBeenCalled();
-        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
         plugin.dispose();
     });
 

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -1,7 +1,6 @@
 import * as findImage from '../../lib/imageEdit/utils/findEditingImage';
 import * as getSelectedImage from '../../lib/imageEdit/utils/getSelectedImage';
 import { ChangeSource, createImage, createParagraph } from 'roosterjs-content-model-dom';
-import { contains } from 'roosterjs-editor-dom';
 import { getSelectedImageMetadata } from '../../lib/imageEdit/utils/updateImageEditInfo';
 import { ImageEditPlugin } from '../../lib/imageEdit/ImageEditPlugin';
 import { initEditor } from '../TestHelper';

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -1,6 +1,7 @@
 import * as findImage from '../../lib/imageEdit/utils/findEditingImage';
 import * as getSelectedImage from '../../lib/imageEdit/utils/getSelectedImage';
 import { ChangeSource, createImage, createParagraph } from 'roosterjs-content-model-dom';
+import { contains } from 'roosterjs-editor-dom';
 import { getSelectedImageMetadata } from '../../lib/imageEdit/utils/updateImageEditInfo';
 import { ImageEditPlugin } from '../../lib/imageEdit/ImageEditPlugin';
 import { initEditor } from '../TestHelper';
@@ -387,6 +388,96 @@ describe('ImageEditPlugin', () => {
         });
         expect(formatContentModelSpy).toHaveBeenCalled();
         expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
+        plugin.dispose();
+    });
+
+    it('mouseDown on non edit image', () => {
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
+        };
+        const plugin = new ImageEditPlugin();
+        plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseDown',
+            rawEvent: {
+                button: 0,
+                target: new Image(),
+            } as any,
+        });
+        expect(formatContentModelSpy).not.toHaveBeenCalled();
+        plugin.dispose();
+    });
+
+    it('mouseDown on text', () => {
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
+        };
+        const plugin = new ImageEditPlugin();
+        plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseUp',
+            rawEvent: {
+                button: 0,
+                target: new Image(),
+            } as any,
+        });
+        getDOMSelectionSpy.and.returnValue({
+            type: 'range',
+            range: {} as any,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseDown',
+            rawEvent: {
+                button: 0,
+                target: new Text(),
+            } as any,
+        });
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
+        plugin.dispose();
+    });
+
+    it('mouseDown  on same line', () => {
+        const target = {
+            contains: () => true,
+        };
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
+        };
+        const plugin = new ImageEditPlugin();
+        plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseUp',
+            rawEvent: {
+                button: 0,
+                target: new Image(),
+            } as any,
+        });
+        getDOMSelectionSpy.and.returnValue({
+            type: 'range',
+            range: {} as any,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseDown',
+            rawEvent: {
+                button: 0,
+                target: target,
+            } as any,
+        });
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
         plugin.dispose();
     });
 

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -1,5 +1,7 @@
+import * as applyChange from '../../lib/imageEdit/utils/applyChange';
 import * as findImage from '../../lib/imageEdit/utils/findEditingImage';
 import * as getSelectedImage from '../../lib/imageEdit/utils/getSelectedImage';
+import * as normalizeImageSelection from '../../lib/imageEdit/utils/normalizeImageSelection';
 import { ChangeSource, createImage, createParagraph } from 'roosterjs-content-model-dom';
 import { getSelectedImageMetadata } from '../../lib/imageEdit/utils/updateImageEditInfo';
 import { ImageEditPlugin } from '../../lib/imageEdit/ImageEditPlugin';
@@ -12,55 +14,54 @@ import {
     IEditor,
 } from 'roosterjs-content-model-types';
 
-const model: ContentModelDocument = {
-    blockGroupType: 'Document',
-    blocks: [
-        {
-            segments: [
-                {
-                    isSelected: true,
-                    segmentType: 'SelectionMarker',
-                    format: {
-                        fontFamily: 'Calibri',
-                        fontSize: '11pt',
-                        textColor: 'rgb(0, 0, 0)',
-                    },
-                },
-                {
-                    src:
-                        'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAsJCQcJCQcJCQkJCwkJCQkJCQsJCwsMCwsLDA0QDB...',
-                    isSelectedAsImageSelection: true,
-                    segmentType: 'Image',
-                    isSelected: true,
-                    format: {
-                        fontFamily: 'Calibri',
-                        fontSize: '11pt',
-                        textColor: 'rgb(0, 0, 0)',
-                        id: 'image_0',
-                        maxWidth: '1123px',
-                    },
-                    dataset: {
-                        isEditing: 'true',
-                    },
-                },
-            ],
-            segmentFormat: {
-                fontFamily: 'Calibri',
-                fontSize: '11pt',
-                textColor: 'rgb(0, 0, 0)',
-            },
-            blockType: 'Paragraph',
-            format: {},
-        },
-    ],
-    format: {
-        fontFamily: 'Calibri',
-        fontSize: '11pt',
-        textColor: '#000000',
-    },
-};
-
 describe('ImageEditPlugin', () => {
+    const model: ContentModelDocument = {
+        blockGroupType: 'Document',
+        blocks: [
+            {
+                segments: [
+                    {
+                        isSelected: true,
+                        segmentType: 'SelectionMarker',
+                        format: {
+                            fontFamily: 'Calibri',
+                            fontSize: '11pt',
+                            textColor: 'rgb(0, 0, 0)',
+                        },
+                    },
+                    {
+                        src:
+                            'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAsJCQcJCQcJCQkJCwkJCQkJCQsJCwsMCwsLDA0QDB...',
+                        isSelectedAsImageSelection: true,
+                        segmentType: 'Image',
+                        isSelected: true,
+                        format: {
+                            fontFamily: 'Calibri',
+                            fontSize: '11pt',
+                            textColor: 'rgb(0, 0, 0)',
+                            id: 'image_0',
+                            maxWidth: '1123px',
+                        },
+                        dataset: {
+                            isEditing: 'true',
+                        },
+                    },
+                ],
+                segmentFormat: {
+                    fontFamily: 'Calibri',
+                    fontSize: '11pt',
+                    textColor: 'rgb(0, 0, 0)',
+                },
+                blockType: 'Paragraph',
+                format: {},
+            },
+        ],
+        format: {
+            fontFamily: 'Calibri',
+            fontSize: '11pt',
+            textColor: '#000000',
+        },
+    };
     let editor: IEditor;
     let mockedEnvironment: EditorEnvironment;
     let attachDomEventSpy: jasmine.Spy;
@@ -610,5 +611,1214 @@ describe('ImageEditPlugin', () => {
         );
         expect(editor.setEditorStyle).toHaveBeenCalledWith('imageEdit', null);
         expect(editor.setEditorStyle).toHaveBeenCalledWith('imageEditCaretColor', null);
+    });
+});
+
+class TestPlugin extends ImageEditPlugin {
+    public setIsEditing(isEditing: boolean) {
+        this.isEditing = isEditing;
+    }
+
+    public setEditingInfo(image: HTMLImageElement) {
+        this.imageEditInfo = {
+            src: image.getAttribute('src') || '',
+            widthPx: image.clientWidth,
+            heightPx: image.clientHeight,
+            naturalWidth: image.naturalWidth,
+            naturalHeight: image.naturalHeight,
+            leftPercent: 0,
+            rightPercent: 0,
+            topPercent: 0,
+            bottomPercent: 0,
+            angleRad: 0,
+        };
+    }
+
+    public applyFormatWithContentModel(
+        editor: IEditor,
+        isCropMode: boolean,
+        shouldSelectImage: boolean,
+        isApiOperation?: boolean
+    ) {
+        super.applyFormatWithContentModel(editor, isCropMode, shouldSelectImage, isApiOperation);
+    }
+}
+
+interface TestOptions {
+    setImageStyle?: boolean;
+    removeImageStyle?: boolean;
+    shouldApplyChange?: boolean;
+    shouldNormalizeSelection?: boolean;
+    shouldCleanInfo?: boolean;
+}
+
+describe('ImageEditPlugin - applyFormatWithContentModel', () => {
+    function runTest(
+        model: ContentModelDocument,
+        expectedModel: ContentModelDocument,
+        isEditing: boolean,
+        isCropMode: boolean,
+        shouldSelectImage: boolean,
+        isApiOperation: boolean,
+        moreOptions: Partial<TestOptions> = {}
+    ) {
+        const plugin = new TestPlugin();
+        let editor: IEditor | null = initEditor('image_edit', [plugin], model);
+        const setEditorStyleSpy = spyOn(editor, 'setEditorStyle');
+        setEditorStyleSpy.and.callThrough();
+        const cleanInfoSpy = spyOn(plugin, 'cleanInfo').and.callThrough();
+        const applyChangeSpy = spyOn(applyChange, 'applyChange');
+        const normalizeImageSelectionSpy = spyOn(
+            normalizeImageSelection,
+            'normalizeImageSelection'
+        );
+        plugin.initialize(editor);
+        const mockedImage = document.createElement('img');
+        document.body.appendChild(mockedImage);
+        mockedImage.src = 'test';
+        plugin.setEditingInfo(mockedImage);
+        plugin.startRotateAndResize(editor, mockedImage);
+        plugin.setIsEditing(isEditing);
+        plugin.applyFormatWithContentModel(editor, isCropMode, shouldSelectImage, isApiOperation);
+        const newModel = editor.getContentModelCopy('disconnected');
+
+        if (moreOptions.removeImageStyle !== undefined) {
+            expect(setEditorStyleSpy).toHaveBeenCalledWith('imageEdit', null);
+            expect(setEditorStyleSpy).toHaveBeenCalledWith('imageEditCaretColor', null);
+        }
+
+        if (moreOptions.setImageStyle !== undefined) {
+            expect(setEditorStyleSpy).toHaveBeenCalledWith(
+                'imageEdit',
+                'outline-style:none!important;',
+                [`span:has(>img)`]
+            );
+            expect(setEditorStyleSpy).toHaveBeenCalledWith(
+                'imageEditCaretColor',
+                'caret-color: transparent;'
+            );
+        }
+
+        if (moreOptions.shouldApplyChange) {
+            expect(applyChangeSpy).toHaveBeenCalled();
+        } else {
+            expect(applyChangeSpy).not.toHaveBeenCalled();
+        }
+
+        if (moreOptions.shouldNormalizeSelection) {
+            expect(normalizeImageSelectionSpy).toHaveBeenCalled();
+        } else {
+            expect(normalizeImageSelectionSpy).not.toHaveBeenCalled();
+        }
+        if (moreOptions.shouldCleanInfo) {
+            expect(cleanInfoSpy).toHaveBeenCalled();
+        } else {
+            expect(cleanInfoSpy).not.toHaveBeenCalled();
+        }
+        expect(newModel).toEqual(expectedModel);
+        plugin.dispose();
+        editor.dispose();
+        editor = null;
+    }
+
+    it('image to text', () => {
+        const model1: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {
+                                isEditing: 'true',
+                            },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                        {
+                            isSelected: true,
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    segmentFormat: {},
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const expectedModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {},
+                            alt: undefined,
+                            title: undefined,
+                            isSelectedAsImageSelection: undefined,
+                            isSelected: undefined,
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: undefined,
+                        },
+                        {
+                            isSelected: true,
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: undefined,
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                },
+            ],
+
+            format: {},
+        };
+        runTest(model1, expectedModel, true, false, false, false, {
+            shouldApplyChange: true,
+            shouldCleanInfo: true,
+            removeImageStyle: true,
+        });
+    });
+
+    it('text to image', () => {
+        const testModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {},
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    segmentFormat: {},
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const expectedModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {
+                                isEditing: 'true',
+                            },
+                            alt: undefined,
+                            title: undefined,
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: undefined,
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                },
+            ],
+
+            format: {},
+        };
+        runTest(testModel, expectedModel, false, false, false, false, {
+            shouldApplyChange: false,
+            shouldCleanInfo: false,
+            setImageStyle: true,
+        });
+    });
+
+    it('image to image', () => {
+        const testModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {
+                                isEditing: 'true',
+                            },
+                        },
+                        {
+                            src: 'test2',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {},
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                        },
+                    ],
+                    segmentFormat: {},
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const expectedModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {},
+                            alt: undefined,
+                            title: undefined,
+                            isSelectedAsImageSelection: undefined,
+                            isSelected: undefined,
+                        },
+                        {
+                            src: 'test2',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {
+                                isEditing: 'true',
+                            },
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                            alt: undefined,
+                            title: undefined,
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                },
+            ],
+
+            format: {},
+        };
+        runTest(testModel, expectedModel, true, false, false, false, {
+            shouldApplyChange: true,
+            shouldCleanInfo: true,
+            removeImageStyle: true,
+            setImageStyle: true,
+        });
+    });
+
+    it('image in a table to text', () => {
+        const testModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [120],
+                    rows: [
+                        {
+                            height: 22,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    src: 'test',
+                                                    segmentType: 'Image',
+                                                    format: {},
+                                                    dataset: {
+                                                        isEditing: 'true',
+                                                    },
+                                                },
+                                            ],
+                                            segmentFormat: undefined,
+                                            blockType: 'Paragraph',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    blockType: 'Table',
+                    format: {
+                        borderCollapse: true,
+                        useBorderBox: true,
+                    },
+                    dataset: {},
+                },
+                {
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const expectedModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [122],
+                    rows: [
+                        {
+                            height: 24,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    src: 'test',
+                                                    isSelectedAsImageSelection: undefined,
+                                                    segmentType: 'Image',
+                                                    isSelected: undefined,
+                                                    format: {},
+                                                    dataset: {},
+                                                    alt: undefined,
+                                                    title: undefined,
+                                                },
+                                            ],
+                                            segmentFormat: undefined,
+                                            blockType: 'Paragraph',
+                                            format: {},
+                                            cachedElement: undefined,
+                                            isImplicit: undefined,
+                                        },
+                                    ],
+                                    format: {
+                                        width: '120px',
+                                        height: '22px',
+                                    },
+                                    dataset: {},
+                                    isSelected: undefined,
+                                    cachedElement: undefined,
+                                },
+                            ],
+                            format: {},
+                            cachedElement: undefined,
+                        },
+                    ],
+                    blockType: 'Table',
+                    format: {
+                        borderCollapse: true,
+                        useBorderBox: true,
+                    },
+                    dataset: {},
+                    cachedElement: undefined,
+                },
+                {
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: undefined,
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: {},
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                },
+            ],
+            format: {},
+        };
+        runTest(testModel, expectedModel, true, false, false, false, {
+            shouldApplyChange: true,
+            shouldCleanInfo: true,
+            removeImageStyle: true,
+        });
+    });
+
+    it('text to image in a table ', () => {
+        const testModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [120],
+                    rows: [
+                        {
+                            height: 22,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    src: 'test',
+                                                    segmentType: 'Image',
+                                                    format: {},
+                                                    dataset: {},
+                                                    isSelectedAsImageSelection: true,
+                                                    isSelected: true,
+                                                },
+                                            ],
+                                            segmentFormat: undefined,
+                                            blockType: 'Paragraph',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    blockType: 'Table',
+                    format: {
+                        borderCollapse: true,
+                        useBorderBox: true,
+                    },
+                    dataset: {},
+                },
+                {
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const expectedModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [122],
+                    rows: [
+                        {
+                            height: 24,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    src: 'test',
+                                                    isSelectedAsImageSelection: true,
+                                                    segmentType: 'Image',
+                                                    isSelected: true,
+                                                    format: {},
+                                                    dataset: {
+                                                        isEditing: 'true',
+                                                    },
+                                                    alt: undefined,
+                                                    title: undefined,
+                                                },
+                                            ],
+                                            segmentFormat: undefined,
+                                            blockType: 'Paragraph',
+                                            format: {},
+                                            cachedElement: undefined,
+                                            isImplicit: undefined,
+                                        },
+                                    ],
+                                    format: {
+                                        width: '120px',
+                                        height: '22px',
+                                    },
+                                    dataset: {},
+                                    isSelected: undefined,
+                                    cachedElement: undefined,
+                                },
+                            ],
+                            format: {},
+                            cachedElement: undefined,
+                        },
+                    ],
+                    blockType: 'Table',
+                    format: {
+                        borderCollapse: true,
+                        useBorderBox: true,
+                    },
+                    dataset: {},
+                    cachedElement: undefined,
+                },
+                {
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: undefined,
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                },
+            ],
+            format: {},
+        };
+        runTest(testModel, expectedModel, false, false, false, false, {
+            shouldApplyChange: false,
+            shouldCleanInfo: false,
+            setImageStyle: true,
+        });
+    });
+
+    it('image to image in a table ', () => {
+        const testModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [120],
+                    rows: [
+                        {
+                            height: 22,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    src: 'test',
+                                                    segmentType: 'Image',
+                                                    format: {},
+                                                    dataset: {
+                                                        isEditing: 'true',
+                                                    },
+                                                    isSelectedAsImageSelection: undefined,
+                                                    isSelected: undefined,
+                                                },
+                                            ],
+                                            segmentFormat: undefined,
+                                            blockType: 'Paragraph',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    dataset: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    blockType: 'Table',
+                    format: {
+                        borderCollapse: true,
+                        useBorderBox: true,
+                    },
+                    dataset: {},
+                },
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {},
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const expectedModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [122],
+                    rows: [
+                        {
+                            height: 24,
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    isHeader: false,
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    src: 'test',
+                                                    isSelectedAsImageSelection: undefined,
+                                                    segmentType: 'Image',
+                                                    isSelected: undefined,
+                                                    format: {},
+                                                    dataset: {},
+                                                    alt: undefined,
+                                                    title: undefined,
+                                                },
+                                            ],
+                                            segmentFormat: undefined,
+                                            blockType: 'Paragraph',
+                                            format: {},
+                                            cachedElement: undefined,
+                                            isImplicit: undefined,
+                                        },
+                                    ],
+                                    format: {
+                                        width: '120px',
+                                        height: '22px',
+                                    },
+                                    dataset: {},
+                                    isSelected: undefined,
+                                    cachedElement: undefined,
+                                },
+                            ],
+                            format: {},
+                            cachedElement: undefined,
+                        },
+                    ],
+                    blockType: 'Table',
+                    format: {
+                        borderCollapse: true,
+                        useBorderBox: true,
+                    },
+                    dataset: {},
+                    cachedElement: undefined,
+                },
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {
+                                isEditing: 'true',
+                            },
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                            alt: undefined,
+                            title: undefined,
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                },
+            ],
+            format: {},
+        };
+        runTest(testModel, expectedModel, true, false, false, false, {
+            shouldApplyChange: true,
+            shouldCleanInfo: true,
+            setImageStyle: true,
+            removeImageStyle: true,
+        });
+    });
+
+    it('image in a list to text', () => {
+        const testModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    formatHolder: {
+                        isSelected: false,
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                    },
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo:
+                                    '{"applyListStyleFromLevel":false,"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    blockType: 'BlockGroup',
+                    format: {},
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            segments: [
+                                {
+                                    src: 'test',
+                                    segmentType: 'Image',
+                                    format: {},
+                                    dataset: {
+                                        isEditing: 'true',
+                                    },
+                                },
+                            ],
+                            segmentFormat: {},
+                            blockType: 'Paragraph',
+                            format: {},
+                        },
+                    ],
+                },
+                {
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                        {
+                            isSelected: true,
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                        },
+                    ],
+                    segmentFormat: {},
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const expectedModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    formatHolder: {
+                        isSelected: false,
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                    },
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo:
+                                    '{"applyListStyleFromLevel":false,"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    blockType: 'BlockGroup',
+                    format: {},
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            segments: [
+                                {
+                                    src: 'test',
+                                    segmentType: 'Image',
+                                    format: {},
+                                    dataset: {},
+                                    isSelectedAsImageSelection: undefined,
+                                    isSelected: undefined,
+                                    alt: undefined,
+                                    title: undefined,
+                                },
+                            ],
+                            segmentFormat: undefined,
+                            blockType: 'Paragraph',
+                            format: {},
+                            cachedElement: undefined,
+                            isImplicit: undefined,
+                        },
+                    ],
+                    cachedElement: undefined,
+                },
+                {
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: undefined,
+                        },
+                        {
+                            isSelected: true,
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                },
+            ],
+            format: {},
+        };
+        runTest(testModel, expectedModel, true, false, false, false, {
+            shouldApplyChange: true,
+            shouldCleanInfo: true,
+            removeImageStyle: true,
+        });
+    });
+
+    it('text to image in a list', () => {
+        const testModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    formatHolder: {
+                        isSelected: false,
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                    },
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo:
+                                    '{"applyListStyleFromLevel":false,"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    blockType: 'BlockGroup',
+                    format: {},
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            segments: [
+                                {
+                                    src: 'test',
+                                    segmentType: 'Image',
+                                    format: {},
+                                    dataset: {},
+                                    isSelectedAsImageSelection: true,
+                                    isSelected: true,
+                                },
+                            ],
+                            segmentFormat: {},
+                            blockType: 'Paragraph',
+                            format: {},
+                        },
+                    ],
+                },
+                {
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    segmentFormat: {},
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const expectedModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    formatHolder: {
+                        isSelected: false,
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                    },
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo:
+                                    '{"applyListStyleFromLevel":false,"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    blockType: 'BlockGroup',
+                    format: {},
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            segments: [
+                                {
+                                    src: 'test',
+                                    segmentType: 'Image',
+                                    format: {},
+                                    dataset: {
+                                        isEditing: 'true',
+                                    },
+                                    isSelectedAsImageSelection: true,
+                                    isSelected: true,
+                                    alt: undefined,
+                                    title: undefined,
+                                },
+                            ],
+                            segmentFormat: undefined,
+                            blockType: 'Paragraph',
+                            format: {},
+                            cachedElement: undefined,
+                            isImplicit: undefined,
+                        },
+                    ],
+                    cachedElement: undefined,
+                },
+                {
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: undefined,
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                },
+            ],
+            format: {},
+        };
+        runTest(testModel, expectedModel, false, false, false, false, {
+            shouldApplyChange: false,
+            shouldCleanInfo: false,
+            setImageStyle: true,
+        });
+    });
+
+    it('image in a list to image', () => {
+        const testModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    formatHolder: {
+                        isSelected: false,
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                    },
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo:
+                                    '{"applyListStyleFromLevel":false,"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    blockType: 'BlockGroup',
+                    format: {},
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            segments: [
+                                {
+                                    src: 'test',
+                                    segmentType: 'Image',
+                                    format: {},
+                                    dataset: {
+                                        isEditing: 'true',
+                                    },
+                                    isSelectedAsImageSelection: undefined,
+                                    isSelected: undefined,
+                                },
+                            ],
+                            segmentFormat: {},
+                            blockType: 'Paragraph',
+                            format: {},
+                        },
+                    ],
+                },
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {},
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                        },
+                    ],
+                    segmentFormat: {},
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        const expectedModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    formatHolder: {
+                        isSelected: false,
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                    },
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo:
+                                    '{"applyListStyleFromLevel":false,"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    blockType: 'BlockGroup',
+                    format: {},
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            segments: [
+                                {
+                                    src: 'test',
+                                    segmentType: 'Image',
+                                    format: {},
+                                    dataset: {},
+                                    isSelectedAsImageSelection: undefined,
+                                    isSelected: undefined,
+                                    alt: undefined,
+                                    title: undefined,
+                                },
+                            ],
+                            segmentFormat: undefined,
+                            blockType: 'Paragraph',
+                            format: {},
+                            cachedElement: undefined,
+                            isImplicit: undefined,
+                        },
+                    ],
+                    cachedElement: undefined,
+                },
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {
+                                isEditing: 'true',
+                            },
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                            alt: undefined,
+                            title: undefined,
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                    cachedElement: undefined,
+                    isImplicit: undefined,
+                },
+            ],
+            format: {},
+        };
+        runTest(testModel, expectedModel, true, false, false, false, {
+            shouldApplyChange: true,
+            shouldCleanInfo: true,
+            setImageStyle: true,
+            removeImageStyle: true,
+        });
     });
 });


### PR DESCRIPTION
If expanded range selection happens while image is in editing mode and the range selection contains the image, when mouse up ensure the image is selected, but not as image selection. 



