### PR TITLE
Remove Image dataset

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -174,7 +174,22 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                     this.onDropHandler(this.editor);
                 }
                 break;
+            case 'extractContentWithDom':
+                this.removeImageEditing(event.clonedRoot);
+                break;
         }
+    }
+
+    private removeImageEditing(clonedRoot: HTMLElement) {
+        const images = clonedRoot.querySelectorAll('img');
+        images.forEach(image => {
+            if (image.dataset.isEditing) {
+                delete image.dataset.isEditing;
+            }
+            if (image.dataset.editingInfo) {
+                delete image.dataset.editingInfo;
+            }
+        });
     }
 
     private isImageSelection(target: Node): target is HTMLElement {

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -3,6 +3,7 @@ import * as findImage from '../../lib/imageEdit/utils/findEditingImage';
 import * as getSelectedImage from '../../lib/imageEdit/utils/getSelectedImage';
 import * as normalizeImageSelection from '../../lib/imageEdit/utils/normalizeImageSelection';
 import { ChangeSource, createImage, createParagraph } from 'roosterjs-content-model-dom';
+import { ExtractContentWithDomEvent } from 'roosterjs-editor-types';
 import { getSelectedImageMetadata } from '../../lib/imageEdit/utils/updateImageEditInfo';
 import { ImageEditPlugin } from '../../lib/imageEdit/ImageEditPlugin';
 import { initEditor } from '../TestHelper';
@@ -647,6 +648,28 @@ describe('ImageEditPlugin', () => {
         );
         expect(editor.setEditorStyle).toHaveBeenCalledWith('imageEdit', null);
         expect(editor.setEditorStyle).toHaveBeenCalledWith('imageEditCaretColor', null);
+    });
+
+    it('extractContentWithDom', () => {
+        const plugin = new ImageEditPlugin();
+        plugin.initialize(editor);
+        const clonedRoot = document.createElement('div');
+        const image = document.createElement('img');
+        clonedRoot.appendChild(image);
+        image.dataset['editingInfo'] = JSON.stringify({
+            src: 'test',
+        });
+        image.dataset['isEditing'] = 'true';
+        const event = {
+            eventType: 'extractContentWithDom',
+            clonedRoot,
+        } as any;
+        plugin.onPluginEvent(event);
+        const expectedClonedRoot = document.createElement('div');
+        const expectedImage = document.createElement('img');
+        expectedClonedRoot.appendChild(expectedImage);
+        expect(event.clonedRoot).toEqual(expectedClonedRoot);
+        plugin.dispose();
     });
 });
 

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -3,7 +3,6 @@ import * as findImage from '../../lib/imageEdit/utils/findEditingImage';
 import * as getSelectedImage from '../../lib/imageEdit/utils/getSelectedImage';
 import * as normalizeImageSelection from '../../lib/imageEdit/utils/normalizeImageSelection';
 import { ChangeSource, createImage, createParagraph } from 'roosterjs-content-model-dom';
-import { ExtractContentWithDomEvent } from 'roosterjs-editor-types';
 import { getSelectedImageMetadata } from '../../lib/imageEdit/utils/updateImageEditInfo';
 import { ImageEditPlugin } from '../../lib/imageEdit/ImageEditPlugin';
 import { initEditor } from '../TestHelper';


### PR DESCRIPTION
When extract content with DOM event is triggered, the `ImageEditPlugin` now removes the `isEditing` and `editingInfo` dataset attributes from any images in the cloned root.