### PR TITLE
Resume triggering the BeforePasteEvent when Paste Type is equal to PlainText

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/paste/generatePasteOptionFromPlugins.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/generatePasteOptionFromPlugins.ts
@@ -39,7 +39,5 @@ export function generatePasteOptionFromPlugins(
         containsBlockElements: !!htmlFromClipboard.containsBlockElements,
     };
 
-    return pasteType == 'asPlainText'
-        ? event
-        : editor.triggerEvent('beforePaste', event, true /* broadcast */);
+    return editor.triggerEvent('beforePaste', event, true /* broadcast */);
 }

--- a/packages/roosterjs-content-model-core/test/command/paste/generatePasteOptionFromPluginsTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/generatePasteOptionFromPluginsTest.ts
@@ -221,6 +221,8 @@ describe('generatePasteOptionFromPlugins', () => {
     it('PasteType=asPlainText', () => {
         triggerPluginEventSpy.and.callFake((core, event) => {
             Object.assign(event, mockedResult);
+
+            return event;
         });
         const result = generatePasteOptionFromPlugins(
             editor,
@@ -236,22 +238,14 @@ describe('generatePasteOptionFromPlugins', () => {
         );
 
         expect(result).toEqual({
-            fragment: mockedFragment,
-            domToModelOption: {
-                additionalAllowedTags: [],
-                additionalDisallowedTags: [],
-                additionalFormatParsers: {},
-                formatParserOverride: {},
-                processorOverride: {},
-                styleSanitizers: {},
-                attributeSanitizers: {},
-            },
-            pasteType: 'asPlainText',
             eventType: 'beforePaste',
-            clipboardData: mockedClipboardData,
-            htmlBefore,
-            htmlAfter,
-            htmlAttributes: mockedMetadata,
+            clipboardData: 'CLIPBOARDDATA' as any,
+            fragment: 'FragmentResult' as any,
+            htmlBefore: 'HTMLBEFORE',
+            htmlAfter: 'HTMLAFTER',
+            htmlAttributes: 'METADATA' as any,
+            pasteType: 'TypeResult' as any,
+            domToModelOption: 'OptionResult' as any,
             containsBlockElements: false,
         });
         expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);

--- a/packages/roosterjs-content-model-core/test/command/paste/generatePasteOptionFromPluginsTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/generatePasteOptionFromPluginsTest.ts
@@ -254,6 +254,6 @@ describe('generatePasteOptionFromPlugins', () => {
             htmlAttributes: mockedMetadata,
             containsBlockElements: false,
         });
-        expect(triggerPluginEventSpy).toHaveBeenCalledTimes(0);
+        expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/roosterjs-content-model-core/test/command/paste/pasteTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/pasteTest.ts
@@ -223,9 +223,9 @@ describe('paste with content model & paste plugin', () => {
 
         paste(editor!, clipboardData, 'asPlainText');
 
-        expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
-        expect(addParserF.addParser).toHaveBeenCalledTimes(0);
-        expect(WordDesktopFile.processPastedContentFromWordDesktop).toHaveBeenCalledTimes(0);
+        expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(1);
+        expect(addParserF.addParser).toHaveBeenCalledTimes(9);
+        expect(WordDesktopFile.processPastedContentFromWordDesktop).toHaveBeenCalledTimes(1);
     });
 
     it('Word Online | Plain Text', () => {
@@ -234,9 +234,9 @@ describe('paste with content model & paste plugin', () => {
 
         paste(editor!, clipboardData, 'asPlainText');
 
-        expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
-        expect(addParserF.addParser).toHaveBeenCalledTimes(0);
-        expect(WacComponents.processPastedContentWacComponents).toHaveBeenCalledTimes(0);
+        expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(2);
+        expect(addParserF.addParser).toHaveBeenCalledTimes(11);
+        expect(WacComponents.processPastedContentWacComponents).toHaveBeenCalledTimes(1);
     });
 
     it('Excel Online | Plain Text', () => {
@@ -246,7 +246,7 @@ describe('paste with content model & paste plugin', () => {
         paste(editor!, clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
-        expect(addParserF.addParser).toHaveBeenCalledTimes(0);
+        expect(addParserF.addParser).toHaveBeenCalledTimes(4);
         expect(ExcelF.processPastedContentFromExcel).toHaveBeenCalledTimes(0);
     });
 
@@ -257,7 +257,7 @@ describe('paste with content model & paste plugin', () => {
         paste(editor!, clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
-        expect(addParserF.addParser).toHaveBeenCalledTimes(0);
+        expect(addParserF.addParser).toHaveBeenCalledTimes(4);
         expect(ExcelF.processPastedContentFromExcel).toHaveBeenCalledTimes(0);
     });
 
@@ -268,8 +268,8 @@ describe('paste with content model & paste plugin', () => {
         paste(editor!, clipboardData, 'asPlainText');
 
         expect(setProcessorF.setProcessor).toHaveBeenCalledTimes(0);
-        expect(addParserF.addParser).toHaveBeenCalledTimes(0);
-        expect(PPT.processPastedContentFromPowerPoint).toHaveBeenCalledTimes(0);
+        expect(addParserF.addParser).toHaveBeenCalledTimes(4);
+        expect(PPT.processPastedContentFromPowerPoint).toHaveBeenCalledTimes(1);
     });
 
     it('Verify the event data is not lost', () => {


### PR DESCRIPTION
Resume triggering the BeforePasteEvent when Paste Type is equal to PlainText. To allow plugins update the result of the paste
