### PR TITLE
Skip CM handling when deleting expanded selection within text node

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -19,6 +19,12 @@ export type EditOptions = {
      * Whether to handle Tab key in keyboard. @default true
      */
     handleTabKey?: boolean;
+
+    /**
+     * Whether expanded selection within a text node should be handled by CM when pressing Backspace/Delete key.
+     * @default true
+     */
+    handleExpandedSelectionOnDelete?: boolean;
 };
 
 const BACKSPACE_KEY = 8;
@@ -33,6 +39,7 @@ const DEAD_KEY = 229;
 
 const DefaultOptions: Partial<EditOptions> = {
     handleTabKey: true,
+    handleExpandedSelectionOnDelete: true,
 };
 
 /**
@@ -164,7 +171,7 @@ export class EditPlugin implements EditorPlugin {
                 case 'Backspace':
                     // Use our API to handle BACKSPACE/DELETE key.
                     // No need to clear cache here since if we rely on browser's behavior, there will be Input event and its handler will reconcile cache
-                    keyboardDelete(editor, rawEvent);
+                    keyboardDelete(editor, rawEvent, this.options.handleExpandedSelectionOnDelete);
                     break;
 
                 case 'Delete':
@@ -172,7 +179,7 @@ export class EditPlugin implements EditorPlugin {
                     // No need to clear cache here since if we rely on browser's behavior, there will be Input event and its handler will reconcile cache
                     // And leave it to browser when shift key is pressed so that browser will trigger cut event
                     if (!event.rawEvent.shiftKey) {
-                        keyboardDelete(editor, rawEvent);
+                        keyboardDelete(editor, rawEvent, this.options.handleExpandedSelectionOnDelete);
                     }
                     break;
 
@@ -225,7 +232,8 @@ export class EditPlugin implements EditorPlugin {
                         key: 'Backspace',
                         keyCode: BACKSPACE_KEY,
                         which: BACKSPACE_KEY,
-                    })
+                    }),
+                    this.options.handleExpandedSelectionOnDelete
                 );
                 break;
             case 'deleteContentForward':
@@ -235,7 +243,8 @@ export class EditPlugin implements EditorPlugin {
                         key: 'Delete',
                         keyCode: DELETE_KEY,
                         which: DELETE_KEY,
-                    })
+                    }),
+                    this.options.handleExpandedSelectionOnDelete
                 );
                 break;
         }

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -94,7 +94,7 @@ function shouldDeleteWithContentModel(selection: DOMSelection | null, rawEvent: 
         const range = selection.range;
         const { startContainer, endContainer } = selection.range;
         const isInSameTextNode = startContainer === endContainer && isNodeOfType(startContainer, 'TEXT_NODE');
-        return !isInSameTextNode || range.startOffset < 1 || range.startOffset > (startContainer.nodeValue?.length ?? 0) - 1;
+        return !(isInSameTextNode && !isModifierKey(rawEvent) && range.endOffset - range.startOffset < (startContainer.nodeValue?.length ?? 0));
     } else {
         const range = selection.range;
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -27,13 +27,14 @@ import type { DOMSelection, DeleteSelectionStep, IEditor } from 'roosterjs-conte
  * Do keyboard event handling for DELETE/BACKSPACE key
  * @param editor The editor object
  * @param rawEvent DOM keyboard event
+ * @param handleExpandedSelection Whether to handle expanded selection within a text node by CM
  * @returns True if the event is handled by content model, otherwise false
  */
-export function keyboardDelete(editor: IEditor, rawEvent: KeyboardEvent) {
+export function keyboardDelete(editor: IEditor, rawEvent: KeyboardEvent, handleExpandedSelection: boolean = true) {
     let handled = false;
     const selection = editor.getDOMSelection();
 
-    if (shouldDeleteWithContentModel(selection, rawEvent)) {
+    if (shouldDeleteWithContentModel(selection, rawEvent, handleExpandedSelection)) {
         editor.formatContentModel(
             (model, context) => {
                 const result = deleteSelection(
@@ -80,11 +81,20 @@ function getDeleteSteps(rawEvent: KeyboardEvent, isMac: boolean): (DeleteSelecti
     ];
 }
 
-function shouldDeleteWithContentModel(selection: DOMSelection | null, rawEvent: KeyboardEvent) {
+function shouldDeleteWithContentModel(selection: DOMSelection | null, rawEvent: KeyboardEvent, handleExpandedSelection: boolean) {
     if (!selection) {
         return false; // Nothing to delete
-    } else if (selection.type != 'range' || !selection.range.collapsed) {
-        return true; // Selection is not collapsed, need to delete all selections
+    } else if (selection.type != 'range') {
+        return true;
+    } else if (!selection.range.collapsed) {
+        if (handleExpandedSelection) {
+            return true; // Selection is not collapsed, need to delete all selections
+        }
+
+        const range = selection.range;
+        const { startContainer, endContainer } = selection.range;
+        const isInSameTextNode = startContainer == endContainer && isNodeOfType(startContainer, 'TEXT_NODE');
+        return !isInSameTextNode || range.startOffset < 1 || range.startOffset > (startContainer.nodeValue?.length ?? 0) - 1;
     } else {
         const range = selection.range;
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -93,7 +93,7 @@ function shouldDeleteWithContentModel(selection: DOMSelection | null, rawEvent: 
 
         const range = selection.range;
         const { startContainer, endContainer } = selection.range;
-        const isInSameTextNode = startContainer == endContainer && isNodeOfType(startContainer, 'TEXT_NODE');
+        const isInSameTextNode = startContainer === endContainer && isNodeOfType(startContainer, 'TEXT_NODE');
         return !isInSameTextNode || range.startOffset < 1 || range.startOffset > (startContainer.nodeValue?.length ?? 0) - 1;
     } else {
         const range = selection.range;

--- a/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
@@ -66,7 +66,7 @@ describe('EditPlugin', () => {
                 rawEvent,
             });
 
-            expect(keyboardDeleteSpy).toHaveBeenCalledWith(editor, rawEvent);
+            expect(keyboardDeleteSpy).toHaveBeenCalledWith(editor, rawEvent, true);
             expect(keyboardInputSpy).not.toHaveBeenCalled();
             expect(keyboardEnterSpy).not.toHaveBeenCalled();
             expect(keyboardTabSpy).not.toHaveBeenCalled();
@@ -83,7 +83,7 @@ describe('EditPlugin', () => {
                 rawEvent,
             });
 
-            expect(keyboardDeleteSpy).toHaveBeenCalledWith(editor, rawEvent);
+            expect(keyboardDeleteSpy).toHaveBeenCalledWith(editor, rawEvent, true);
             expect(keyboardInputSpy).not.toHaveBeenCalled();
             expect(keyboardEnterSpy).not.toHaveBeenCalled();
             expect(keyboardTabSpy).not.toHaveBeenCalled();
@@ -104,6 +104,20 @@ describe('EditPlugin', () => {
             expect(keyboardInputSpy).not.toHaveBeenCalled();
             expect(keyboardEnterSpy).not.toHaveBeenCalled();
             expect(keyboardTabSpy).not.toHaveBeenCalled();
+        });
+
+        it('handleExpandedSelectionOnDelete disabled', () => {
+            plugin = new EditPlugin({ handleExpandedSelectionOnDelete: false });
+            const rawEvent = { key: 'Delete' } as any;
+
+            plugin.initialize(editor);
+
+            plugin.onPluginEvent({
+                eventType: 'keyDown',
+                rawEvent,
+            });
+
+            expect(keyboardDeleteSpy).toHaveBeenCalledWith(editor, rawEvent, false);
         });
 
         it('Tab', () => {
@@ -261,7 +275,7 @@ describe('EditPlugin', () => {
 
             expect(keyboardDeleteSpy).toHaveBeenCalledWith(editor, {
                 key: 'Delete',
-            } as any);
+            } as any, true);
 
             plugin.onPluginEvent({
                 eventType: 'keyDown',
@@ -271,7 +285,7 @@ describe('EditPlugin', () => {
             expect(keyboardDeleteSpy).toHaveBeenCalledTimes(2);
             expect(keyboardDeleteSpy).toHaveBeenCalledWith(editor, {
                 key: 'Delete',
-            } as any);
+            } as any, true);
             expect(keyboardInputSpy).not.toHaveBeenCalled();
             expect(keyboardEnterSpy).not.toHaveBeenCalled();
             expect(keyboardTabSpy).not.toHaveBeenCalled();
@@ -309,7 +323,8 @@ describe('EditPlugin', () => {
                     key: 'Backspace',
                     keyCode: 8,
                     which: 8,
-                })
+                }),
+                true
             );
         });
 
@@ -337,7 +352,8 @@ describe('EditPlugin', () => {
                     key: 'Delete',
                     keyCode: 46,
                     which: 46,
-                })
+                }),
+                true
             );
         });
     });

--- a/packages/roosterjs-content-model-plugins/test/edit/keyboardDeleteTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/keyboardDeleteTest.ts
@@ -580,6 +580,31 @@ describe('keyboardDelete', () => {
         expect(formatWithContentModelSpy).not.toHaveBeenCalled();
     });
 
+    it('No need to delete - handleExpandedSelection disabled', () => {
+        const rawEvent = { key: 'Backspace' } as any;
+        const formatWithContentModelSpy = jasmine.createSpy('formatContentModel');
+        const node = document.createTextNode('test');
+        const range: DOMSelection = {
+            type: 'range',
+            range: ({
+                collapsed: false,
+                startContainer: node,
+                endContainer: node,
+                startOffset: 1,
+                endOffset: 3,
+            } as any) as Range,
+            isReverted: false,
+        };
+        const editor = {
+            formatContentModel: formatWithContentModelSpy,
+            getDOMSelection: () => range,
+        } as any;
+
+        keyboardDelete(editor, rawEvent, false /* handleExpandedSelectionOnDelete */);
+
+        expect(formatWithContentModelSpy).not.toHaveBeenCalled();
+    });
+
     it('Backspace from the beginning', () => {
         const rawEvent = { key: 'Backspace' } as any;
         const formatWithContentModelSpy = jasmine.createSpy('formatContentModel');
@@ -622,6 +647,31 @@ describe('keyboardDelete', () => {
         } as any;
 
         keyboardDelete(editor, rawEvent);
+
+        expect(formatWithContentModelSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Delete the first or the last character - handleExpandedSelection disabled', () => {
+        const rawEvent = { key: 'Backspace' } as any;
+        const formatWithContentModelSpy = jasmine.createSpy('formatContentModel');
+        const node = document.createTextNode('test');
+        const range: DOMSelection = {
+            type: 'range',
+            range: ({
+                collapsed: false,
+                startContainer: node,
+                endContainer: node,
+                startOffset: 0,
+                endOffset: 3,
+            } as any) as Range,
+            isReverted: false,
+        };
+        const editor = {
+            formatContentModel: formatWithContentModelSpy,
+            getDOMSelection: () => range,
+        } as any;
+
+        keyboardDelete(editor, rawEvent, false /* handleExpandedSelectionOnDelete */);
 
         expect(formatWithContentModelSpy).toHaveBeenCalledTimes(1);
     });

--- a/packages/roosterjs-content-model-plugins/test/edit/keyboardDeleteTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/keyboardDeleteTest.ts
@@ -651,7 +651,7 @@ describe('keyboardDelete', () => {
         expect(formatWithContentModelSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('Delete the first or the last character - handleExpandedSelection disabled', () => {
+    it('Delete all the content of text node - handleExpandedSelection disabled', () => {
         const rawEvent = { key: 'Backspace' } as any;
         const formatWithContentModelSpy = jasmine.createSpy('formatContentModel');
         const node = document.createTextNode('test');
@@ -662,7 +662,7 @@ describe('keyboardDelete', () => {
                 startContainer: node,
                 endContainer: node,
                 startOffset: 0,
-                endOffset: 3,
+                endOffset: 4,
             } as any) as Range,
             isReverted: false,
         };


### PR DESCRIPTION
Some Android IMEs automatically select the character before the cursor when pressing Backspace. As a result, `shouldDeleteWithContentModel` always returns true, which triggers the model-DOM conversion. If the user presses Backspace multiple times in a long content, the editor will enter continuous model-DOM conversions, causing memory usage to consistently increase.

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/b36ea4b3-ddb4-474c-9cb0-7b091443e8ea" />

To mitigate this issue, this PR is adding an option in `EditPlugin` to skip CM handling for the expanded selection within the same text node. After enabling it, the memory usage is reduced: 

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/3efff587-8623-440c-a4fe-1490b31263e8" />
