### PR TITLE
Respect font weight in TH element

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/config/defaultContentModelFormatMap.ts
+++ b/packages/roosterjs-content-model-dom/lib/config/defaultContentModelFormatMap.ts
@@ -52,4 +52,7 @@ export const defaultContentModelFormatMap: DefaultImplicitFormatMap = {
         marginTop: '1em',
         marginBottom: '1em',
     },
+    th: {
+        fontWeight: 'bold',
+    },
 };

--- a/packages/roosterjs-content-model-dom/lib/config/defaultHTMLStyleMap.ts
+++ b/packages/roosterjs-content-model-dom/lib/config/defaultHTMLStyleMap.ts
@@ -117,6 +117,7 @@ export const defaultHTMLStyleMap: DefaultStyleMap = {
     },
     th: {
         display: 'table-cell',
+        fontWeight: 'bold',
     },
     u: {
         textDecoration: 'underline',

--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/applyTableFormat.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/applyTableFormat.ts
@@ -262,6 +262,10 @@ export function setFirstColumnFormatBorders(
                 switch (rowIndex) {
                     case 0:
                         cell.isHeader = !!format.hasHeaderRow;
+
+                        if (cell.isHeader) {
+                            cell.format.fontWeight = 'bold';
+                        }
                         break;
                     case rows.length - 1:
                         setBorderColor(cell.format, 'borderTop');
@@ -295,6 +299,7 @@ function setHeaderRowFormat(
         const cell = mutateBlock(readonlyCell);
 
         cell.isHeader = true;
+        cell.format.fontWeight = 'bold';
 
         if (format.headerRowColor) {
             if (!metaOverrides.bgColorOverrides[rowIndex][cellIndex]) {

--- a/packages/roosterjs-content-model-dom/test/endToEndTest.ts
+++ b/packages/roosterjs-content-model-dom/test/endToEndTest.ts
@@ -2278,7 +2278,7 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
         );
     });
 
-    it('TH with font-weight', () => {
+    it('TH with font-weight: 400', () => {
         runTest(
             '<table><tr><th style="font-weight:400">test</th></tr></table>',
             {
@@ -2326,6 +2326,57 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
             },
             'test',
             '<table><tbody><tr><th><span style="font-weight: 400;">test</span></th></tr></tbody></table>'
+        );
+    });
+
+    it('TH with font-weight: bold', () => {
+        runTest(
+            '<table><tr><th style="font-weight: bold">test</th></tr></table>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        widths: [],
+                        rows: [
+                            {
+                                height: 0,
+                                cells: [
+                                    {
+                                        spanAbove: false,
+                                        spanLeft: false,
+                                        isHeader: true,
+                                        blockGroupType: 'TableCell',
+                                        blocks: [
+                                            {
+                                                isImplicit: true,
+                                                segments: [
+                                                    {
+                                                        text: 'test',
+                                                        segmentType: 'Text',
+                                                        format: {
+                                                            fontWeight: 'bold',
+                                                        },
+                                                    },
+                                                ],
+                                                blockType: 'Paragraph',
+                                                format: {},
+                                            },
+                                        ],
+                                        format: {},
+                                        dataset: {},
+                                    },
+                                ],
+                                format: {},
+                            },
+                        ],
+                        blockType: 'Table',
+                        format: {},
+                        dataset: {},
+                    },
+                ],
+            },
+            'test',
+            '<table><tbody><tr><th>test</th></tr></tbody></table>'
         );
     });
 });

--- a/packages/roosterjs-content-model-dom/test/endToEndTest.ts
+++ b/packages/roosterjs-content-model-dom/test/endToEndTest.ts
@@ -2226,4 +2226,106 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
             '<div style="text-align: center;">test</div>'
         );
     });
+
+    it('TH without font-weight', () => {
+        runTest(
+            '<table><tr><th>test</th></tr></table>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        widths: [],
+                        rows: [
+                            {
+                                height: 0,
+                                cells: [
+                                    {
+                                        spanAbove: false,
+                                        spanLeft: false,
+                                        isHeader: true,
+                                        blockGroupType: 'TableCell',
+                                        blocks: [
+                                            {
+                                                isImplicit: true,
+                                                segments: [
+                                                    {
+                                                        text: 'test',
+                                                        segmentType: 'Text',
+                                                        format: {
+                                                            fontWeight: 'bold',
+                                                        },
+                                                    },
+                                                ],
+                                                blockType: 'Paragraph',
+                                                format: {},
+                                            },
+                                        ],
+                                        format: {},
+                                        dataset: {},
+                                    },
+                                ],
+                                format: {},
+                            },
+                        ],
+                        blockType: 'Table',
+                        format: {},
+                        dataset: {},
+                    },
+                ],
+            },
+            'test',
+            '<table><tbody><tr><th>test</th></tr></tbody></table>'
+        );
+    });
+
+    it('TH with font-weight', () => {
+        runTest(
+            '<table><tr><th style="font-weight:400">test</th></tr></table>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        widths: [],
+                        rows: [
+                            {
+                                height: 0,
+                                cells: [
+                                    {
+                                        spanAbove: false,
+                                        spanLeft: false,
+                                        isHeader: true,
+                                        blockGroupType: 'TableCell',
+                                        blocks: [
+                                            {
+                                                isImplicit: true,
+                                                segments: [
+                                                    {
+                                                        text: 'test',
+                                                        segmentType: 'Text',
+                                                        format: {
+                                                            fontWeight: '400',
+                                                        },
+                                                    },
+                                                ],
+                                                blockType: 'Paragraph',
+                                                format: {},
+                                            },
+                                        ],
+                                        format: {},
+                                        dataset: {},
+                                    },
+                                ],
+                                format: {},
+                            },
+                        ],
+                        blockType: 'Table',
+                        format: {},
+                        dataset: {},
+                    },
+                ],
+            },
+            'test',
+            '<table><tbody><tr><th><span style="font-weight: 400;">test</span></th></tr></tbody></table>'
+        );
+    });
 });

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelTableCellFormat.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelTableCellFormat.ts
@@ -1,3 +1,4 @@
+import type { BoldFormat } from 'roosterjs/lib';
 import type { BorderBoxFormat } from './formatParts/BorderBoxFormat';
 import type { ContentModelBlockFormat } from './ContentModelBlockFormat';
 import type { SizeFormat } from './formatParts/SizeFormat';
@@ -13,4 +14,5 @@ export type ContentModelTableCellFormat = ContentModelBlockFormat &
     VerticalAlignFormat &
     WordBreakFormat &
     TextColorFormat &
-    SizeFormat;
+    SizeFormat &
+    BoldFormat;

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelTableCellFormat.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelTableCellFormat.ts
@@ -1,4 +1,4 @@
-import type { BoldFormat } from 'roosterjs/lib';
+import type { BoldFormat } from './formatParts/BoldFormat';
 import type { BorderBoxFormat } from './formatParts/BorderBoxFormat';
 import type { ContentModelBlockFormat } from './ContentModelBlockFormat';
 import type { SizeFormat } from './formatParts/SizeFormat';


### PR DESCRIPTION
Original bug: https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/334221/?triage=truehttps://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/334221/?triage=true

Minimum repro:

```html
<table><tr><th style="font-weight:400">test</th></tr></table>
```

Since font-weight:400 is the default value for most elements, it is ignored here. However TH has a default style: font-weight: bold, so we need to recognize its default font weight and respect this value.