### PR TITLE
Fix 335899: Split paragraph by BR before doing block format

### DIFF
--- a/packages/roosterjs-content-model-api/lib/modelApi/block/setModelAlignment.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/block/setModelAlignment.ts
@@ -1,5 +1,6 @@
 import { alignTable } from '../table/alignTable';
 import { getOperationalBlocks, mutateBlock } from 'roosterjs-content-model-dom';
+import { splitSelectedParagraphByBr } from './splitSelectedParagraphByBr';
 import type {
     ContentModelListItem,
     ReadonlyContentModelDocument,
@@ -53,6 +54,8 @@ export function setModelAlignment(
     model: ReadonlyContentModelDocument,
     alignment: 'left' | 'center' | 'right' | 'justify'
 ) {
+    splitSelectedParagraphByBr(model);
+
     const paragraphOrListItemOrTable = getOperationalBlocks<ContentModelListItem>(
         model,
         ['ListItem'],

--- a/packages/roosterjs-content-model-api/lib/modelApi/block/setModelDirection.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/block/setModelDirection.ts
@@ -1,4 +1,5 @@
 import { findListItemsInSameThread } from '../list/findListItemsInSameThread';
+import { splitSelectedParagraphByBr } from './splitSelectedParagraphByBr';
 import {
     applyTableFormat,
     getOperationalBlocks,
@@ -19,6 +20,8 @@ import type {
  * @internal
  */
 export function setModelDirection(model: ReadonlyContentModelDocument, direction: 'ltr' | 'rtl') {
+    splitSelectedParagraphByBr(model);
+
     const paragraphOrListItemOrTable = getOperationalBlocks<ContentModelListItem>(
         model,
         ['ListItem'],

--- a/packages/roosterjs-content-model-api/lib/modelApi/block/setModelIndentation.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/block/setModelIndentation.ts
@@ -1,5 +1,6 @@
 import { findListItemsInSameThread } from '../list/findListItemsInSameThread';
 import { getListAnnounceData } from '../list/getListAnnounceData';
+import { splitSelectedParagraphByBr } from './splitSelectedParagraphByBr';
 import {
     createListLevel,
     getOperationalBlocks,
@@ -33,6 +34,8 @@ export function setModelIndentation(
     length: number = IndentStepInPixel,
     context?: FormatContentModelContext
 ) {
+    splitSelectedParagraphByBr(model);
+
     const paragraphOrListItem = getOperationalBlocks<ContentModelListItem>(
         model,
         ['ListItem'],

--- a/packages/roosterjs-content-model-api/lib/modelApi/block/splitSelectedParagraphByBr.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/block/splitSelectedParagraphByBr.ts
@@ -1,0 +1,68 @@
+import {
+    createParagraph,
+    getSelectedSegmentsAndParagraphs,
+    mutateBlock,
+} from 'roosterjs-content-model-dom';
+import type {
+    ReadonlyContentModelDocument,
+    ReadonlyContentModelParagraph,
+    ShallowMutableContentModelParagraph,
+} from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ * For all selected paragraphs, if it has BR in middle of other segments, split the paragraph into multiple paragraphs
+ * @param model The model to process
+ */
+export function splitSelectedParagraphByBr(model: ReadonlyContentModelDocument) {
+    const selections = getSelectedSegmentsAndParagraphs(
+        model,
+        false /*includingFormatHolder*/,
+        false /*includingEntity*/
+    );
+
+    for (const [_, para, path] of selections) {
+        if (para?.segments.some(s => s.segmentType == 'Br')) {
+            let currentParagraph = shallowColonParagraph(para);
+            let hasVisibleSegment = false;
+            const newParagraphs: ShallowMutableContentModelParagraph[] = [];
+            const parent = mutateBlock(path[0]);
+            const index = parent.blocks.indexOf(para);
+
+            if (index >= 0) {
+                for (const segment of mutateBlock(para).segments) {
+                    if (segment.segmentType == 'Br') {
+                        if (!hasVisibleSegment) {
+                            currentParagraph.segments.push(segment);
+                        }
+
+                        if (currentParagraph.segments.length > 0) {
+                            newParagraphs.push(currentParagraph);
+                        }
+
+                        currentParagraph = shallowColonParagraph(para);
+                        hasVisibleSegment = false;
+                    } else {
+                        currentParagraph.segments.push(segment);
+
+                        if (segment.segmentType != 'SelectionMarker') {
+                            hasVisibleSegment = true;
+                        }
+                    }
+                }
+
+                if (currentParagraph.segments.length > 0) {
+                    newParagraphs.push(currentParagraph);
+                }
+
+                parent.blocks.splice(index, 1, ...newParagraphs);
+            }
+        }
+    }
+}
+
+function shallowColonParagraph(
+    para: ReadonlyContentModelParagraph
+): ShallowMutableContentModelParagraph {
+    return createParagraph(false /*isImplicit*/, para.format, para.segmentFormat, para.decorator);
+}

--- a/packages/roosterjs-content-model-api/lib/modelApi/block/toggleModelBlockQuote.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/block/toggleModelBlockQuote.ts
@@ -1,3 +1,4 @@
+import { splitSelectedParagraphByBr } from './splitSelectedParagraphByBr';
 import { wrapBlockStep1, wrapBlockStep2 } from '../common/wrapBlock';
 import {
     getOperationalBlocks,
@@ -28,6 +29,8 @@ export function toggleModelBlockQuote(
     formatLtr: ContentModelFormatContainerFormat,
     formatRtl: ContentModelFormatContainerFormat
 ): boolean {
+    splitSelectedParagraphByBr(model);
+
     const paragraphOfQuote = getOperationalBlocks<
         ContentModelFormatContainer | ContentModelListItem
     >(model, ['FormatContainer', 'ListItem'], ['TableCell'], true /*deepFirst*/);

--- a/packages/roosterjs-content-model-api/lib/modelApi/list/setListType.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/list/setListType.ts
@@ -1,3 +1,4 @@
+import { splitSelectedParagraphByBr } from '../block/splitSelectedParagraphByBr';
 import {
     createListItem,
     createListLevel,
@@ -27,6 +28,8 @@ export function setListType(
     listType: 'OL' | 'UL',
     removeMargins: boolean = false
 ) {
+    splitSelectedParagraphByBr(model);
+
     const paragraphOrListItems = getOperationalBlocks<ContentModelListItem>(
         model,
         ['ListItem'],

--- a/packages/roosterjs-content-model-api/lib/publicApi/utils/formatParagraphWithContentModel.ts
+++ b/packages/roosterjs-content-model-api/lib/publicApi/utils/formatParagraphWithContentModel.ts
@@ -1,4 +1,5 @@
 import { getSelectedParagraphs } from 'roosterjs-content-model-dom';
+import { splitSelectedParagraphByBr } from '../../modelApi/block/splitSelectedParagraphByBr';
 import type { IEditor, ShallowMutableContentModelParagraph } from 'roosterjs-content-model-types';
 
 /**
@@ -14,6 +15,8 @@ export function formatParagraphWithContentModel(
 ) {
     editor.formatContentModel(
         (model, context) => {
+            splitSelectedParagraphByBr(model);
+
             const paragraphs = getSelectedParagraphs(model, true /*mutate*/);
 
             paragraphs.forEach(setStyleCallback);

--- a/packages/roosterjs-content-model-api/test/modelApi/block/setModelAlignmentTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/block/setModelAlignmentTest.ts
@@ -1,3 +1,4 @@
+import * as splitSelectedParagraphByBrModule from '../../../lib/modelApi/block/splitSelectedParagraphByBr';
 import { ContentModelBlockFormat } from 'roosterjs-content-model-types';
 import { setModelAlignment } from '../../../lib/modelApi/block/setModelAlignment';
 import {
@@ -12,6 +13,14 @@ import {
 
 describe('align left', () => {
     const mockedCachedElement = 'CACHE' as any;
+    let splitSelectedParagraphByBrSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        splitSelectedParagraphByBrSpy = spyOn(
+            splitSelectedParagraphByBrModule,
+            'splitSelectedParagraphByBr'
+        ).and.callThrough();
+    });
 
     function createParagraph(isImplicit?: boolean, format?: ContentModelBlockFormat) {
         const result = originalCreateParagraph(isImplicit, format);
@@ -31,6 +40,8 @@ describe('align left', () => {
             blocks: [],
         });
         expect(result).toBeFalse();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group without selection', () => {
@@ -45,6 +56,8 @@ describe('align left', () => {
             blocks: [para],
         });
         expect(result).toBeFalse();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected paragraph', () => {
@@ -91,6 +104,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with multiple selected paragraph', () => {
@@ -141,6 +156,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected  paragraph in RTL', () => {
@@ -170,6 +187,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with paragraph under OL', () => {
@@ -214,6 +233,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('align table, list, paragraph left', () => {
@@ -329,6 +350,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('align table, list, paragraph center', () => {
@@ -442,6 +465,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('align table, list, paragraph right', () => {
@@ -555,6 +580,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('[RTL] align table, list, paragraph left', () => {
@@ -675,6 +702,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('[RTL] align table, list, paragraph center', () => {
@@ -795,6 +824,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('[RTL] align table, list, paragraph right', () => {
@@ -916,6 +947,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('align justify paragraph', () => {
@@ -941,6 +974,8 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTruthy();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('align justify list item', () => {
@@ -985,5 +1020,7 @@ describe('align left', () => {
             ],
         });
         expect(result).toBeTruthy();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 });

--- a/packages/roosterjs-content-model-api/test/modelApi/block/setModelDirectionTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/block/setModelDirectionTest.ts
@@ -1,3 +1,4 @@
+import * as splitSelectedParagraphByBrModule from '../../../lib/modelApi/block/splitSelectedParagraphByBr';
 import { ContentModelDocument } from 'roosterjs-content-model-types';
 import { setModelDirection } from '../../../lib/modelApi/block/setModelDirection';
 
@@ -7,6 +8,7 @@ describe('setModelDirection', () => {
     const color = '#AABBCC';
     const testBorderString = `${width} ${style} ${color}`;
     const mockedCachedElement = 'CACHE' as any;
+    let splitSelectedParagraphByBrSpy: jasmine.Spy;
 
     function runTest(
         model: ContentModelDocument,
@@ -23,7 +25,16 @@ describe('setModelDirection', () => {
             model.blocks[0].dataset = {};
         }
         expect(model).toEqual(expectedModel);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(model);
     }
+
+    beforeEach(() => {
+        splitSelectedParagraphByBrSpy = spyOn(
+            splitSelectedParagraphByBrModule,
+            'splitSelectedParagraphByBr'
+        );
+    });
 
     it('set direction for paragraph', () => {
         runTest(

--- a/packages/roosterjs-content-model-api/test/modelApi/block/setModelIndentationTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/block/setModelIndentationTest.ts
@@ -1,4 +1,5 @@
 import * as getListAnnounceData from '../../../lib/modelApi/list/getListAnnounceData';
+import * as splitSelectedParagraphByBrModule from '../../../lib/modelApi/block/splitSelectedParagraphByBr';
 import { ContentModelDocument, FormatContentModelContext } from 'roosterjs-content-model-types';
 import { setModelIndentation } from '../../../lib/modelApi/block/setModelIndentation';
 import {
@@ -12,12 +13,18 @@ import {
 
 describe('indent', () => {
     let getListAnnounceDataSpy: jasmine.Spy;
+    let splitSelectedParagraphByBrSpy: jasmine.Spy;
     const mockedAnnounceData = 'ANNOUNCE' as any;
 
     beforeEach(() => {
         getListAnnounceDataSpy = spyOn(getListAnnounceData, 'getListAnnounceData').and.returnValue(
             mockedAnnounceData
         );
+
+        splitSelectedParagraphByBrSpy = spyOn(
+            splitSelectedParagraphByBrModule,
+            'splitSelectedParagraphByBr'
+        ).and.callThrough();
     });
 
     it('Empty group', () => {
@@ -41,6 +48,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group without selection', () => {
@@ -66,6 +75,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected paragraph', () => {
@@ -121,6 +132,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected indented paragraph', () => {
@@ -182,6 +195,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected indented paragraph in RTL', () => {
@@ -225,6 +240,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with multiple selected paragraph - 1', () => {
@@ -283,6 +300,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with multiple selected paragraph - 2', () => {
@@ -341,6 +360,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with paragraph under OL', () => {
@@ -398,6 +419,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with paragraph under OL with formats', () => {
@@ -471,6 +494,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with paragraph and multiple OL', () => {
@@ -527,6 +552,8 @@ describe('indent', () => {
         });
         expect(getListAnnounceDataSpy).toHaveBeenCalledTimes(1);
         expect(getListAnnounceDataSpy).toHaveBeenCalledWith([listItem2, group]);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with multiple selected paragraph and multiple OL', () => {
@@ -608,6 +635,8 @@ describe('indent', () => {
         expect(getListAnnounceDataSpy).toHaveBeenCalledTimes(2);
         expect(getListAnnounceDataSpy).toHaveBeenCalledWith([listItem2, group]);
         expect(getListAnnounceDataSpy).toHaveBeenCalledWith([listItem3, group]);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with multiple selected paragraph and UL and OL', () => {
@@ -689,6 +718,8 @@ describe('indent', () => {
         });
         expect(getListAnnounceDataSpy).toHaveBeenCalledTimes(1);
         expect(getListAnnounceDataSpy).toHaveBeenCalledWith([listItem2, group]);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Mixed with paragraph, list item and quote', () => {
@@ -776,6 +807,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected indented paragraph, outdent with different length', () => {
@@ -815,6 +848,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with list with first item selected', () => {
@@ -898,6 +933,8 @@ describe('indent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Indent and follow previous item style', () => {
@@ -991,6 +1028,8 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(model);
     });
 
     it('Indent and follow next item style', () => {
@@ -1108,6 +1147,8 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(model);
     });
 
     it('Indent, no style to follow', () => {
@@ -1195,17 +1236,24 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(model);
     });
 });
 
 describe('outdent', () => {
     let getListAnnounceDataSpy: jasmine.Spy;
+    let splitSelectedParagraphByBrSpy: jasmine.Spy;
     const mockedAnnounceData = 'ANNOUNCE' as any;
 
     beforeEach(() => {
         getListAnnounceDataSpy = spyOn(getListAnnounceData, 'getListAnnounceData').and.returnValue(
             mockedAnnounceData
         );
+        splitSelectedParagraphByBrSpy = spyOn(
+            splitSelectedParagraphByBrModule,
+            'splitSelectedParagraphByBr'
+        ).and.callThrough();
     });
 
     it('Empty group', () => {
@@ -1229,6 +1277,8 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group without selection', () => {
@@ -1291,6 +1341,8 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected single indented paragraph', () => {
@@ -1356,6 +1408,8 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected 2 indented paragraph', () => {
@@ -1427,6 +1481,8 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected multiple indented paragraph', () => {
@@ -1487,6 +1543,8 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected list item', () => {
@@ -1523,6 +1581,8 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected multiple level list item', () => {
@@ -1583,6 +1643,8 @@ describe('outdent', () => {
         });
         expect(getListAnnounceDataSpy).toHaveBeenCalledTimes(1);
         expect(getListAnnounceDataSpy).toHaveBeenCalledWith([listItem, group]);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with mixed list item, quote and paragraph', () => {
@@ -1645,6 +1707,8 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with selected indented paragraph in RTL', () => {
@@ -1727,6 +1791,8 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with list with no indention selected', () => {
@@ -1786,6 +1852,8 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Outdent parent format container, ltr', () => {
@@ -1859,6 +1927,8 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Outdent parent format container, rtl', () => {
@@ -1941,5 +2011,7 @@ describe('outdent', () => {
             newImages: [],
         });
         expect(getListAnnounceDataSpy).not.toHaveBeenCalled();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 });

--- a/packages/roosterjs-content-model-api/test/modelApi/block/splitSelectedParagraphByBrTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/block/splitSelectedParagraphByBrTest.ts
@@ -1,0 +1,507 @@
+import { splitSelectedParagraphByBr } from '../../../lib/modelApi/block/splitSelectedParagraphByBr';
+import {
+    createBr,
+    createContentModelDocument,
+    createParagraph,
+    createText,
+} from 'roosterjs-content-model-dom';
+
+describe('splitSelectedParagraphByBr', () => {
+    it('empty model', () => {
+        const model = createContentModelDocument();
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [],
+        });
+    });
+
+    it('model without selection', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        const text = createText('text');
+
+        paragraph.segments.push(text);
+        model.blocks.push(paragraph);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('model without br', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        const text = createText('text');
+
+        text.isSelected = true;
+
+        paragraph.segments.push(text);
+        model.blocks.push(paragraph);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('model with br at the end', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        const text = createText('text');
+        const br = createBr();
+
+        text.isSelected = true;
+
+        paragraph.segments.push(text, br);
+        model.blocks.push(paragraph);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('model with br in middle', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        const text1 = createText('text1');
+        const text2 = createText('text2');
+        const br = createBr();
+
+        text1.isSelected = true;
+
+        paragraph.segments.push(text1, br, text2);
+        model.blocks.push(paragraph);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text1],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text2],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('model with br at beginning', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        const text1 = createText('text1');
+        const br = createBr();
+
+        text1.isSelected = true;
+
+        paragraph.segments.push(br, text1);
+        model.blocks.push(paragraph);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [br],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text1],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('model with br only', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        const br = createBr();
+
+        br.isSelected = true;
+
+        paragraph.segments.push(br);
+        model.blocks.push(paragraph);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [br],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('model with continuous br', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        const text1 = createText('text1');
+        const br1 = createBr();
+        const br2 = createBr();
+        const br3 = createBr();
+        const text2 = createText('text2');
+
+        text1.isSelected = true;
+
+        paragraph.segments.push(text1, br1, br2, br3, text2);
+        model.blocks.push(paragraph);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text1],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [br2],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [br3],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text2],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('model with separated br', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        const text1 = createText('text1');
+        const text2 = createText('text2');
+        const text3 = createText('text3');
+        const br1 = createBr();
+        const br2 = createBr();
+
+        text1.isSelected = true;
+
+        paragraph.segments.push(text1, br1, text2, br2, text3);
+        model.blocks.push(paragraph);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text1],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text2],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text3],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('paragraph with format and decorator', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph(
+            false,
+            { borderTop: 'test' },
+            { textColor: 'red' },
+            {
+                tagName: 'p',
+                format: {},
+            }
+        );
+        const text1 = createText('text1');
+        const text2 = createText('text2');
+        const br = createBr();
+
+        text1.isSelected = true;
+
+        paragraph.segments.push(text1, br, text2);
+        model.blocks.push(paragraph);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text1],
+                    format: { borderTop: 'test' },
+                    segmentFormat: { textColor: 'red' },
+                    decorator: {
+                        tagName: 'p',
+                        format: {},
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text2],
+                    format: { borderTop: 'test' },
+                    segmentFormat: { textColor: 'red' },
+                    decorator: {
+                        tagName: 'p',
+                        format: {},
+                    },
+                },
+            ],
+        });
+    });
+
+    it('implicit paragraph', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph(true);
+        const text1 = createText('text1');
+        const text2 = createText('text2');
+        const br = createBr();
+
+        text1.isSelected = true;
+
+        paragraph.segments.push(text1, br, text2);
+        model.blocks.push(paragraph);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text1],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text2],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('mulitple paragraphs', () => {
+        const model = createContentModelDocument();
+        const paragraph1 = createParagraph();
+        const paragraph2 = createParagraph();
+        const text1 = createText('text1');
+        const text2 = createText('text2');
+        const text3 = createText('text3');
+        const text4 = createText('text4');
+        const br1 = createBr();
+        const br2 = createBr();
+
+        text2.isSelected = true;
+        text3.isSelected = true;
+
+        paragraph1.segments.push(text1, br1, text2);
+        paragraph2.segments.push(text3, br2, text4);
+        model.blocks.push(paragraph1, paragraph2);
+
+        splitSelectedParagraphByBr(model);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text1],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text2],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text3],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text4],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('complex model with cache', () => {
+        const mockedCache = 'CACHE' as any;
+
+        const model = createContentModelDocument();
+        const paragraph1 = createParagraph();
+        const paragraph2 = createParagraph(true);
+        const paragraph3 = createParagraph();
+        const paragraph4 = createParagraph();
+        const paragraph5 = createParagraph(true);
+        const paragraph6 = createParagraph();
+        const paragraph7 = createParagraph();
+
+        const text1_1 = createText('text1_1');
+        const text2_1 = createText('text2_1');
+        const text2_2 = createText('text2_2');
+        const text2_3 = createText('text2_3');
+        const text2_4 = createText('text2_4');
+        const text3_1 = createText('text3_1');
+        const text4_1 = createText('text4_1');
+        const text5_1 = createText('text5_1');
+        const text5_2 = createText('text5_2');
+        const text5_3 = createText('text5_3');
+        const text6_1 = createText('text6_1');
+
+        const br2_1 = createBr();
+        const br2_2 = createBr();
+        const br2_3 = createBr();
+        const br5_1 = createBr();
+        const br5_2 = createBr();
+        const br7_1 = createBr();
+
+        text2_3.isSelected = true;
+        text2_4.isSelected = true;
+        text3_1.isSelected = true;
+        text4_1.isSelected = true;
+        text5_1.isSelected = true;
+        text5_2.isSelected = true;
+
+        paragraph1.segments.push(text1_1);
+        paragraph2.segments.push(text2_1, br2_1, text2_2, br2_2, text2_3, br2_3, text2_4);
+        paragraph3.segments.push(text3_1);
+        paragraph4.segments.push(text4_1);
+        paragraph5.segments.push(text5_1, br5_1, text5_2, br5_2, text5_3);
+        paragraph6.segments.push(text6_1);
+        paragraph7.segments.push(br7_1);
+
+        paragraph1.cachedElement = mockedCache;
+        paragraph2.cachedElement = mockedCache;
+        paragraph3.cachedElement = mockedCache;
+        paragraph4.cachedElement = mockedCache;
+        paragraph5.cachedElement = mockedCache;
+        paragraph6.cachedElement = mockedCache;
+        paragraph7.cachedElement = mockedCache;
+
+        model.blocks.push(
+            paragraph1,
+            paragraph2,
+            paragraph3,
+            paragraph4,
+            paragraph5,
+            paragraph6,
+            paragraph7
+        );
+
+        splitSelectedParagraphByBr(model);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [text1_1],
+                    format: {},
+                    cachedElement: mockedCache,
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text2_1],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text2_2],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text2_3],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text2_4],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text3_1],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text4_1],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text5_1],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text5_2],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text5_3],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [text6_1],
+                    format: {},
+                    cachedElement: mockedCache,
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [br7_1],
+                    format: {},
+                    cachedElement: mockedCache,
+                },
+            ],
+        });
+    });
+});

--- a/packages/roosterjs-content-model-api/test/modelApi/block/toggleModelBlockQuoteTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/block/toggleModelBlockQuoteTest.ts
@@ -1,3 +1,4 @@
+import * as splitSelectedParagraphByBrModule from '../../../lib/modelApi/block/splitSelectedParagraphByBr';
 import { toggleModelBlockQuote } from '../../../lib/modelApi/block/toggleModelBlockQuote';
 import {
     createContentModelDocument,
@@ -8,6 +9,15 @@ import {
 } from 'roosterjs-content-model-dom';
 
 describe('toggleModelBlockQuote', () => {
+    let splitSelectedParagraphByBrSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        splitSelectedParagraphByBrSpy = spyOn(
+            splitSelectedParagraphByBrModule,
+            'splitSelectedParagraphByBr'
+        ).and.callThrough();
+    });
+
     it('empty model', () => {
         const doc = createContentModelDocument();
 
@@ -17,6 +27,8 @@ describe('toggleModelBlockQuote', () => {
             blockGroupType: 'Document',
             blocks: [],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('no selection', () => {
@@ -45,6 +57,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Has single selection, wrap', () => {
@@ -83,6 +97,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Has multiple selection, wrap together', () => {
@@ -138,6 +154,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Has multiple selection, with RTL, do not merge', () => {
@@ -231,6 +249,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Has single selection, merge before', () => {
@@ -286,6 +306,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Has single selection, merge after', () => {
@@ -341,6 +363,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Has single selection, merge both', () => {
@@ -413,6 +437,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Has single selection, cannot merge', () => {
@@ -501,6 +527,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Has mixed selection', () => {
@@ -591,6 +619,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Has selection under list', () => {
@@ -645,6 +675,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Unwrap', () => {
@@ -712,6 +744,8 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 
     it('Unwrap quote with multiple paragraphs', () => {
@@ -760,5 +794,7 @@ describe('toggleModelBlockQuote', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
 });

--- a/packages/roosterjs-content-model-api/test/modelApi/list/setListTypeTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/list/setListTypeTest.ts
@@ -1,4 +1,5 @@
 import * as normalizeContentModel from 'roosterjs-content-model-dom/lib/modelApi/common/normalizeContentModel';
+import * as splitSelectedParagraphByBrModule from '../../../lib/modelApi/block/splitSelectedParagraphByBr';
 import { ContentModelDocument } from 'roosterjs-content-model-types';
 import { setListType } from '../../../lib/modelApi/list/setListType';
 import { setModelIndentation } from '../../../lib/modelApi/block/setModelIndentation';
@@ -19,8 +20,14 @@ import {
 
 describe('indent', () => {
     let normalizeContentModelSpy: jasmine.Spy;
+    let splitSelectedParagraphByBrSpy: jasmine.Spy;
+
     beforeEach(() => {
         normalizeContentModelSpy = spyOn(normalizeContentModel, 'normalizeContentModel');
+        splitSelectedParagraphByBrSpy = spyOn(
+            splitSelectedParagraphByBrModule,
+            'splitSelectedParagraphByBr'
+        ).and.callThrough();
     });
 
     it('Empty group', () => {
@@ -33,6 +40,8 @@ describe('indent', () => {
             blocks: [],
         });
         expect(result).toBeFalse();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group without selection', () => {
@@ -48,6 +57,8 @@ describe('indent', () => {
             blocks: [para],
         });
         expect(result).toBeFalse();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with single paragraph selection', () => {
@@ -108,6 +119,8 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with single paragraph selection remove margins', () => {
@@ -170,7 +183,10 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
+
     it('Group with single list item selection in a different type', () => {
         const group = createContentModelDocument();
         const para = createParagraph();
@@ -199,6 +215,8 @@ describe('indent', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with single list item selection in same type', () => {
@@ -229,6 +247,8 @@ describe('indent', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with single list item selection in same type and then normalize', () => {
@@ -252,6 +272,8 @@ describe('indent', () => {
             blocks: [para],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with single list item selection in same type with implicit paragraph', () => {
@@ -296,6 +318,8 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Group with mixed selection', () => {
@@ -387,6 +411,8 @@ describe('indent', () => {
             ],
         });
         expect(result).toBeTrue();
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Carry over existing segment and direction format', () => {
@@ -469,6 +495,8 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('do not turn on list for empty paragraphs', () => {
@@ -554,6 +582,8 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('still turn on list for empty paragraphs if it is the only selected paragraph', () => {
@@ -610,6 +640,8 @@ describe('indent', () => {
                 para3,
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('do not turn on list for table', () => {
@@ -722,6 +754,8 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('Change style type to existing list', () => {
@@ -752,6 +786,8 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('turn on list on indented paragraph', () => {
@@ -829,6 +865,8 @@ describe('indent', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(2);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 
     it('turn off list on indented paragraph', () => {
@@ -961,5 +999,7 @@ describe('indent', () => {
             ],
             format: {},
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(group);
     });
 });

--- a/packages/roosterjs-content-model-api/test/publicApi/utils/formatParagraphWithContentModelTest.ts
+++ b/packages/roosterjs-content-model-api/test/publicApi/utils/formatParagraphWithContentModelTest.ts
@@ -1,5 +1,7 @@
+import * as splitSelectedParagraphByBrModule from '../../../lib/modelApi/block/splitSelectedParagraphByBr';
 import { formatParagraphWithContentModel } from '../../../lib/publicApi/utils/formatParagraphWithContentModel';
 import { IEditor } from 'roosterjs-content-model-types';
+
 import {
     ContentModelDocument,
     ContentModelParagraph,
@@ -17,6 +19,7 @@ describe('formatParagraphWithContentModel', () => {
     let editor: IEditor;
     let model: ContentModelDocument;
     let context: FormatContentModelContext;
+    let splitSelectedParagraphByBrSpy: jasmine.Spy;
 
     const mockedContainer = 'C' as any;
     const mockedOffset = 'O' as any;
@@ -43,6 +46,11 @@ describe('formatParagraphWithContentModel', () => {
             getFocusedPosition: () => ({ node: mockedContainer, offset: mockedOffset }),
             formatContentModel,
         } as any) as IEditor;
+
+        splitSelectedParagraphByBrSpy = spyOn(
+            splitSelectedParagraphByBrModule,
+            'splitSelectedParagraphByBr'
+        ).and.callThrough();
     });
 
     it('empty doc', () => {
@@ -58,6 +66,8 @@ describe('formatParagraphWithContentModel', () => {
             blockGroupType: 'Document',
             blocks: [],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(model);
     });
 
     it('doc with selection', () => {
@@ -92,6 +102,8 @@ describe('formatParagraphWithContentModel', () => {
                 },
             ],
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(model);
     });
 
     it('Preserve pending format', () => {
@@ -117,5 +129,7 @@ describe('formatParagraphWithContentModel', () => {
             rawEvent: undefined,
             newPendingFormat: 'preserve',
         });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(model);
     });
 });


### PR DESCRIPTION
When current paragraph has BR and do any paragraph format such as set indentation or bullet list, we need to split the paragraph by BR into multiple paragraphs then only format selected paragraphs.

For example:
```html
<div>aaaa</div>
bbb<br>ccc<br>ddd<br>eee
<div>ffff</div>
<div>gggg</div>
hhh<br>iii<br>jjj
<div>kkk</div><!--{"type":"range","start":[3,2],"end":[13,1],"isReverted":false,"isDarkMode":false}-->
```

Before:
![before](https://github.com/user-attachments/assets/94cfbe00-80ac-46da-bf05-0e31fd6753f3)

After:
![after](https://github.com/user-attachments/assets/47183f15-f365-46fa-ba4a-d8c2a5f06b52)


Original bug: https://outlookweb.visualstudio.com/Outlook%20Web/_queries/edit/335899/?triage=true