### PR TITLE
Fix #317607

### DIFF
--- a/packages/roosterjs-content-model-api/lib/publicApi/segment/toggleUnderline.ts
+++ b/packages/roosterjs-content-model-api/lib/publicApi/segment/toggleUnderline.ts
@@ -20,7 +20,6 @@ export function toggleUnderline(editor: IEditor) {
             }
         },
         (format, segment) => !!format.underline || !!segment?.link?.format?.underline,
-        false /*includingFormatHolder*/,
-        adjustTrailingSpaceSelection
+        false /*includingFormatHolder*/
     );
 }

--- a/packages/roosterjs-content-model-api/lib/publicApi/segment/toggleUnderline.ts
+++ b/packages/roosterjs-content-model-api/lib/publicApi/segment/toggleUnderline.ts
@@ -1,4 +1,3 @@
-import { adjustTrailingSpaceSelection } from '../../modelApi/selection/adjustTrailingSpaceSelection';
 import { formatSegmentWithContentModel } from '../utils/formatSegmentWithContentModel';
 import type { IEditor } from 'roosterjs-content-model-types';
 

--- a/packages/roosterjs-content-model-api/test/publicApi/segment/toggleUnderlineTest.ts
+++ b/packages/roosterjs-content-model-api/test/publicApi/segment/toggleUnderlineTest.ts
@@ -491,16 +491,10 @@ describe('toggleUnderline', () => {
                         segments: [
                             {
                                 segmentType: 'Text',
-                                text: 'Test',
+                                text: 'Test    ',
                                 format: {
                                     underline: true,
                                 },
-                                isSelected: true,
-                            },
-                            {
-                                segmentType: 'Text',
-                                text: '    ',
-                                format: {},
                                 isSelected: true,
                             },
                         ],


### PR DESCRIPTION
Bug link: https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/317607/?triage=true

This is caused by https://github.com/microsoft/roosterjs/pull/2288, it was fixing an issue that trailing space is also included into link. However I feel underline should not be excluded, since it will cause the underline button to be unchecked.