### PR TITLE
Allow browser's default paste behavior when pasting from Office Android

### DIFF
--- a/packages/roosterjs-content-model-core/test/corePlugin/copyPaste/CopyPastePluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/copyPaste/CopyPastePluginTest.ts
@@ -1394,7 +1394,7 @@ describe('CopyPastePlugin |', () => {
 
     describe('shouldPreventDefaultPaste', () => {
         it('should not prevent default for empty clipboard data', () => {
-            const clipboardData = <ClipboardData>(<any>{
+            const clipboardData = <DataTransfer>(<any>{
                 items: null
             });
             const editor = <IEditor>(<any>{});
@@ -1403,7 +1403,7 @@ describe('CopyPastePlugin |', () => {
         });
 
         it('should prevent default on non-Android platforms', () => {
-            const clipboardData = <ClipboardData>(<any>{
+            const clipboardData = <DataTransfer>(<any>{
                 items: [{ type: '', kind: 'file' }]
             });
             const editor = <IEditor>(<any>{
@@ -1413,10 +1413,10 @@ describe('CopyPastePlugin |', () => {
         });
 
         it('should prevent default for text or image clipboard data on Android platform', () => {
-            const textClipboardData = <ClipboardData>(<any>{
+            const textClipboardData = <DataTransfer>(<any>{
                 items: [{ type: 'text/plain', kind: 'string' }]
             });
-            const imageClipboardData = <ClipboardData>(<any>{
+            const imageClipboardData = <DataTransfer>(<any>{
                 items: [{ type: 'image/png', kind: 'file' }]
             });
             const editor = <IEditor>(<any>{
@@ -1427,7 +1427,7 @@ describe('CopyPastePlugin |', () => {
         });
 
         it('should not prevent default for file-only clipboard data on Android platform', () => {
-            const clipboardData = <ClipboardData>(<any>{
+            const clipboardData = <DataTransfer>(<any>{
                 items: [{ type: '', kind: 'file' }]
             });
             const editor = <IEditor>(<any>{

--- a/packages/roosterjs-content-model-core/test/corePlugin/copyPaste/CopyPastePluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/copyPaste/CopyPastePluginTest.ts
@@ -1394,46 +1394,46 @@ describe('CopyPastePlugin |', () => {
 
     describe('shouldPreventDefaultPaste', () => {
         it('should not prevent default for empty clipboard data', () => {
-            const clipboardData = <ClipboardData>{
+            const clipboardData = <ClipboardData>(<any>{
                 items: null
-            };
+            });
             const editor = <IEditor>(<any>{});
-            expect(shouldPreventDefaultPaste(editor, clipboardData)).toBeFalse();
-            expect(shouldPreventDefaultPaste(editor, null)).toBeFalse();
+            expect(shouldPreventDefaultPaste(clipboardData, editor)).toBeFalse();
+            expect(shouldPreventDefaultPaste(null, editor)).toBeFalse();
         });
 
         it('should prevent default on non-Android platforms', () => {
-            const clipboardData = <ClipboardData>{
+            const clipboardData = <ClipboardData>(<any>{
                 items: [{ type: '', kind: 'file' }]
-            };
+            });
             const editor = <IEditor>(<any>{
                 getEnvironment: () => ({ isAndroid: false })
             });
-            expect(shouldPreventDefaultPaste(editor, clipboardData)).toBeTrue();
+            expect(shouldPreventDefaultPaste(clipboardData, editor)).toBeTrue();
         });
 
         it('should prevent default for text or image clipboard data on Android platform', () => {
-            const textClipboardData = <ClipboardData>{
+            const textClipboardData = <ClipboardData>(<any>{
                 items: [{ type: 'text/plain', kind: 'string' }]
-            };
-            const imageClipboardData = <ClipboardData>{
+            });
+            const imageClipboardData = <ClipboardData>(<any>{
                 items: [{ type: 'image/png', kind: 'file' }]
-            };
+            });
             const editor = <IEditor>(<any>{
                 getEnvironment: () => ({ isAndroid: true })
             });
-            expect(shouldPreventDefaultPaste(editor, textClipboardData)).toBeTrue();
-            expect(shouldPreventDefaultPaste(editor, imageClipboardData)).toBeTrue();
+            expect(shouldPreventDefaultPaste(textClipboardData, editor)).toBeTrue();
+            expect(shouldPreventDefaultPaste(imageClipboardData, editor)).toBeTrue();
         });
 
         it('should not prevent default for file-only clipboard data on Android platform', () => {
-            const clipboardData = <ClipboardData>{
+            const clipboardData = <ClipboardData>(<any>{
                 items: [{ type: '', kind: 'file' }]
-            };
+            });
             const editor = <IEditor>(<any>{
                 getEnvironment: () => ({ isAndroid: true })
             });
-            expect(shouldPreventDefaultPaste(editor, clipboardData)).toBeFalse();
+            expect(shouldPreventDefaultPaste(clipboardData, editor)).toBeFalse();
         });
     });
 });

--- a/packages/roosterjs-content-model-core/test/corePlugin/copyPaste/CopyPastePluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/copyPaste/CopyPastePluginTest.ts
@@ -27,6 +27,7 @@ import {
     createCopyPastePlugin,
     onNodeCreated,
     preprocessTable,
+    shouldPreventDefaultPaste,
 } from '../../../lib/corePlugin/copyPaste/CopyPastePlugin';
 
 const modelValue = {
@@ -1388,6 +1389,51 @@ describe('CopyPastePlugin |', () => {
                 ],
                 format: {},
             });
+        });
+    });
+
+    describe('shouldPreventDefaultPaste', () => {
+        it('should not prevent default for empty clipboard data', () => {
+            const clipboardData = <ClipboardData>{
+                items: null
+            };
+            const editor = <IEditor>(<any>{});
+            expect(shouldPreventDefaultPaste(editor, clipboardData)).toBeFalse();
+            expect(shouldPreventDefaultPaste(editor, null)).toBeFalse();
+        });
+
+        it('should prevent default on non-Android platforms', () => {
+            const clipboardData = <ClipboardData>{
+                items: [{ type: '', kind: 'file' }]
+            };
+            const editor = <IEditor>(<any>{
+                getEnvironment: () => ({ isAndroid: false })
+            });
+            expect(shouldPreventDefaultPaste(editor, clipboardData)).toBeTrue();
+        });
+
+        it('should prevent default for text or image clipboard data on Android platform', () => {
+            const textClipboardData = <ClipboardData>{
+                items: [{ type: 'text/plain', kind: 'string' }]
+            };
+            const imageClipboardData = <ClipboardData>{
+                items: [{ type: 'image/png', kind: 'file' }]
+            };
+            const editor = <IEditor>(<any>{
+                getEnvironment: () => ({ isAndroid: true })
+            });
+            expect(shouldPreventDefaultPaste(editor, textClipboardData)).toBeTrue();
+            expect(shouldPreventDefaultPaste(editor, imageClipboardData)).toBeTrue();
+        });
+
+        it('should not prevent default for file-only clipboard data on Android platform', () => {
+            const clipboardData = <ClipboardData>{
+                items: [{ type: '', kind: 'file' }]
+            };
+            const editor = <IEditor>(<any>{
+                getEnvironment: () => ({ isAndroid: true })
+            });
+            expect(shouldPreventDefaultPaste(editor, clipboardData)).toBeFalse();
         });
     });
 });


### PR DESCRIPTION
Android users are unable to paste content from Word to Outlook after recent Chromium update. The root cause is that the clipboard data from Word contains only a File object, without any HTML or plain text. And we can't use `FileReader` to extract paste content from it.

![image](https://github.com/user-attachments/assets/2645f3b5-ca47-4a0d-8542-27feaba5dc1b)
![image](https://github.com/user-attachments/assets/abd8602f-ba6d-4fae-a71d-96a4ba309230)

To workaround this issue, we are adding a check to `CopyPastePlugin`: if the clipboard data can't be processed by roosterjs (e.g., it doesn't have any plain text, HTML and image), preventDefault() shouldn't be called, allowing the browser to handle the paste event instead. 

