### PR TITLE
Do not treat image without src as empty image

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelApi/common/isEmpty.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/common/isEmpty.ts
@@ -56,9 +56,6 @@ export function isSegmentEmpty(segment: ReadonlyContentModelSegment): boolean {
         case 'Text':
             return !segment.text;
 
-        case 'Image':
-            return !segment.src;
-
         default:
             return false;
     }


### PR DESCRIPTION
When image has no src, we should not treat it as empty, so return false from isEmpty() function.

This is to avoid image without src to be removed from Content Model when calling `normalizeContentModel`