### PR TITLE
Fix #2835 Ignore HTML align when there is CSS text-align

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/block/htmlAlignFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/block/htmlAlignFormatHandler.ts
@@ -16,12 +16,15 @@ export const htmlAlignFormatHandler: FormatHandler<
     parse: (format, element, context, defaultStyle) => {
         directionFormatHandler.parse(format, element, context, defaultStyle);
 
-        const htmlAlign = element.getAttribute('align');
+        // When there is text-align in CSS style on the same element, we should ignore HTML align
+        if (!element.style.textAlign) {
+            const htmlAlign = element.getAttribute('align');
 
-        if (htmlAlign) {
-            format.htmlAlign = calcAlign(htmlAlign, format.direction);
-            delete format.textAlign;
-            delete context.blockFormat.textAlign;
+            if (htmlAlign) {
+                format.htmlAlign = calcAlign(htmlAlign, format.direction);
+                delete format.textAlign;
+                delete context.blockFormat.textAlign;
+            }
         }
     },
     apply: (format, element) => {

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/block/htmlAlignFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/block/htmlAlignFormatHandler.ts
@@ -14,10 +14,10 @@ export const htmlAlignFormatHandler: FormatHandler<
     DirectionFormat & HtmlAlignFormat & TextAlignFormat
 > = {
     parse: (format, element, context, defaultStyle) => {
-        directionFormatHandler.parse(format, element, context, defaultStyle);
-
         // When there is text-align in CSS style on the same element, we should ignore HTML align
         if (!element.style.textAlign) {
+            directionFormatHandler.parse(format, element, context, defaultStyle);
+
             const htmlAlign = element.getAttribute('align');
 
             if (htmlAlign) {

--- a/packages/roosterjs-content-model-dom/test/endToEndTest.ts
+++ b/packages/roosterjs-content-model-dom/test/endToEndTest.ts
@@ -2199,4 +2199,31 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
             '<div style="font-family: Calibri; font-size: 11pt; color: rgb(245, 212, 39);"><a href="http://www.bing.com" style="color: rgb(245, 212, 39);">www.bing.com</a></div>'
         );
     });
+
+    it('HTML align together with CSS text-align', () => {
+        runTest(
+            '<div align="left" style="text-align:center">test</div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            {
+                                segmentType: 'Text',
+                                text: 'test',
+                                format: {},
+                            },
+                        ],
+                        format: {
+                            textAlign: 'center',
+                        },
+                        isImplicit: false,
+                    },
+                ],
+            },
+            'test',
+            '<div style="text-align: center;">test</div>'
+        );
+    });
 });

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/block/htmlAlignFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/block/htmlAlignFormatHandlerTest.ts
@@ -82,6 +82,15 @@ describe('htmlAlignFormatHandler.parse', () => {
             htmlAlign: 'start',
         });
     });
+
+    it('Ignore HTML align when there is CSS text-align', () => {
+        div.setAttribute('align', 'left');
+        div.style.textAlign = 'center';
+
+        htmlAlignFormatHandler.parse(format, div, context, {});
+
+        expect(format.htmlAlign).toBeUndefined();
+    });
 });
 
 describe('htmlAlignFormatHandler.apply', () => {


### PR DESCRIPTION
See #2835 if there is CSS text-align on the same element, it should override HTML align. So `htmlAlignFormatHandler` should skip the attribute.