### PR TITLE
New getEditorHTMLContent api

### DIFF
--- a/packages/roosterjs-content-model-api/lib/index.ts
+++ b/packages/roosterjs-content-model-api/lib/index.ts
@@ -51,6 +51,7 @@ export { formatParagraphWithContentModel } from './publicApi/utils/formatParagra
 export { formatSegmentWithContentModel } from './publicApi/utils/formatSegmentWithContentModel';
 export { formatTextSegmentBeforeSelectionMarker } from './publicApi/utils/formatTextSegmentBeforeSelectionMarker';
 export { formatInsertPointWithContentModel } from './publicApi/utils/formatInsertPointWithContentModel';
+export { getEditorHTMLContent } from './publicApi/utils/getEditorHTMLContent';
 
 export { setListType } from './modelApi/list/setListType';
 export { setModelListStyle } from './modelApi/list/setModelListStyle';

--- a/packages/roosterjs-content-model-api/lib/publicApi/utils/getEditorHTMLContent.ts
+++ b/packages/roosterjs-content-model-api/lib/publicApi/utils/getEditorHTMLContent.ts
@@ -1,0 +1,25 @@
+import { transformColor } from 'roosterjs-content-model-dom';
+import type { IEditor } from 'roosterjs-content-model-types';
+
+/**
+ * Return the inner HTML content of the editor
+ * @param editor The editor object
+ * @returns
+ */
+export function getEditorHTMLContent(editor: IEditor): string {
+    const clonedRoot = editor.getDOMHelper().getClonedRoot();
+
+    if (editor.isDarkMode()) {
+        transformColor(clonedRoot, false /*includeSelf*/, 'darkToLight', editor.getColorManager());
+    }
+
+    editor.triggerEvent(
+        'extractContentWithDom',
+        {
+            clonedRoot,
+        },
+        true /*broadcast*/
+    );
+
+    return clonedRoot.innerHTML;
+}

--- a/packages/roosterjs-content-model-api/test/publicApi/utils/getEditorHTMLContentTest.ts
+++ b/packages/roosterjs-content-model-api/test/publicApi/utils/getEditorHTMLContentTest.ts
@@ -1,0 +1,48 @@
+import * as transformColor from '../../../../roosterjs-content-model-dom/lib/domUtils/style/transformColor';
+import { getEditorHTMLContent } from '../../../lib/publicApi/utils/getEditorHTMLContent';
+
+describe('getEditorHTMLContent', () => {
+    function runTest(isDarkMode: boolean) {
+        const clonedRoot = document.createElement('div');
+        clonedRoot.innerHTML = 'test';
+        const getClonedRootSpy = jasmine.createSpy('getClonedRoot').and.returnValue(clonedRoot);
+        const isDarkModeSpy = jasmine.createSpy('isDarkMode').and.returnValue(isDarkMode);
+        const getDOMHelperSpy = jasmine.createSpy('getDOMHelper').and.returnValue({
+            getClonedRoot: getClonedRootSpy,
+        });
+        const triggerEventSpy = jasmine.createSpy('triggerEvent');
+        const transformColorSpy = spyOn(transformColor, 'transformColor');
+        const getColorManagerSpy = jasmine.createSpy('getColorManager');
+
+        const editor = {
+            getDOMHelper: getDOMHelperSpy,
+            isDarkMode: isDarkModeSpy,
+            triggerEvent: triggerEventSpy,
+            getColorManager: getColorManagerSpy,
+        } as any;
+
+        const result = getEditorHTMLContent(editor);
+        expect(isDarkModeSpy).toHaveBeenCalled();
+        expect(triggerEventSpy).toHaveBeenCalledWith('extractContentWithDom', { clonedRoot }, true);
+        if (isDarkMode) {
+            expect(transformColorSpy).toHaveBeenCalledWith(
+                clonedRoot,
+                false /*includeSelf*/,
+                'darkToLight',
+                editor.getColorManager()
+            );
+        } else {
+            expect(transformColorSpy).not.toHaveBeenCalled();
+        }
+
+        expect(result).toBe('test');
+    }
+
+    it('should return the inner HTML content of the editor in dark mode', () => {
+        runTest(true);
+    });
+
+    it('should return the inner HTML content of the editor in light mode', () => {
+        runTest(false);
+    });
+});


### PR DESCRIPTION
Add `getEditorHTMLContent` API to `roosterjs-content-model-api`. This API uses getClonnedRoot to retrieve the inner HTML content of the editor.