### PR TITLE
Remove dragging suffix

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -121,6 +121,16 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                     }
                 },
             },
+            dragend: {
+                beforeDispatch: ev => {
+                    if (this.editor) {
+                        const target = ev.target as Node;
+                        if (this.isImageSelection(target) && target.id.includes(DRAG_ID)) {
+                            target.id = target.id.replace(DRAG_ID, '').trim();
+                        }
+                    }
+                },
+            },
         });
     }
 


### PR DESCRIPTION
When the image is dragged, the suffix dragging is added to the image id. If the image is never dropped, this suffix remains at the image id. Therefore, when dragend event happens, remove the suffix from the image id. This change ensures that the image id is adjusted after the dragend event.