### PR TITLE
Trigger ordinals after link

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
@@ -68,7 +68,7 @@ const ORDINAL_LENGTH = 2;
     return shouldAddSuperScript;
 }
 
-function getNumericValue(text: string, checkFullText = false): number | null {
+function getNumericValue(text: string, checkFullText: boolean = false): number | null {
     const number = checkFullText ? text : text.substring(0, text.length - ORDINAL_LENGTH);
     const isNumber = /^-?\d+$/.test(number);
     if (isNumber) {

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
@@ -1,4 +1,5 @@
 import { splitTextSegment } from 'roosterjs-content-model-api';
+
 import type {
     ContentModelText,
     FormatContentModelContext,
@@ -14,6 +15,8 @@ const getOrdinal = (value: number) => {
     return ORDINALS[value] || 'th';
 };
 
+const ORDINALS = ['st', 'nd', 'rd', 'th'];
+
 /**
  * The two last characters of ordinal number (st, nd, rd, th)
  */
@@ -27,10 +30,30 @@ const ORDINAL_LENGTH = 2;
     context: FormatContentModelContext
 ): boolean {
     const value = previousSegment.text.split(' ').pop()?.trim();
+    let shouldAddSuperScript = false;
     if (value) {
-        const ordinal = value.substring(value.length - ORDINAL_LENGTH); // This value  is equal st, nd, rd, th
-        const numericValue = getNumericValue(value); //This is the numeric part. Ex: 10th, numeric value = 10
-        if (numericValue && getOrdinal(numericValue) === ordinal) {
+        const isOrdinal = ORDINALS.indexOf(value) > -1;
+        if (isOrdinal) {
+            const index = paragraph.segments.indexOf(previousSegment);
+            const numberSegment = paragraph.segments[index - 1];
+            let numericValue: number | null = null;
+            if (
+                numberSegment &&
+                numberSegment.segmentType == 'Text' &&
+                (numericValue = getNumericValue(numberSegment.text, true /* checkFullText */)) &&
+                getOrdinal(numericValue) === value
+            ) {
+                shouldAddSuperScript = true;
+            }
+        } else {
+            const ordinal = value.substring(value.length - ORDINAL_LENGTH); // This value  is equal st, nd, rd, th
+            const numericValue = getNumericValue(value); //This is the numeric part. Ex: 10th, numeric value =
+            if (numericValue && getOrdinal(numericValue) === ordinal) {
+                shouldAddSuperScript = true;
+            }
+        }
+
+        if (shouldAddSuperScript) {
             const ordinalSegment = splitTextSegment(
                 previousSegment,
                 paragraph,
@@ -40,14 +63,13 @@ const ORDINAL_LENGTH = 2;
 
             ordinalSegment.format.superOrSubScriptSequence = 'super';
             context.canUndoByBackspace = true;
-            return true;
         }
     }
-    return false;
+    return shouldAddSuperScript;
 }
 
-function getNumericValue(text: string) {
-    const number = text.substring(0, text.length - ORDINAL_LENGTH);
+function getNumericValue(text: string, checkFullText = false): number | null {
+    const number = checkFullText ? text : text.substring(0, text.length - ORDINAL_LENGTH);
     const isNumber = /^-?\d+$/.test(number);
     if (isNumber) {
         return parseInt(text);

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/numbers/transformOrdinalsTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/numbers/transformOrdinalsTest.ts
@@ -183,4 +183,178 @@ describe('transformOrdinals', () => {
         };
         runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
     });
+
+    it('link - 1st', () => {
+        const link: ContentModelText = {
+            segmentType: 'Text',
+            text: '1',
+            link: {
+                dataset: {},
+                format: {
+                    href: 'http://www.bing.com',
+                },
+            },
+            format: {},
+        };
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: 'st',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [link, segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('link - 2nd', () => {
+        const link: ContentModelText = {
+            segmentType: 'Text',
+            text: '2',
+            link: {
+                dataset: {},
+                format: {
+                    href: 'http://www.bing.com',
+                },
+            },
+            format: {},
+        };
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: 'nd',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [link, segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('link - 3rd', () => {
+        const link: ContentModelText = {
+            segmentType: 'Text',
+            text: '3',
+            link: {
+                dataset: {},
+                format: {
+                    href: 'http://www.bing.com',
+                },
+            },
+            format: {},
+        };
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: 'rd',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [link, segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('link - 4th', () => {
+        const link: ContentModelText = {
+            segmentType: 'Text',
+            text: '4',
+            link: {
+                dataset: {},
+                format: {
+                    href: 'http://www.bing.com',
+                },
+            },
+            format: {},
+        };
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: 'th',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [link, segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('link - 123th', () => {
+        const link: ContentModelText = {
+            segmentType: 'Text',
+            text: '123',
+            link: {
+                dataset: {},
+                format: {
+                    href: 'http://www.bing.com',
+                },
+            },
+            format: {},
+        };
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: 'th',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [link, segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('link - 3th', () => {
+        const link: ContentModelText = {
+            segmentType: 'Text',
+            text: '3',
+            link: {
+                dataset: {},
+                format: {
+                    href: 'http://www.bing.com',
+                },
+            },
+            format: {},
+        };
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: 'th',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [link, segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
+    });
+    it('link - 24e5th', () => {
+        const link: ContentModelText = {
+            segmentType: 'Text',
+            text: '24e5',
+            link: {
+                dataset: {},
+                format: {
+                    href: 'http://www.bing.com',
+                },
+            },
+            format: {},
+        };
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: 'th',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [link, segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
+    });
 });


### PR DESCRIPTION
If st, nd, rd and th are typed after a link with a number, trigger superscript. [Bug 278807](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/278807)
![linkOrdinals](https://github.com/user-attachments/assets/bc204c4c-adcf-4048-b06b-5f08c88d990a)
