### PR TITLE
Add change data and apiName to ContentChangedEvent when handle keyboard input

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardEnter.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardEnter.ts
@@ -58,6 +58,8 @@ export function keyboardEnter(
             rawEvent,
             scrollCaretIntoView: true,
             changeSource: ChangeSource.Keyboard,
+            getChangeData: () => rawEvent.which,
+            apiName: 'handleEnterKey',
         }
     );
 }

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardInput.ts
@@ -38,6 +38,8 @@ export function keyboardInput(editor: IEditor, rawEvent: KeyboardEvent) {
                 scrollCaretIntoView: true,
                 rawEvent,
                 changeSource: ChangeSource.Keyboard,
+                getChangeData: () => rawEvent.which,
+                apiName: 'handleInputKey',
             }
         );
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardTab.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardTab.ts
@@ -30,6 +30,9 @@ export function keyboardTab(editor: IEditor, rawEvent: KeyboardEvent) {
                 },
                 {
                     apiName: 'handleTabKey',
+                    rawEvent,
+                    changeSource: ChangeSource.Keyboard,
+                    getChangeData: () => rawEvent.which,
                 }
             );
 
@@ -41,7 +44,9 @@ export function keyboardTab(editor: IEditor, rawEvent: KeyboardEvent) {
                 },
                 {
                     apiName: 'handleTabKey',
+                    rawEvent,
                     changeSource: ChangeSource.Keyboard,
+                    getChangeData: () => rawEvent.which,
                 }
             );
             return true;

--- a/packages/roosterjs-content-model-plugins/test/edit/inputSteps/handleEnterOnListTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/inputSteps/handleEnterOnListTest.ts
@@ -1817,7 +1817,7 @@ describe('handleEnterOnList - keyboardEnter', () => {
         let editor: any;
 
         editingTestCommon(
-            undefined,
+            'handleEnterKey',
             newEditor => {
                 editor = newEditor;
 


### PR DESCRIPTION
In order to allow knowing which key is pressed when handling ContentChangedEvent with ChangeSource=Keyboard, we add apiName and change data into the event object. Then plugin can check event.data or event.formatApiName to know the key:

![image](https://github.com/user-attachments/assets/024a2cde-f2fd-4a69-8aa8-c40bbcb1f6af)
