### PR TITLE
Support undeletable anchor Step 4: Prevent deleting undeletable anchor

### DIFF
--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -4,6 +4,7 @@ import SampleEntityPlugin from '../plugins/SampleEntityPlugin';
 import { ApiPlaygroundPlugin } from '../sidePane/apiPlayground/ApiPlaygroundPlugin';
 import { ContentModelPanePlugin } from '../sidePane/contentModel/ContentModelPanePlugin';
 import { darkModeButton } from '../demoButtons/darkModeButton';
+import { defaultDomToModelOption } from '../options/defaultDomToModelOption';
 import { Editor } from 'roosterjs-content-model-core';
 import { EditorOptionsPlugin } from '../sidePane/editorOptions/EditorOptionsPlugin';
 import { EventViewPlugin } from '../sidePane/eventViewer/EventViewPlugin';
@@ -27,6 +28,7 @@ import { SnapshotPlugin } from '../sidePane/snapshot/SnapshotPlugin';
 import { ThemeProvider } from '@fluentui/react/lib/Theme';
 import { TitleBar } from '../titleBar/TitleBar';
 import { trustedHTMLHandler } from '../../utils/trustedHTMLHandler';
+import { undeletableLinkChecker } from '../options/demoUndeletableAnchorParser';
 import { UpdateContentPlugin } from '../plugins/UpdateContentPlugin';
 import { WindowProvider } from '@fluentui/react/lib/WindowProvider';
 import { zoomButton } from '../demoButtons/zoomButton';
@@ -377,6 +379,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
                             experimentalFeatures={Array.from(
                                 this.state.initState.experimentalFeatures
                             )}
+                            defaultDomToModelOptions={defaultDomToModelOption}
                         />
                     )}
                 </div>
@@ -528,7 +531,10 @@ export class MainPane extends React.Component<{}, MainPaneState> {
                         : linkTitle
                 ),
             pluginList.customReplace && new CustomReplacePlugin(customReplacements),
-            pluginList.hiddenProperty && new HiddenPropertyPlugin({}),
+            pluginList.hiddenProperty &&
+                new HiddenPropertyPlugin({
+                    undeletableLinkChecker: undeletableLinkChecker,
+                }),
         ].filter(x => !!x);
     }
 }

--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -58,6 +58,7 @@ import {
     AutoFormatPlugin,
     CustomReplacePlugin,
     EditPlugin,
+    HiddenPropertyPlugin,
     HyperlinkPlugin,
     ImageEditPlugin,
     MarkdownPlugin,
@@ -527,6 +528,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
                         : linkTitle
                 ),
             pluginList.customReplace && new CustomReplacePlugin(customReplacements),
+            pluginList.hiddenProperty && new HiddenPropertyPlugin({}),
         ].filter(x => !!x);
     }
 }

--- a/demo/scripts/controlsV2/options/defaultDomToModelOption.ts
+++ b/demo/scripts/controlsV2/options/defaultDomToModelOption.ts
@@ -1,0 +1,8 @@
+import { demoUndeletableAnchorParser } from './demoUndeletableAnchorParser';
+import { DomToModelOption } from 'roosterjs-content-model-types';
+
+export const defaultDomToModelOption: DomToModelOption = {
+    additionalFormatParsers: {
+        link: [demoUndeletableAnchorParser],
+    },
+};

--- a/demo/scripts/controlsV2/options/demoUndeletableAnchorParser.ts
+++ b/demo/scripts/controlsV2/options/demoUndeletableAnchorParser.ts
@@ -1,0 +1,13 @@
+import { FormatParser, UndeletableFormat } from 'roosterjs-content-model-types';
+
+const DemoUndeletableName = 'DemoUndeletable';
+
+export function undeletableLinkChecker(a: HTMLAnchorElement): boolean {
+    return a.getAttribute('name') == DemoUndeletableName;
+}
+
+export const demoUndeletableAnchorParser: FormatParser<UndeletableFormat> = (format, element) => {
+    if (undeletableLinkChecker(element as HTMLAnchorElement)) {
+        format.undeletable = true;
+    }
+};

--- a/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -21,6 +21,7 @@ const initialState: OptionState = {
         imageEditPlugin: true,
         hyperlink: true,
         customReplace: true,
+        hiddenProperty: true,
     },
     defaultFormat: {
         fontFamily: 'Calibri',

--- a/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
@@ -22,6 +22,7 @@ export interface BuildInPluginList {
     hyperlink: boolean;
     imageEditPlugin: boolean;
     customReplace: boolean;
+    hiddenProperty: boolean;
 }
 
 export interface OptionState {

--- a/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
@@ -305,6 +305,7 @@ export class Plugins extends PluginsBase<keyof BuildInPluginList> {
                     )}
                     {this.renderPluginItem('customReplace', 'Custom Replace')}
                     {this.renderPluginItem('imageEditPlugin', 'ImageEditPlugin')}
+                    {this.renderPluginItem('hiddenProperty', 'Hidden Property')}
                 </tbody>
             </table>
         );

--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/linkProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/linkProcessor.ts
@@ -1,21 +1,45 @@
+import { addSegment } from '../../modelApi/common/addSegment';
+import { createText } from '../../modelApi/creators/createText';
 import { knownElementProcessor } from './knownElementProcessor';
 import { parseFormat } from '../utils/parseFormat';
 import { stackFormat } from '../utils/stackFormat';
+import type { StackFormatOptions } from '../utils/stackFormat';
 import type { ElementProcessor } from 'roosterjs-content-model-types';
 
 /**
  * @internal
  */
 export const linkProcessor: ElementProcessor<HTMLElement> = (group, element, context) => {
-    if (element.hasAttribute('href')) {
-        stackFormat(context, { link: 'linkDefault' }, () => {
+    const name = element.getAttribute('name');
+    const href = element.getAttribute('href');
+
+    if (name || href) {
+        const isAnchor = !!name && !href;
+        const option: StackFormatOptions = {
+            // For anchor (name without ref), no need to add other styles
+            // For link (href exists), add default link styles
+            link: isAnchor ? 'empty' : 'linkDefault',
+        };
+
+        stackFormat(context, option, () => {
             parseFormat(element, context.formatParsers.link, context.link.format, context);
             parseFormat(element, context.formatParsers.dataset, context.link.dataset, context);
 
-            knownElementProcessor(group, element, context);
+            if (isAnchor && !element.firstChild) {
+                // Empty anchor, need to make sure it has some child in model
+                addSegment(
+                    group,
+                    createText('', context.segmentFormat, {
+                        dataset: context.link.dataset,
+                        format: context.link.format,
+                    })
+                );
+            } else {
+                knownElementProcessor(group, element, context);
+            }
         });
     } else {
-        // A tag without href, can be treated as normal SPAN tag
+        // A tag without name or href, can be treated as normal SPAN tag
         knownElementProcessor(group, element, context);
     }
 };

--- a/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/hiddenProperty.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/hiddenProperty.ts
@@ -2,9 +2,10 @@
  * @internal
  */
 export interface HiddenProperty {
-    dummy?: {}; // Temp used by test, will be removed later
-
-    // TODO: Add more properties as needed
+    /**
+     * Specify we should not delete this element when delete/backspace key is pressed
+     */
+    undeletable?: boolean;
 }
 
 interface NodeWithHiddenProperty extends Node {

--- a/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/hiddenProperty.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/hiddenProperty.ts
@@ -1,0 +1,40 @@
+/**
+ * @internal
+ */
+export interface HiddenProperty {
+    dummy?: {}; // Temp used by test, will be removed later
+
+    // TODO: Add more properties as needed
+}
+
+interface NodeWithHiddenProperty extends Node {
+    __roosterjsHiddenProperty?: HiddenProperty;
+}
+
+/**
+ * @internal
+ */
+export function getHiddenProperty<Key extends keyof HiddenProperty>(
+    node: Node,
+    key: Key
+): HiddenProperty[Key] | undefined {
+    const nodeWithHiddenProperty = node as NodeWithHiddenProperty;
+    const hiddenProperty = nodeWithHiddenProperty.__roosterjsHiddenProperty;
+
+    return hiddenProperty ? hiddenProperty[key] : undefined;
+}
+
+/**
+ * @internal
+ */
+export function setHiddenProperty<Key extends keyof HiddenProperty>(
+    node: Node,
+    key: Key,
+    value: HiddenProperty[Key]
+) {
+    const nodeWithHiddenProperty = node as NodeWithHiddenProperty;
+    const hiddenProperty = nodeWithHiddenProperty.__roosterjsHiddenProperty || {};
+
+    hiddenProperty[key] = value;
+    nodeWithHiddenProperty.__roosterjsHiddenProperty = hiddenProperty;
+}

--- a/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/undeletableLink.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/undeletableLink.ts
@@ -1,0 +1,24 @@
+import { getHiddenProperty, setHiddenProperty } from './hiddenProperty';
+import type { HiddenProperty } from './hiddenProperty';
+
+const UndeletableLinkKey: keyof HiddenProperty = 'undeletable';
+
+/**
+ * Set a hidden property on a link element to indicate whether it is undeletable or not.
+ * This is used to prevent the link from being deleted when the user tries to delete it.
+ * @param a The link element to set the property on
+ * @param undeletable Whether the link is undeletable or not
+ */
+export function setLinkUndeletable(a: HTMLAnchorElement, undeletable: boolean) {
+    setHiddenProperty(a, UndeletableLinkKey, undeletable);
+}
+
+/**
+ * Check if a link element is undeletable or not.
+ * This is used to determine if the link can be deleted when the user tries to delete it.
+ * @param a The link element to check
+ * @returns True if the link is undeletable, false otherwise
+ */
+export function isLinkUndeletable(a: HTMLAnchorElement): boolean {
+    return !!getHiddenProperty(a, UndeletableLinkKey);
+}

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
@@ -32,6 +32,7 @@ import { textAlignFormatHandler } from './block/textAlignFormatHandler';
 import { textColorFormatHandler } from './segment/textColorFormatHandler';
 import { textColorOnTableCellFormatHandler } from './table/textColorOnTableCellFormatHandler';
 import { textIndentFormatHandler } from './block/textIndentFormatHandler';
+import { undeletableLinkFormatHandler } from './segment/undeletableLinkFormatHandler';
 import { underlineFormatHandler } from './segment/underlineFormatHandler';
 import { verticalAlignFormatHandler } from './common/verticalAlignFormatHandler';
 import { whiteSpaceFormatHandler } from './block/whiteSpaceFormatHandler';
@@ -85,6 +86,7 @@ const defaultFormatHandlerMap: FormatHandlers = {
     textColor: textColorFormatHandler,
     textColorOnTableCell: textColorOnTableCellFormatHandler,
     textIndent: textIndentFormatHandler,
+    undeletableLink: undeletableLinkFormatHandler,
     underline: underlineFormatHandler,
     verticalAlign: verticalAlignFormatHandler,
     whiteSpace: whiteSpaceFormatHandler,
@@ -200,6 +202,7 @@ export const defaultFormatKeysPerCategory: {
         'border',
         'size',
         'textAlign',
+        'undeletableLink',
     ],
     segmentUnderLink: ['textColor'],
     code: ['fontFamily', 'display'],

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/segment/linkFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/segment/linkFormatHandler.ts
@@ -46,8 +46,10 @@ export const linkFormatHandler: FormatHandler<LinkFormat> = {
         }
     },
     apply: (format, element) => {
-        if (isElementOfType(element, 'a') && format.href) {
-            element.href = format.href;
+        if (isElementOfType(element, 'a') && (format.href || format.name)) {
+            if (format.href) {
+                element.href = format.href;
+            }
 
             if (format.name) {
                 element.name = format.name;

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/segment/undeletableLinkFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/segment/undeletableLinkFormatHandler.ts
@@ -1,0 +1,24 @@
+import { isElementOfType } from '../../domUtils/isElementOfType';
+import {
+    isLinkUndeletable,
+    setLinkUndeletable,
+} from '../../domUtils/hiddenProperties/undeletableLink';
+import type { UndeletableFormat } from 'roosterjs-content-model-types';
+import type { FormatHandler } from '../FormatHandler';
+
+/**
+ * @internal
+ */
+export const undeletableLinkFormatHandler: FormatHandler<UndeletableFormat> = {
+    parse: (format, element) => {
+        if (isElementOfType(element, 'a') && isLinkUndeletable(element)) {
+            format.undeletable = true;
+        }
+    },
+
+    apply: (format, element) => {
+        if (format.undeletable && isElementOfType(element, 'a')) {
+            setLinkUndeletable(element, true);
+        }
+    },
+};

--- a/packages/roosterjs-content-model-dom/lib/index.ts
+++ b/packages/roosterjs-content-model-dom/lib/index.ts
@@ -39,6 +39,8 @@ export { reuseCachedElement } from './domUtils/reuseCachedElement';
 export { isWhiteSpacePreserved } from './domUtils/isWhiteSpacePreserved';
 export { normalizeRect } from './domUtils/normalizeRect';
 
+export { setLinkUndeletable, isLinkUndeletable } from './domUtils/hiddenProperties/undeletableLink';
+
 export { createBr } from './modelApi/creators/createBr';
 export { createListItem } from './modelApi/creators/createListItem';
 export { createFormatContainer } from './modelApi/creators/createFormatContainer';

--- a/packages/roosterjs-content-model-dom/lib/modelApi/common/addDecorators.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/common/addDecorators.ts
@@ -12,7 +12,7 @@ export function addLink(
     segment: ShallowMutableContentModelSegment,
     link: ReadonlyContentModelLink
 ) {
-    if (link.format.href) {
+    if (link.format.href || link.format.name) {
         segment.link = {
             format: { ...link.format },
             dataset: { ...link.dataset },

--- a/packages/roosterjs-content-model-dom/lib/modelApi/common/isEmpty.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/common/isEmpty.ts
@@ -51,10 +51,13 @@ export function isBlockGroupEmpty(group: ReadonlyContentModelBlockGroup): boolea
 /**
  * @internal
  */
-export function isSegmentEmpty(segment: ReadonlyContentModelSegment): boolean {
+export function isSegmentEmpty(
+    segment: ReadonlyContentModelSegment,
+    treatAnchorAsNotEmpty?: boolean
+): boolean {
     switch (segment.segmentType) {
         case 'Text':
-            return !segment.text;
+            return !segment.text && (!treatAnchorAsNotEmpty || !segment.link?.format.name);
 
         default:
             return false;

--- a/packages/roosterjs-content-model-dom/lib/modelApi/common/normalizeParagraph.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/common/normalizeParagraph.ts
@@ -65,7 +65,7 @@ function normalizeParagraphStyle(paragraph: ReadonlyContentModelParagraph) {
 
 function removeEmptySegments(block: ReadonlyContentModelParagraph) {
     for (let j = block.segments.length - 1; j >= 0; j--) {
-        if (isSegmentEmpty(block.segments[j])) {
+        if (isSegmentEmpty(block.segments[j], true /*treatAnchorAsNotEmpty*/)) {
             mutateBlock(block).segments.splice(j, 1);
         }
     }

--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/deleteExpandedSelection.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/deleteExpandedSelection.ts
@@ -38,6 +38,7 @@ export function deleteExpandedSelection(
         deleteResult: 'notDeleted',
         insertPoint: null,
         formatContext,
+        undeletableSegments: [],
     };
 
     iterateSelections(
@@ -64,6 +65,8 @@ export function deleteExpandedSelection(
                     insertMarkerIndex = indexes[0];
                     markerFormat = getSegmentTextFormat(segments[0], true /*includingBIU*/);
 
+                    const isFirstDeletingParagraph = !context.lastParagraph;
+
                     context.lastParagraph = paragraph;
                     context.lastTableContext = tableContext;
 
@@ -81,7 +84,15 @@ export function deleteExpandedSelection(
                                 path,
                                 tableContext
                             );
-                        } else if (deleteSegment(block, segment, context.formatContext)) {
+                        } else if (
+                            deleteSegment(
+                                block,
+                                segment,
+                                context.formatContext,
+                                undefined /*direction*/,
+                                isFirstDeletingParagraph ? undefined : context.undeletableSegments // For first paragraph we can keep undeletable segments so ono need to merge it later
+                            )
+                        ) {
                             context.deleteResult = 'range';
                         }
                     });

--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/deleteSelection.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/deleteSelection.ts
@@ -34,7 +34,13 @@ export function deleteSelection(
 
 // If we end up with multiple paragraphs impacted, we need to merge them
 function mergeParagraphAfterDelete(context: DeleteSelectionContext) {
-    const { insertPoint, deleteResult, lastParagraph, lastTableContext } = context;
+    const {
+        insertPoint,
+        deleteResult,
+        lastParagraph,
+        lastTableContext,
+        undeletableSegments,
+    } = context;
 
     if (
         insertPoint &&
@@ -45,8 +51,13 @@ function mergeParagraphAfterDelete(context: DeleteSelectionContext) {
         lastTableContext == insertPoint.tableContext
     ) {
         const mutableLastParagraph = mutateBlock(lastParagraph);
+        const mutableInsertingParagraph = mutateBlock(insertPoint.paragraph);
 
-        mutateBlock(insertPoint.paragraph).segments.push(...mutableLastParagraph.segments);
+        if (undeletableSegments) {
+            mutableLastParagraph.segments.unshift(...undeletableSegments);
+        }
+
+        mutableInsertingParagraph.segments.push(...mutableLastParagraph.segments);
         mutableLastParagraph.segments = [];
     }
 }

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/linkProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/linkProcessorTest.ts
@@ -205,4 +205,158 @@ describe('linkProcessor', () => {
             ],
         });
     });
+
+    it('undeletable link', () => {
+        const group = createContentModelDocument();
+        const a = document.createElement('a');
+
+        (a as any).__roosterjsHiddenProperty = {
+            undeletable: true,
+        };
+
+        a.href = '/test';
+        a.textContent = 'test';
+
+        linkProcessor(group, a, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    isImplicit: true,
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            link: {
+                                format: { href: '/test', underline: true, undeletable: true },
+                                dataset: {},
+                            },
+                            text: 'test',
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(context.link).toEqual({
+            format: {},
+            dataset: {},
+        });
+    });
+
+    it('anchor with child', () => {
+        const group = createContentModelDocument();
+        const a = document.createElement('a');
+
+        a.name = 'name';
+        a.textContent = 'test';
+
+        linkProcessor(group, a, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    isImplicit: true,
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            link: {
+                                format: { name: 'name' },
+                                dataset: {},
+                            },
+                            text: 'test',
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(context.link).toEqual({
+            format: {},
+            dataset: {},
+        });
+    });
+
+    it('anchor without child', () => {
+        const group = createContentModelDocument();
+        const a = document.createElement('a');
+
+        a.name = 'name';
+
+        linkProcessor(group, a, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    isImplicit: true,
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            link: {
+                                format: { name: 'name' },
+                                dataset: {},
+                            },
+                            text: '',
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(context.link).toEqual({
+            format: {},
+            dataset: {},
+        });
+    });
+
+    it('undeletable anchor', () => {
+        const group = createContentModelDocument();
+        const a = document.createElement('a');
+
+        (a as any).__roosterjsHiddenProperty = {
+            undeletable: true,
+        };
+
+        a.name = 'name';
+
+        linkProcessor(group, a, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    isImplicit: true,
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            link: {
+                                format: { name: 'name', undeletable: true },
+                                dataset: {},
+                            },
+                            text: '',
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(context.link).toEqual({
+            format: {},
+            dataset: {},
+        });
+    });
 });

--- a/packages/roosterjs-content-model-dom/test/domUtils/hiddenProperties/hiddenPropertyTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domUtils/hiddenProperties/hiddenPropertyTest.ts
@@ -1,0 +1,47 @@
+import {
+    getHiddenProperty,
+    setHiddenProperty,
+} from '../../../lib/domUtils/hiddenProperties/hiddenProperty';
+
+describe('hiddenProperty.getHiddenProperty', () => {
+    it('should return undefined if no hidden property is set', () => {
+        const mockedNode: Node = {} as any;
+        expect(getHiddenProperty(mockedNode, 'test' as any)).toBeUndefined();
+    });
+
+    it('should return the value of the hidden property if set', () => {
+        const mockedNode: Node = {
+            __roosterjsHiddenProperty: {
+                test: 'testValue',
+            },
+        } as any;
+
+        expect(getHiddenProperty(mockedNode, 'test' as any)).toBe('testValue');
+    });
+});
+
+describe('hiddenProperty.setHiddenProperty', () => {
+    it('should set the hidden property on the node', () => {
+        const mockedNode: Node = {} as any;
+        setHiddenProperty(mockedNode, 'test' as any, 'testValue');
+
+        expect((mockedNode as any).__roosterjsHiddenProperty).toEqual({
+            test: 'testValue',
+        });
+    });
+
+    it('should update the hidden property if it already exists', () => {
+        const mockedNode: Node = {
+            __roosterjsHiddenProperty: {
+                otherValue: 'otherValue',
+                test: 'oldValue',
+            },
+        } as any;
+        setHiddenProperty(mockedNode, 'test' as any, 'newValue');
+
+        expect((mockedNode as any).__roosterjsHiddenProperty).toEqual({
+            otherValue: 'otherValue',
+            test: 'newValue',
+        });
+    });
+});

--- a/packages/roosterjs-content-model-dom/test/domUtils/hiddenProperties/undeletableLinkTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domUtils/hiddenProperties/undeletableLinkTest.ts
@@ -1,0 +1,36 @@
+import {
+    isLinkUndeletable,
+    setLinkUndeletable,
+} from '../../../lib/domUtils/hiddenProperties/undeletableLink';
+
+describe('setLinkUndeletable', () => {
+    it('should set the undeletable property on the link element', () => {
+        const linkElement = document.createElement('a');
+
+        setLinkUndeletable(linkElement, true);
+
+        expect((linkElement as any).__roosterjsHiddenProperty).toEqual({
+            undeletable: true,
+        });
+
+        setLinkUndeletable(linkElement, false);
+
+        expect((linkElement as any).__roosterjsHiddenProperty).toEqual({
+            undeletable: false,
+        });
+    });
+});
+
+describe('isLinkUndeletable', () => {
+    it('should read link undeletable value', () => {
+        const linkElement = document.createElement('a');
+
+        expect(isLinkUndeletable(linkElement)).toBe(false);
+
+        (linkElement as any).__roosterjsHiddenProperty = {
+            undeletable: true,
+        };
+
+        expect(isLinkUndeletable(linkElement)).toBe(true);
+    });
+});

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/segment/linkFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/segment/linkFormatHandlerTest.ts
@@ -58,6 +58,18 @@ describe('linkFormatHandler.parse', () => {
             name: 'name',
         });
     });
+
+    it('Anchor', () => {
+        let a = document.createElement('a');
+
+        a.name = 'name';
+
+        linkFormatHandler.parse(format, a, context, defaultHTMLStyleMap.a!);
+
+        expect(format).toEqual({
+            name: 'name',
+        });
+    });
 });
 
 describe('linkFormatHandler.apply', () => {
@@ -106,5 +118,16 @@ describe('linkFormatHandler.apply', () => {
         expect(a.outerHTML).toEqual(
             '<a href="/test" name="name" target="target" id="id" class="class" title="title" rel="rel">test</a>'
         );
+    });
+
+    it('Anchor', () => {
+        format.name = 'name';
+
+        const a = document.createElement('a');
+        a.innerHTML = 'test';
+
+        linkFormatHandler.apply(format, a, context);
+
+        expect(a.outerHTML).toEqual('<a name="name">test</a>');
     });
 });

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/segment/undeletableLinkFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/segment/undeletableLinkFormatHandlerTest.ts
@@ -1,0 +1,78 @@
+import { UndeletableFormat } from 'roosterjs-content-model-types';
+import { undeletableLinkFormatHandler } from '../../../lib/formatHandlers/segment/undeletableLinkFormatHandler';
+
+describe('undeletableLinkFormatHandler.parse', () => {
+    it('parse from other node', () => {
+        const div = document.createElement('div');
+        const format: UndeletableFormat = {};
+
+        undeletableLinkFormatHandler.parse(format, div, {} as any, {});
+
+        expect(format).toEqual({});
+    });
+
+    it('parse from a', () => {
+        const a = document.createElement('a');
+        const format: UndeletableFormat = {};
+
+        undeletableLinkFormatHandler.parse(format, a, {} as any, {});
+
+        expect(format).toEqual({});
+    });
+
+    it('parse from a with the hidden property', () => {
+        const a = document.createElement('a');
+        const format: UndeletableFormat = {};
+
+        (a as any).__roosterjsHiddenProperty = {
+            undeletable: true,
+        };
+
+        undeletableLinkFormatHandler.parse(format, a, {} as any, {});
+
+        expect(format).toEqual({
+            undeletable: true,
+        });
+    });
+});
+
+describe('undeletableLinkFormatHandler.apply', () => {
+    it('apply to other node', () => {
+        const div = document.createElement('div');
+        const format: UndeletableFormat = {
+            undeletable: true,
+        };
+
+        undeletableLinkFormatHandler.apply(format, div, {} as any);
+
+        expect((div as any).__roosterjsHiddenProperty).toBeUndefined();
+    });
+
+    it('apply to a without the hidden property', () => {
+        const a = document.createElement('a');
+        const format: UndeletableFormat = {
+            undeletable: true,
+        };
+
+        undeletableLinkFormatHandler.apply(format, a, {} as any);
+
+        expect((a as any).__roosterjsHiddenProperty).toEqual({
+            undeletable: true,
+        });
+    });
+
+    it('apply to a with the hidden property', () => {
+        const a = document.createElement('a');
+        const format: UndeletableFormat = {};
+
+        (a as any).__roosterjsHiddenProperty = {
+            test: 'value',
+        };
+
+        undeletableLinkFormatHandler.apply(format, a, {} as any);
+
+        expect((a as any).__roosterjsHiddenProperty).toEqual({
+            test: 'value',
+        });
+    });
+});

--- a/packages/roosterjs-content-model-dom/test/modelApi/common/addDecoratorsTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/common/addDecoratorsTest.ts
@@ -100,6 +100,43 @@ describe('addLink', () => {
             },
         });
     });
+
+    it('has anchor', () => {
+        const segment = createSelectionMarker();
+        const link: ContentModelLink = {
+            format: {
+                name: 'name',
+            },
+            dataset: {},
+        };
+        addLink(segment, link);
+
+        expect(segment).toEqual({
+            segmentType: 'SelectionMarker',
+            format: {},
+            isSelected: true,
+            link: {
+                format: {
+                    name: 'name',
+                },
+                dataset: {},
+            },
+        });
+
+        link.format.name = 'name2';
+
+        expect(segment).toEqual({
+            segmentType: 'SelectionMarker',
+            format: {},
+            isSelected: true,
+            link: {
+                format: {
+                    name: 'name',
+                },
+                dataset: {},
+            },
+        });
+    });
 });
 
 describe('addCode', () => {

--- a/packages/roosterjs-content-model-dom/test/modelApi/common/isEmptyTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/common/isEmptyTest.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from '../../../lib/modelApi/common/isEmpty';
+import { isEmpty, isSegmentEmpty } from '../../../lib/modelApi/common/isEmpty';
 
 describe('isEmpty', () => {
     it('Empty paragraph', () => {
@@ -323,6 +323,97 @@ describe('isEmpty', () => {
             segmentType: 'Br',
             format: {},
             isSelected: true,
+        });
+
+        expect(result).toBeFalse();
+    });
+});
+
+describe('isSegmentEmpty', () => {
+    it('Empty text', () => {
+        const result = isSegmentEmpty({
+            segmentType: 'Text',
+            format: {},
+            text: '',
+        });
+
+        expect(result).toBeTrue();
+    });
+
+    it('Text has only spaces', () => {
+        const result = isSegmentEmpty({
+            segmentType: 'Text',
+            format: {},
+            text: ' \t \r \n ',
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Text has content', () => {
+        const result = isSegmentEmpty({
+            segmentType: 'Text',
+            format: {},
+            text: '  aa  ',
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Empty anchor with treatAnchorAsNotEmpty = false', () => {
+        const result = isSegmentEmpty(
+            {
+                segmentType: 'Text',
+                format: {},
+                text: '',
+                link: {
+                    format: {
+                        name: 'name',
+                    },
+                    dataset: {},
+                },
+            },
+            false
+        );
+
+        expect(result).toBeTrue();
+    });
+
+    it('Empty anchor with treatAnchorAsNotEmpty = true', () => {
+        const result = isSegmentEmpty(
+            {
+                segmentType: 'Text',
+                format: {},
+                text: '',
+                link: {
+                    format: {
+                        name: 'name',
+                    },
+                    dataset: {},
+                },
+            },
+            true
+        );
+
+        expect(result).toBeFalse();
+    });
+
+    it('Br', () => {
+        const result = isSegmentEmpty({
+            segmentType: 'Br',
+            format: {},
+            isSelected: true,
+        });
+
+        expect(result).toBeFalse();
+    });
+
+    it('Image', () => {
+        const result = isSegmentEmpty({
+            segmentType: 'Image',
+            format: {},
+            dataset: {},
+            src: 'src',
         });
 
         expect(result).toBeFalse();

--- a/packages/roosterjs-content-model-dom/test/modelApi/common/normalizeParagraphTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/common/normalizeParagraphTest.ts
@@ -839,4 +839,26 @@ describe('Move up format', () => {
             format: { whiteSpace: 'pre-wrap' },
         });
     });
+
+    it('Paragraph has empty anchor', () => {
+        const para = createParagraph(false, { whiteSpace: 'pre-wrap' });
+        const text = createText(
+            '',
+            {},
+            {
+                dataset: {},
+                format: { name: 'name' },
+            }
+        );
+
+        para.segments.push(text);
+
+        normalizeParagraph(para);
+
+        expect(para).toEqual({
+            blockType: 'Paragraph',
+            segments: [text],
+            format: { whiteSpace: 'pre-wrap' },
+        });
+    });
 });

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -1,12 +1,14 @@
-import { deleteAllSegmentBefore } from './deleteSteps/deleteAllSegmentBefore';
-import { deleteEmptyQuote } from './deleteSteps/deleteEmptyQuote';
-import { deleteList } from './deleteSteps/deleteList';
 import {
     ChangeSource,
     deleteSelection,
+    isElementOfType,
+    isLinkUndeletable,
     isModifierKey,
     isNodeOfType,
 } from 'roosterjs-content-model-dom';
+import { deleteAllSegmentBefore } from './deleteSteps/deleteAllSegmentBefore';
+import { deleteEmptyQuote } from './deleteSteps/deleteEmptyQuote';
+import { deleteList } from './deleteSteps/deleteList';
 import {
     handleKeyboardEventResult,
     shouldDeleteAllSegmentsBefore,
@@ -30,7 +32,11 @@ import type { DOMSelection, DeleteSelectionStep, IEditor } from 'roosterjs-conte
  * @param handleExpandedSelection Whether to handle expanded selection within a text node by CM
  * @returns True if the event is handled by content model, otherwise false
  */
-export function keyboardDelete(editor: IEditor, rawEvent: KeyboardEvent, handleExpandedSelection: boolean = true) {
+export function keyboardDelete(
+    editor: IEditor,
+    rawEvent: KeyboardEvent,
+    handleExpandedSelection: boolean = true
+) {
     let handled = false;
     const selection = editor.getDOMSelection();
 
@@ -81,7 +87,11 @@ function getDeleteSteps(rawEvent: KeyboardEvent, isMac: boolean): (DeleteSelecti
     ];
 }
 
-function shouldDeleteWithContentModel(selection: DOMSelection | null, rawEvent: KeyboardEvent, handleExpandedSelection: boolean) {
+function shouldDeleteWithContentModel(
+    selection: DOMSelection | null,
+    rawEvent: KeyboardEvent,
+    handleExpandedSelection: boolean
+) {
     if (!selection) {
         return false; // Nothing to delete
     } else if (selection.type != 'range') {
@@ -93,27 +103,52 @@ function shouldDeleteWithContentModel(selection: DOMSelection | null, rawEvent: 
 
         const range = selection.range;
         const { startContainer, endContainer } = selection.range;
-        const isInSameTextNode = startContainer === endContainer && isNodeOfType(startContainer, 'TEXT_NODE');
-        return !(isInSameTextNode && !isModifierKey(rawEvent) && range.endOffset - range.startOffset < (startContainer.nodeValue?.length ?? 0));
+        const isInSameTextNode =
+            startContainer === endContainer && isNodeOfType(startContainer, 'TEXT_NODE');
+        return !(
+            isInSameTextNode &&
+            !isModifierKey(rawEvent) &&
+            range.endOffset - range.startOffset < (startContainer.nodeValue?.length ?? 0)
+        );
     } else {
         const range = selection.range;
+        const startContainer = range.startContainer;
+        const startOffset = range.startOffset;
 
         // When selection is collapsed and is in middle of text node, no need to use Content Model to delete
         return !(
-            isNodeOfType(range.startContainer, 'TEXT_NODE') &&
+            isNodeOfType(startContainer, 'TEXT_NODE') &&
             !isModifierKey(rawEvent) &&
-            (canDeleteBefore(rawEvent, range) || canDeleteAfter(rawEvent, range))
+            (canDeleteBefore(rawEvent, startContainer, startOffset) ||
+                canDeleteAfter(rawEvent, startContainer, startOffset))
         );
     }
 }
 
-function canDeleteBefore(rawEvent: KeyboardEvent, range: Range) {
-    return rawEvent.key == 'Backspace' && range.startOffset > 1;
+function canDeleteBefore(rawEvent: KeyboardEvent, text: Text, offset: number) {
+    if (rawEvent.key != 'Backspace' || offset <= 1) {
+        return false;
+    }
+
+    const length = text.nodeValue?.length ?? 0;
+
+    if (offset == length) {
+        // At the end of text, need to check if next segment is deletable
+        const nextSibling = text.nextSibling;
+        const isNextSiblingUndeletable =
+            isNodeOfType(nextSibling, 'ELEMENT_NODE') &&
+            isElementOfType(nextSibling, 'a') &&
+            isLinkUndeletable(nextSibling);
+
+        // If next sibling is undeletable, we cannot let browser handle it since it will remove the anchor
+        // So we return false here to let Content Model handle it
+        return !isNextSiblingUndeletable;
+    } else {
+        // In middle of text, we can safely let browser handle deletion
+        return true;
+    }
 }
 
-function canDeleteAfter(rawEvent: KeyboardEvent, range: Range) {
-    return (
-        rawEvent.key == 'Delete' &&
-        range.startOffset < (range.startContainer.nodeValue?.length ?? 0) - 1
-    );
+function canDeleteAfter(rawEvent: KeyboardEvent, text: Text, offset: number) {
+    return rawEvent.key == 'Delete' && offset < (text.nodeValue?.length ?? 0) - 1;
 }

--- a/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyOptions.ts
+++ b/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyOptions.ts
@@ -1,0 +1,6 @@
+/**
+ * Options for HiddenProperty plugin
+ */
+export interface HiddenPropertyOptions {
+    // TODO: Add options here
+}

--- a/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyOptions.ts
+++ b/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyOptions.ts
@@ -2,5 +2,10 @@
  * Options for HiddenProperty plugin
  */
 export interface HiddenPropertyOptions {
-    // TODO: Add options here
+    /**
+     * A helper function to check if a link should be undeletable or not.
+     * @param link The link to check
+     * @returns True if the link should be undeletable, false otherwise
+     */
+    undeletableLinkChecker?: (link: HTMLAnchorElement) => boolean;
 }

--- a/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyPlugin.ts
@@ -5,8 +5,6 @@ import type { HiddenPropertyOptions } from './HiddenPropertyOptions';
 
 /**
  * HiddenPropertyPlugin helps editor to maintain hidden properties in DOM after editor content is reset using HTML
- * This includes:
- * TODO: ADD more hidden properties here
  */
 export class HiddenPropertyPlugin implements EditorPlugin {
     private editor: IEditor | null = null;

--- a/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/hiddenProperty/HiddenPropertyPlugin.ts
@@ -1,0 +1,61 @@
+import { ChangeSource } from 'roosterjs-content-model-dom';
+import { fixupHiddenProperties } from './fixupHiddenProperties';
+import type { IEditor, PluginEvent, EditorPlugin } from 'roosterjs-content-model-types';
+import type { HiddenPropertyOptions } from './HiddenPropertyOptions';
+
+/**
+ * HiddenPropertyPlugin helps editor to maintain hidden properties in DOM after editor content is reset using HTML
+ * This includes:
+ * TODO: ADD more hidden properties here
+ */
+export class HiddenPropertyPlugin implements EditorPlugin {
+    private editor: IEditor | null = null;
+
+    /**
+     * Construct a new instance of FormatPlugin class
+     * @param option The editor option
+     */
+    constructor(private option: HiddenPropertyOptions) {}
+
+    /**
+     * Get name of this plugin
+     */
+    getName() {
+        return 'HiddenProperty';
+    }
+
+    /**
+     * The first method that editor will call to a plugin when editor is initializing.
+     * It will pass in the editor instance, plugin should take this chance to save the
+     * editor reference so that it can call to any editor method or format API later.
+     * @param editor The editor object
+     */
+    initialize(editor: IEditor) {
+        this.editor = editor;
+    }
+
+    /**
+     * The last method that editor will call to a plugin before it is disposed.
+     * Plugin can take this chance to clear the reference to editor. After this method is
+     * called, plugin should not call to any editor method since it will result in error.
+     */
+    dispose() {
+        this.editor = null;
+    }
+
+    /**
+     * Core method for a plugin. Once an event happens in editor, editor will call this
+     * method of each plugin to handle the event as long as the event is not handled
+     * exclusively by another plugin.
+     * @param event The event to handle:
+     */
+    onPluginEvent(event: PluginEvent) {
+        if (!this.editor) {
+            return;
+        }
+
+        if (event.eventType == 'contentChanged' && event.source == ChangeSource.SetContent) {
+            fixupHiddenProperties(this.editor, this.option);
+        }
+    }
+}

--- a/packages/roosterjs-content-model-plugins/lib/hiddenProperty/fixupHiddenProperties.ts
+++ b/packages/roosterjs-content-model-plugins/lib/hiddenProperty/fixupHiddenProperties.ts
@@ -1,0 +1,9 @@
+import type { HiddenPropertyOptions } from './HiddenPropertyOptions';
+import type { IEditor } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ */
+export function fixupHiddenProperties(editor: IEditor, options: HiddenPropertyOptions) {
+    // TODO: We can add more checkers here
+}

--- a/packages/roosterjs-content-model-plugins/lib/hiddenProperty/fixupHiddenProperties.ts
+++ b/packages/roosterjs-content-model-plugins/lib/hiddenProperty/fixupHiddenProperties.ts
@@ -1,9 +1,27 @@
+import { setLinkUndeletable } from 'roosterjs-content-model-dom';
 import type { HiddenPropertyOptions } from './HiddenPropertyOptions';
 import type { IEditor } from 'roosterjs-content-model-types';
 
 /**
  * @internal
+ * Maintain hidden properties in DOM after editor content is reset using HTML
+ * This includes:
+ * 1. Undeletable property
  */
 export function fixupHiddenProperties(editor: IEditor, options: HiddenPropertyOptions) {
-    // TODO: We can add more checkers here
+    if (options.undeletableLinkChecker) {
+        checkUndeletable(editor, options.undeletableLinkChecker);
+    }
+
+    // Add more hidden properties checkers here
+}
+
+function checkUndeletable(editor: IEditor, checker: (link: HTMLAnchorElement) => boolean) {
+    const anchors = editor.getDOMHelper().queryElements('a');
+
+    for (const a of anchors) {
+        if (checker(a)) {
+            setLinkUndeletable(a, true);
+        }
+    }
 }

--- a/packages/roosterjs-content-model-plugins/lib/index.ts
+++ b/packages/roosterjs-content-model-plugins/lib/index.ts
@@ -39,3 +39,5 @@ export { PickerSelectionChangMode, PickerDirection, PickerHandler } from './pick
 export { CustomReplacePlugin, CustomReplace } from './customReplace/CustomReplacePlugin';
 export { ImageEditPlugin } from './imageEdit/ImageEditPlugin';
 export { ImageEditOptions } from './imageEdit/types/ImageEditOptions';
+export { HiddenPropertyPlugin } from './hiddenProperty/HiddenPropertyPlugin';
+export { HiddenPropertyOptions } from './hiddenProperty/HiddenPropertyOptions';

--- a/packages/roosterjs-content-model-plugins/test/hiddenProperty/HiddenPropertyPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/hiddenProperty/HiddenPropertyPluginTest.ts
@@ -1,0 +1,46 @@
+import * as fixupHiddenPropertiesModule from '../../lib/hiddenProperty/fixupHiddenProperties';
+import { HiddenPropertyOptions } from '../../lib/hiddenProperty/HiddenPropertyOptions';
+import { HiddenPropertyPlugin } from '../../lib/hiddenProperty/HiddenPropertyPlugin';
+import { IEditor } from 'roosterjs-content-model-types';
+
+describe('HiddenPropertyPluginTest', () => {
+    let editor: IEditor;
+    let fixupHiddenPropertiesSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        editor = {} as any;
+        fixupHiddenPropertiesSpy = spyOn(fixupHiddenPropertiesModule, 'fixupHiddenProperties');
+    });
+
+    it('Call fixupHiddenProperties when setContent', () => {
+        const mockedOptions: HiddenPropertyOptions = {
+            test: 'testValue',
+        } as any;
+        const plugin = new HiddenPropertyPlugin(mockedOptions);
+
+        plugin.initialize(editor);
+
+        plugin.onPluginEvent({
+            eventType: 'contentChanged',
+            source: 'SetContent',
+        } as any);
+
+        expect(fixupHiddenPropertiesSpy).toHaveBeenCalledWith(editor, mockedOptions);
+    });
+
+    it('Do not call fixupHiddenProperties when other source setContent', () => {
+        const mockedOptions: HiddenPropertyOptions = {
+            test: 'testValue',
+        } as any;
+        const plugin = new HiddenPropertyPlugin(mockedOptions);
+
+        plugin.initialize(editor);
+
+        plugin.onPluginEvent({
+            eventType: 'contentChanged',
+            source: 'test',
+        } as any);
+
+        expect(fixupHiddenPropertiesSpy).not.toHaveBeenCalled();
+    });
+});

--- a/packages/roosterjs-content-model-plugins/test/hiddenProperty/fixupHiddenPropertiesTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/hiddenProperty/fixupHiddenPropertiesTest.ts
@@ -1,4 +1,6 @@
 import { fixupHiddenProperties } from '../../lib/hiddenProperty/fixupHiddenProperties';
+import { HiddenPropertyOptions } from '../../lib/hiddenProperty/HiddenPropertyOptions';
+import { IEditor } from 'roosterjs-content-model-types';
 
 describe('fixupHiddenProperties', () => {
     it('should not throw an error when called', () => {
@@ -6,5 +8,47 @@ describe('fixupHiddenProperties', () => {
         const options: any = {}; // Mocked options object
 
         expect(() => fixupHiddenProperties(editor, options)).not.toThrow();
+    });
+});
+
+describe('fixupHiddenProperties with undeletableLinkChecker', () => {
+    it('should call checker for each element', () => {
+        const mockedNode1: HTMLElement = {
+            name: 'node1',
+        } as any;
+        const mockedNode2: HTMLElement = {
+            name: 'node2',
+        } as any;
+        const queryElementsSpy = jasmine
+            .createSpy('queryElements')
+            .and.returnValue([mockedNode1, mockedNode2]);
+        const editor: IEditor = {
+            getDOMHelper: () => {
+                return {
+                    queryElements: queryElementsSpy,
+                };
+            },
+        } as any;
+
+        const checker = jasmine.createSpy('checker').and.callFake((node: HTMLElement) => {
+            return (node as any).name === 'node1';
+        });
+        const options: HiddenPropertyOptions = {
+            undeletableLinkChecker: checker,
+        };
+
+        fixupHiddenProperties(editor, options);
+
+        expect(mockedNode1).toEqual({
+            name: 'node1',
+            __roosterjsHiddenProperty: { undeletable: true },
+        } as any);
+        expect(mockedNode2).toEqual({
+            name: 'node2',
+        } as any);
+        expect(queryElementsSpy).toHaveBeenCalledWith('a');
+        expect(checker).toHaveBeenCalledTimes(2);
+        expect(checker.calls.argsFor(0)).toEqual([mockedNode1]);
+        expect(checker.calls.argsFor(1)).toEqual([mockedNode2]);
     });
 });

--- a/packages/roosterjs-content-model-plugins/test/hiddenProperty/fixupHiddenPropertiesTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/hiddenProperty/fixupHiddenPropertiesTest.ts
@@ -1,0 +1,10 @@
+import { fixupHiddenProperties } from '../../lib/hiddenProperty/fixupHiddenProperties';
+
+describe('fixupHiddenProperties', () => {
+    it('should not throw an error when called', () => {
+        const editor: any = {}; // Mocked editor object
+        const options: any = {}; // Mocked options object
+
+        expect(() => fixupHiddenProperties(editor, options)).not.toThrow();
+    });
+});

--- a/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
@@ -1522,6 +1522,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                                 underline: true,
                                                 textColor: 'rgb(70, 120, 134)',
                                             },
+                                            link: {
+                                                format: { name: 'OLE_LINK3' },
+                                                dataset: {},
+                                            },
                                         },
                                     ],
                                     blockType: 'Paragraph',
@@ -1631,6 +1635,12 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                         underline: true,
                                         textColor: 'rgb(70, 120, 134)',
                                     },
+                                },
+                                {
+                                    text: '',
+                                    segmentType: 'Text',
+                                    format: { underline: true, textColor: 'rgb(70, 120, 134)' },
+                                    link: { format: { name: 'OLE_LINK2' }, dataset: {} },
                                 },
                             ],
                             blockType: 'Paragraph',
@@ -4271,6 +4281,10 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                             text: 'text',
                                             segmentType: 'Text',
                                             format: {},
+                                            link: {
+                                                format: { name: '_Hlk155259411' },
+                                                dataset: {},
+                                            },
                                         },
                                         {
                                             text: '.',

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelHyperLinkFormat.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelHyperLinkFormat.ts
@@ -7,6 +7,7 @@ import type { PaddingFormat } from './formatParts/PaddingFormat';
 import type { SizeFormat } from './formatParts/SizeFormat';
 import type { TextAlignFormat } from './formatParts/TextAlignFormat';
 import type { TextColorFormat } from './formatParts/TextColorFormat';
+import type { UndeletableFormat } from './formatParts/UndeletableFormat';
 import type { UnderlineFormat } from './formatParts/UnderlineFormat';
 
 /**
@@ -21,4 +22,5 @@ export type ContentModelHyperLinkFormat = LinkFormat &
     PaddingFormat &
     BorderFormat &
     SizeFormat &
-    TextAlignFormat;
+    TextAlignFormat &
+    UndeletableFormat;

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/FormatHandlerTypeMap.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/FormatHandlerTypeMap.ts
@@ -29,6 +29,7 @@ import type { TableLayoutFormat } from './formatParts/TableLayoutFormat';
 import type { TextAlignFormat } from './formatParts/TextAlignFormat';
 import type { TextColorFormat } from './formatParts/TextColorFormat';
 import type { TextIndentFormat } from './formatParts/TextIndentFormat';
+import type { UndeletableFormat } from './formatParts/UndeletableFormat';
 import type { UnderlineFormat } from './formatParts/UnderlineFormat';
 import type { VerticalAlignFormat } from './formatParts/VerticalAlignFormat';
 import type { WhiteSpaceFormat } from './formatParts/WhiteSpaceFormat';
@@ -202,6 +203,11 @@ export interface FormatHandlerTypeMap {
      * Format for TextIndentFormat
      */
     textIndent: TextIndentFormat;
+
+    /**
+     * Format for Undeletable link
+     */
+    undeletableLink: UndeletableFormat;
 
     /**
      * Format for UnderlineFormat

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/formatParts/UndeletableFormat.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/formatParts/UndeletableFormat.ts
@@ -1,0 +1,10 @@
+/**
+ * Format of undeletable segments
+ */
+export type UndeletableFormat = {
+    /**
+     * When set to true, this link is not allowed to be deleted by deleteSelection API.
+     * This is used to protect links that are not allowed to be deleted by user action.
+     */
+    undeletable?: boolean;
+};

--- a/packages/roosterjs-content-model-types/lib/index.ts
+++ b/packages/roosterjs-content-model-types/lib/index.ts
@@ -57,6 +57,7 @@ export { ListThreadFormat } from './contentModel/format/formatParts/ListThreadFo
 export { ListStyleFormat } from './contentModel/format/formatParts/ListStyleFormat';
 export { FloatFormat } from './contentModel/format/formatParts/FloatFormat';
 export { EntityInfoFormat } from './contentModel/format/formatParts/EntityInfoFormat';
+export { UndeletableFormat } from './contentModel/format/formatParts/UndeletableFormat';
 
 export { DatasetFormat, ReadonlyDatasetFormat } from './contentModel/format/metadata/DatasetFormat';
 export { TableMetadataFormat } from './contentModel/format/metadata/TableMetadataFormat';

--- a/packages/roosterjs-content-model-types/lib/parameter/DeleteSelectionStep.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/DeleteSelectionStep.ts
@@ -3,6 +3,7 @@ import type { DeleteResult } from '../enum/DeleteResult';
 import type { FormatContentModelContext } from './FormatContentModelContext';
 import type { InsertPoint } from '../selection/InsertPoint';
 import type { ReadonlyTableSelectionContext } from '../selection/TableSelectionContext';
+import type { ShallowMutableContentModelSegment } from '../contentModel/segment/ContentModelSegment';
 
 /**
  * Result of deleteSelection API
@@ -37,6 +38,12 @@ export interface DeleteSelectionContext extends DeleteSelectionResult {
      * Format context provided by formatContentModel API
      */
     formatContext?: FormatContentModelContext;
+
+    /**
+     * To store those undeletable segments whose paragraph is deleted.
+     * So at the end we can insert them back in to the remaining paragraph
+     */
+    undeletableSegments?: ShallowMutableContentModelSegment[];
 }
 
 /**


### PR DESCRIPTION
This is the first step to support undeletable anchor.

The final goal is to allow adding anchor such as and specify what kind of anchor is not deletable, then all editing function will not delete it.

This is the last step, I'm modifying code for deleting content to avoid deleting undeletable anchors. This includes:
1. When delete segment, make sure undeletable anchor is not removed from model
2. When delete selection, we can delete text content of anchor, but need to leave the text segment not deleted
3. When delete multiple lines, if there is undeletable anchor in middle of them, add them back after delete
4. When BACKSPACE between regular text and undeletable anchor, use content model code handle this deletion, because if delete using browser's behavior, if the anchor is empty, it will also be removed.

For 1-3, we read undeletable property from content model. For 4, in order to make it fast, we read undeletable property from DOM directly. This is the reason why we need to keep undeletable property into hidden property.