### PR TITLE
Fix Korean input issue

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/format/applyPendingFormat.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/format/applyPendingFormat.ts
@@ -51,7 +51,7 @@ export function applyPendingFormat(
                         if (subStr == data || (data == ANSI_SPACE && subStr == NON_BREAK_SPACE)) {
                             if (
                                 segmentFormat &&
-                                !includeSegmentFormat(previousSegment.format, segmentFormat)
+                                !isSubFormatIncluded(previousSegment.format, segmentFormat)
                             ) {
                                 mutateSegment(block, previousSegment, previousSegment => {
                                     previousSegment.text = text.substring(
@@ -80,7 +80,7 @@ export function applyPendingFormat(
 
                             if (
                                 paragraphFormat &&
-                                !includeSegmentFormat(block.format, paragraphFormat)
+                                !isSubFormatIncluded(block.format, paragraphFormat)
                             ) {
                                 const mutableParagraph = mutateBlock(block);
 
@@ -106,7 +106,7 @@ export function applyPendingFormat(
     );
 }
 
-function includeSegmentFormat<T extends ContentModelFormatBase>(containerFormat: T, subFormat: T) {
+function isSubFormatIncluded<T extends ContentModelFormatBase>(containerFormat: T, subFormat: T) {
     const keys = getObjectKeys(subFormat);
     let result = true;
 


### PR DESCRIPTION
Repro Steps:
1. Add Korean IME and set Korean as the default input language
2. open OWA/new outlook
3. New-mail
4. Typing gksrmf(한글)

This is because we are always applying pending format if it exists which will interrupt current IME behavior.

Fix: Add a check to the format and do not apply if it is already applied