### PR TITLE
Fix ZoomScaleChangedEvent no longer being triggered in EditorAdapter

### DIFF
--- a/packages/roosterjs-editor-adapter/lib/editor/EditorAdapter.ts
+++ b/packages/roosterjs-editor-adapter/lib/editor/EditorAdapter.ts
@@ -1093,17 +1093,13 @@ export class EditorAdapter extends Editor implements ILegacyEditor {
      */
     setZoomScale(scale: number): void {
         if (scale > 0 && scale <= 10) {
-            const oldValue = this.getZoomScale();
-
-            if (oldValue != scale) {
-                this.triggerEvent(
-                    'zoomChanged',
-                    {
-                        newZoomScale: scale,
-                    },
-                    true /*broadcast*/
-                );
-            }
+            this.triggerEvent(
+                'zoomChanged',
+                {
+                    newZoomScale: scale,
+                },
+                true /*broadcast*/
+            );
         }
     }
 


### PR DESCRIPTION
Right now, when the Zoom Changes. The Editor is not triggering the ZoomChanged event. This is because the function DOMHelper().calculateZoomScale() is always returning the value as the new zoomScale. Causing that the event is never triggered to the legacy plugins.

To fix remove the check in EditorAdapter::setZoomScale, since it is always falsy.