### PR TITLE
Add a null check in getListAnnounceData

### DIFF
--- a/packages/roosterjs-content-model-api/lib/modelApi/list/getListAnnounceData.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/list/getListAnnounceData.ts
@@ -24,7 +24,7 @@ export function getListAnnounceData(path: ReadonlyContentModelBlockGroup[]): Ann
         const listItem = path[index] as ContentModelListItem;
         const level = listItem.levels[listItem.levels.length - 1];
 
-        if (level.format.displayForDummyItem) {
+        if (level?.format.displayForDummyItem) {
             return null;
         } else if (level.listType == 'OL') {
             const listNumber = getListNumber(path, listItem);

--- a/packages/roosterjs-content-model-api/lib/modelApi/list/getListAnnounceData.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/list/getListAnnounceData.ts
@@ -24,7 +24,7 @@ export function getListAnnounceData(path: ReadonlyContentModelBlockGroup[]): Ann
         const listItem = path[index] as ContentModelListItem;
         const level = listItem.levels[listItem.levels.length - 1];
 
-        if (level?.format.displayForDummyItem) {
+        if (!level || level.format.displayForDummyItem) {
             return null;
         } else if (level.listType == 'OL') {
             const listNumber = getListNumber(path, listItem);

--- a/packages/roosterjs-content-model-api/test/modelApi/list/getListAnnounceDataTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/list/getListAnnounceDataTest.ts
@@ -71,6 +71,18 @@ describe('getListAnnounceData', () => {
         expect(getAutoListStyleTypeSpy).not.toHaveBeenCalled();
     });
 
+    it('path has list item without list levels', () => {
+        const doc = createContentModelDocument();
+        const listItem = createListItem([]);
+
+        doc.blocks.push(listItem);
+
+        const result = getListAnnounceData([listItem, doc]);
+
+        expect(result).toEqual(null);
+        expect(getAutoListStyleTypeSpy).not.toHaveBeenCalled();
+    });
+
     it('path with bullet list', () => {
         const doc = createContentModelDocument();
         const listItem = createListItem([createListLevel('UL')]);


### PR DESCRIPTION
Add a null check in getListAnnounceData

Error callstack:

at webpack://owa/packages/roosterjs-content-model-api/lib/modelApi/list/getListAnnounceData.ts:27
at webpack://owa/packages/roosterjs-content-model-plugins/lib/edit/inputSteps/handleEnterOnList.ts:46
at webpack://owa/packages/roosterjs-content-model-dom/lib/modelApi/editing/runEditSteps.ts:16
at Native Browser Function(Array.forEach)
at webpack://owa/packages/roosterjs-content-model-dom/lib/modelApi/editing/runEditSteps.ts:14
at webpack://owa/packages/roosterjs-content-model-plugins/lib/edit/keyboardEnter.ts:42
at webpack://owa/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts:40
at webpack://owa/packages/roosterjs-content-model-core/lib/editor/Editor.ts:181
at webpack://owa/packages/roosterjs-content-model-plugins/lib/edit/keyboardEnter.ts:23
at webpack://owa/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts:207
at webpack://owa/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts:112
at webpack://owa/packages/common/controls/packages/controls/owa-editor-lazy-plugin/src/utils/createLazyContentModelPlugin.ts:135