### PR TITLE
Support MixedPlugin

### DIFF
--- a/packages/roosterjs-editor-adapter/lib/index.ts
+++ b/packages/roosterjs-editor-adapter/lib/index.ts
@@ -1,5 +1,6 @@
 export { EditorAdapterOptions } from './publicTypes/EditorAdapterOptions';
 export { BeforePasteAdapterEvent } from './publicTypes/BeforePasteAdapterEvent';
+export { MixedPlugin } from './publicTypes/MixedPlugin';
 
 export { EditorAdapter } from './editor/EditorAdapter';
 

--- a/packages/roosterjs-editor-adapter/lib/publicTypes/MixedPlugin.ts
+++ b/packages/roosterjs-editor-adapter/lib/publicTypes/MixedPlugin.ts
@@ -1,0 +1,35 @@
+import type { PluginEvent, IEditor } from 'roosterjs-content-model-types';
+import type { EditorPlugin } from 'roosterjs-editor-types';
+
+/**
+ * Represents a mixed version plugin that can handle both v8 and v9 events.
+ * This is not commonly used, but just for transitioning from v8 to v9 plugins
+ */
+export interface MixedPlugin extends EditorPlugin {
+    /**
+     * The first method that editor will call to a plugin when editor is initializing.
+     * It will pass in the editor instance, plugin should take this chance to save the
+     * editor reference so that it can call to any editor method or format API later.
+     * @param editor The editor object
+     */
+
+    initializeV9: (editor: IEditor) => void;
+
+    /**
+     * Check if the plugin should handle the given event exclusively.
+     * Handle an event exclusively means other plugin will not receive this event in
+     * onPluginEvent method.
+     * If two plugins will return true in willHandleEventExclusively() for the same event,
+     * the final result depends on the order of the plugins are added into editor
+     * @param event The event to check:
+     */
+    willHandleEventExclusivelyV9?: (event: PluginEvent) => boolean;
+
+    /**
+     * Core method for a plugin. Once an event happens in editor, editor will call this
+     * method of each plugin to handle the event as long as the event is not handled
+     * exclusively by another plugin.
+     * @param event The event to handle:
+     */
+    onPluginEventV9?: (event: PluginEvent) => void;
+}


### PR DESCRIPTION
To help porting old plugin to new plugin, with some mixed state, we want to support "MixedPlugin", which can accept both v8 and v9 types. For v9 types, the function names will have a postfix "V9", including:
- initializeV9
- onPluginEventV9
- willHandleEventExclusivelyV9

So that a plugin can implement the new interface `MixedPlugin` and add these methods, so it will receive new editor and events via the methods above.