### PR TITLE
Fix #2857

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/inputSteps/handleEnterOnList.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/inputSteps/handleEnterOnList.ts
@@ -98,7 +98,7 @@ const createNewListItem = (
     const levels = createNewListLevel(listItem);
     const newListItem: ShallowMutableContentModelListItem = createListItem(
         levels,
-        insertPoint.marker.format
+        listItem.formatHolder.format
     );
 
     newListItem.blocks.push(newParagraph);

--- a/packages/roosterjs-content-model-plugins/test/edit/inputSteps/handleEnterOnListTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/inputSteps/handleEnterOnListTest.ts
@@ -1797,6 +1797,108 @@ describe('handleEnterOnList', () => {
         };
         runTest(model, expectedModel, 'range', listItem);
     });
+
+    it('Selection Marker has styles from previous list item', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'SelectionMarker',
+                                    isSelected: true,
+                                    format: { fontSize: '20pt', fontWeight: 'bold' },
+                                },
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test',
+                                    format: { fontWeight: 'bold' },
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: { fontSize: '10pt' },
+                    },
+                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                },
+            ],
+        };
+        const listItem: ContentModelListItem = {
+            blockType: 'BlockGroup',
+            blockGroupType: 'ListItem',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            isSelected: true,
+                            format: { fontSize: '20pt', fontWeight: 'bold' },
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: { fontWeight: 'bold' },
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            levels: [
+                {
+                    listType: 'UL',
+                    format: {
+                        startNumberOverride: undefined,
+                        displayForDummyItem: undefined,
+                    },
+                    dataset: {},
+                },
+            ],
+            formatHolder: {
+                segmentType: 'SelectionMarker',
+                isSelected: false,
+                format: { fontSize: '10pt' },
+            },
+            format: {},
+        };
+        const expectedModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Br',
+                                    format: { fontSize: '20pt', fontWeight: 'bold' },
+                                },
+                            ],
+                            format: {},
+                            segmentFormat: { fontSize: '20pt' },
+                        },
+                    ],
+                    format: {},
+                    formatHolder: { segmentType: 'SelectionMarker', format: { fontSize: '10pt' } },
+                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                },
+                listItem,
+            ],
+        };
+
+        runTest(model, expectedModel, 'range', listItem);
+    });
 });
 
 describe('handleEnterOnList - keyboardEnter', () => {


### PR DESCRIPTION
#2857 
Bold style is missing when ENTER on list item

This is because when create new list item, instead of inheriting list item format from previous list item, we actually inherit format from current selection marker, that causes bold format is incorrectly set into list item format holder, which causes when recreate the new list item, it thoughts there is already bold format applied in container level, so bold format is skipped.

Fix: Inherit format from previous list item instead.