### PR TITLE
Send anchor event in Auto Link

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -25,13 +25,8 @@ export const formatContentModel: FormatContentModel = (
     options,
     domToModelOptions
 ) => {
-    const {
-        onNodeCreated,
-        getChangeData,
-        rawEvent,
-        selectionOverride,
-        scrollCaretIntoView: scroll,
-    } = options || {};
+    const { onNodeCreated, rawEvent, selectionOverride, scrollCaretIntoView: scroll } =
+        options || {};
     const model = core.api.createContentModel(core, domToModelOptions, selectionOverride);
     const context: FormatContentModelContext = {
         newEntities: [],

--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -81,7 +81,7 @@ export const formatContentModel: FormatContentModel = (
                 contentModel: clearModelCache ? undefined : model,
                 selection: clearModelCache ? undefined : selection,
                 source: options?.changeSource || ChangeSource.Format,
-                data: options?.getChangeData?.() || getChangeData?.(),
+                data: options?.getChangeData?.(),
                 formatApiName: options?.apiName,
                 changedEntities: getChangedEntities(context, rawEvent),
             };

--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -81,7 +81,7 @@ export const formatContentModel: FormatContentModel = (
                 contentModel: clearModelCache ? undefined : model,
                 selection: clearModelCache ? undefined : selection,
                 source: options?.changeSource || ChangeSource.Format,
-                data: getChangeData?.(),
+                data: options?.getChangeData?.() || getChangeData?.(),
                 formatApiName: options?.apiName,
                 changedEntities: getChangedEntities(context, rawEvent),
             };

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
@@ -114,6 +114,7 @@ export class AutoFormatPlugin implements EditorPlugin {
                     const formatOptions: FormatContentModelOptions = {
                         changeSource: '',
                         apiName: '',
+                        getChangeData: () => null,
                     };
                     formatTextSegmentBeforeSelectionMarker(
                         editor,
@@ -147,11 +148,17 @@ export class AutoFormatPlugin implements EditorPlugin {
                             }
 
                             if (autoLink || autoTel || autoMailto) {
-                                shouldLink = !!promoteLink(previousSegment, paragraph, {
+                                const linkSegment = promoteLink(previousSegment, paragraph, {
                                     autoLink,
                                     autoTel,
                                     autoMailto,
                                 });
+                                const anchorNode = createAnchor(
+                                    linkSegment?.link?.format?.href || '',
+                                    linkSegment?.text || ''
+                                );
+                                formatOptions.getChangeData = () => anchorNode;
+                                shouldLink = !!linkSegment;
 
                                 if (shouldLink) {
                                     context.canUndoByBackspace = true;
@@ -269,4 +276,11 @@ const getChangeSource = (shouldList: boolean, shouldHyphen: boolean, shouldLink:
         : shouldLink
         ? ChangeSource.AutoLink
         : '';
+};
+
+const createAnchor = (url: string, text: string) => {
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.textContent = text;
+    return anchor;
 };

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
@@ -114,7 +114,7 @@ export class AutoFormatPlugin implements EditorPlugin {
                     const formatOptions: FormatContentModelOptions = {
                         changeSource: '',
                         apiName: '',
-                        getChangeData: () => null,
+                        getChangeData: undefined,
                     };
                     formatTextSegmentBeforeSelectionMarker(
                         editor,
@@ -153,14 +153,15 @@ export class AutoFormatPlugin implements EditorPlugin {
                                     autoTel,
                                     autoMailto,
                                 });
-                                const anchorNode = createAnchor(
-                                    linkSegment?.link?.format?.href || '',
-                                    linkSegment?.text || ''
-                                );
-                                formatOptions.getChangeData = () => anchorNode;
-                                shouldLink = !!linkSegment;
 
-                                if (shouldLink) {
+                                if (linkSegment) {
+                                    const anchor = createAnchor(
+                                        linkSegment.link?.format.href || '',
+                                        linkSegment.text
+                                    );
+                                    formatOptions.getChangeData = () => anchor;
+
+                                    shouldLink = true;
                                     context.canUndoByBackspace = true;
                                 }
                             }


### PR DESCRIPTION
After a text is automatically transformed into a link by typing and pressing space, send the anchor element when the ContentChanged event is triggered. Also add more unit tests. 