### PR TITLE
Add a vertical alignment to the image wrapper

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
@@ -69,7 +69,7 @@ const createShadowSpan = (wrapper: HTMLElement, imageSpan: HTMLSpanElement) => {
     const shadowRoot = imageSpan.attachShadow({
         mode: 'open',
     });
-    imageSpan.style.verticalAlign = 'bottom';
+    wrapper.style.verticalAlign = 'bottom';
     shadowRoot.appendChild(wrapper);
     return imageSpan;
 };

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/utils/createImageWrapperTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/utils/createImageWrapperTest.ts
@@ -202,7 +202,7 @@ const createShadowSpan = (wrapper: HTMLSpanElement) => {
     const shadowRoot = span.attachShadow({
         mode: 'open',
     });
-    span.style.verticalAlign = 'bottom';
+    wrapper.style.verticalAlign = 'bottom';
     shadowRoot.append(wrapper);
     return span;
 };


### PR DESCRIPTION
Instead of adding the vertical align to the image span, add to the image wrapper. 
Before: 
![rotateImageBugBeforeFix](https://github.com/user-attachments/assets/0a56a0f7-43bf-4334-8fda-a15fb995bf32)


After: 
![rotateImageBug](https://github.com/user-attachments/assets/67567425-11a5-4c8f-b31f-03940525aec1)
