### PR TITLE
Fix #2927 Fix the check of format state change

### DIFF
--- a/packages/roosterjs-react/lib/ribbon/plugin/createRibbonPlugin.ts
+++ b/packages/roosterjs-react/lib/ribbon/plugin/createRibbonPlugin.ts
@@ -153,9 +153,11 @@ class RibbonPluginImpl implements RibbonPlugin {
     private updateFormat() {
         if (this.editor && this.onFormatChanged) {
             const newFormatState = getFormatState(this.editor);
+            const newFormatKeys = getObjectKeys(newFormatState);
 
             if (
                 !this.formatState ||
+                newFormatKeys.length != getObjectKeys(this.formatState).length ||
                 getObjectKeys(newFormatState).some(
                     key => newFormatState[key] != this.formatState?.[key]
                 )


### PR DESCRIPTION
There is a code bug in RibbonPlugin in roosterjs-react that causes the format state change check to fail when some property does not exist in the new format state.

Fix it by checking key count as well.