### PR TITLE
#2861 Allow specify pending format for paragraph

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -136,10 +136,19 @@ function handlePendingFormat(
         context.newPendingFormat == 'preserve'
             ? core.format.pendingFormat?.format
             : context.newPendingFormat;
+    const pendingParagraphFormat =
+        context.newPendingParagraphFormat == 'preserve'
+            ? core.format.pendingFormat?.paragraphFormat
+            : context.newPendingParagraphFormat;
 
-    if (pendingFormat && selection?.type == 'range' && selection.range.collapsed) {
+    if (
+        (pendingFormat || pendingParagraphFormat) &&
+        selection?.type == 'range' &&
+        selection.range.collapsed
+    ) {
         core.format.pendingFormat = {
-            format: { ...pendingFormat },
+            format: pendingFormat ? { ...pendingFormat } : undefined,
+            paragraphFormat: pendingParagraphFormat ? { ...pendingParagraphFormat } : undefined,
             insertPoint: {
                 node: selection.range.startContainer,
                 offset: selection.range.startOffset,

--- a/packages/roosterjs-content-model-core/lib/corePlugin/format/FormatPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/format/FormatPlugin.ts
@@ -118,13 +118,16 @@ class FormatPlugin implements PluginWithState<FormatPluginState> {
                 break;
 
             case 'keyDown':
-                const isAndroidIME = this.editor.getEnvironment().isAndroid && event.rawEvent.key == UnidentifiedKey;
+                const isAndroidIME =
+                    this.editor.getEnvironment().isAndroid && event.rawEvent.key == UnidentifiedKey;
                 if (isCursorMovingKey(event.rawEvent)) {
                     this.clearPendingFormat();
                     this.lastCheckedNode = null;
                 } else if (
                     this.defaultFormatKeys.size > 0 &&
-                    (isAndroidIME || isCharacterValue(event.rawEvent) || event.rawEvent.key == ProcessKey) &&
+                    (isAndroidIME ||
+                        isCharacterValue(event.rawEvent) ||
+                        event.rawEvent.key == ProcessKey) &&
                     this.shouldApplyDefaultFormat(this.editor)
                 ) {
                     applyDefaultFormat(this.editor, this.state.defaultFormat);
@@ -145,7 +148,12 @@ class FormatPlugin implements PluginWithState<FormatPluginState> {
 
     private checkAndApplyPendingFormat(data: string | null) {
         if (this.editor && data && this.state.pendingFormat) {
-            applyPendingFormat(this.editor, data, this.state.pendingFormat.format);
+            applyPendingFormat(
+                this.editor,
+                data,
+                this.state.pendingFormat.format,
+                this.state.pendingFormat.paragraphFormat
+            );
             this.clearPendingFormat();
         }
     }

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -658,6 +658,7 @@ describe('formatContentModel', () => {
         it('Has pending format, callback returns true, preserve pending format', () => {
             core.format.pendingFormat = {
                 format: mockedFormat1,
+                paragraphFormat: mockedFormat2,
                 insertPoint: {
                     node: mockedStartContainer1,
                     offset: mockedStartOffset1,
@@ -679,9 +680,35 @@ describe('formatContentModel', () => {
             } as any);
         });
 
-        it('Has pending format, callback returns false, preserve pending format', () => {
+        it('Has pending format, callback returns true, preserve paragraph pending format', () => {
             core.format.pendingFormat = {
                 format: mockedFormat1,
+                paragraphFormat: mockedFormat2,
+                insertPoint: {
+                    node: mockedStartContainer1,
+                    offset: mockedStartOffset1,
+                },
+            };
+
+            formatContentModel(core, (model, context) => {
+                context.newPendingParagraphFormat = 'preserve';
+                return true;
+            });
+
+            expect(core.format.pendingFormat).toEqual({
+                format: undefined,
+                paragraphFormat: mockedFormat2,
+                insertPoint: {
+                    node: mockedStartContainer2,
+                    offset: mockedStartOffset2,
+                },
+            } as any);
+        });
+
+        it('Has pending format, callback returns true, preserve both pending format', () => {
+            core.format.pendingFormat = {
+                format: mockedFormat1,
+                paragraphFormat: mockedFormat2,
                 insertPoint: {
                     node: mockedStartContainer1,
                     offset: mockedStartOffset1,
@@ -690,12 +717,39 @@ describe('formatContentModel', () => {
 
             formatContentModel(core, (model, context) => {
                 context.newPendingFormat = 'preserve';
+                context.newPendingParagraphFormat = 'preserve';
+                return true;
+            });
+
+            expect(core.format.pendingFormat).toEqual({
+                format: mockedFormat1,
+                paragraphFormat: mockedFormat2,
+                insertPoint: {
+                    node: mockedStartContainer2,
+                    offset: mockedStartOffset2,
+                },
+            } as any);
+        });
+
+        it('Has pending format, callback returns false, preserve both pending format', () => {
+            core.format.pendingFormat = {
+                format: mockedFormat1,
+                paragraphFormat: mockedFormat2,
+                insertPoint: {
+                    node: mockedStartContainer1,
+                    offset: mockedStartOffset1,
+                },
+            };
+
+            formatContentModel(core, (model, context) => {
+                context.newPendingFormat = 'preserve';
+                context.newPendingParagraphFormat = 'preserve';
                 return false;
             });
 
             expect(core.format.pendingFormat).toEqual({
                 format: mockedFormat1,
-                paragraphFormat: undefined,
+                paragraphFormat: mockedFormat2,
                 insertPoint: {
                     node: mockedStartContainer2,
                     offset: mockedStartOffset2,
@@ -712,6 +766,22 @@ describe('formatContentModel', () => {
             expect(core.format.pendingFormat).toEqual({
                 format: mockedFormat2,
                 paragraphFormat: undefined,
+                insertPoint: {
+                    node: mockedStartContainer2,
+                    offset: mockedStartOffset2,
+                },
+            });
+        });
+
+        it('No pending format, callback returns true, new paragraph format', () => {
+            formatContentModel(core, (model, context) => {
+                context.newPendingParagraphFormat = mockedFormat2;
+                return true;
+            });
+
+            expect(core.format.pendingFormat).toEqual({
+                format: undefined,
+                paragraphFormat: mockedFormat2,
                 insertPoint: {
                     node: mockedStartContainer2,
                     offset: mockedStartOffset2,
@@ -776,6 +846,30 @@ describe('formatContentModel', () => {
             expect(core.format.pendingFormat).toEqual({
                 format: mockedFormat2,
                 paragraphFormat: undefined,
+                insertPoint: {
+                    node: mockedStartContainer2,
+                    offset: mockedStartOffset2,
+                },
+            });
+        });
+
+        it('Has pending format, callback returns false, new paragraph format', () => {
+            core.format.pendingFormat = {
+                paragraphFormat: mockedFormat1,
+                insertPoint: {
+                    node: mockedStartContainer1,
+                    offset: mockedStartOffset1,
+                },
+            };
+
+            formatContentModel(core, (model, context) => {
+                context.newPendingParagraphFormat = mockedFormat2;
+                return false;
+            });
+
+            expect(core.format.pendingFormat).toEqual({
+                format: undefined,
+                paragraphFormat: mockedFormat2,
                 insertPoint: {
                     node: mockedStartContainer2,
                     offset: mockedStartOffset2,

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -671,6 +671,7 @@ describe('formatContentModel', () => {
 
             expect(core.format.pendingFormat).toEqual({
                 format: mockedFormat1,
+                paragraphFormat: undefined,
                 insertPoint: {
                     node: mockedStartContainer2,
                     offset: mockedStartOffset2,
@@ -694,6 +695,7 @@ describe('formatContentModel', () => {
 
             expect(core.format.pendingFormat).toEqual({
                 format: mockedFormat1,
+                paragraphFormat: undefined,
                 insertPoint: {
                     node: mockedStartContainer2,
                     offset: mockedStartOffset2,
@@ -709,6 +711,7 @@ describe('formatContentModel', () => {
 
             expect(core.format.pendingFormat).toEqual({
                 format: mockedFormat2,
+                paragraphFormat: undefined,
                 insertPoint: {
                     node: mockedStartContainer2,
                     offset: mockedStartOffset2,
@@ -724,6 +727,7 @@ describe('formatContentModel', () => {
 
             expect(core.format.pendingFormat).toEqual({
                 format: mockedFormat2,
+                paragraphFormat: undefined,
                 insertPoint: {
                     node: mockedStartContainer2,
                     offset: mockedStartOffset2,
@@ -747,6 +751,7 @@ describe('formatContentModel', () => {
 
             expect(core.format.pendingFormat).toEqual({
                 format: mockedFormat2,
+                paragraphFormat: undefined,
                 insertPoint: {
                     node: mockedStartContainer2,
                     offset: mockedStartOffset2,
@@ -770,6 +775,7 @@ describe('formatContentModel', () => {
 
             expect(core.format.pendingFormat).toEqual({
                 format: mockedFormat2,
+                paragraphFormat: undefined,
                 insertPoint: {
                     node: mockedStartContainer2,
                     offset: mockedStartOffset2,

--- a/packages/roosterjs-content-model-core/test/corePlugin/format/FormatPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/format/FormatPluginTest.ts
@@ -60,7 +60,7 @@ describe('FormatPlugin', () => {
         plugin.dispose();
 
         expect(applyPendingFormatSpy).toHaveBeenCalledTimes(1);
-        expect(applyPendingFormatSpy).toHaveBeenCalledWith(editor, 'a', mockedFormat);
+        expect(applyPendingFormatSpy).toHaveBeenCalledWith(editor, 'a', mockedFormat, undefined);
         expect(state.pendingFormat).toBeNull();
     });
 
@@ -92,7 +92,7 @@ describe('FormatPlugin', () => {
         });
         plugin.dispose();
 
-        expect(applyPendingFormatSpy).toHaveBeenCalledWith(editor, 'test', mockedFormat);
+        expect(applyPendingFormatSpy).toHaveBeenCalledWith(editor, 'test', mockedFormat, undefined);
         expect(state.pendingFormat).toBeNull();
     });
 

--- a/packages/roosterjs-content-model-core/test/corePlugin/format/FormatPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/format/FormatPluginTest.ts
@@ -8,6 +8,9 @@ describe('FormatPlugin', () => {
     const mockedFormat = {
         fontSize: '10px',
     };
+    const mockedFormat2 = {
+        lineSpace: 2,
+    };
     let applyPendingFormatSpy: jasmine.Spy;
 
     beforeEach(() => {
@@ -49,6 +52,7 @@ describe('FormatPlugin', () => {
 
         (state.pendingFormat = {
             format: mockedFormat,
+            paragraphFormat: mockedFormat2,
         } as any),
             plugin.initialize(editor);
 
@@ -60,7 +64,12 @@ describe('FormatPlugin', () => {
         plugin.dispose();
 
         expect(applyPendingFormatSpy).toHaveBeenCalledTimes(1);
-        expect(applyPendingFormatSpy).toHaveBeenCalledWith(editor, 'a', mockedFormat, undefined);
+        expect(applyPendingFormatSpy).toHaveBeenCalledWith(
+            editor,
+            'a',
+            mockedFormat,
+            mockedFormat2
+        );
         expect(state.pendingFormat).toBeNull();
     });
 
@@ -111,7 +120,7 @@ describe('FormatPlugin', () => {
         const state = plugin.getState();
 
         state.pendingFormat = {
-            format: mockedFormat,
+            paragraphFormat: mockedFormat2,
         } as any;
 
         plugin.onPluginEvent({
@@ -122,7 +131,7 @@ describe('FormatPlugin', () => {
 
         expect(applyPendingFormatSpy).not.toHaveBeenCalled();
         expect(state.pendingFormat).toEqual({
-            format: mockedFormat,
+            paragraphFormat: mockedFormat2,
         } as any);
     });
 

--- a/packages/roosterjs-content-model-core/test/corePlugin/format/applyPendingFormatTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/format/applyPendingFormatTest.ts
@@ -94,6 +94,225 @@ describe('applyPendingFormat', () => {
         });
     });
 
+    it('Has pending paragraph format', () => {
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'abc',
+            format: {},
+        };
+        const marker: ContentModelSelectionMarker = {
+            segmentType: 'SelectionMarker',
+            isSelected: true,
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [text, marker],
+            format: { textAlign: 'start', textIndent: '10pt' },
+        };
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [paragraph],
+        };
+
+        const formatContentModelSpy = jasmine
+            .createSpy('formatContentModel')
+            .and.callFake((callback: ContentModelFormatter, options: FormatContentModelOptions) => {
+                expect(options.apiName).toEqual('applyPendingFormat');
+                callback(model, {
+                    newEntities: [],
+                    deletedEntities: [],
+                    newImages: [],
+                });
+            });
+
+        const editor = ({
+            formatContentModel: formatContentModelSpy,
+        } as any) as IEditor;
+
+        spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
+            callback([model], undefined, paragraph, [marker]);
+            return false;
+        });
+
+        applyPendingFormat(editor, 'c', undefined, {
+            textIndent: '20pt',
+            lineHeight: '2',
+        });
+
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: { textAlign: 'start', textIndent: '20pt', lineHeight: '2' },
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'abc',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Has pending both format', () => {
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'abc',
+            format: {},
+        };
+        const marker: ContentModelSelectionMarker = {
+            segmentType: 'SelectionMarker',
+            isSelected: true,
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [text, marker],
+            format: { textAlign: 'start', textIndent: '10pt' },
+        };
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [paragraph],
+        };
+
+        const formatContentModelSpy = jasmine
+            .createSpy('formatContentModel')
+            .and.callFake((callback: ContentModelFormatter, options: FormatContentModelOptions) => {
+                expect(options.apiName).toEqual('applyPendingFormat');
+                callback(model, {
+                    newEntities: [],
+                    deletedEntities: [],
+                    newImages: [],
+                });
+            });
+
+        const editor = ({
+            formatContentModel: formatContentModelSpy,
+        } as any) as IEditor;
+
+        spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
+            callback([model], undefined, paragraph, [marker]);
+            return false;
+        });
+
+        applyPendingFormat(
+            editor,
+            'c',
+            { fontSize: '10px' },
+            {
+                textIndent: '20pt',
+                lineHeight: '2',
+            }
+        );
+
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: { textAlign: 'start', textIndent: '20pt', lineHeight: '2' },
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'ab',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'c',
+                            format: {
+                                fontSize: '10px',
+                            },
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: { fontSize: '10px' },
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Has no pending format', () => {
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'abc',
+            format: {},
+        };
+        const marker: ContentModelSelectionMarker = {
+            segmentType: 'SelectionMarker',
+            isSelected: true,
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [text, marker],
+            format: {},
+        };
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [paragraph],
+        };
+
+        const formatContentModelSpy = jasmine
+            .createSpy('formatContentModel')
+            .and.callFake((callback: ContentModelFormatter, options: FormatContentModelOptions) => {
+                expect(options.apiName).toEqual('applyPendingFormat');
+                callback(model, {
+                    newEntities: [],
+                    deletedEntities: [],
+                    newImages: [],
+                });
+            });
+
+        const editor = ({
+            formatContentModel: formatContentModelSpy,
+        } as any) as IEditor;
+
+        spyOn(iterateSelections, 'iterateSelections').and.callFake((_, callback) => {
+            callback([model], undefined, paragraph, [marker]);
+            return false;
+        });
+
+        applyPendingFormat(editor, 'c');
+
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'abc',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
     it('Has pending format but wrong text', () => {
         const text: ContentModelText = {
             segmentType: 'Text',

--- a/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelContext.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelContext.ts
@@ -1,9 +1,9 @@
-import { ContentModelBlockFormat } from 'roosterjs/lib';
 import type { AnnounceData } from './AnnounceData';
 import type { ContentModelEntity } from '../contentModel/entity/ContentModelEntity';
 import type { ContentModelImage } from '../contentModel/segment/ContentModelImage';
 import type { ContentModelSegmentFormat } from '../contentModel/format/ContentModelSegmentFormat';
 import type { EntityRemovalOperation } from '../enum/EntityOperation';
+import type { ContentModelBlockFormat } from '../contentModel/format/ContentModelBlockFormat';
 
 /**
  * State for an entity. This is used for storing entity undo snapshot

--- a/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelContext.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelContext.ts
@@ -1,3 +1,4 @@
+import { ContentModelBlockFormat } from 'roosterjs/lib';
 import type { AnnounceData } from './AnnounceData';
 import type { ContentModelEntity } from '../contentModel/entity/ContentModelEntity';
 import type { ContentModelImage } from '../contentModel/segment/ContentModelImage';
@@ -86,6 +87,15 @@ export interface FormatContentModelContext {
      * Otherwise, leave it there and editor will automatically decide if the original pending format is still available
      */
     newPendingFormat?: ContentModelSegmentFormat | 'preserve';
+
+    /**
+     * @optional
+     * Specify new pending format for paragraph
+     * To keep current format event selection position is changed, set this value to "preserved", editor will update pending format position to the new position
+     * To set a new pending format, set this property to the format object
+     * Otherwise, leave it there and editor will automatically decide if the original pending format is still available
+     */
+    newPendingParagraphFormat?: ContentModelBlockFormat | 'preserve';
 
     /**
      * @optional Entity states related to the format API that will be added together with undo snapshot.

--- a/packages/roosterjs-content-model-types/lib/pluginState/FormatPluginState.ts
+++ b/packages/roosterjs-content-model-types/lib/pluginState/FormatPluginState.ts
@@ -1,5 +1,6 @@
 import type { DOMInsertPoint } from '../selection/DOMSelection';
 import type { ContentModelSegmentFormat } from '../contentModel/format/ContentModelSegmentFormat';
+import type { ContentModelBlockFormat } from '../contentModel/format/ContentModelBlockFormat';
 
 /**
  * Pending format holder interface
@@ -8,7 +9,12 @@ export interface PendingFormat {
     /**
      * The pending format
      */
-    format: ContentModelSegmentFormat;
+    format?: ContentModelSegmentFormat;
+
+    /**
+     * Customized format for paragraph
+     */
+    paragraphFormat?: ContentModelBlockFormat;
 
     /**
      * Insert point of pending format


### PR DESCRIPTION
In addition to pending segment format, we now support specify pending format for paragraph. To do that, assign a pending format object to context.newPendingParagraphFormat within callback of `formatContentModel`:

```ts
                    this.editor.formatContentModel((_, context) => {
                        context.newPendingParagraphFormat = {...};

                        return false;
                    });
```