### PR TITLE
Apply formatting to document block groups in handleBlockGroupChildren

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleBlockGroupChildren.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleBlockGroupChildren.ts
@@ -1,3 +1,4 @@
+import { applyFormat } from '../utils/applyFormat';
 import { isNodeOfType } from '../../domUtils/isNodeOfType';
 import type {
     ContentModelBlockGroup,
@@ -38,6 +39,14 @@ export const handleBlockGroupChildren: ContentModelHandler<ContentModelBlockGrou
                 context.domIndexer?.onBlockEntity(childBlock, group);
             }
         });
+
+        if (
+            group.blockGroupType == 'Document' &&
+            group.format &&
+            isNodeOfType(parent, 'ELEMENT_NODE')
+        ) {
+            applyFormat(parent, context.formatAppliers.segment, group.format, context);
+        }
 
         // Remove all rest node if any since they don't appear in content model
         while (refNode) {

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleBlockGroupChildrenTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleBlockGroupChildrenTest.ts
@@ -456,4 +456,57 @@ describe('handleBlockGroupChildren', () => {
             removedBlockElements: [],
         });
     });
+
+    it('handle document and update the parent format based on the document format', () => {
+        const div1 = document.createElement('div');
+        const div2 = document.createElement('div');
+
+        div1.textContent = 'test1';
+        div2.textContent = 'test2';
+
+        parent.appendChild(div1);
+        parent.appendChild(div2);
+
+        const group: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [],
+                    cachedElement: div1,
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [],
+                    cachedElement: div2,
+                },
+            ],
+            format: {
+                fontFamily: 'Arial',
+                fontSize: '12px',
+                fontWeight: 'bold',
+                backgroundColor: 'red',
+                textColor: 'blue',
+            },
+        };
+
+        handleBlockGroupChildren(document, parent, group, context);
+
+        expect(parent.outerHTML).toBe(
+            '<div style="font-family: Arial; font-size: 12px; color: blue; background-color: red;"><b><div>test1</div><div>test2</div></b></div>'
+        );
+        expect(parent.firstChild?.firstChild).toBe(div1);
+        expect(parent.firstChild?.lastChild).toBe(div2);
+        expect(context.rewriteFromModel).toEqual({
+            addedBlockElements: [],
+            removedBlockElements: [],
+        });
+        expect(parent.style.fontFamily).toBe('Arial');
+        expect(parent.style.fontSize).toBe('12px');
+        expect(parent.style.color).toBe('blue');
+        expect(parent.style.backgroundColor).toBe('red');
+        expect((parent.firstChild as HTMLElement | undefined)?.tagName).toBe('B');
+    });
 });

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleBlockGroupChildrenTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleBlockGroupChildrenTest.ts
@@ -458,31 +458,9 @@ describe('handleBlockGroupChildren', () => {
     });
 
     it('handle document and update the parent format based on the document format', () => {
-        const div1 = document.createElement('div');
-        const div2 = document.createElement('div');
-
-        div1.textContent = 'test1';
-        div2.textContent = 'test2';
-
-        parent.appendChild(div1);
-        parent.appendChild(div2);
-
         const group: ContentModelDocument = {
             blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'Paragraph',
-                    format: {},
-                    segments: [],
-                    cachedElement: div1,
-                },
-                {
-                    blockType: 'Paragraph',
-                    format: {},
-                    segments: [],
-                    cachedElement: div2,
-                },
-            ],
+            blocks: [],
             format: {
                 fontFamily: 'Arial',
                 fontSize: '12px',
@@ -494,15 +472,6 @@ describe('handleBlockGroupChildren', () => {
 
         handleBlockGroupChildren(document, parent, group, context);
 
-        expect(parent.outerHTML).toBe(
-            '<div style="font-family: Arial; font-size: 12px; color: blue; background-color: red;"><b><div>test1</div><div>test2</div></b></div>'
-        );
-        expect(parent.firstChild?.firstChild).toBe(div1);
-        expect(parent.firstChild?.lastChild).toBe(div2);
-        expect(context.rewriteFromModel).toEqual({
-            addedBlockElements: [],
-            removedBlockElements: [],
-        });
         expect(parent.style.fontFamily).toBe('Arial');
         expect(parent.style.fontSize).toBe('12px');
         expect(parent.style.color).toBe('blue');


### PR DESCRIPTION
Currently if the format of the ContentModelDocument is modified the change is not reflected when calling formatContentModel, the reason seems to be that we do not apply the style to the parent element where the contentModelToDom is being handled.

This PR adds an applyFormat when the model being handled is a ContentModelDocument, so changes to the default format of the ContentModelDocument are applied correctly in the root where the contentModelToDom is being handled..