### PR TITLE
Fix table header state

### DIFF
--- a/demo/scripts/controlsV2/demoButtons/formatTableButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/formatTableButton.ts
@@ -28,7 +28,7 @@ const PREDEFINED_STYLES: Record<
             color /** verticalColors*/,
             false /** bandedRows */,
             false /** bandedColumns */,
-            false /** headerRow */,
+            true /** headerRow */,
             false /** firstColumn */,
             TableBorderFormat.Default /** tableBorderFormat */,
             null /** bgColorEven */,

--- a/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
@@ -224,6 +224,7 @@ describe('mergePasteContent', () => {
                                                     format: {},
                                                 },
                                             ],
+                                            decorator: undefined,
                                             format: {},
                                             isImplicit: true,
                                         },

--- a/packages/roosterjs-content-model-dom/test/modelApi/editing/applyTableFormatTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/editing/applyTableFormatTest.ts
@@ -1,6 +1,7 @@
 import { applyTableFormat } from '../../../lib/modelApi/editing/applyTableFormat';
 import { TableBorderFormat } from '../../../lib/constants/TableBorderFormat';
 import {
+    ContentModelParagraphDecorator,
     ContentModelTable,
     ContentModelTableCell,
     ContentModelTableRow,
@@ -630,6 +631,76 @@ describe('applyTableFormat', () => {
                     expect(segment.format?.textColor).toBe(undefined);
                 });
             }
+        });
+    });
+
+    function runHeaderTest(
+        table: ReadonlyContentModelTable,
+        format: TableMetadataFormat | undefined,
+        expectedDecorator?: ContentModelParagraphDecorator
+    ) {
+        applyTableFormat(table, format);
+
+        expect(table.cachedElement).toBeUndefined();
+
+        for (let col = 0; col < 4; col++) {
+            const cell = table.rows[0].cells[col];
+            cell.blocks.forEach(block => {
+                if (block.blockType == 'Paragraph') {
+                    if (expectedDecorator) {
+                        expect(block.decorator).toEqual(expectedDecorator);
+                    } else {
+                        expect(block.decorator).toBeUndefined();
+                    }
+                }
+            });
+        }
+    }
+
+    it('apply header row', () => {
+        const table: ReadonlyContentModelTable = createTable(3, 4);
+        applyTableFormat(table);
+        runHeaderTest(
+            table,
+            {
+                hasHeaderRow: true,
+                headerRowColor: 'red',
+            },
+            {
+                tagName: 'span',
+                format: {
+                    fontWeight: 'bold',
+                },
+            }
+        );
+    });
+
+    it('apply header row', () => {
+        const table: ReadonlyContentModelTable = createTable(3, 4);
+        applyTableFormat(table);
+        runHeaderTest(
+            table,
+            {
+                hasHeaderRow: true,
+                headerRowColor: 'red',
+            },
+            {
+                tagName: 'div',
+                format: {
+                    fontWeight: 'bold',
+                },
+            }
+        );
+    });
+
+    it('remove header row', () => {
+        const table: ReadonlyContentModelTable = createTable(3, 4);
+        applyTableFormat(table, {
+            hasHeaderRow: true,
+            headerRowColor: 'red',
+        });
+        runHeaderTest(table, {
+            hasHeaderRow: false,
         });
     });
 });


### PR DESCRIPTION
The default font-weight of the TH element overrides the font-weight of the segment. To resolve this, set the paragraph decorator inside the table header, so the TH element will not override the paragraph styles. 

