### PR TITLE
Do not handle ENTER key when CTRL is pressed

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -150,6 +150,7 @@ export class EditPlugin implements EditorPlugin {
 
     private handleKeyDownEvent(editor: IEditor, event: KeyDownEvent) {
         const rawEvent = event.rawEvent;
+        const hasCtrlOrMetaKey = rawEvent.ctrlKey || rawEvent.metaKey;
 
         if (!rawEvent.defaultPrevented && !event.handledByEditFeature) {
             switch (rawEvent.key) {
@@ -169,7 +170,7 @@ export class EditPlugin implements EditorPlugin {
                     break;
 
                 case 'Tab':
-                    if (this.options.handleTabKey) {
+                    if (this.options.handleTabKey && !hasCtrlOrMetaKey) {
                         keyboardTab(editor, rawEvent);
                     }
                     break;
@@ -180,7 +181,9 @@ export class EditPlugin implements EditorPlugin {
                     break;
 
                 case 'Enter':
-                    keyboardEnter(editor, rawEvent, this.handleNormalEnter);
+                    if (!hasCtrlOrMetaKey) {
+                        keyboardEnter(editor, rawEvent, this.handleNormalEnter);
+                    }
                     break;
 
                 default:

--- a/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
@@ -183,6 +183,26 @@ describe('EditPlugin', () => {
             expect(keyboardTabSpy).not.toHaveBeenCalled();
         });
 
+        it('Ctrl+Enter, nothing happens', () => {
+            plugin = new EditPlugin();
+            const rawEvent = { which: 13, key: 'Enter', ctrlKey: true } as any;
+            const addUndoSnapshotSpy = jasmine.createSpy('addUndoSnapshot');
+
+            editor.takeSnapshot = addUndoSnapshotSpy;
+
+            plugin.initialize(editor);
+
+            plugin.onPluginEvent({
+                eventType: 'keyDown',
+                rawEvent,
+            });
+
+            expect(keyboardDeleteSpy).not.toHaveBeenCalled();
+            expect(keyboardInputSpy).not.toHaveBeenCalled();
+            expect(keyboardEnterSpy).not.toHaveBeenCalled();
+            expect(keyboardTabSpy).not.toHaveBeenCalled();
+        });
+
         it('Other key', () => {
             plugin = new EditPlugin();
             const rawEvent = { which: 41, key: 'A' } as any;


### PR DESCRIPTION
https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/313638/?triage=true

When handle ENTER key, if CTRL (or META) is also pressed, we should leave it to browser.