### PR TITLE
Make image edit features work with touch

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -420,6 +420,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         if (this.imageEditInfo) {
             this.startEditing(editor, image, ['resize', 'rotate']);
             if (this.selectedImage && this.imageEditInfo && this.wrapper && this.clonedImage) {
+                const isMobileOrTable = !!editor.getEnvironment().isMobileOrTablet;
                 this.dndHelpers = [
                     ...getDropAndDragHelpers(
                         this.wrapper,
@@ -445,7 +446,8 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                                 this.wasImageResized = true;
                             }
                         },
-                        this.zoomScale
+                        this.zoomScale,
+                        isMobileOrTable
                     ),
                     ...getDropAndDragHelpers(
                         this.wrapper,
@@ -476,7 +478,8 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                                 );
                             }
                         },
-                        this.zoomScale
+                        this.zoomScale,
+                        isMobileOrTable
                     ),
                 ];
 
@@ -571,7 +574,8 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                                 this.isCropMode = true;
                             }
                         },
-                        this.zoomScale
+                        this.zoomScale,
+                        !!editor.getEnvironment().isMobileOrTablet
                     ),
                 ];
                 updateWrapper(

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/getDropAndDragHelpers.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/getDropAndDragHelpers.ts
@@ -16,7 +16,8 @@ export function getDropAndDragHelpers(
     elementClass: ImageEditElementClass,
     helper: DragAndDropHandler<DragAndDropContext, any>,
     updateWrapper: (context: DragAndDropContext, _handle: HTMLElement) => void,
-    zoomScale: number
+    zoomScale: number,
+    useTouch: boolean
 ): DragAndDropHelper<DragAndDropContext, any>[] {
     return getEditElements(wrapper, elementClass).map(
         element =>
@@ -31,7 +32,8 @@ export function getDropAndDragHelpers(
                 },
                 updateWrapper,
                 helper,
-                zoomScale
+                zoomScale,
+                useTouch
             )
     );
 }

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/utils/getDropAndDragHelpersTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/utils/getDropAndDragHelpersTest.ts
@@ -54,7 +54,8 @@ describe('getDropAndDragHelpers', () => {
             elementClass,
             helper,
             () => {},
-            1
+            1,
+            false
         );
         expect(JSON.stringify(result)).toEqual(JSON.stringify(expectResult));
     }


### PR DESCRIPTION
Enable resize/rotate/crop images using touch events. 
![TouchWithImages](https://github.com/user-attachments/assets/3ff5b1c6-ca5c-49c0-bc5a-83b1a4340652)
