### PR TITLE
Support text/uri-list when pasting

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/domUtils/event/extractClipboardItems.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/event/extractClipboardItems.ts
@@ -8,6 +8,7 @@ const ContentHandlers: {
     ['text/plain']: (data, value) => (data.text = value),
     ['text/*']: (data, value, type?) => !!type && (data.customValues[type] = value),
     ['text/link-preview']: tryParseLinkPreview,
+    ['text/uri-list']: (data, value) => (data.text = value),
 };
 
 /**

--- a/packages/roosterjs-content-model-dom/test/domUtils/event/extractClipboardItemsTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domUtils/event/extractClipboardItemsTest.ts
@@ -292,4 +292,20 @@ describe('extractClipboardItems', () => {
             pasteNativeEvent: true,
         });
     });
+
+    it('input with text/uri-list', async () => {
+        const text = 'https://example.com';
+        const clipboardData = await extractClipboardItems([
+            createStringItem('text/uri-list', text),
+        ]);
+        expect(clipboardData).toEqual({
+            types: ['text/uri-list'],
+            text: text,
+            image: null,
+            files: [],
+            rawHtml: null,
+            customValues: {},
+            pasteNativeEvent: true,
+        });
+    });
 });


### PR DESCRIPTION
Lont press safari's address bar to copy will get the web link in the type text/uri-list. Handling it in roosterjs to support pasting it.
To solve the issue #2942