### PR TITLE
#2855 Add a parameter for formatContentModel to allow auto detection of new/removed entities

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -148,20 +148,25 @@ function handlePendingFormat(
     }
 }
 
-function getChangedEntities(context: FormatContentModelContext, rawEvent?: Event): ChangedEntity[] {
-    return context.newEntities
-        .map(
-            (entity): ChangedEntity => ({
-                entity,
-                operation: 'newEntity',
-                rawEvent,
-            })
-        )
-        .concat(
-            context.deletedEntities.map(entry => ({
-                entity: entry.entity,
-                operation: entry.operation,
-                rawEvent,
-            }))
-        );
+function getChangedEntities(
+    context: FormatContentModelContext,
+    rawEvent?: Event
+): ChangedEntity[] | undefined {
+    return context.autoDetectChangedEntities
+        ? undefined
+        : context.newEntities
+              .map(
+                  (entity): ChangedEntity => ({
+                      entity,
+                      operation: 'newEntity',
+                      rawEvent,
+                  })
+              )
+              .concat(
+                  context.deletedEntities.map(entry => ({
+                      entity: entry.entity,
+                      operation: entry.operation,
+                      rawEvent,
+                  }))
+              );
 }

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -970,4 +970,138 @@ describe('formatContentModel', () => {
             expect(announce).toHaveBeenCalledWith(core, mockedData);
         });
     });
+
+    describe('Changed entities', () => {
+        it('Callback return true, changed entities are not specified', () => {
+            const callback = jasmine.createSpy('callback').and.returnValue(true);
+
+            formatContentModel(core, callback, { apiName });
+
+            expect(callback).toHaveBeenCalledWith(mockedModel, {
+                newEntities: [],
+                deletedEntities: [],
+                rawEvent: undefined,
+                newImages: [],
+            });
+            expect(createContentModel).toHaveBeenCalledTimes(1);
+            expect(addUndoSnapshot).toHaveBeenCalled();
+            expect(setContentModel).toHaveBeenCalled();
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: 'contentChanged',
+                    contentModel: mockedModel,
+                    selection: mockedSelection,
+                    source: 'Format',
+                    data: undefined,
+                    formatApiName: 'mockedApi',
+                    changedEntities: [],
+                },
+                true
+            );
+        });
+
+        it('Callback return true, changed entities are specified', () => {
+            const wrapper1 = document.createElement('span');
+            const wrapper2 = document.createElement('div');
+            const callback = jasmine
+                .createSpy('callback')
+                .and.callFake((model: any, context: FormatContentModelContext) => {
+                    context.newEntities.push({
+                        segmentType: 'Entity',
+                        blockType: 'Entity',
+                        entityFormat: {
+                            entityType: 'test',
+                        },
+                        format: {},
+                        wrapper: wrapper1,
+                    });
+                    context.deletedEntities.push({
+                        entity: {
+                            segmentType: 'Entity',
+                            blockType: 'Entity',
+                            entityFormat: {
+                                entityType: 'test',
+                            },
+                            format: {},
+                            wrapper: wrapper2,
+                        },
+                        operation: 'overwrite',
+                    });
+                    return true;
+                });
+
+            formatContentModel(core, callback, { apiName });
+
+            expect(callback).toHaveBeenCalled();
+            expect(createContentModel).toHaveBeenCalledTimes(1);
+            expect(addUndoSnapshot).toHaveBeenCalled();
+            expect(setContentModel).toHaveBeenCalled();
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: 'contentChanged',
+                    contentModel: mockedModel,
+                    selection: mockedSelection,
+                    source: 'Format',
+                    data: undefined,
+                    formatApiName: 'mockedApi',
+                    changedEntities: [
+                        {
+                            entity: {
+                                segmentType: 'Entity',
+                                blockType: 'Entity',
+                                entityFormat: { entityType: 'test' },
+                                format: {},
+                                wrapper: wrapper1,
+                            },
+                            operation: 'newEntity',
+                            rawEvent: undefined,
+                        },
+                        {
+                            entity: {
+                                segmentType: 'Entity',
+                                blockType: 'Entity',
+                                entityFormat: { entityType: 'test' },
+                                format: {},
+                                wrapper: wrapper2,
+                            },
+                            operation: 'overwrite',
+                            rawEvent: undefined,
+                        },
+                    ],
+                },
+                true
+            );
+        });
+
+        it('Callback return true, auto detect entity change', () => {
+            const callback = jasmine
+                .createSpy('callback')
+                .and.callFake((model: any, context: FormatContentModelContext) => {
+                    context.autoDetectChangedEntities = true;
+                    return true;
+                });
+
+            formatContentModel(core, callback, { apiName });
+
+            expect(callback).toHaveBeenCalled();
+            expect(createContentModel).toHaveBeenCalledTimes(1);
+            expect(addUndoSnapshot).toHaveBeenCalled();
+            expect(setContentModel).toHaveBeenCalled();
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: 'contentChanged',
+                    contentModel: mockedModel,
+                    selection: mockedSelection,
+                    source: 'Format',
+                    data: undefined,
+                    formatApiName: 'mockedApi',
+                    changedEntities: undefined,
+                },
+                true
+            );
+        });
+    });
 });

--- a/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelContext.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelContext.ts
@@ -46,12 +46,13 @@ export interface DeletedEntity {
  */
 export interface FormatContentModelContext {
     /**
-     * New entities added during the format process
+     * New entities added during the format process. This value is only respected when autoDetectChangedEntities is not set to true
      */
     readonly newEntities: ContentModelEntity[];
 
     /**
      * Entities got deleted during formatting. Need to be set by the formatter function
+     * This value is only respected when autoDetectChangedEntities is not set to true
      */
     readonly deletedEntities: DeletedEntity[];
 
@@ -103,4 +104,9 @@ export interface FormatContentModelContext {
      * @optional Set this value to tell AnnouncePlugin to announce the given information
      */
     announceData?: AnnounceData | null;
+
+    /**
+     * @optional When set to true, EntityPlugin will detect any entity changes during this process, newEntities and deletedEntities will be ignored
+     */
+    autoDetectChangedEntities?: boolean;
 }


### PR DESCRIPTION
Now we can let editor (EntityPlugin) to auto detect changed entity (added, removed) during `formatContentModel`.

To do this, set `context.autoDetectChangedEntities` to be true:

```ts
editor.formatContentModel((model, context)=>{
 ... // add or remove entities
 context.autoDetectChangedEntities = true;

 return true;
});
```

Then there will be code to search all changed entities and trigger `entityOperation` event for each of them.

But if possible, you can still use `context.newEntities` and `context.deletedEntities` to manually specify changed entities since they have better performance. Once `autoDetectChangedEntities` is set to true, `context.newEntities` and `context.deletedEntities` will be ignored.