### PR TITLE
Select image with keyboard

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -646,21 +646,23 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
 
             //If am image selection changed to a wider range due a keyboard event, we should update the selection
             const selection = this.editor.getDocument().getSelection();
-
-            if (
-                newSelection?.type == 'image' &&
-                selection &&
-                selection.focusNode &&
-                !isSingleImageInSelection(selection)
-            ) {
-                const range = selection.getRangeAt(0);
-                this.editor.setDOMSelection({
-                    type: 'range',
-                    range,
-                    isReverted:
-                        selection.focusNode != range.endContainer ||
-                        selection.focusOffset != range.endOffset,
-                });
+            if (selection && selection.focusNode) {
+                const image = isSingleImageInSelection(selection);
+                if (newSelection?.type == 'image' && !image) {
+                    const range = selection.getRangeAt(0);
+                    this.editor.setDOMSelection({
+                        type: 'range',
+                        range,
+                        isReverted:
+                            selection.focusNode != range.endContainer ||
+                            selection.focusOffset != range.endOffset,
+                    });
+                } else if (newSelection?.type !== 'image' && image) {
+                    this.editor.setDOMSelection({
+                        type: 'image',
+                        image,
+                    });
+                }
             }
 
             // Safari has problem to handle onBlur event. When blur, we cannot get the original selection from editor.

--- a/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
@@ -2857,4 +2857,39 @@ describe('SelectionPlugin selectionChange on image selected', () => {
         expect(setDOMSelectionSpy).not.toHaveBeenCalled();
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('onSelectionChange on image | 4', () => {
+        const image = document.createElement('img');
+        spyOn(isSingleImageInSelection, 'isSingleImageInSelection').and.returnValue(image);
+
+        const plugin = createSelectionPlugin({});
+        const state = plugin.getState();
+        const mockedOldSelection = {
+            type: 'image',
+            image: {} as any,
+        } as DOMSelection;
+
+        state.selection = mockedOldSelection;
+
+        plugin.initialize(editor);
+
+        const onSelectionChange = addEventListenerSpy.calls.argsFor(0)[1] as Function;
+        const mockedNewSelection = {
+            type: 'range',
+            range: {} as any,
+        } as any;
+
+        hasFocusSpy.and.returnValue(true);
+        isInShadowEditSpy.and.returnValue(false);
+        getDOMSelectionSpy.and.returnValue(mockedNewSelection);
+        getRangeAtSpy.and.returnValue({ startContainer: {} });
+
+        onSelectionChange();
+
+        expect(setDOMSelectionSpy).toHaveBeenCalledWith({
+            type: 'image',
+            image,
+        });
+        expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION
If there were no image selected, and the selection changed to a single image, select the image as image selection.
 
![ImageKeyboardSelection](https://github.com/user-attachments/assets/3e698441-355d-4408-827f-f959554202d4)
