### PR TITLE
Revert Shortcut command for Clear Format on mac

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
@@ -121,7 +121,7 @@ export class ShortcutPlugin implements EditorPlugin {
             const editor = this.editor;
             const { ctrlKey, metaKey } = event.rawEvent;
             if (ctrlKey && metaKey) {
-                // We don't support both Ctrl and Meta key pressed at the same time
+                // We don't support both Ctrl and Meta key pressed at the same time.
                 return null;
             }
             return (

--- a/packages/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
@@ -119,7 +119,11 @@ export class ShortcutPlugin implements EditorPlugin {
     private cacheGetCommand(event: KeyDownEvent) {
         return cacheGetEventData(event, CommandCacheKey, event => {
             const editor = this.editor;
-
+            const { ctrlKey, metaKey } = event.rawEvent;
+            if (ctrlKey && metaKey) {
+                // We don't support both Ctrl and Meta key pressed at the same time
+                return null;
+            }
             return (
                 editor &&
                 this.shortcuts.filter(

--- a/packages/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
+++ b/packages/roosterjs-content-model-plugins/lib/shortcut/shortcuts.ts
@@ -71,7 +71,7 @@ export const ShortcutUnderline: ShortcutCommand = {
 /**
  * Shortcut command for Clear Format
  * Windows: Ctrl + Space
- * MacOS: N/A
+ * MacOS: Meta + Space, this shortcut is the same as the default global spotlight shortcut, so it is invalid if the user keeps spotlight‘s.
  */
 export const ShortcutClearFormat: ShortcutCommand = {
     shortcutKey: {
@@ -80,7 +80,6 @@ export const ShortcutClearFormat: ShortcutCommand = {
         which: Keys.SPACE,
     },
     onClick: editor => clearFormat(editor),
-    environment: 'nonMac',
 };
 
 /**

--- a/packages/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
@@ -448,6 +448,26 @@ describe('ShortcutPlugin', () => {
             expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
         });
 
+        it('clear format', () => {
+            const apiSpy = spyOn(clearFormat, 'clearFormat');
+            const plugin = new ShortcutPlugin();
+            const event: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent(Keys.SPACE, false, false, false, true),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            const exclusively = plugin.willHandleEventExclusively(event);
+
+            expect(exclusively).toBeTrue();
+            expect(event.eventDataCache!.__ShortcutCommandCache).toBeDefined();
+
+            plugin.onPluginEvent(event);
+
+            expect(apiSpy).toHaveBeenCalledWith(mockedEditor);
+        });
+
         it('undo 1', () => {
             const apiSpy = spyOn(undo, 'undo');
             const plugin = new ShortcutPlugin();


### PR DESCRIPTION
This shortcut is the same as the default global spotlight shortcut, so it is invalid if the user keeps spotlight‘s. Some users prefer to keep it the same as Windows by disable spotlight