### PR TITLE
Auto format list on TAB

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
@@ -208,6 +208,31 @@ export class AutoFormatPlugin implements EditorPlugin {
                         unlink(editor, rawEvent);
                     }
                     break;
+                case 'Tab':
+                    formatTextSegmentBeforeSelectionMarker(
+                        editor,
+                        (model, _previousSegment, paragraph, _markerFormat, context) => {
+                            const { autoBullet, autoNumbering } = this.options;
+                            let shouldList = false;
+                            if (autoBullet || autoNumbering) {
+                                shouldList = keyboardListTrigger(
+                                    model,
+                                    paragraph,
+                                    context,
+                                    autoBullet,
+                                    autoNumbering
+                                );
+                                context.canUndoByBackspace = shouldList;
+                                event.rawEvent.preventDefault();
+                            }
+
+                            return shouldList;
+                        },
+                        {
+                            changeSource: ChangeSource.AutoFormat,
+                            apiName: 'autoToggleList',
+                        }
+                    );
             }
         }
     }

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/list/keyboardListTrigger.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/list/keyboardListTrigger.ts
@@ -60,7 +60,6 @@ const triggerList = (
               }
     );
 };
-
 function setAnnounceData(model: ReadonlyContentModelDocument, context: FormatContentModelContext) {
     const [paragraphOrListItems] = getOperationalBlocks<ContentModelListItem>(
         model,

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/list/keyboardListTrigger.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/list/keyboardListTrigger.ts
@@ -60,6 +60,7 @@ const triggerList = (
               }
     );
 };
+
 function setAnnounceData(model: ReadonlyContentModelDocument, context: FormatContentModelContext) {
     const [paragraphOrListItems] = getOperationalBlocks<ContentModelListItem>(
         model,


### PR DESCRIPTION
Use TAB key to auto format list. [269932]( https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/269932)
![ListTAB](https://github.com/user-attachments/assets/4141f70a-3f1b-402a-8b5d-5a74c0e8b86e)
