### PR TITLE
Trigger only one auto format at time

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
@@ -9,13 +9,36 @@ import { unlink } from './link/unlink';
 import type { AutoFormatOptions } from './interface/AutoFormatOptions';
 import type {
     ContentChangedEvent,
+    ContentModelText,
     EditorInputEvent,
     EditorPlugin,
+    FormatContentModelContext,
     FormatContentModelOptions,
     IEditor,
     KeyDownEvent,
     PluginEvent,
+    ReadonlyContentModelDocument,
+    ShallowMutableContentModelParagraph,
 } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ */
+type AutoFormatFeature = 'list' | 'link' | 'hyphen' | 'fraction' | 'ordinal';
+
+/**
+ * @internal
+ */
+interface Feature {
+    autoFormat: AutoFormatFeature;
+    enabled: boolean;
+    transformFunction: (
+        model: ReadonlyContentModelDocument,
+        previousSegment: ContentModelText,
+        paragraph: ShallowMutableContentModelParagraph,
+        context: FormatContentModelContext
+    ) => boolean | HTMLElement;
+}
 
 /**
  * @internal
@@ -100,6 +123,57 @@ export class AutoFormatPlugin implements EditorPlugin {
         }
     }
 
+    private features: Feature[] = [
+        {
+            autoFormat: 'list',
+            enabled: !!(this.options.autoBullet || this.options.autoNumbering),
+            transformFunction: (model, _previousSegment, paragraph, context) =>
+                keyboardListTrigger(
+                    model,
+                    paragraph,
+                    context,
+                    this.options.autoBullet,
+                    this.options.autoNumbering,
+                    this.options.removeListMargins
+                ),
+        },
+        {
+            autoFormat: 'link',
+            enabled: !!(this.options.autoLink || this.options.autoTel || this.options.autoMailto),
+            transformFunction: (_model, previousSegment, paragraph, context) => {
+                const { autoLink, autoTel, autoMailto } = this.options;
+                const linkSegment = promoteLink(previousSegment, paragraph, {
+                    autoLink,
+                    autoTel,
+                    autoMailto,
+                });
+
+                if (linkSegment) {
+                    return createAnchor(linkSegment.link?.format.href || '', linkSegment.text);
+                }
+                return false;
+            },
+        },
+        {
+            autoFormat: 'hyphen',
+            enabled: !!this.options.autoHyphen,
+            transformFunction: (_model, previousSegment, paragraph, context) =>
+                transformHyphen(previousSegment, paragraph, context),
+        },
+        {
+            autoFormat: 'fraction',
+            enabled: !!this.options.autoFraction,
+            transformFunction: (_model, previousSegment, paragraph, context) =>
+                transformFraction(previousSegment, paragraph, context),
+        },
+        {
+            autoFormat: 'ordinal',
+            enabled: !!this.options.autoOrdinals,
+            transformFunction: (_model, previousSegment, paragraph, context) =>
+                transformOrdinals(previousSegment, paragraph, context),
+        },
+    ];
+
     private handleEditorInputEvent(editor: IEditor, event: EditorInputEvent) {
         const rawEvent = event.rawEvent;
         const selection = editor.getDOMSelection();
@@ -119,87 +193,32 @@ export class AutoFormatPlugin implements EditorPlugin {
                     formatTextSegmentBeforeSelectionMarker(
                         editor,
                         (model, previousSegment, paragraph, _markerFormat, context) => {
-                            const {
-                                autoBullet,
-                                autoNumbering,
-                                autoLink,
-                                autoHyphen,
-                                autoFraction,
-                                autoOrdinals,
-                                autoMailto,
-                                autoTel,
-                                removeListMargins,
-                            } = this.options;
-                            let shouldHyphen = false;
-                            let shouldLink = false;
-                            let shouldList = false;
-                            let shouldFraction = false;
-                            let shouldOrdinals = false;
+                            let formatApplied: AutoFormatFeature | undefined = undefined;
 
-                            if (autoBullet || autoNumbering) {
-                                shouldList = keyboardListTrigger(
-                                    model,
-                                    paragraph,
-                                    context,
-                                    autoBullet,
-                                    autoNumbering,
-                                    removeListMargins
-                                );
-                            }
-
-                            if (autoLink || autoTel || autoMailto) {
-                                const linkSegment = promoteLink(previousSegment, paragraph, {
-                                    autoLink,
-                                    autoTel,
-                                    autoMailto,
-                                });
-
-                                if (linkSegment) {
-                                    const anchor = createAnchor(
-                                        linkSegment.link?.format.href || '',
-                                        linkSegment.text
+                            for (const feature of this.features) {
+                                if (feature.enabled) {
+                                    const result = feature.transformFunction(
+                                        model,
+                                        previousSegment,
+                                        paragraph,
+                                        context
                                     );
-                                    formatOptions.getChangeData = () => anchor;
-
-                                    shouldLink = true;
-                                    context.canUndoByBackspace = true;
+                                    if (result) {
+                                        if (typeof result !== 'boolean') {
+                                            formatOptions.getChangeData = () => result;
+                                        }
+                                        formatApplied = feature.autoFormat;
+                                        break;
+                                    }
                                 }
                             }
 
-                            if (autoHyphen) {
-                                shouldHyphen = transformHyphen(previousSegment, paragraph, context);
+                            if (formatApplied) {
+                                formatOptions.changeSource = getChangeSource(formatApplied);
+                                formatOptions.apiName = getApiName(formatApplied);
                             }
 
-                            if (autoFraction) {
-                                shouldFraction = transformFraction(
-                                    previousSegment,
-                                    paragraph,
-                                    context
-                                );
-                            }
-
-                            if (autoOrdinals) {
-                                shouldOrdinals = transformOrdinals(
-                                    previousSegment,
-                                    paragraph,
-                                    context
-                                );
-                            }
-
-                            formatOptions.apiName = getApiName(shouldList, shouldHyphen);
-                            formatOptions.changeSource = getChangeSource(
-                                shouldList,
-                                shouldHyphen,
-                                shouldLink
-                            );
-
-                            return (
-                                shouldList ||
-                                shouldHyphen ||
-                                shouldLink ||
-                                shouldFraction ||
-                                shouldOrdinals
-                            );
+                            return !!formatApplied;
                         },
                         formatOptions
                     );
@@ -267,14 +286,14 @@ export class AutoFormatPlugin implements EditorPlugin {
     }
 }
 
-const getApiName = (shouldList: boolean, shouldHyphen: boolean) => {
-    return shouldList ? 'autoToggleList' : shouldHyphen ? 'autoHyphen' : '';
+const getApiName = (autoFormat: AutoFormatFeature) => {
+    return autoFormat == 'list' ? 'autoToggleList' : autoFormat == 'hyphen' ? 'autoHyphen' : '';
 };
 
-const getChangeSource = (shouldList: boolean, shouldHyphen: boolean, shouldLink: boolean) => {
-    return shouldList || shouldHyphen
+const getChangeSource = (autoFormat: AutoFormatFeature) => {
+    return autoFormat == 'list' || autoFormat == 'hyphen'
         ? ChangeSource.AutoFormat
-        : shouldLink
+        : autoFormat == 'link'
         ? ChangeSource.AutoLink
         : '';
 };

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/hyphen/transformHyphen.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/hyphen/transformHyphen.ts
@@ -13,11 +13,6 @@ export function transformHyphen(
     paragraph: ShallowMutableContentModelParagraph,
     context: FormatContentModelContext
 ): boolean {
-    // If the selection marker is at the beginning of a paragraph, there is no text to be transformed before it
-    if (paragraph.segments[0].segmentType == 'SelectionMarker') {
-        return false;
-    }
-
     const segments = previousSegment.text.split(' ');
     const dashes = segments[segments.length - 2];
     if (dashes === '--') {

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/hyphen/transformHyphen.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/hyphen/transformHyphen.ts
@@ -13,12 +13,16 @@ export function transformHyphen(
     paragraph: ShallowMutableContentModelParagraph,
     context: FormatContentModelContext
 ): boolean {
+    // If the selection marker is at the beginning of a paragraph, there is no text to be transformed before it
+    if (paragraph.segments[0].segmentType == 'SelectionMarker') {
+        return false;
+    }
+
     const segments = previousSegment.text.split(' ');
     const dashes = segments[segments.length - 2];
     if (dashes === '--') {
         const textIndex = previousSegment.text.lastIndexOf('--');
         const textSegment = splitTextSegment(previousSegment, paragraph, textIndex, textIndex + 2);
-
         textSegment.text = textSegment.text.replace('--', '—');
         context.canUndoByBackspace = true;
         return true;

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/hyphen/transformHyphenTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/hyphen/transformHyphenTest.ts
@@ -142,6 +142,27 @@ describe('transformHyphen', () => {
         };
         runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
     });
+
+    it('selection before text', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: 'test--test',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [
+                {
+                    segmentType: 'SelectionMarker',
+                    isSelected: true,
+                    format: {},
+                },
+                segment,
+            ],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
+    });
 });
 
 describe('formatTextSegmentBeforeSelectionMarker - transformHyphen', () => {

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/hyphen/transformHyphenTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/hyphen/transformHyphenTest.ts
@@ -142,27 +142,6 @@ describe('transformHyphen', () => {
         };
         runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
     });
-
-    it('selection before text', () => {
-        const segment: ContentModelText = {
-            segmentType: 'Text',
-            text: 'test--test',
-            format: {},
-        };
-        const paragraph: ContentModelParagraph = {
-            blockType: 'Paragraph',
-            segments: [
-                {
-                    segmentType: 'SelectionMarker',
-                    isSelected: true,
-                    format: {},
-                },
-                segment,
-            ],
-            format: {},
-        };
-        runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
-    });
 });
 
 describe('formatTextSegmentBeforeSelectionMarker - transformHyphen', () => {


### PR DESCRIPTION
Refactor the `AutoFormatPlugin` class to trigger only one auto format at a time to avoid conflict between the formatting.  
Before: 
![Bug Hyphen list](https://github.com/user-attachments/assets/d9c11840-7d7b-43d4-b12a-150cca1ee261)

After: 
![FixHyphenList](https://github.com/user-attachments/assets/75fc086a-fbdd-44f0-bed7-d6371f772649)
