### PR TITLE
Fix resize table with width

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/features/CellResizer.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/features/CellResizer.ts
@@ -8,6 +8,7 @@ import {
     MIN_ALLOWED_TABLE_CELL_WIDTH,
     mutateBlock,
     MIN_ALLOWED_TABLE_CELL_HEIGHT,
+    parseValueWithUnit,
 } from 'roosterjs-content-model-dom';
 import type { DragAndDropHandler } from '../../../pluginUtils/DragAndDrop/DragAndDropHandler';
 import type { IEditor, ReadonlyContentModelTable } from 'roosterjs-content-model-types';
@@ -46,7 +47,15 @@ export function createCellResizer(
 
     (anchorContainer || document.body).appendChild(div);
 
-    const context: CellResizerContext = { editor, td, table, isRTL, zoomScale, onStart };
+    const context: CellResizerContext = {
+        editor,
+        td,
+        table,
+        isRTL,
+        zoomScale,
+        onStart,
+        originalWidth: parseValueWithUnit(table.style.width),
+    };
     const setPosition = isHorizontal ? setHorizontalPosition : setVerticalPosition;
     setPosition(context, div);
 
@@ -79,6 +88,7 @@ export interface CellResizerContext {
     table: HTMLTableElement;
     isRTL: boolean;
     zoomScale: number;
+    originalWidth: number;
     onStart: () => void;
 }
 
@@ -228,6 +238,13 @@ export function onDraggingVertical(
             for (let col = 0; col < tableRow.cells.length; col++) {
                 tableRow.cells[col].style.width = cmTable.widths[col] + 'px';
             }
+        }
+
+        if (context.originalWidth > 0) {
+            const newWidth = context.originalWidth + change + 'px';
+
+            mutableTable.format.width = newWidth;
+            table.style.width = newWidth;
         }
 
         return true;

--- a/packages/roosterjs-content-model-plugins/test/tableEdit/cellResizerTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/tableEdit/cellResizerTest.ts
@@ -69,6 +69,7 @@ describe('Cell Resizer tests', () => {
             isRTL: false,
             zoomScale: 1,
             onStart: onStartSpy,
+            originalWidth: 0,
         };
         const editorCMTable = getCMTableFromTable(editor, target as HTMLTableElement);
 
@@ -119,6 +120,7 @@ describe('Cell Resizer tests', () => {
                 isRTL: false,
                 zoomScale: 1,
                 onStart: onStartSpy,
+                originalWidth: 0,
             };
             const delta = 10 * growth;
             const beforeHeight = getCurrentTable(editor).rows[cellRow].getBoundingClientRect()
@@ -194,6 +196,7 @@ describe('Cell Resizer tests', () => {
                 isRTL: false,
                 zoomScale: 1,
                 onStart: onStartSpy,
+                originalWidth: 0,
             };
             const delta = 10 * growth;
             const beforeWidth = getCurrentTable(editor).rows[cellRow].cells[


### PR DESCRIPTION
Original bug: https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/331303/?triage=true

If table has style "width", resize may not work since its whole width is not changed. Fix it by setting the table width if it exists.