### PR TITLE
Fix #2804 adjustLinkSelection does not select whole link

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/domIndexerImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/domIndexerImpl.ts
@@ -1,5 +1,7 @@
 import {
     EmptySegmentFormat,
+    addCode,
+    addLink,
     createParagraph,
     createSelectionMarker,
     createText,
@@ -447,6 +449,16 @@ export class DomIndexerImpl implements DomIndexer {
                 if (endOffset === undefined) {
                     const marker = createSelectionMarker(first.format);
                     newSegments.push(marker);
+
+                    if (startOffset < (textNode.nodeValue ?? '').length) {
+                        if (first.link) {
+                            addLink(marker, first.link);
+                        }
+
+                        if (first.code) {
+                            addCode(marker, first.code);
+                        }
+                    }
 
                     selectable = marker;
                     endOffset = startOffset;


### PR DESCRIPTION
#2804 
This is because when cache is enabled, the updated selection marker does not copy link info from text segment, so `adjustLinkSelection` failed to match the text segment around the selection marker.

Fix: Include link and code info in reconciled selection marker.