### PR TITLE
Bump roosterjs-editor-adapter to 8.62.3

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
     "react": "9.0.0",
     "main": "9.15.0",
-    "legacyAdapter": "8.62.2",
+    "legacyAdapter": "8.62.3",
     "overrides": {}
 }


### PR DESCRIPTION
Bump roosterjs-editor-adapter to 8.62.3 since we have type changes for EditorReadyEvent in v9