### PR TITLE
Fix unhandled exception when using Regex in long Excel content and additional approach to get table from clipboard

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/paste/Excel/processPastedContentFromExcel.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/Excel/processPastedContentFromExcel.ts
@@ -26,8 +26,7 @@ export function processPastedContentFromExcel(
     domCreator: DOMCreator,
     allowExcelNoBorderTable?: boolean
 ) {
-    const { htmlBefore, htmlAfter, clipboardData } = event;
-    let { fragment } = event;
+    const { fragment, htmlBefore, htmlAfter, clipboardData } = event;
 
     validateExcelFragment(fragment, domCreator, htmlBefore, clipboardData, htmlAfter);
 

--- a/packages/roosterjs-content-model-plugins/lib/paste/Excel/processPastedContentFromExcel.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/Excel/processPastedContentFromExcel.ts
@@ -1,13 +1,19 @@
 import { addParser } from '../utils/addParser';
 import { isNodeOfType, moveChildNodes } from 'roosterjs-content-model-dom';
 import { setProcessor } from '../utils/setProcessor';
-import type { BeforePasteEvent, DOMCreator, ElementProcessor } from 'roosterjs-content-model-types';
+import type {
+    BeforePasteEvent,
+    ClipboardData,
+    DOMCreator,
+    ElementProcessor,
+} from 'roosterjs-content-model-types';
 
 const LAST_TD_END_REGEX = /<\/\s*td\s*>((?!<\/\s*tr\s*>)[\s\S])*$/i;
 const LAST_TR_END_REGEX = /<\/\s*tr\s*>((?!<\/\s*table\s*>)[\s\S])*$/i;
 const LAST_TR_REGEX = /<tr[^>]*>[^<]*/i;
 const LAST_TABLE_REGEX = /<table[^>]*>[^<]*/i;
 const DEFAULT_BORDER_STYLE = 'solid 1px #d4d4d4';
+const TABLE_SELECTOR = 'table';
 
 /**
  * @internal
@@ -20,13 +26,10 @@ export function processPastedContentFromExcel(
     domCreator: DOMCreator,
     allowExcelNoBorderTable?: boolean
 ) {
-    const { fragment, htmlBefore, clipboardData } = event;
-    const html = clipboardData.html ? excelHandler(clipboardData.html, htmlBefore) : undefined;
+    const { htmlBefore, htmlAfter, clipboardData } = event;
+    let { fragment } = event;
 
-    if (html && clipboardData.html != html) {
-        const doc = domCreator.htmlToDOM(html);
-        moveChildNodes(fragment, doc?.body);
-    }
+    validateExcelFragment(fragment, domCreator, htmlBefore, clipboardData, htmlAfter);
 
     // For Excel Online
     const firstChild = fragment.firstChild;
@@ -87,21 +90,62 @@ export const childProcessor: ElementProcessor<ParentNode> = (group, element, con
 };
 
 /**
+ * @internal
+ * Exported only for unit test
+ */
+export function validateExcelFragment(
+    fragment: DocumentFragment,
+    domCreator: DOMCreator,
+    htmlBefore: string,
+    clipboardData: ClipboardData,
+    htmlAfter: string
+) {
+    // Clipboard content of Excel may contain the <StartFragment> and EndFragment comment tags inside the table
+    //
+    // @example
+    // <table>
+    // <!--StartFragment-->
+    // <tr>...</tr>
+    // <!--EndFragment-->
+    // </table>
+    //
+    // This causes that the fragment is not properly created and the table is not extracted.
+    // The content that is before the StartFragment is htmlBefore and the content that is after the EndFragment is htmlAfter.
+    // So attempt to create a new document fragment with the content of htmlBefore + clipboardData.html + htmlAfter
+    // If a table is found, replace the fragment with the new fragment
+    const result =
+        !fragment.querySelector(TABLE_SELECTOR) &&
+        domCreator.htmlToDOM(htmlBefore + clipboardData.html + htmlAfter);
+    if (result && result.querySelector(TABLE_SELECTOR)) {
+        moveChildNodes(fragment, result?.body);
+    } else {
+        // If the table is still not found, try to extract the table from the clipboard data using Regex
+        const html = clipboardData.html ? excelHandler(clipboardData.html, htmlBefore) : undefined;
+
+        if (html && clipboardData.html != html) {
+            const doc = domCreator.htmlToDOM(html);
+            moveChildNodes(fragment, doc?.body);
+        }
+    }
+}
+
+/**
  * @internal Export for test only
  * @param html Source html
  */
-
 export function excelHandler(html: string, htmlBefore: string): string {
-    if (html.match(LAST_TD_END_REGEX)) {
-        const trMatch = htmlBefore.match(LAST_TR_REGEX);
-        const tr = trMatch ? trMatch[0] : '<TR>';
-        html = tr + html + '</TR>';
+    try {
+        if (html.match(LAST_TD_END_REGEX)) {
+            const trMatch = htmlBefore.match(LAST_TR_REGEX);
+            const tr = trMatch ? trMatch[0] : '<TR>';
+            html = tr + html + '</TR>';
+        }
+        if (html.match(LAST_TR_END_REGEX)) {
+            const tableMatch = htmlBefore.match(LAST_TABLE_REGEX);
+            const table = tableMatch ? tableMatch[0] : '<TABLE>';
+            html = table + html + '</TABLE>';
+        }
+    } finally {
+        return html;
     }
-    if (html.match(LAST_TR_END_REGEX)) {
-        const tableMatch = htmlBefore.match(LAST_TABLE_REGEX);
-        const table = tableMatch ? tableMatch[0] : '<TABLE>';
-        html = table + html + '</TABLE>';
-    }
-
-    return html;
 }

--- a/packages/roosterjs-content-model-plugins/test/paste/validateExcelFragmentTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/validateExcelFragmentTest.ts
@@ -1,0 +1,48 @@
+import { ClipboardData, DOMCreator } from 'roosterjs-content-model-types';
+import { validateExcelFragment } from '../../lib/paste/Excel/processPastedContentFromExcel';
+
+describe('validateExcelFragment', () => {
+    let domCreator: DOMCreator;
+    let fragment: DocumentFragment;
+    let clipboardData: ClipboardData;
+    let htmlToDomSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        htmlToDomSpy = jasmine.createSpy();
+        htmlToDomSpy.and.callFake((html: string) => {
+            return new DOMParser().parseFromString(html, 'text/html');
+        });
+
+        domCreator = {
+            htmlToDOM: htmlToDomSpy,
+        };
+        fragment = document.createDocumentFragment();
+        clipboardData = {
+            html: '',
+        } as ClipboardData;
+    });
+
+    it('should replace fragment with new fragment containing table from combined htmlBefore, clipboardData.html, and htmlAfter', () => {
+        const htmlBefore = '<table>';
+        const htmlAfter = '</table>';
+        clipboardData.html = '<tr><td>Test</td></tr></table>';
+
+        validateExcelFragment(fragment, domCreator, htmlBefore, clipboardData, htmlAfter);
+
+        expect(fragment.querySelector('table')).not.toBeNull();
+        expect(domCreator.htmlToDOM).toHaveBeenCalledWith(
+            htmlBefore + clipboardData.html + htmlAfter
+        );
+    });
+
+    it('should use excelHandler to extract table from clipboard data if not found initially', () => {
+        const htmlBefore = '';
+        const htmlAfter = '';
+        clipboardData.html = '<tr><td>Test</td></tr>';
+
+        validateExcelFragment(fragment, domCreator, htmlBefore, clipboardData, htmlAfter);
+
+        expect(fragment.querySelector('table')).not.toBeNull();
+        expect(domCreator.htmlToDOM).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
We got report of this exception: RangeError: Maximum call stack size exceeded

Which is comming from this callstack: 
```
at webpack://packages/roosterjs-content-model-plugins/lib/paste/Excel/processPastedContentFromExcel.ts:99
at webpack://packages/roosterjs-content-model-plugins/lib/paste/Excel/processPastedContentFromExcel.ts:28
at webpack://packages/roosterjs-content-model-plugins/lib/paste/PastePlugin.ts:112
at webpack://packages/common/controls/packages/controls/owa-editor-lazy-plugin/src/utils/createLazyContentModelPlugin.ts:135
at webpack://packages/roosterjs-content-model-core/lib/coreApi/triggerEvent/triggerEvent.ts:30
at Native Browser Function(Array.forEach)
at webpack://packages/roosterjs-content-model-core/lib/coreApi/triggerEvent/triggerEvent.ts:28
at webpack://packages/roosterjs-content-model-core/lib/editor/Editor.ts:265
at webpack://packages/roosterjs-content-model-core/lib/command/paste/generatePasteOptionFromPlugins.ts:44
at webpack://packages/roosterjs-content-model-core/lib/corePlugin/copyPaste/CopyPastePlugin.ts:208
```

To fix wrap this in a try catch block to prevent this error. Additionally added a new way to try get the table from the clipboard data without regex involved which could potentially be better when the string from excel is long.
