### PR TITLE
Let contentModelToText accepts readonly types

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelToText/contentModelToText.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToText/contentModelToText.ts
@@ -1,7 +1,7 @@
 import type {
-    ContentModelBlockGroup,
-    ContentModelDocument,
     ModelToTextCallbacks,
+    ReadonlyContentModelBlockGroup,
+    ReadonlyContentModelDocument,
 } from 'roosterjs-content-model-types';
 
 const TextForHR = '________________________________________';
@@ -24,7 +24,7 @@ const defaultCallbacks: Required<ModelToTextCallbacks> = {
  * @param callbacks  Callbacks to customize the behavior of contentModelToText function
  */
 export function contentModelToText(
-    model: ContentModelDocument,
+    model: ReadonlyContentModelDocument,
     separator: string = '\r\n',
     callbacks?: ModelToTextCallbacks
 ): string {
@@ -37,7 +37,7 @@ export function contentModelToText(
 }
 
 function contentModelToTextArray(
-    group: ContentModelBlockGroup,
+    group: ReadonlyContentModelBlockGroup,
     textArray: string[],
     callbacks: Required<ModelToTextCallbacks>
 ) {

--- a/packages/roosterjs-content-model-types/lib/parameter/ModelToTextCallbacks.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/ModelToTextCallbacks.ts
@@ -1,11 +1,11 @@
-import type { ContentModelBlockGroup } from '../contentModel/blockGroup/ContentModelBlockGroup';
-import type { ContentModelDivider } from '../contentModel/block/ContentModelDivider';
+import type { ReadonlyContentModelBlockGroup } from '../contentModel/blockGroup/ContentModelBlockGroup';
+import type { ReadonlyContentModelDivider } from '../contentModel/block/ContentModelDivider';
 import type { ContentModelEntity } from '../contentModel/entity/ContentModelEntity';
-import type { ContentModelGeneralSegment } from '../contentModel/segment/ContentModelGeneralSegment';
-import type { ContentModelImage } from '../contentModel/segment/ContentModelImage';
-import type { ContentModelParagraph } from '../contentModel/block/ContentModelParagraph';
-import type { ContentModelTable } from '../contentModel/block/ContentModelTable';
-import type { ContentModelText } from '../contentModel/segment/ContentModelText';
+import type { ReadonlyContentModelGeneralSegment } from '../contentModel/segment/ContentModelGeneralSegment';
+import type { ReadonlyContentModelImage } from '../contentModel/segment/ContentModelImage';
+import type { ReadonlyContentModelParagraph } from '../contentModel/block/ContentModelParagraph';
+import type { ReadonlyContentModelTable } from '../contentModel/block/ContentModelTable';
+import type { ReadonlyContentModelText } from '../contentModel/segment/ContentModelText';
 
 /**
  * Callback function type for converting a given Content Model object to plain text
@@ -36,35 +36,35 @@ export interface ModelToTextCallbacks {
     /**
      * Customize the behavior of converting general segment to plain text
      */
-    onGeneralSegment?: ModelToTextCallback<ContentModelGeneralSegment>;
+    onGeneralSegment?: ModelToTextCallback<ReadonlyContentModelGeneralSegment>;
 
     /**
      * Customize the behavior of converting text model to plain text
      */
-    onText?: ModelToTextCallback<ContentModelText>;
+    onText?: ModelToTextCallback<ReadonlyContentModelText>;
 
     /**
      * Customize the behavior of converting image model to plain text
      */
-    onImage?: ModelToTextCallback<ContentModelImage>;
+    onImage?: ModelToTextCallback<ReadonlyContentModelImage>;
 
     /**
      * Customize the behavior of converting divider model to plain text
      */
-    onDivider?: ModelToTextCallback<ContentModelDivider>;
+    onDivider?: ModelToTextCallback<ReadonlyContentModelDivider>;
 
     /**
      * Customize the check if we should convert a paragraph model to plain text
      */
-    onParagraph?: ModelToTextChecker<ContentModelParagraph>;
+    onParagraph?: ModelToTextChecker<ReadonlyContentModelParagraph>;
 
     /**
      * Customize the check if we should convert a table model to plain text
      */
-    onTable?: ModelToTextChecker<ContentModelTable>;
+    onTable?: ModelToTextChecker<ReadonlyContentModelTable>;
 
     /**
      * Customize the check if we should convert a block group model to plain text
      */
-    onBlockGroup?: ModelToTextChecker<ContentModelBlockGroup>;
+    onBlockGroup?: ModelToTextChecker<ReadonlyContentModelBlockGroup>;
 }


### PR DESCRIPTION
This change is to allow calling `contentModelToText` using readonly content model types.