### PR TITLE
#2878 Provide a callback function to allow fixup model before write back

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/setContentModel/setContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setContentModel/setContentModel.ts
@@ -29,6 +29,8 @@ export const setContentModel: SetContentModel = (core, model, option, onNodeCrea
 
     modelToDomContext.onNodeCreated = onNodeCreated;
 
+    core.onFixUpModel?.(model);
+
     const selection = contentModelToDom(
         core.logicalRoot.ownerDocument,
         core.logicalRoot,

--- a/packages/roosterjs-content-model-core/lib/editor/core/createEditorCore.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/createEditorCore.ts
@@ -47,6 +47,7 @@ export function createEditorCore(contentDiv: HTMLDivElement, options: EditorOpti
         domHelper: createDOMHelper(contentDiv),
         ...getPluginState(corePlugins),
         disposeErrorHandler: options.disposeErrorHandler,
+        onFixUpModel: options.onFixUpModel,
         experimentalFeatures: options.experimentalFeatures ? [...options.experimentalFeatures] : [],
     };
 }

--- a/packages/roosterjs-content-model-core/test/coreApi/setContentModel/setContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setContentModel/setContentModelTest.ts
@@ -114,10 +114,13 @@ describe('setContentModel', () => {
         const mockedRange = {
             type: 'image',
         } as any;
+        const mockedOnFixUpModel = jasmine.createSpy('fixupModel');
 
         contentModelToDomSpy.and.returnValue(mockedRange);
 
         core.environment.modelToDomSettings.builtIn = defaultOption;
+        (core as any).onFixUpModel = mockedOnFixUpModel;
+
         setContentModel(core, mockedModel, additionalOption);
 
         expect(createModelToDomContextSpy).toHaveBeenCalledWith(
@@ -133,6 +136,8 @@ describe('setContentModel', () => {
             mockedContext
         );
         expect(setDOMSelectionSpy).toHaveBeenCalledWith(core, mockedRange);
+        expect(mockedOnFixUpModel).toHaveBeenCalledWith(mockedModel);
+        expect(mockedOnFixUpModel).toHaveBeenCalledBefore(contentModelToDomSpy);
     });
 
     it('no default option, with shadow edit', () => {

--- a/packages/roosterjs-content-model-core/test/editor/core/createEditorCoreTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/createEditorCoreTest.ts
@@ -101,6 +101,7 @@ describe('createEditorCore', () => {
             domHelper: mockedDOMHelper,
             disposeErrorHandler: undefined,
             experimentalFeatures: [],
+            onFixUpModel: undefined,
             ...additionalResult,
         });
 
@@ -149,6 +150,7 @@ describe('createEditorCore', () => {
         const mockedDisposeErrorHandler = 'DISPOSE' as any;
         const mockedGenerateColorKey = 'KEY' as any;
         const mockedKnownColors = 'COLORS' as any;
+        const mockedOnFixUpModel = 'FIXUP' as any;
         const mockedOptions = {
             coreApiOverride: {
                 a: 'b',
@@ -159,6 +161,7 @@ describe('createEditorCore', () => {
             disposeErrorHandler: mockedDisposeErrorHandler,
             generateColorKey: mockedGenerateColorKey,
             knownColors: mockedKnownColors,
+            onFixUpModel: mockedOnFixUpModel,
         } as any;
 
         runTest(mockedDiv, mockedOptions, {
@@ -181,6 +184,7 @@ describe('createEditorCore', () => {
             darkColorHandler: mockedDarkColorHandler,
             trustedHTMLHandler: mockedTrustHtmlHandler,
             disposeErrorHandler: mockedDisposeErrorHandler,
+            onFixUpModel: mockedOnFixUpModel,
         });
 
         expect(DarkColorHandlerImpl.createDarkColorHandler).toHaveBeenCalledWith(

--- a/packages/roosterjs-content-model-types/lib/editor/EditorCore.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/EditorCore.ts
@@ -7,7 +7,10 @@ import type { DOMEventRecord } from '../parameter/DOMEventRecord';
 import type { Snapshot } from '../parameter/Snapshot';
 import type { EntityState } from '../parameter/FormatContentModelContext';
 import type { DarkColorHandler } from '../context/DarkColorHandler';
-import type { ContentModelDocument } from '../contentModel/blockGroup/ContentModelDocument';
+import type {
+    ContentModelDocument,
+    ReadonlyContentModelDocument,
+} from '../contentModel/blockGroup/ContentModelDocument';
 import type { DOMSelection } from '../selection/DOMSelection';
 import type { DomToModelOptionForCreateModel } from '../context/DomToModelOption';
 import type { EditorContext } from '../context/EditorContext';
@@ -369,6 +372,13 @@ export interface EditorCore extends PluginState {
      * @param error The error object we got
      */
     readonly disposeErrorHandler?: (plugin: EditorPlugin, error: Error) => void;
+
+    /**
+     * An optional callback function that will be invoked before write content model back to editor.
+     * This is used for make sure model can satisfy some customized requirement
+     * @param model The model to fix up
+     */
+    readonly onFixUpModel?: (model: ReadonlyContentModelDocument) => void;
 
     /**
      * Enabled experimental features

--- a/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
@@ -7,7 +7,10 @@ import type { ContentModelSegmentFormat } from '../contentModel/format/ContentMo
 import type { CoreApiMap } from './EditorCore';
 import type { DomToModelOption } from '../context/DomToModelOption';
 import type { ModelToDomOption } from '../context/ModelToDomOption';
-import type { ContentModelDocument } from '../contentModel/blockGroup/ContentModelDocument';
+import type {
+    ContentModelDocument,
+    ReadonlyContentModelDocument,
+} from '../contentModel/blockGroup/ContentModelDocument';
 import type { Snapshots } from '../parameter/Snapshot';
 import type { TrustedHTMLHandler } from '../parameter/TrustedHTMLHandler';
 
@@ -67,6 +70,13 @@ export interface ContentModelOptions {
      * Default value is the computed style of editor content DIV
      */
     defaultSegmentFormat?: ContentModelSegmentFormat;
+
+    /**
+     * An optional callback function that will be invoked before write content model back to editor.
+     * This is used for make sure model can satisfy some customized requirement
+     * @param model The model to fix up
+     */
+    onFixUpModel?: (model: ReadonlyContentModelDocument) => void;
 
     /**
      * @deprecated


### PR DESCRIPTION
Some feature has requirement that content model should satisfy some format, such as there must be an entity before / after something. We now provide a callback to allow them do those fix up work before write back to editor. To use it:

```ts
const editor = new Editor(div, {
 ...
 onFixUpModel: model => {
    ... // fix up model, for example
    model.blocks.push({ ... });
  }
});
```