### PR TITLE
Remove Table Header Row font weight

### DIFF
--- a/demo/scripts/controlsV2/demoButtons/formatTableButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/formatTableButton.ts
@@ -28,7 +28,7 @@ const PREDEFINED_STYLES: Record<
             color /** verticalColors*/,
             false /** bandedRows */,
             false /** bandedColumns */,
-            false /** headerRow */,
+            true /** headerRow */,
             false /** firstColumn */,
             TableBorderFormat.Default /** tableBorderFormat */,
             null /** bgColorEven */,

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
@@ -11,6 +11,7 @@ import { entityFormatHandler } from './entity/entityFormatHandler';
 import { floatFormatHandler } from './common/floatFormatHandler';
 import { fontFamilyFormatHandler } from './segment/fontFamilyFormatHandler';
 import { fontSizeFormatHandler } from './segment/fontSizeFormatHandler';
+import { fontWeightOnTableCellFormatHandler } from './table/fontWeightOnTableCellFormatHandler';
 import { getObjectKeys } from '../domUtils/getObjectKeys';
 import { htmlAlignFormatHandler } from './block/htmlAlignFormatHandler';
 import { idFormatHandler } from './common/idFormatHandler';
@@ -64,6 +65,7 @@ const defaultFormatHandlerMap: FormatHandlers = {
     float: floatFormatHandler,
     fontFamily: fontFamilyFormatHandler,
     fontSize: fontSizeFormatHandler,
+    fontWeightOnTableCell: fontWeightOnTableCellFormatHandler,
     entity: entityFormatHandler,
     htmlAlign: htmlAlignFormatHandler,
     id: idFormatHandler,
@@ -154,6 +156,7 @@ export const defaultFormatKeysPerCategory: {
     tableCell: [
         'border',
         'backgroundColor',
+        'fontWeightOnTableCell',
         'padding',
         'verticalAlign',
         'wordBreak',

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/table/fontWeightOnTableCellFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/table/fontWeightOnTableCellFormatHandler.ts
@@ -11,7 +11,6 @@ export const fontWeightOnTableCellFormatHandler: FormatHandler<BoldFormat> = {
         }
     },
     apply: (format, element) => {
-        // If the element is a TH, remove the font weight so it do not override the font weight of the segment
         if (format.fontWeight == 'normal') {
             element.style.fontWeight = 'normal';
         }

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/table/fontWeightOnTableCellFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/table/fontWeightOnTableCellFormatHandler.ts
@@ -1,0 +1,15 @@
+import type { FormatHandler } from '../FormatHandler';
+import type { BoldFormat } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ */
+export const fontWeightOnTableCellFormatHandler: FormatHandler<BoldFormat> = {
+    parse: () => {},
+    apply: (_format, element) => {
+        // If the element is a TH, remove the font weight so it do not override the font weight of the segment
+        if (element.tagName == 'TH') {
+            element.style.fontWeight = 'normal';
+        }
+    },
+};

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/table/fontWeightOnTableCellFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/table/fontWeightOnTableCellFormatHandler.ts
@@ -5,11 +5,14 @@ import type { BoldFormat } from 'roosterjs-content-model-types';
  * @internal
  */
 export const fontWeightOnTableCellFormatHandler: FormatHandler<BoldFormat> = {
-    parse: () => {},
-    apply: (_format, element) => {
+    parse: (format, element) => {
+        if (element.style.fontWeight == 'normal') {
+            format.fontWeight = 'normal';
+        }
+    },
+    apply: (format, element) => {
         // If the element is a TH, remove the font weight so it do not override the font weight of the segment
-
-        if (element.tagName == 'TH' && !element.style.fontWeight) {
+        if (format.fontWeight == 'normal') {
             element.style.fontWeight = 'normal';
         }
     },

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/table/fontWeightOnTableCellFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/table/fontWeightOnTableCellFormatHandler.ts
@@ -8,7 +8,8 @@ export const fontWeightOnTableCellFormatHandler: FormatHandler<BoldFormat> = {
     parse: () => {},
     apply: (_format, element) => {
         // If the element is a TH, remove the font weight so it do not override the font weight of the segment
-        if (element.tagName == 'TH') {
+
+        if (element.tagName == 'TH' && !element.style.fontWeight) {
             element.style.fontWeight = 'normal';
         }
     },

--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/applyTableFormat.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/applyTableFormat.ts
@@ -1,6 +1,6 @@
 import { BorderKeys } from '../../formatHandlers/common/borderFormatHandler';
 import { combineBorderValue, extractBorderValues } from '../../domUtils/style/borderValues';
-import { mutateBlock } from '../common/mutate';
+import { mutateBlock, mutateSegment } from '../common/mutate';
 import { setTableCellBackgroundColor } from './setTableCellBackgroundColor';
 import { TableBorderFormat } from '../../constants/TableBorderFormat';
 import { updateTableCellMetadata } from '../metadata/updateTableCellMetadata';
@@ -8,6 +8,7 @@ import { updateTableMetadata } from '../metadata/updateTableMetadata';
 import type {
     BorderFormat,
     ReadonlyContentModelTable,
+    ShallowMutableContentModelTableCell,
     ShallowMutableContentModelTableRow,
     TableMetadataFormat,
 } from 'roosterjs-content-model-types';
@@ -305,7 +306,7 @@ function setHeaderRowFormat(
                     true /*applyToSegments*/
                 );
             }
-
+            setBoldOnHeaderCell(cell);
             setBorderColor(cell.format, 'borderTop', format.headerRowColor);
             setBorderColor(cell.format, 'borderRight', format.headerRowColor);
             setBorderColor(cell.format, 'borderLeft', format.headerRowColor);
@@ -327,4 +328,16 @@ function setBorderColor(format: BorderFormat, key: keyof BorderFormat, value?: s
 
 function getBorderStyleFromColor(color?: string): string {
     return !color || color == 'transparent' ? 'none' : 'solid';
+}
+
+function setBoldOnHeaderCell(cell: ShallowMutableContentModelTableCell) {
+    for (const block of cell.blocks) {
+        if (block.blockType == 'Paragraph') {
+            for (const segment of block.segments) {
+                mutateSegment(block, segment, segment => {
+                    segment.format.fontWeight = 'bold';
+                });
+            }
+        }
+    }
 }

--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/applyTableFormat.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/applyTableFormat.ts
@@ -235,6 +235,10 @@ function formatCells(
 
             // Format Header
             cell.isHeader = false;
+
+            if (rowIndex === 0 && cell.format.fontWeight) {
+                setCellFontWeight(cell, false /*isHeader*/);
+            }
         });
     });
 }
@@ -297,6 +301,7 @@ function setHeaderRowFormat(
 
         cell.isHeader = true;
 
+        setCellFontWeight(cell, true /*isHeader*/);
         if (format.headerRowColor) {
             if (!metaOverrides.bgColorOverrides[rowIndex][cellIndex]) {
                 setTableCellBackgroundColor(
@@ -306,7 +311,6 @@ function setHeaderRowFormat(
                     true /*applyToSegments*/
                 );
             }
-            setBoldOnHeaderCell(cell);
             setBorderColor(cell.format, 'borderTop', format.headerRowColor);
             setBorderColor(cell.format, 'borderRight', format.headerRowColor);
             setBorderColor(cell.format, 'borderLeft', format.headerRowColor);
@@ -330,14 +334,15 @@ function getBorderStyleFromColor(color?: string): string {
     return !color || color == 'transparent' ? 'none' : 'solid';
 }
 
-function setBoldOnHeaderCell(cell: ShallowMutableContentModelTableCell) {
+function setCellFontWeight(cell: ShallowMutableContentModelTableCell, isHeader: boolean) {
     for (const block of cell.blocks) {
         if (block.blockType == 'Paragraph') {
             for (const segment of block.segments) {
                 mutateSegment(block, segment, segment => {
-                    segment.format.fontWeight = 'bold';
+                    segment.format.fontWeight = isHeader ? 'bold' : undefined;
                 });
             }
         }
     }
+    cell.format.fontWeight = isHeader ? 'normal' : undefined;
 }

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/table/fontWeightOnTableCellFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/table/fontWeightOnTableCellFormatHandlerTest.ts
@@ -1,0 +1,26 @@
+import { BoldFormat, ModelToDomContext } from 'roosterjs-content-model-types';
+import { createModelToDomContext } from '../../../lib';
+import { fontWeightOnTableCellFormatHandler } from '../../../lib/formatHandlers/table/fontWeightOnTableCellFormatHandler';
+
+describe('fontWeightOnTableCellFormatHandler.apply', () => {
+    let th: HTMLTableCellElement;
+    let format: BoldFormat;
+    let context: ModelToDomContext;
+
+    beforeEach(() => {
+        format = {};
+        context = createModelToDomContext();
+    });
+
+    it('remove font weight', () => {
+        th = document.createElement('th');
+        fontWeightOnTableCellFormatHandler.apply(format, th, context);
+        expect(th.style.fontWeight).toEqual('normal');
+    });
+
+    it(' do not remove font weight', () => {
+        th = document.createElement('td');
+        fontWeightOnTableCellFormatHandler.apply(format, th, context);
+        expect(th.style.fontWeight).toEqual('');
+    });
+});

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/table/fontWeightOnTableCellFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/table/fontWeightOnTableCellFormatHandlerTest.ts
@@ -1,5 +1,5 @@
-import { BoldFormat, ModelToDomContext } from 'roosterjs-content-model-types';
-import { createModelToDomContext } from '../../../lib';
+import { BoldFormat, DomToModelContext, ModelToDomContext } from 'roosterjs-content-model-types';
+import { createDomToModelContext, createModelToDomContext } from '../../../lib';
 import { fontWeightOnTableCellFormatHandler } from '../../../lib/formatHandlers/table/fontWeightOnTableCellFormatHandler';
 
 describe('fontWeightOnTableCellFormatHandler.apply', () => {
@@ -8,19 +8,46 @@ describe('fontWeightOnTableCellFormatHandler.apply', () => {
     let context: ModelToDomContext;
 
     beforeEach(() => {
-        format = {};
         context = createModelToDomContext();
     });
 
     it('remove font weight', () => {
         th = document.createElement('th');
+        format = { fontWeight: 'normal' };
         fontWeightOnTableCellFormatHandler.apply(format, th, context);
         expect(th.style.fontWeight).toEqual('normal');
     });
 
     it(' do not remove font weight', () => {
         th = document.createElement('td');
+        format = {};
         fontWeightOnTableCellFormatHandler.apply(format, th, context);
         expect(th.style.fontWeight).toEqual('');
+    });
+});
+
+describe('fontWeightOnTableCellFormatHandler.parse', () => {
+    let th: HTMLTableCellElement;
+    let format: BoldFormat;
+    let context: DomToModelContext;
+
+    beforeEach(() => {
+        context = createDomToModelContext();
+    });
+
+    it('remove font weight', () => {
+        th = document.createElement('td');
+        th.style.fontWeight = 'normal';
+        format = { fontWeight: undefined };
+        fontWeightOnTableCellFormatHandler.parse(format, th, context, {});
+        expect(format.fontWeight).toEqual('normal');
+    });
+
+    it('do not remove font weight', () => {
+        th = document.createElement('td');
+        th.style.fontWeight = '';
+        format = {};
+        fontWeightOnTableCellFormatHandler.parse(format, th, context, {});
+        expect(format.fontWeight).toBeUndefined();
     });
 });

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
@@ -240,7 +240,7 @@ describe('handleTable', () => {
                 widths: [],
                 dataset: {},
             },
-            '<table><tbody><tr><th></th></tr><tr><td></td></tr></tbody></table>'
+            '<table><tbody><tr><th style="font-weight: normal;"></th></tr><tr><td></td></tr></tbody></table>'
         );
     });
 
@@ -355,7 +355,7 @@ describe('handleTable', () => {
         handleTable(document, parent, table, context, null);
 
         expect(parent.innerHTML).toBe(
-            '<table><tbody><tr><th></th></tr><tr><td></td></tr></tbody></table>'
+            '<table><tbody><tr><th style="font-weight: normal;"></th></tr><tr><td></td></tr></tbody></table>'
         );
         const tableNode = parent.querySelector('table') as HTMLTableElement;
 

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
@@ -240,7 +240,7 @@ describe('handleTable', () => {
                 widths: [],
                 dataset: {},
             },
-            '<table><tbody><tr><th style="font-weight: normal;"></th></tr><tr><td></td></tr></tbody></table>'
+            '<table><tbody><tr><th></th></tr><tr><td></td></tr></tbody></table>'
         );
     });
 
@@ -355,7 +355,7 @@ describe('handleTable', () => {
         handleTable(document, parent, table, context, null);
 
         expect(parent.innerHTML).toBe(
-            '<table><tbody><tr><th style="font-weight: normal;"></th></tr><tr><td></td></tr></tbody></table>'
+            '<table><tbody><tr><th></th></tr><tr><td></td></tr></tbody></table>'
         );
         const tableNode = parent.querySelector('table') as HTMLTableElement;
 

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelTableCellFormat.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelTableCellFormat.ts
@@ -1,3 +1,4 @@
+import type { BoldFormat } from './formatParts/BoldFormat';
 import type { BorderBoxFormat } from './formatParts/BorderBoxFormat';
 import type { ContentModelBlockFormat } from './ContentModelBlockFormat';
 import type { SizeFormat } from './formatParts/SizeFormat';
@@ -13,4 +14,5 @@ export type ContentModelTableCellFormat = ContentModelBlockFormat &
     VerticalAlignFormat &
     WordBreakFormat &
     TextColorFormat &
+    BoldFormat &
     SizeFormat;

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/FormatHandlerTypeMap.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/FormatHandlerTypeMap.ts
@@ -104,6 +104,11 @@ export interface FormatHandlerTypeMap {
     fontSize: FontSizeFormat;
 
     /**
+     * Format for BoldFormat, for Table Cell only
+     */
+    fontWeightOnTableCell: BoldFormat;
+
+    /**
      * Format for HtmlAlignFormat
      */
     htmlAlign: HtmlAlignFormat;


### PR DESCRIPTION
The default font-weight of the TH element overrides the font-weight of the segment. To resolve this, set the TH font-weight to normal when it has no predefined style. This way, when adding a header row to a table, the bold font-weight will be applied directly to the text segments.

Before the change the bold button was showing the wrong state. 
![image](https://github.com/user-attachments/assets/743f6d3a-4ef7-4668-ae31-901a1ad7a429)

After the change the bold button was showing the text is bold, as expected.
![image](https://github.com/user-attachments/assets/01a41aba-7b8d-4d21-ad31-0c7cb41497c8)
