### PR TITLE
Support undeletable anchor Step 1: Support hidden properties

### DIFF
--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -58,6 +58,7 @@ import {
     AutoFormatPlugin,
     CustomReplacePlugin,
     EditPlugin,
+    HiddenPropertyPlugin,
     HyperlinkPlugin,
     ImageEditPlugin,
     MarkdownPlugin,
@@ -527,6 +528,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
                         : linkTitle
                 ),
             pluginList.customReplace && new CustomReplacePlugin(customReplacements),
+            pluginList.hiddenProperty && new HiddenPropertyPlugin({}),
         ].filter(x => !!x);
     }
 }

--- a/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -21,6 +21,7 @@ const initialState: OptionState = {
         imageEditPlugin: true,
         hyperlink: true,
         customReplace: true,
+        hiddenProperty: true,
     },
     defaultFormat: {
         fontFamily: 'Calibri',

--- a/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
@@ -22,6 +22,7 @@ export interface BuildInPluginList {
     hyperlink: boolean;
     imageEditPlugin: boolean;
     customReplace: boolean;
+    hiddenProperty: boolean;
 }
 
 export interface OptionState {

--- a/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
@@ -305,6 +305,7 @@ export class Plugins extends PluginsBase<keyof BuildInPluginList> {
                     )}
                     {this.renderPluginItem('customReplace', 'Custom Replace')}
                     {this.renderPluginItem('imageEditPlugin', 'ImageEditPlugin')}
+                    {this.renderPluginItem('hiddenProperty', 'Hidden Property')}
                 </tbody>
             </table>
         );

--- a/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/hiddenProperty.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/hiddenProperty.ts
@@ -1,0 +1,40 @@
+/**
+ * @internal
+ */
+export interface HiddenProperty {
+    dummy?: {}; // Temp used by test, will be removed later
+
+    // TODO: Add more properties as needed
+}
+
+interface NodeWithHiddenProperty extends Node {
+    __roosterjsHiddenProperty?: HiddenProperty;
+}
+
+/**
+ * @internal
+ */
+export function getHiddenProperty<Key extends keyof HiddenProperty>(
+    node: Node,
+    key: Key
+): HiddenProperty[Key] | undefined {
+    const nodeWithHiddenProperty = node as NodeWithHiddenProperty;
+    const hiddenProperty = nodeWithHiddenProperty.__roosterjsHiddenProperty;
+
+    return hiddenProperty ? hiddenProperty[key] : undefined;
+}
+
+/**
+ * @internal
+ */
+export function setHiddenProperty<Key extends keyof HiddenProperty>(
+    node: Node,
+    key: Key,
+    value: HiddenProperty[Key]
+) {
+    const nodeWithHiddenProperty = node as NodeWithHiddenProperty;
+    const hiddenProperty = nodeWithHiddenProperty.__roosterjsHiddenProperty || {};
+
+    hiddenProperty[key] = value;
+    nodeWithHiddenProperty.__roosterjsHiddenProperty = hiddenProperty;
+}

--- a/packages/roosterjs-content-model-dom/test/domUtils/hiddenProperties/hiddenPropertyTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domUtils/hiddenProperties/hiddenPropertyTest.ts
@@ -1,0 +1,47 @@
+import {
+    getHiddenProperty,
+    setHiddenProperty,
+} from '../../../lib/domUtils/hiddenProperties/hiddenProperty';
+
+describe('hiddenProperty.getHiddenProperty', () => {
+    it('should return undefined if no hidden property is set', () => {
+        const mockedNode: Node = {} as any;
+        expect(getHiddenProperty(mockedNode, 'test' as any)).toBeUndefined();
+    });
+
+    it('should return the value of the hidden property if set', () => {
+        const mockedNode: Node = {
+            __roosterjsHiddenProperty: {
+                test: 'testValue',
+            },
+        } as any;
+
+        expect(getHiddenProperty(mockedNode, 'test' as any)).toBe('testValue');
+    });
+});
+
+describe('hiddenProperty.setHiddenProperty', () => {
+    it('should set the hidden property on the node', () => {
+        const mockedNode: Node = {} as any;
+        setHiddenProperty(mockedNode, 'test' as any, 'testValue');
+
+        expect((mockedNode as any).__roosterjsHiddenProperty).toEqual({
+            test: 'testValue',
+        });
+    });
+
+    it('should update the hidden property if it already exists', () => {
+        const mockedNode: Node = {
+            __roosterjsHiddenProperty: {
+                otherValue: 'otherValue',
+                test: 'oldValue',
+            },
+        } as any;
+        setHiddenProperty(mockedNode, 'test' as any, 'newValue');
+
+        expect((mockedNode as any).__roosterjsHiddenProperty).toEqual({
+            otherValue: 'otherValue',
+            test: 'newValue',
+        });
+    });
+});

--- a/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyOptions.ts
+++ b/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyOptions.ts
@@ -1,0 +1,6 @@
+/**
+ * Options for HiddenProperty plugin
+ */
+export interface HiddenPropertyOptions {
+    // TODO: Add options here
+}

--- a/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyPlugin.ts
@@ -1,0 +1,61 @@
+import { ChangeSource } from 'roosterjs-content-model-dom';
+import { fixupHiddenProperties } from './fixupHiddenProperties';
+import type { IEditor, PluginEvent, EditorPlugin } from 'roosterjs-content-model-types';
+import type { HiddenPropertyOptions } from './HiddenPropertyOptions';
+
+/**
+ * HiddenPropertyPlugin helps editor to maintain hidden properties in DOM after editor content is reset using HTML
+ * This includes:
+ * TODO: ADD more hidden properties here
+ */
+export class HiddenPropertyPlugin implements EditorPlugin {
+    private editor: IEditor | null = null;
+
+    /**
+     * Construct a new instance of FormatPlugin class
+     * @param option The editor option
+     */
+    constructor(private option: HiddenPropertyOptions) {}
+
+    /**
+     * Get name of this plugin
+     */
+    getName() {
+        return 'HiddenProperty';
+    }
+
+    /**
+     * The first method that editor will call to a plugin when editor is initializing.
+     * It will pass in the editor instance, plugin should take this chance to save the
+     * editor reference so that it can call to any editor method or format API later.
+     * @param editor The editor object
+     */
+    initialize(editor: IEditor) {
+        this.editor = editor;
+    }
+
+    /**
+     * The last method that editor will call to a plugin before it is disposed.
+     * Plugin can take this chance to clear the reference to editor. After this method is
+     * called, plugin should not call to any editor method since it will result in error.
+     */
+    dispose() {
+        this.editor = null;
+    }
+
+    /**
+     * Core method for a plugin. Once an event happens in editor, editor will call this
+     * method of each plugin to handle the event as long as the event is not handled
+     * exclusively by another plugin.
+     * @param event The event to handle:
+     */
+    onPluginEvent(event: PluginEvent) {
+        if (!this.editor) {
+            return;
+        }
+
+        if (event.eventType == 'contentChanged' && event.source == ChangeSource.SetContent) {
+            fixupHiddenProperties(this.editor, this.option);
+        }
+    }
+}

--- a/packages/roosterjs-content-model-plugins/lib/hiddenProperty/fixupHiddenProperties.ts
+++ b/packages/roosterjs-content-model-plugins/lib/hiddenProperty/fixupHiddenProperties.ts
@@ -1,0 +1,9 @@
+import type { HiddenPropertyOptions } from './HiddenPropertyOptions';
+import type { IEditor } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ */
+export function fixupHiddenProperties(editor: IEditor, options: HiddenPropertyOptions) {
+    // TODO: We can add more checkers here
+}

--- a/packages/roosterjs-content-model-plugins/lib/index.ts
+++ b/packages/roosterjs-content-model-plugins/lib/index.ts
@@ -39,3 +39,5 @@ export { PickerSelectionChangMode, PickerDirection, PickerHandler } from './pick
 export { CustomReplacePlugin, CustomReplace } from './customReplace/CustomReplacePlugin';
 export { ImageEditPlugin } from './imageEdit/ImageEditPlugin';
 export { ImageEditOptions } from './imageEdit/types/ImageEditOptions';
+export { HiddenPropertyPlugin } from './hiddenProperty/HiddenPropertyPlugin';
+export { HiddenPropertyOptions } from './hiddenProperty/HiddenPropertyOptions';

--- a/packages/roosterjs-content-model-plugins/test/hiddenProperty/HiddenPropertyPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/hiddenProperty/HiddenPropertyPluginTest.ts
@@ -1,0 +1,46 @@
+import * as fixupHiddenPropertiesModule from '../../lib/hiddenProperty/fixupHiddenProperties';
+import { HiddenPropertyOptions } from '../../lib/hiddenProperty/HiddenPropertyOptions';
+import { HiddenPropertyPlugin } from '../../lib/hiddenProperty/HiddenPropertyPlugin';
+import { IEditor } from 'roosterjs-content-model-types';
+
+describe('HiddenPropertyPluginTest', () => {
+    let editor: IEditor;
+    let fixupHiddenPropertiesSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        editor = {} as any;
+        fixupHiddenPropertiesSpy = spyOn(fixupHiddenPropertiesModule, 'fixupHiddenProperties');
+    });
+
+    it('Call fixupHiddenProperties when setContent', () => {
+        const mockedOptions: HiddenPropertyOptions = {
+            test: 'testValue',
+        } as any;
+        const plugin = new HiddenPropertyPlugin(mockedOptions);
+
+        plugin.initialize(editor);
+
+        plugin.onPluginEvent({
+            eventType: 'contentChanged',
+            source: 'SetContent',
+        } as any);
+
+        expect(fixupHiddenPropertiesSpy).toHaveBeenCalledWith(editor, mockedOptions);
+    });
+
+    it('Do not call fixupHiddenProperties when other source setContent', () => {
+        const mockedOptions: HiddenPropertyOptions = {
+            test: 'testValue',
+        } as any;
+        const plugin = new HiddenPropertyPlugin(mockedOptions);
+
+        plugin.initialize(editor);
+
+        plugin.onPluginEvent({
+            eventType: 'contentChanged',
+            source: 'test',
+        } as any);
+
+        expect(fixupHiddenPropertiesSpy).not.toHaveBeenCalled();
+    });
+});

--- a/packages/roosterjs-content-model-plugins/test/hiddenProperty/fixupHiddenPropertiesTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/hiddenProperty/fixupHiddenPropertiesTest.ts
@@ -1,0 +1,10 @@
+import { fixupHiddenProperties } from '../../lib/hiddenProperty/fixupHiddenProperties';
+
+describe('fixupHiddenProperties', () => {
+    it('should not throw an error when called', () => {
+        const editor: any = {}; // Mocked editor object
+        const options: any = {}; // Mocked options object
+
+        expect(() => fixupHiddenProperties(editor, options)).not.toThrow();
+    });
+});


### PR DESCRIPTION
This is the first step to support undeletable anchor.

The final goal is to allow adding anchor such as `<a name="myAnchor"></a>` and specify what kind of anchor is not deletable, then all editing function will not delete it.

In this PR, I add support for hidden property.

A hidden property is something we store on DOM that will not reflect in HTML string, but we can read/write it in our code. For example:

```ts
interface HiddenProperty extends Node {
  hiddenProperty?: string;
}

const value = (node as HiddenProperty).hiddenProperty;
(node as HiddenProperty).value = 'some value';
```

This is allowed by javascript, and a hidden property will be there until the DOM node is removed or we remove it from our code.

I added new API to help read write hidden properties under a unified root property `__roosterjsHiddenProperty`, it can be found in debugger from a DOM node. The following API are added as internal API, later I'll add specific API to use them to read/write specific property:
- getHiddenProperty
- setHiddenProperty

Hidden property can be lost after we set editor content using HTML directly, so I also added a new plugin `HiddenPropertyPlugin` to help maintain this properties. For now it does nothing, in further PR I'll add code to help maintain undeletable property.