### PR TITLE
Fix #2862 Keep format when replace a selection

### DIFF
--- a/packages/roosterjs-content-model-core/test/corePlugin/format/FormatPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/format/FormatPluginTest.ts
@@ -225,14 +225,12 @@ describe('FormatPlugin for default format', () => {
     let getDOMSelection: jasmine.Spy;
     let getPendingFormatSpy: jasmine.Spy;
     let cacheContentModelSpy: jasmine.Spy;
-    let takeSnapshotSpy: jasmine.Spy;
     let formatContentModelSpy: jasmine.Spy;
 
     beforeEach(() => {
         getPendingFormatSpy = jasmine.createSpy('getPendingFormat');
         getDOMSelection = jasmine.createSpy('getDOMSelection');
         cacheContentModelSpy = jasmine.createSpy('cacheContentModel');
-        takeSnapshotSpy = jasmine.createSpy('takeSnapshot');
         formatContentModelSpy = jasmine.createSpy('formatContentModelSpy');
         contentDiv = document.createElement('div');
 
@@ -243,7 +241,6 @@ describe('FormatPlugin for default format', () => {
             getDOMSelection,
             getPendingFormat: getPendingFormatSpy,
             cacheContentModel: cacheContentModelSpy,
-            takeSnapshot: takeSnapshotSpy,
             formatContentModel: formatContentModelSpy,
             getEnvironment: () => ({}),
         } as any) as IEditor;
@@ -355,7 +352,6 @@ describe('FormatPlugin for default format', () => {
         });
 
         expect(context).toEqual({});
-        expect(takeSnapshotSpy).toHaveBeenCalledTimes(1);
     });
 
     it('Collapsed range, IME input, under editor directly', () => {

--- a/packages/roosterjs-content-model-core/test/corePlugin/format/applyDefaultFormatTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/format/applyDefaultFormatTest.ts
@@ -1,5 +1,4 @@
 import * as deleteSelection from 'roosterjs-content-model-dom/lib/modelApi/editing/deleteSelection';
-import * as normalizeContentModel from 'roosterjs-content-model-dom/lib/modelApi/common/normalizeContentModel';
 import { applyDefaultFormat } from '../../../lib/corePlugin/format/applyDefaultFormat';
 import {
     ContentModelDocument,
@@ -24,8 +23,6 @@ describe('applyDefaultFormat', () => {
     let getDOMSelectionSpy: jasmine.Spy;
     let formatContentModelSpy: jasmine.Spy;
     let deleteSelectionSpy: jasmine.Spy;
-    let normalizeContentModelSpy: jasmine.Spy;
-    let takeSnapshotSpy: jasmine.Spy;
     let getPendingFormatSpy: jasmine.Spy;
     let isNodeInEditorSpy: jasmine.Spy;
 
@@ -46,8 +43,6 @@ describe('applyDefaultFormat', () => {
 
         getDOMSelectionSpy = jasmine.createSpy('getDOMSelectionSpy');
         deleteSelectionSpy = spyOn(deleteSelection, 'deleteSelection');
-        normalizeContentModelSpy = spyOn(normalizeContentModel, 'normalizeContentModel');
-        takeSnapshotSpy = jasmine.createSpy('takeSnapshot');
         getPendingFormatSpy = jasmine.createSpy('getPendingFormat');
         isNodeInEditorSpy = jasmine.createSpy('isNodeInEditor');
 
@@ -71,7 +66,6 @@ describe('applyDefaultFormat', () => {
             }),
             getDOMSelection: getDOMSelectionSpy,
             formatContentModel: formatContentModelSpy,
-            takeSnapshot: takeSnapshotSpy,
             getPendingFormat: getPendingFormatSpy,
         } as any;
     });
@@ -82,7 +76,7 @@ describe('applyDefaultFormat', () => {
 
         applyDefaultFormat(editor, defaultFormat);
 
-        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).not.toHaveBeenCalled();
     });
 
     it('Selection already has style', () => {
@@ -99,6 +93,7 @@ describe('applyDefaultFormat', () => {
             range: {
                 startContainer: node,
                 startOffset: 0,
+                collapsed: true,
             },
         });
         deleteSelectionSpy.and.returnValue({
@@ -124,6 +119,7 @@ describe('applyDefaultFormat', () => {
             range: {
                 startContainer: text,
                 startOffset: 0,
+                collapsed: true,
             },
         });
         deleteSelectionSpy.and.returnValue({
@@ -143,6 +139,7 @@ describe('applyDefaultFormat', () => {
             range: {
                 startContainer: node,
                 startOffset: 0,
+                collapsed: true,
             },
         });
 
@@ -154,9 +151,7 @@ describe('applyDefaultFormat', () => {
         applyDefaultFormat(editor, defaultFormat);
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(normalizeContentModelSpy).toHaveBeenCalledWith(model);
-        expect(takeSnapshotSpy).toHaveBeenCalledTimes(1);
-        expect(formatResult).toBeTrue();
+        expect(formatResult).toBeFalse();
         expect(context).toEqual({
             deletedEntities: [],
             newEntities: [],
@@ -174,6 +169,7 @@ describe('applyDefaultFormat', () => {
             range: {
                 startContainer: node,
                 startOffset: 0,
+                collapsed: true,
             },
         });
 
@@ -185,8 +181,6 @@ describe('applyDefaultFormat', () => {
         applyDefaultFormat(editor, defaultFormat);
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(normalizeContentModelSpy).not.toHaveBeenCalledWith();
-        expect(takeSnapshotSpy).not.toHaveBeenCalled();
         expect(formatResult).toBeFalse();
         expect(context).toEqual({
             deletedEntities: [],
@@ -204,6 +198,7 @@ describe('applyDefaultFormat', () => {
             range: {
                 startContainer: node,
                 startOffset: 0,
+                collapsed: true,
             },
         });
 
@@ -215,8 +210,6 @@ describe('applyDefaultFormat', () => {
         applyDefaultFormat(editor, defaultFormat);
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(normalizeContentModelSpy).not.toHaveBeenCalledWith();
-        expect(takeSnapshotSpy).not.toHaveBeenCalled();
         expect(formatResult).toBeFalse();
         expect(context).toEqual({
             deletedEntities: [],
@@ -246,6 +239,7 @@ describe('applyDefaultFormat', () => {
             range: {
                 startContainer: node,
                 startOffset: 0,
+                collapsed: true,
             },
         });
 
@@ -257,8 +251,6 @@ describe('applyDefaultFormat', () => {
         applyDefaultFormat(editor, defaultFormat);
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(normalizeContentModelSpy).not.toHaveBeenCalled();
-        expect(takeSnapshotSpy).not.toHaveBeenCalled();
         expect(formatResult).toBeFalse();
         expect(context).toEqual({
             deletedEntities: [],
@@ -288,6 +280,7 @@ describe('applyDefaultFormat', () => {
             range: {
                 startContainer: node,
                 startOffset: 0,
+                collapsed: true,
             },
         });
 
@@ -299,8 +292,6 @@ describe('applyDefaultFormat', () => {
         applyDefaultFormat(editor, defaultFormat);
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(normalizeContentModelSpy).not.toHaveBeenCalled();
-        expect(takeSnapshotSpy).not.toHaveBeenCalled();
         expect(formatResult).toBeFalse();
         expect(context).toEqual({
             deletedEntities: [],
@@ -331,6 +322,7 @@ describe('applyDefaultFormat', () => {
             range: {
                 startContainer: node,
                 startOffset: 0,
+                collapsed: true,
             },
         });
 
@@ -342,8 +334,6 @@ describe('applyDefaultFormat', () => {
         applyDefaultFormat(editor, defaultFormat);
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(normalizeContentModelSpy).not.toHaveBeenCalled();
-        expect(takeSnapshotSpy).not.toHaveBeenCalled();
         expect(formatResult).toBeFalse();
         expect(context).toEqual({
             deletedEntities: [],
@@ -373,6 +363,7 @@ describe('applyDefaultFormat', () => {
             range: {
                 startContainer: node,
                 startOffset: 0,
+                collapsed: true,
             },
         });
 
@@ -384,8 +375,6 @@ describe('applyDefaultFormat', () => {
         applyDefaultFormat(editor, defaultFormat);
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(normalizeContentModelSpy).not.toHaveBeenCalled();
-        expect(takeSnapshotSpy).not.toHaveBeenCalled();
         expect(formatResult).toBeFalse();
         expect(context).toEqual({
             deletedEntities: [],
@@ -419,6 +408,7 @@ describe('applyDefaultFormat', () => {
             range: {
                 startContainer: node,
                 startOffset: 0,
+                collapsed: true,
             },
         });
 
@@ -435,8 +425,6 @@ describe('applyDefaultFormat', () => {
         applyDefaultFormat(editor, defaultFormat);
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
-        expect(normalizeContentModelSpy).not.toHaveBeenCalled();
-        expect(takeSnapshotSpy).not.toHaveBeenCalled();
         expect(formatResult).toBeFalse();
         expect(context).toEqual({
             deletedEntities: [],

--- a/packages/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/keyboardInputTest.ts
@@ -99,7 +99,11 @@ describe('keyboardInput', () => {
         expect(getDOMSelectionSpy).toHaveBeenCalled();
         expect(takeSnapshotSpy).toHaveBeenCalled();
         expect(formatContentModelSpy).toHaveBeenCalled();
-        expect(deleteSelectionSpy).toHaveBeenCalledWith(mockedModel, [], mockedContext);
+        expect(deleteSelectionSpy).toHaveBeenCalledWith(
+            mockedModel,
+            [jasmine.anything()],
+            mockedContext
+        );
         expect(formatResult).toBeFalse();
         expect(mockedContext).toEqual({
             deletedEntities: [],
@@ -130,7 +134,11 @@ describe('keyboardInput', () => {
         expect(getDOMSelectionSpy).toHaveBeenCalled();
         expect(takeSnapshotSpy).toHaveBeenCalled();
         expect(formatContentModelSpy).toHaveBeenCalled();
-        expect(deleteSelectionSpy).toHaveBeenCalledWith(mockedModel, [], mockedContext);
+        expect(deleteSelectionSpy).toHaveBeenCalledWith(
+            mockedModel,
+            [jasmine.anything()],
+            mockedContext
+        );
         expect(formatResult).toBeTrue();
         expect(mockedContext).toEqual({
             deletedEntities: [],
@@ -140,6 +148,90 @@ describe('keyboardInput', () => {
             newPendingFormat: undefined,
         });
         expect(normalizeContentModelSpy).toHaveBeenCalledWith(mockedModel);
+    });
+
+    it('Letter input, expanded selection, no modifier key, deleteSelection returns range, do real deleting', () => {
+        getDOMSelectionSpy.and.returnValue({
+            type: 'range',
+            range: {
+                collapsed: false,
+            },
+        });
+        deleteSelectionSpy.and.callThrough();
+
+        mockedModel = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'aa',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '',
+                            format: { fontSize: '10pt' },
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const rawEvent = {
+            key: 'A',
+        } as any;
+
+        keyboardInput(editor, rawEvent);
+
+        expect(getDOMSelectionSpy).toHaveBeenCalled();
+        expect(takeSnapshotSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(deleteSelectionSpy).toHaveBeenCalledWith(
+            mockedModel,
+            [jasmine.anything()],
+            mockedContext
+        );
+        expect(formatResult).toBeTrue();
+        expect(mockedContext).toEqual({
+            deletedEntities: [],
+            newEntities: [],
+            newImages: [],
+            skipUndoSnapshot: true,
+            newPendingFormat: { fontSize: '10pt' },
+        });
+        expect(normalizeContentModelSpy).toHaveBeenCalledWith(mockedModel);
+        expect(mockedModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'aa',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: '\u200B',
+                            format: { fontSize: '10pt' },
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: { fontSize: '10pt' },
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
     });
 
     it('Letter input, table selection, no modifier key, deleteSelection returns range', () => {
@@ -159,7 +251,11 @@ describe('keyboardInput', () => {
         expect(getDOMSelectionSpy).toHaveBeenCalled();
         expect(takeSnapshotSpy).toHaveBeenCalled();
         expect(formatContentModelSpy).toHaveBeenCalled();
-        expect(deleteSelectionSpy).toHaveBeenCalledWith(mockedModel, [], mockedContext);
+        expect(deleteSelectionSpy).toHaveBeenCalledWith(
+            mockedModel,
+            [jasmine.anything()],
+            mockedContext
+        );
         expect(formatResult).toBeTrue();
         expect(mockedContext).toEqual({
             deletedEntities: [],
@@ -188,7 +284,11 @@ describe('keyboardInput', () => {
         expect(getDOMSelectionSpy).toHaveBeenCalled();
         expect(takeSnapshotSpy).toHaveBeenCalled();
         expect(formatContentModelSpy).toHaveBeenCalled();
-        expect(deleteSelectionSpy).toHaveBeenCalledWith(mockedModel, [], mockedContext);
+        expect(deleteSelectionSpy).toHaveBeenCalledWith(
+            mockedModel,
+            [jasmine.anything()],
+            mockedContext
+        );
         expect(formatResult).toBeTrue();
         expect(mockedContext).toEqual({
             deletedEntities: [],
@@ -273,7 +373,11 @@ describe('keyboardInput', () => {
         expect(getDOMSelectionSpy).toHaveBeenCalled();
         expect(takeSnapshotSpy).toHaveBeenCalled();
         expect(formatContentModelSpy).toHaveBeenCalled();
-        expect(deleteSelectionSpy).toHaveBeenCalledWith(mockedModel, [], mockedContext);
+        expect(deleteSelectionSpy).toHaveBeenCalledWith(
+            mockedModel,
+            [jasmine.anything()],
+            mockedContext
+        );
         expect(formatResult).toBeTrue();
         expect(mockedContext).toEqual({
             deletedEntities: [],
@@ -338,7 +442,11 @@ describe('keyboardInput', () => {
         expect(getDOMSelectionSpy).toHaveBeenCalled();
         expect(takeSnapshotSpy).toHaveBeenCalled();
         expect(formatContentModelSpy).toHaveBeenCalled();
-        expect(deleteSelectionSpy).toHaveBeenCalledWith(mockedModel, [], mockedContext);
+        expect(deleteSelectionSpy).toHaveBeenCalledWith(
+            mockedModel,
+            [jasmine.anything()],
+            mockedContext
+        );
         expect(formatResult).toBeTrue();
         expect(mockedContext).toEqual({
             deletedEntities: [],


### PR DESCRIPTION
#2862 

When select text and type to replace, we first delete it, keep its format, then let browser to handle the input. However, if there is text with different format right before it, browser will apply the format from existing text.

To fix this, we set a SPAN with ZeroWidthSpace in it and make it selected so browser will replace this selection instead of applying format from text before.