### PR TITLE
Find previously marked paragraph

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/createEditorContext/createEditorContext.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/createEditorContext/createEditorContext.ts
@@ -20,6 +20,7 @@ export const createEditorContext: CreateEditorContext = (core, saveIndex) => {
         domIndexer: saveIndex ? cache.domIndexer : undefined,
         zoomScale: domHelper.calculateZoomScale(),
         experimentalFeatures: core.experimentalFeatures ?? [],
+        paragraphMap: core.cache.paragraphMap,
         ...getRootComputedStyleForContext(logicalRoot.ownerDocument),
     };
 

--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -33,6 +33,7 @@ export const formatContentModel: FormatContentModel = (
         deletedEntities: [],
         rawEvent,
         newImages: [],
+        paragraphIndexer: core.cache.paragraphMap,
     };
 
     const hasFocus = core.domHelper.hasFocus();

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/CachePlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/CachePlugin.ts
@@ -1,4 +1,5 @@
 import { areSameSelections } from './areSameSelections';
+import { createParagraphMap } from './ParagraphMapImpl';
 import { createTextMutationObserver } from './textMutationObserver';
 import { DomIndexerImpl } from './domIndexerImpl';
 import { updateCache } from './updateCache';
@@ -32,6 +33,7 @@ class CachePlugin implements PluginWithState<CachePluginState> {
                           option.experimentalFeatures.indexOf('PersistCache') >= 0
                   ),
                   textMutationObserver: createTextMutationObserver(contentDiv, this.onMutation),
+                  paragraphMap: createParagraphMap(),
               };
     }
 
@@ -172,6 +174,10 @@ class CachePlugin implements PluginWithState<CachePluginState> {
         if (!this.editor?.isInShadowEdit()) {
             this.state.cachedModel = undefined;
             this.state.cachedSelection = undefined;
+
+            // Clear paragraph indexer to prevent stale references to old paragraphs
+            // It will be rebuild next time when we create a new Content Model
+            this.state.paragraphMap?.clear();
         }
     }
 

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/ParagraphMapImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/ParagraphMapImpl.ts
@@ -1,0 +1,101 @@
+import { getParagraphMarker, setParagraphMarker } from 'roosterjs-content-model-dom';
+import type {
+    ContentModelParagraph,
+    ContentModelParagraphCommon,
+    ParagraphIndexer,
+    ParagraphMap,
+    ReadonlyContentModelParagraph,
+} from 'roosterjs-content-model-types';
+
+interface ParagraphWithMarker extends ContentModelParagraphCommon {
+    _marker?: string;
+}
+
+/**
+ * @internal, used by test code only
+ */
+export interface ParagraphMapReset {
+    _reset(): void;
+    _getMap(): { [key: string]: ReadonlyContentModelParagraph };
+}
+
+const idPrefix = 'paragraph';
+
+class ParagraphMapImpl implements ParagraphMap, ParagraphIndexer, ParagraphMapReset {
+    private static prefixNum = 0;
+    private nextId = 0;
+    private paragraphMap: { [key: string]: ReadonlyContentModelParagraph } = {};
+
+    constructor() {
+        ParagraphMapImpl.prefixNum++;
+    }
+
+    assignMarkerToModel(element: HTMLElement, paragraph: ContentModelParagraph): void {
+        const marker = getParagraphMarker(element);
+        const paragraphWithMarker = paragraph as ParagraphWithMarker;
+
+        if (marker) {
+            paragraphWithMarker._marker = marker;
+
+            this.paragraphMap[marker] = paragraph;
+        } else {
+            paragraphWithMarker._marker = this.generateId();
+
+            this.applyMarkerToDom(element, paragraph);
+        }
+    }
+
+    applyMarkerToDom(element: HTMLElement, paragraph: ContentModelParagraph): void {
+        const paragraphWithMarker = paragraph as ParagraphWithMarker;
+
+        if (!paragraphWithMarker._marker) {
+            paragraphWithMarker._marker = this.generateId();
+        }
+
+        const marker = paragraphWithMarker._marker;
+
+        if (marker) {
+            setParagraphMarker(element, marker);
+
+            this.paragraphMap[marker] = paragraph;
+        }
+    }
+
+    /**
+     * Get paragraph using a previously marked paragraph
+     * @param markedParagraph The previously marked paragraph to get
+     */
+    getParagraphFromMarker(
+        markerParagraph: ReadonlyContentModelParagraph
+    ): ReadonlyContentModelParagraph | null {
+        const marker = (markerParagraph as ParagraphWithMarker)._marker;
+
+        return marker ? this.paragraphMap[marker] || null : null;
+    }
+
+    clear() {
+        this.paragraphMap = {};
+    }
+
+    //#region For test code only
+    _reset() {
+        ParagraphMapImpl.prefixNum = 0;
+        this.nextId = 0;
+    }
+
+    _getMap() {
+        return this.paragraphMap;
+    }
+    //#endregion
+
+    private generateId() {
+        return `${idPrefix}_${ParagraphMapImpl.prefixNum}_${this.nextId++}`;
+    }
+}
+
+/**
+ * @internal
+ */
+export function createParagraphMap(): ParagraphMap & ParagraphIndexer {
+    return new ParagraphMapImpl();
+}

--- a/packages/roosterjs-content-model-core/test/coreApi/createEditorContext/createEditorContextTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/createEditorContext/createEditorContextTest.ts
@@ -9,6 +9,7 @@ describe('createEditorContext', () => {
         const calculateZoomScaleSpy = jasmine.createSpy('calculateZoomScale').and.returnValue(1);
         const domIndexer = 'DOMINDEXER' as any;
         const isRtlSpy = jasmine.createSpy('isRtl');
+        const mockedParagraphMap = 'PARAMAP' as any;
 
         const div = {
             ownerDocument: {},
@@ -26,6 +27,7 @@ describe('createEditorContext', () => {
             darkColorHandler,
             cache: {
                 domIndexer: domIndexer,
+                paragraphMap: mockedParagraphMap,
             },
             domHelper: {
                 calculateZoomScale: calculateZoomScaleSpy,
@@ -46,6 +48,7 @@ describe('createEditorContext', () => {
             zoomScale: 1,
             rootFontSize: 16,
             experimentalFeatures: [],
+            paragraphMap: mockedParagraphMap,
         });
     });
 
@@ -56,6 +59,7 @@ describe('createEditorContext', () => {
         const calculateZoomScaleSpy = jasmine.createSpy('calculateZoomScale').and.returnValue(1);
         const isRtlSpy = jasmine.createSpy('isRtl');
         const domIndexer = 'DOMINDEXER' as any;
+        const mockedParagraphMap = 'PARAMAP' as any;
 
         const div = {
             ownerDocument: {},
@@ -73,6 +77,7 @@ describe('createEditorContext', () => {
             darkColorHandler,
             cache: {
                 domIndexer,
+                paragraphMap: mockedParagraphMap,
             },
             domHelper: {
                 calculateZoomScale: calculateZoomScaleSpy,
@@ -93,6 +98,7 @@ describe('createEditorContext', () => {
             zoomScale: 1,
             rootFontSize: 16,
             experimentalFeatures: [],
+            paragraphMap: mockedParagraphMap,
         });
     });
 
@@ -102,6 +108,7 @@ describe('createEditorContext', () => {
         const darkColorHandler = 'DARKHANDLER' as any;
         const mockedPendingFormat = 'PENDINGFORMAT' as any;
         const calculateZoomScaleSpy = jasmine.createSpy('calculateZoomScale').and.returnValue(1);
+        const mockedParagraphMap = 'PARAMAP' as any;
 
         const div = {
             ownerDocument: {},
@@ -118,7 +125,7 @@ describe('createEditorContext', () => {
                 pendingFormat: mockedPendingFormat,
             },
             darkColorHandler,
-            cache: {},
+            cache: { paragraphMap: mockedParagraphMap },
             domHelper: {
                 calculateZoomScale: calculateZoomScaleSpy,
                 isRightToLeft: jasmine.createSpy('isRtl'),
@@ -138,6 +145,7 @@ describe('createEditorContext', () => {
             zoomScale: 1,
             rootFontSize: 16,
             experimentalFeatures: [],
+            paragraphMap: mockedParagraphMap,
         });
     });
 
@@ -148,7 +156,7 @@ describe('createEditorContext', () => {
         const mockedPendingFormat = 'PENDINGFORMAT' as any;
         const calculateZoomScaleSpy = jasmine.createSpy('calculateZoomScale').and.returnValue(1);
         const isRtlSpy = jasmine.createSpy('isRtl');
-
+        const mockedParagraphMap = 'PARAMAP' as any;
         const div = {
             ownerDocument: {},
         };
@@ -165,7 +173,9 @@ describe('createEditorContext', () => {
                 pendingFormat: mockedPendingFormat,
             },
             darkColorHandler,
-            cache: {},
+            cache: {
+                paragraphMap: mockedParagraphMap,
+            },
             domHelper: {
                 calculateZoomScale: calculateZoomScaleSpy,
                 isRightToLeft: isRtlSpy,
@@ -185,6 +195,7 @@ describe('createEditorContext', () => {
             zoomScale: 1,
             rootFontSize: 16,
             experimentalFeatures: [],
+            paragraphMap: mockedParagraphMap,
         });
     });
 });
@@ -197,6 +208,7 @@ describe('createEditorContext - checkZoomScale', () => {
     const isDarkMode = 'DARKMODE' as any;
     const defaultFormat = 'DEFAULTFORMAT' as any;
     const darkColorHandler = 'DARKHANDLER' as any;
+    const mockedParagraphMap = 'PARAMAP' as any;
 
     beforeEach(() => {
         calculateZoomScaleSpy = jasmine.createSpy('calculateZoomScale');
@@ -215,7 +227,7 @@ describe('createEditorContext - checkZoomScale', () => {
                 defaultFormat,
             },
             darkColorHandler,
-            cache: {},
+            cache: { paragraphMap: mockedParagraphMap },
             domHelper: {
                 calculateZoomScale: calculateZoomScaleSpy,
                 isRightToLeft: isRtlSpy,
@@ -239,6 +251,7 @@ describe('createEditorContext - checkZoomScale', () => {
             pendingFormat: undefined,
             rootFontSize: 16,
             experimentalFeatures: [],
+            paragraphMap: mockedParagraphMap,
         });
     });
 });
@@ -251,6 +264,7 @@ describe('createEditorContext - checkRootDir', () => {
     const isDarkMode = 'DARKMODE' as any;
     const defaultFormat = 'DEFAULTFORMAT' as any;
     const darkColorHandler = 'DARKHANDLER' as any;
+    const mockedParagraphMap = 'PARAMAP' as any;
 
     beforeEach(() => {
         calculateZoomScaleSpy = jasmine.createSpy('calculateZoomScale').and.returnValue(1);
@@ -268,7 +282,9 @@ describe('createEditorContext - checkRootDir', () => {
                 defaultFormat,
             },
             darkColorHandler,
-            cache: {},
+            cache: {
+                paragraphMap: mockedParagraphMap,
+            },
             domHelper: {
                 calculateZoomScale: calculateZoomScaleSpy,
                 isRightToLeft: isRtlSpy,
@@ -291,6 +307,7 @@ describe('createEditorContext - checkRootDir', () => {
             zoomScale: 1,
             rootFontSize: 16,
             experimentalFeatures: [],
+            paragraphMap: mockedParagraphMap,
         });
     });
 
@@ -310,6 +327,7 @@ describe('createEditorContext - checkRootDir', () => {
             zoomScale: 1,
             rootFontSize: 16,
             experimentalFeatures: [],
+            paragraphMap: mockedParagraphMap,
         });
     });
 });

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -27,6 +27,7 @@ describe('formatContentModel', () => {
     const mockedContainer = 'C' as any;
     const mockedOffset = 'O' as any;
     const mockedSelection = 'Selection' as any;
+    const mockedParagraphMap = 'PARAMAP' as any;
 
     beforeEach(() => {
         mockedModel = ({} as any) as ContentModelDocument;
@@ -56,7 +57,9 @@ describe('formatContentModel', () => {
                 announce,
             },
             lifecycle: {},
-            cache: {},
+            cache: {
+                paragraphMap: mockedParagraphMap,
+            },
             undo: {
                 snapshotsManager: {},
             },
@@ -82,6 +85,7 @@ describe('formatContentModel', () => {
                 deletedEntities: [],
                 rawEvent: undefined,
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).not.toHaveBeenCalled();
@@ -100,6 +104,7 @@ describe('formatContentModel', () => {
                 deletedEntities: [],
                 rawEvent: undefined,
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).toHaveBeenCalledTimes(2);
@@ -137,6 +142,7 @@ describe('formatContentModel', () => {
                 rawEvent: undefined,
                 skipUndoSnapshot: true,
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).not.toHaveBeenCalled();
@@ -174,6 +180,7 @@ describe('formatContentModel', () => {
                 rawEvent: undefined,
                 skipUndoSnapshot: false,
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).toHaveBeenCalledTimes(2);
@@ -211,6 +218,7 @@ describe('formatContentModel', () => {
                 rawEvent: undefined,
                 skipUndoSnapshot: 'DoNotSkip',
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).toHaveBeenCalledTimes(2);
@@ -248,6 +256,7 @@ describe('formatContentModel', () => {
                 rawEvent: undefined,
                 skipUndoSnapshot: 'MarkNewContent',
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).toHaveBeenCalledTimes(0);
@@ -285,6 +294,7 @@ describe('formatContentModel', () => {
                 rawEvent: undefined,
                 skipUndoSnapshot: 'SkipAll',
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).toHaveBeenCalledTimes(0);
@@ -318,6 +328,7 @@ describe('formatContentModel', () => {
                 deletedEntities: [],
                 rawEvent: undefined,
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).toHaveBeenCalledWith(core, false, undefined);
@@ -359,6 +370,7 @@ describe('formatContentModel', () => {
                 rawEvent: undefined,
                 skipUndoSnapshot: true,
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).not.toHaveBeenCalled();
@@ -392,6 +404,7 @@ describe('formatContentModel', () => {
                 deletedEntities: [],
                 rawEvent: undefined,
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).toHaveBeenCalled();
@@ -696,6 +709,7 @@ describe('formatContentModel', () => {
             expect(core.cache).toEqual({
                 cachedModel: undefined,
                 cachedSelection: undefined,
+                paragraphMap: mockedParagraphMap,
             });
             expect(announce).not.toHaveBeenCalled();
         });
@@ -752,7 +766,9 @@ describe('formatContentModel', () => {
                 undefined
             );
             expect(triggerEvent).toHaveBeenCalled();
-            expect(core.cache).toEqual({});
+            expect(core.cache).toEqual({
+                paragraphMap: mockedParagraphMap,
+            });
         });
     });
 
@@ -1229,6 +1245,7 @@ describe('formatContentModel', () => {
                 deletedEntities: [],
                 rawEvent: undefined,
                 newImages: [],
+                paragraphIndexer: mockedParagraphMap,
             });
             expect(createContentModel).toHaveBeenCalledTimes(1);
             expect(addUndoSnapshot).toHaveBeenCalled();

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/CachePluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/CachePluginTest.ts
@@ -1,3 +1,4 @@
+import * as createParagraphMap from '../../../lib/corePlugin/cache/ParagraphMapImpl';
 import * as textMutationObserver from '../../../lib/corePlugin/cache/textMutationObserver';
 import { createCachePlugin } from '../../../lib/corePlugin/cache/CachePlugin';
 import { DomIndexerImpl } from '../../../lib/corePlugin/cache/domIndexerImpl';
@@ -8,6 +9,8 @@ import {
     IEditor,
     PluginWithState,
     EditorOptions,
+    ParagraphIndexer,
+    ParagraphMap,
 } from 'roosterjs-content-model-types';
 
 describe('CachePlugin', () => {
@@ -21,6 +24,18 @@ describe('CachePlugin', () => {
     let isInShadowEditSpy: jasmine.Spy;
     let domIndexer: DomIndexer;
     let contentDiv: HTMLDivElement;
+    let resetMapSpy: jasmine.Spy;
+    let mockedParagraphMap: ParagraphIndexer & ParagraphMap;
+
+    beforeEach(() => {
+        resetMapSpy = jasmine.createSpy('resetMapSpy');
+
+        mockedParagraphMap = {
+            clear: resetMapSpy,
+        } as any;
+
+        spyOn(createParagraphMap, 'createParagraphMap').and.returnValue(mockedParagraphMap);
+    });
 
     function init(option: EditorOptions) {
         addEventListenerSpy = jasmine.createSpy('addEventListenerSpy');
@@ -78,7 +93,9 @@ describe('CachePlugin', () => {
             expect(plugin.getState()).toEqual({
                 domIndexer: new DomIndexerImpl(),
                 textMutationObserver: mockedObserver,
+                paragraphMap: mockedParagraphMap,
             });
+            expect(resetMapSpy).not.toHaveBeenCalled();
             expect(startObservingSpy).toHaveBeenCalledTimes(1);
         });
     });
@@ -119,11 +136,13 @@ describe('CachePlugin', () => {
                 cachedSelection: undefined,
                 domIndexer: new DomIndexerImpl(),
                 textMutationObserver: mockedObserver,
+                paragraphMap: mockedParagraphMap,
             });
             expect(stopObservingSpy).toHaveBeenCalledTimes(1);
             expect(startObservingSpy).toHaveBeenCalledTimes(2);
             expect(textMutationObserverSpy).toHaveBeenCalledTimes(2);
             expect(textMutationObserverSpy.calls.argsFor(1)[0]).toBe(mockedNode);
+            expect(resetMapSpy).toHaveBeenCalledTimes(1);
 
             plugin.dispose();
         });
@@ -149,6 +168,7 @@ describe('CachePlugin', () => {
                 cachedModel: undefined,
                 cachedSelection: undefined,
             });
+            expect(resetMapSpy).not.toHaveBeenCalled();
         });
 
         it('Other key without selection', () => {
@@ -163,6 +183,7 @@ describe('CachePlugin', () => {
                 cachedModel: undefined,
                 cachedSelection: undefined,
             });
+            expect(resetMapSpy).not.toHaveBeenCalled();
         });
 
         it('Other key with collapsed selection', () => {
@@ -187,6 +208,7 @@ describe('CachePlugin', () => {
                 cachedModel: undefined,
                 cachedSelection: undefined,
             });
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
 
         it('Expanded selection with arrow input', () => {
@@ -210,6 +232,7 @@ describe('CachePlugin', () => {
                 cachedModel: undefined,
                 cachedSelection: undefined,
             });
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
 
         it('Do not clear cache when in shadow edit', () => {
@@ -224,6 +247,7 @@ describe('CachePlugin', () => {
             });
 
             expect(state).toEqual({});
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
     });
 
@@ -252,6 +276,7 @@ describe('CachePlugin', () => {
                 cachedModel: undefined,
                 cachedSelection: undefined,
             });
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
     });
 
@@ -286,6 +311,7 @@ describe('CachePlugin', () => {
                 domIndexer,
             });
             expect(reconcileSelectionSpy).not.toHaveBeenCalled();
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
 
         it('Different range', () => {
@@ -312,6 +338,7 @@ describe('CachePlugin', () => {
                 domIndexer,
             });
             expect(reconcileSelectionSpy).toHaveBeenCalledWith(model, newRangeEx, oldRangeEx);
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
 
         it('Different range and fail to reconcile', () => {
@@ -338,6 +365,7 @@ describe('CachePlugin', () => {
                 domIndexer,
             });
             expect(reconcileSelectionSpy).toHaveBeenCalledWith(model, newRangeEx, oldRangeEx);
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
     });
 
@@ -366,6 +394,7 @@ describe('CachePlugin', () => {
                 cachedSelection: undefined,
             });
             expect(reconcileSelectionSpy).not.toHaveBeenCalled();
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
 
         it('No domIndexer, has model in event', () => {
@@ -391,6 +420,7 @@ describe('CachePlugin', () => {
                 cachedSelection: undefined,
             });
             expect(reconcileSelectionSpy).not.toHaveBeenCalled();
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
 
         it('Has domIndexer, has model in event', () => {
@@ -418,6 +448,7 @@ describe('CachePlugin', () => {
                 domIndexer,
             });
             expect(reconcileSelectionSpy).not.toHaveBeenCalled();
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
     });
 
@@ -472,7 +503,9 @@ describe('CachePlugin', () => {
                 textMutationObserver: mockedObserver,
                 cachedModel: undefined,
                 cachedSelection: undefined,
+                paragraphMap: mockedParagraphMap,
             });
+            expect(resetMapSpy).toHaveBeenCalledTimes(1);
         });
 
         it('text, can reconcile', () => {
@@ -496,7 +529,9 @@ describe('CachePlugin', () => {
                 textMutationObserver: mockedObserver,
                 cachedModel: 'MODEL' as any,
                 cachedSelection: mockedSelection,
+                paragraphMap: mockedParagraphMap,
             });
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
 
         it('text, cannot reconcile', () => {
@@ -520,7 +555,9 @@ describe('CachePlugin', () => {
                 textMutationObserver: mockedObserver,
                 cachedModel: undefined,
                 cachedSelection: undefined,
+                paragraphMap: mockedParagraphMap,
             });
+            expect(resetMapSpy).toHaveBeenCalledTimes(1);
         });
 
         it('childList, cannot reconcile', () => {
@@ -549,7 +586,9 @@ describe('CachePlugin', () => {
                 textMutationObserver: mockedObserver,
                 cachedModel: undefined,
                 cachedSelection: undefined,
+                paragraphMap: mockedParagraphMap,
             });
+            expect(resetMapSpy).toHaveBeenCalledTimes(1);
         });
 
         it('childList, can reconcile', () => {
@@ -578,7 +617,9 @@ describe('CachePlugin', () => {
                 textMutationObserver: mockedObserver,
                 cachedModel: 'MODEL' as any,
                 cachedSelection: 'SELECTION' as any,
+                paragraphMap: mockedParagraphMap,
             });
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
 
         it('elementId, can reconcile', () => {
@@ -603,7 +644,9 @@ describe('CachePlugin', () => {
                 textMutationObserver: mockedObserver,
                 cachedModel: 'MODEL' as any,
                 cachedSelection: 'SELECTION' as any,
+                paragraphMap: mockedParagraphMap,
             });
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
         });
 
         it('elementId, cannot reconcile', () => {
@@ -628,7 +671,9 @@ describe('CachePlugin', () => {
                 textMutationObserver: mockedObserver,
                 cachedModel: undefined,
                 cachedSelection: undefined,
+                paragraphMap: mockedParagraphMap,
             });
+            expect(resetMapSpy).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/ParagraphMapImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/ParagraphMapImplTest.ts
@@ -1,0 +1,252 @@
+import { createParagraph } from 'roosterjs-content-model-dom';
+import {
+    ContentModelParagraph,
+    ParagraphIndexer,
+    ParagraphMap,
+} from 'roosterjs-content-model-types';
+import {
+    createParagraphMap,
+    ParagraphMapReset,
+} from '../../../lib/corePlugin/cache/ParagraphMapImpl';
+
+describe('ParagraphMapImpl', () => {
+    let map: ParagraphMap & ParagraphIndexer & ParagraphMapReset;
+
+    beforeEach(() => {
+        map = createParagraphMap() as ParagraphMap & ParagraphIndexer & ParagraphMapReset;
+
+        map._reset();
+    });
+
+    describe('assignMarkerToModel', () => {
+        it('no marker', () => {
+            const element = document.createElement('div');
+            const paragraph: ContentModelParagraph = {
+                blockType: 'Paragraph',
+                segments: [],
+                format: {},
+            };
+
+            map.assignMarkerToModel(element, paragraph);
+
+            expect((element as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'paragraph_0_0',
+            });
+            expect((paragraph as any)._marker).toBe('paragraph_0_0');
+            expect(map._getMap()).toEqual({
+                paragraph_0_0: paragraph,
+            });
+        });
+
+        it('element has marker', () => {
+            const element = document.createElement('div');
+            const paragraph: ContentModelParagraph = {
+                blockType: 'Paragraph',
+                segments: [],
+                format: {},
+            };
+            (element as any).__roosterjsHiddenProperty = {
+                paragraphMarker: 'testMarker',
+            };
+
+            map.assignMarkerToModel(element, paragraph);
+
+            expect((element as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'testMarker',
+            });
+            expect((paragraph as any)._marker).toBe('testMarker');
+            expect(map._getMap()).toEqual({
+                testMarker: paragraph,
+            });
+        });
+
+        it('multiple elements marker', () => {
+            const element1 = document.createElement('div');
+            const element2 = document.createElement('div');
+            const element3 = document.createElement('div');
+            const element4 = document.createElement('div');
+            const paragraph1 = createParagraph();
+            const paragraph2 = createParagraph();
+            const paragraph3 = createParagraph();
+            const paragraph4 = createParagraph();
+
+            (element2 as any).__roosterjsHiddenProperty = {
+                paragraphMarker: 'testMarker',
+            };
+            (paragraph4 as any)._marker = 'testMarker2';
+
+            map.assignMarkerToModel(element1, paragraph1);
+            map.assignMarkerToModel(element2, paragraph2);
+            map.assignMarkerToModel(element3, paragraph3);
+
+            const map2 = createParagraphMap();
+
+            map2.assignMarkerToModel(element4, paragraph4);
+
+            expect((element1 as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'paragraph_0_0',
+            });
+            expect((paragraph1 as any)._marker).toBe('paragraph_0_0');
+            expect((element2 as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'testMarker',
+            });
+            expect((paragraph2 as any)._marker).toBe('testMarker');
+            expect((element3 as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'paragraph_0_1',
+            });
+            expect((paragraph3 as any)._marker).toBe('paragraph_0_1');
+            expect((element4 as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'paragraph_1_0',
+            });
+            expect((paragraph4 as any)._marker).toBe('paragraph_1_0');
+            expect(map._getMap()).toEqual({
+                paragraph_0_0: paragraph1,
+                testMarker: paragraph2,
+                paragraph_0_1: paragraph3,
+            });
+            expect((map2 as ParagraphMap & ParagraphIndexer & ParagraphMapReset)._getMap()).toEqual(
+                {
+                    paragraph_1_0: paragraph4,
+                }
+            );
+        });
+    });
+
+    describe('applyMarkerToDom', () => {
+        it('no marker', () => {
+            const element = document.createElement('div');
+            const paragraph: ContentModelParagraph = {
+                blockType: 'Paragraph',
+                segments: [],
+                format: {},
+            };
+
+            map.applyMarkerToDom(element, paragraph);
+
+            expect((element as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'paragraph_0_0',
+            });
+            expect((paragraph as any)._marker).toBe('paragraph_0_0');
+            expect(map._getMap()).toEqual({
+                paragraph_0_0: paragraph,
+            });
+        });
+
+        it('element has marker', () => {
+            const element = document.createElement('div');
+            const paragraph: ContentModelParagraph = {
+                blockType: 'Paragraph',
+                segments: [],
+                format: {},
+            };
+            (paragraph as any)._marker = 'testMarker';
+
+            map.applyMarkerToDom(element, paragraph);
+
+            expect((element as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'testMarker',
+            });
+            expect((paragraph as any)._marker).toBe('testMarker');
+            expect(map._getMap()).toEqual({
+                testMarker: paragraph,
+            });
+        });
+
+        it('multiple elements marker', () => {
+            const element1 = document.createElement('div');
+            const element2 = document.createElement('div');
+            const element3 = document.createElement('div');
+            const element4 = document.createElement('div');
+            const paragraph1 = createParagraph();
+            const paragraph2 = createParagraph();
+            const paragraph3 = createParagraph();
+            const paragraph4 = createParagraph();
+
+            (paragraph2 as any)._marker = 'testMarker';
+            (element4 as any).__roosterjsHiddenProperty = {
+                paragraphMarker: 'testMarker',
+            };
+
+            map.applyMarkerToDom(element1, paragraph1);
+            map.applyMarkerToDom(element2, paragraph2);
+            map.applyMarkerToDom(element3, paragraph3);
+
+            const map2 = createParagraphMap();
+
+            map2.applyMarkerToDom(element4, paragraph4);
+
+            expect((element1 as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'paragraph_0_0',
+            });
+            expect((paragraph1 as any)._marker).toBe('paragraph_0_0');
+            expect((element2 as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'testMarker',
+            });
+            expect((paragraph2 as any)._marker).toBe('testMarker');
+            expect((element3 as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'paragraph_0_1',
+            });
+            expect((paragraph3 as any)._marker).toBe('paragraph_0_1');
+            expect((element4 as any).__roosterjsHiddenProperty).toEqual({
+                paragraphMarker: 'paragraph_1_0',
+            });
+            expect((paragraph4 as any)._marker).toBe('paragraph_1_0');
+            expect(map._getMap()).toEqual({
+                paragraph_0_0: paragraph1,
+                testMarker: paragraph2,
+                paragraph_0_1: paragraph3,
+            });
+            expect((map2 as ParagraphMap & ParagraphIndexer & ParagraphMapReset)._getMap()).toEqual(
+                {
+                    paragraph_1_0: paragraph4,
+                }
+            );
+        });
+    });
+
+    describe('getParagraphFromMarker', () => {
+        it('has the result', () => {
+            const mockedParagraph = 'MockedParagraph' as any;
+            map._getMap()['testMarker'] = mockedParagraph;
+
+            const paragraph = map.getParagraphFromMarker({
+                blockType: 'Paragraph',
+                segments: [],
+                format: {},
+                _marker: 'testMarker',
+            } as ContentModelParagraph);
+
+            expect(paragraph).toBe(mockedParagraph);
+        });
+
+        it('no result', () => {
+            const paragraph = map.getParagraphFromMarker({
+                blockType: 'Paragraph',
+                segments: [],
+                format: {},
+                _marker: 'testMarker',
+            } as ContentModelParagraph);
+
+            expect(paragraph).toBe(null);
+        });
+    });
+
+    describe('clear', () => {
+        it('should clear the map', () => {
+            const element = document.createElement('div');
+            const paragraph: ContentModelParagraph = {
+                blockType: 'Paragraph',
+                segments: [],
+                format: {},
+            };
+
+            map.assignMarkerToModel(element, paragraph);
+            expect(map._getMap()).toEqual({
+                paragraph_0_0: paragraph,
+            });
+
+            map.clear();
+            expect(map._getMap()).toEqual({});
+        });
+    });
+});

--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/blockProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/blockProcessor.ts
@@ -42,6 +42,8 @@ export function blockProcessor(
             decorator
         );
 
+        context.paragraphMap?.assignMarkerToModel(element, paragraph);
+
         addBlock(group, paragraph);
     }
 

--- a/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/hiddenProperty.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/hiddenProperty.ts
@@ -2,7 +2,11 @@
  * @internal
  */
 export interface HiddenProperty {
-    dummy?: {}; // Temp used by test, will be removed later
+    /**
+     * A marker string that can be used to identify a specific paragraph in the DOM.
+     * This is useful for scenarios where you need to track or manipulate specific paragraphs
+     */
+    paragraphMarker?: string;
 
     // TODO: Add more properties as needed
 }

--- a/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/paragraphMarker.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/hiddenProperties/paragraphMarker.ts
@@ -1,0 +1,15 @@
+import { getHiddenProperty, setHiddenProperty } from './hiddenProperty';
+
+/**
+ * Get paragraph marker from element. This is used to mark the end of a paragraph in a block element.
+ */
+export function getParagraphMarker(element: HTMLElement): string | undefined {
+    return getHiddenProperty(element, 'paragraphMarker');
+}
+
+/**
+ * Set paragraph marker to element. This is used to mark the end of a paragraph in a block element.
+ */
+export function setParagraphMarker(element: HTMLElement, marker: string): void {
+    setHiddenProperty(element, 'paragraphMarker', marker);
+}

--- a/packages/roosterjs-content-model-dom/lib/index.ts
+++ b/packages/roosterjs-content-model-dom/lib/index.ts
@@ -109,6 +109,10 @@ export { readFile } from './domUtils/readFile';
 export { transformColor } from './domUtils/style/transformColor';
 export { extractClipboardItems } from './domUtils/event/extractClipboardItems';
 export { cacheGetEventData } from './domUtils/event/cacheGetEventData';
+export {
+    setParagraphMarker,
+    getParagraphMarker,
+} from './domUtils/hiddenProperties/paragraphMarker';
 
 export { isBlockGroupOfType } from './modelApi/typeCheck/isBlockGroupOfType';
 

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
@@ -94,6 +94,8 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
                     formatOnWrapper,
                     context
                 );
+
+                context.paragraphMap?.applyMarkerToDom(container, paragraph);
             } else {
                 handleSegments();
             }

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/blockProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/blockProcessorTest.ts
@@ -12,22 +12,30 @@ describe('blockProcessor', () => {
     let context: DomToModelContext;
     let group: ContentModelDocument;
     let childSpy: jasmine.Spy;
+    let assignMarkerToModelSpy: jasmine.Spy;
 
     beforeEach(() => {
         group = createContentModelDocument();
         childSpy = jasmine.createSpy('child');
+
+        assignMarkerToModelSpy = jasmine.createSpy('assignMarkerToModel');
 
         context = createDomToModelContext(undefined, {
             processorOverride: {
                 child: childSpy,
             },
         });
+
+        context.paragraphMap = {
+            assignMarkerToModel: assignMarkerToModelSpy,
+        } as any;
     });
 
     function runTest(
         element: HTMLElement,
         expectedModel: ContentModelDocument,
         expectContextFormat: ContentModelBlockFormat,
+        paragraphMapCalledTimes: number,
         segmentFormat?: ContentModelSegmentFormat
     ) {
         blockProcessor(group, element, context, segmentFormat);
@@ -37,6 +45,8 @@ describe('blockProcessor', () => {
 
         expect(childSpy).toHaveBeenCalledTimes(1);
         expect(childSpy).toHaveBeenCalledWith(group, element, context);
+
+        expect(assignMarkerToModelSpy).toHaveBeenCalledTimes(paragraphMapCalledTimes);
     }
 
     it('empty DIV', () => {
@@ -54,7 +64,8 @@ describe('blockProcessor', () => {
                     },
                 ],
             },
-            {}
+            {},
+            1
         );
     });
 
@@ -82,7 +93,8 @@ describe('blockProcessor', () => {
                     },
                 ],
             },
-            {}
+            {},
+            1
         );
     });
 
@@ -105,7 +117,8 @@ describe('blockProcessor', () => {
                     },
                 ],
             },
-            { lineHeight: '2' }
+            { lineHeight: '2' },
+            1
         );
     });
 
@@ -130,7 +143,8 @@ describe('blockProcessor', () => {
                     },
                 ],
             },
-            { lineHeight: '2' }
+            { lineHeight: '2' },
+            1
         );
     });
 
@@ -157,7 +171,8 @@ describe('blockProcessor', () => {
                     },
                 ],
             },
-            { marginLeft: '60px', marginRight: '20px' }
+            { marginLeft: '60px', marginRight: '20px' },
+            1
         );
     });
 
@@ -170,7 +185,8 @@ describe('blockProcessor', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            {}
+            {},
+            0
         );
     });
 
@@ -191,6 +207,7 @@ describe('blockProcessor', () => {
                 ],
             },
             {},
+            1,
             {
                 fontSize: '20px',
             }

--- a/packages/roosterjs-content-model-dom/test/domUtils/hiddenProperties/paragraphMarkerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domUtils/hiddenProperties/paragraphMarkerTest.ts
@@ -1,0 +1,36 @@
+import {
+    setParagraphMarker,
+    getParagraphMarker,
+} from '../../../lib/domUtils/hiddenProperties/paragraphMarker';
+
+describe('setParagraphMarker', () => {
+    it('should set the property', () => {
+        const element = document.createElement('div');
+
+        setParagraphMarker(element, 'testMarker');
+
+        expect((element as any).__roosterjsHiddenProperty).toEqual({
+            paragraphMarker: 'testMarker',
+        });
+
+        setParagraphMarker(element, 'testMarker2');
+
+        expect((element as any).__roosterjsHiddenProperty).toEqual({
+            paragraphMarker: 'testMarker2',
+        });
+    });
+});
+
+describe('getParagraphMarker', () => {
+    it('should read value', () => {
+        const element = document.createElement('div');
+
+        expect(getParagraphMarker(element)).toBe(undefined);
+
+        (element as any).__roosterjsHiddenProperty = {
+            paragraphMarker: 'testMarker',
+        };
+
+        expect(getParagraphMarker(element)).toBe('testMarker');
+    });
+});

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleParagraphTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleParagraphTest.ts
@@ -19,10 +19,12 @@ describe('handleParagraph', () => {
     let parent: HTMLElement;
     let context: ModelToDomContext;
     let handleSegment: jasmine.Spy<ContentModelSegmentHandler<ContentModelSegment>>;
+    let applyMarkerToDomSpy: jasmine.Spy;
 
     beforeEach(() => {
         parent = document.createElement('div');
         handleSegment = jasmine.createSpy('handleSegment');
+        applyMarkerToDomSpy = jasmine.createSpy('applyMarkerToDom');
         context = createModelToDomContext(
             {
                 allowCacheElement: true,
@@ -33,18 +35,24 @@ describe('handleParagraph', () => {
                 },
             }
         );
+
+        context.paragraphMap = {
+            applyMarkerToDom: applyMarkerToDomSpy,
+        } as any;
     });
 
     function runTest(
         paragraph: ContentModelParagraph,
         expectedInnerHTML: string,
-        expectedCreateSegmentFromContentCalledTimes: number
+        expectedCreateSegmentFromContentCalledTimes: number,
+        applyMarkerToDomCalledTimes: number
     ) {
         handleParagraph(document, parent, paragraph, context, null);
 
         expect(parent.innerHTML).toBe(expectedInnerHTML);
         expect(handleSegment).toHaveBeenCalledTimes(expectedCreateSegmentFromContentCalledTimes);
         expect(paragraph.cachedElement).toBe((parent.firstChild as HTMLElement) || undefined);
+        expect(applyMarkerToDomSpy).toHaveBeenCalledTimes(applyMarkerToDomCalledTimes);
     }
 
     it('Handle empty explicit paragraph', () => {
@@ -55,7 +63,8 @@ describe('handleParagraph', () => {
                 format: {},
             },
             '<div></div>',
-            0
+            0,
+            1
         );
         expect(context.rewriteFromModel).toEqual({
             addedBlockElements: [parent.firstChild as HTMLElement],
@@ -72,6 +81,7 @@ describe('handleParagraph', () => {
                 format: {},
             },
             '',
+            0,
             0
         );
         expect(context.rewriteFromModel).toEqual({
@@ -93,6 +103,7 @@ describe('handleParagraph', () => {
                 format: {},
             },
             '<div></div>',
+            1,
             1
         );
 
@@ -123,7 +134,8 @@ describe('handleParagraph', () => {
                 format: {},
             },
             '',
-            1
+            1,
+            0
         );
 
         expect(handleSegment).toHaveBeenCalledWith(document, parent, segment, context, []);
@@ -154,7 +166,8 @@ describe('handleParagraph', () => {
                 format: {},
             },
             '<div></div>',
-            2
+            2,
+            1
         );
 
         expect(handleSegment).toHaveBeenCalledWith(
@@ -197,6 +210,7 @@ describe('handleParagraph', () => {
                 ],
             },
             '<p style="margin-top: 0px; margin-bottom: 0px;">test</p>',
+            1,
             1
         );
         expect(context.rewriteFromModel).toEqual({
@@ -225,6 +239,7 @@ describe('handleParagraph', () => {
                 ],
             },
             '<p>test</p>',
+            1,
             1
         );
         expect(context.rewriteFromModel).toEqual({
@@ -253,6 +268,7 @@ describe('handleParagraph', () => {
                 ],
             },
             '<h1>test</h1>',
+            1,
             1
         );
         expect(context.rewriteFromModel).toEqual({
@@ -281,6 +297,7 @@ describe('handleParagraph', () => {
                 ],
             },
             '<h1 style="font-size: 20px;">test</h1>',
+            1,
             1
         );
         expect(context.rewriteFromModel).toEqual({
@@ -309,6 +326,7 @@ describe('handleParagraph', () => {
                 ],
             },
             '<h1>test</h1>',
+            1,
             1
         );
         expect(context.rewriteFromModel).toEqual({
@@ -344,7 +362,8 @@ describe('handleParagraph', () => {
                 ],
             },
             '<h1>test 1<span style="font-weight: normal;">test 2</span></h1>',
-            2
+            2,
+            1
         );
         expect(context.rewriteFromModel).toEqual({
             addedBlockElements: [parent.firstChild as HTMLElement],
@@ -373,6 +392,7 @@ describe('handleParagraph', () => {
                 ],
             },
             '<h1><i>test</i></h1>',
+            1,
             1
         );
         expect(context.rewriteFromModel).toEqual({
@@ -400,6 +420,7 @@ describe('handleParagraph', () => {
                 ],
             },
             '<div style="text-align: center;">test</div>',
+            1,
             1
         );
         expect(context.rewriteFromModel).toEqual({
@@ -430,6 +451,7 @@ describe('handleParagraph', () => {
                 ],
             },
             '<h1>test</h1>',
+            1,
             1
         );
 

--- a/packages/roosterjs-content-model-types/lib/context/EditorContext.ts
+++ b/packages/roosterjs-content-model-types/lib/context/EditorContext.ts
@@ -2,6 +2,7 @@ import type { DarkColorHandler } from './DarkColorHandler';
 import type { DomIndexer } from './DomIndexer';
 import type { ContentModelSegmentFormat } from '../contentModel/format/ContentModelSegmentFormat';
 import type { PendingFormat } from '../pluginState/FormatPluginState';
+import type { ParagraphMap } from '../parameter/ParagraphMap';
 
 /**
  * An editor context interface used by ContentModel PAI
@@ -62,4 +63,9 @@ export interface EditorContext {
      * Enabled experimental features
      */
     experimentalFeatures?: ReadonlyArray<string>;
+
+    /**
+     * A helper class that manages a mapping from paragraph marker to paragraph object.
+     */
+    paragraphMap?: ParagraphMap;
 }

--- a/packages/roosterjs-content-model-types/lib/index.ts
+++ b/packages/roosterjs-content-model-types/lib/index.ts
@@ -453,6 +453,7 @@ export {
     ModelToTextChecker,
 } from './parameter/ModelToTextCallbacks';
 export { ConflictFormatSolution } from './parameter/ConflictFormatSolution';
+export { ParagraphMap, ParagraphIndexer } from './parameter/ParagraphMap';
 
 export { BasePluginEvent, BasePluginDomEvent } from './event/BasePluginEvent';
 export { BeforeCutCopyEvent } from './event/BeforeCutCopyEvent';

--- a/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelContext.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelContext.ts
@@ -4,6 +4,7 @@ import type { ContentModelImage } from '../contentModel/segment/ContentModelImag
 import type { ContentModelSegmentFormat } from '../contentModel/format/ContentModelSegmentFormat';
 import type { EntityRemovalOperation } from '../enum/EntityOperation';
 import type { ContentModelBlockFormat } from '../contentModel/format/ContentModelBlockFormat';
+import type { ParagraphIndexer } from './ParagraphMap';
 
 /**
  * State for an entity. This is used for storing entity undo snapshot
@@ -61,6 +62,11 @@ export interface FormatContentModelContext {
      * Images inserted in the editor that needs to have their size adjusted
      */
     readonly newImages: ContentModelImage[];
+
+    /**
+     * A helper class to help find paragraph from its marker
+     */
+    readonly paragraphIndexer?: ParagraphIndexer;
 
     /**
      * Raw Event that triggers this format call

--- a/packages/roosterjs-content-model-types/lib/parameter/ParagraphMap.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/ParagraphMap.ts
@@ -1,0 +1,44 @@
+import type {
+    ContentModelParagraph,
+    ReadonlyContentModelParagraph,
+} from '../contentModel/block/ContentModelParagraph';
+
+/**
+ * ParagraphMap is used to map a paragraph marker to a paragraph in the model.
+ */
+export interface ParagraphMap {
+    /**
+     * When create content model from DOM, assign a marker to a paragraph in the model.
+     * This marker is used to identify the paragraph in the model.
+     * If the DOM element does not have a marker, a new marker will be generated and assigned to the paragraph and write back to DOM.
+     * @param element The DOM element to assign marker to
+     * @param paragraph The paragraph in the model to assign marker to
+     */
+    assignMarkerToModel(element: HTMLElement, paragraph: ContentModelParagraph): void;
+
+    /**
+     * When create DOM elements from content model, assign a marker to a paragraph in the DOM.
+     * This marker is used to identify the paragraph in the model.
+     * @param element The DOM element to assign marker to
+     * @param paragraph The paragraph in the model to assign marker to
+     */
+    applyMarkerToDom(element: HTMLElement, paragraph: ContentModelParagraph): void;
+
+    /**
+     * Clear cached marker map
+     */
+    clear(): void;
+}
+
+/**
+ * A helper class to help find paragraph from its marker
+ */
+export interface ParagraphIndexer {
+    /**
+     * Get paragraph using a previously marked paragraph
+     * @param paragraphWithMarker The paragraph with marker to find
+     */
+    getParagraphFromMarker(
+        paragraphWithMarker: ReadonlyContentModelParagraph
+    ): ReadonlyContentModelParagraph | null;
+}

--- a/packages/roosterjs-content-model-types/lib/pluginState/CachePluginState.ts
+++ b/packages/roosterjs-content-model-types/lib/pluginState/CachePluginState.ts
@@ -7,6 +7,7 @@ import type {
     SelectionBase,
     TableSelection,
 } from '../selection/DOMSelection';
+import type { ParagraphIndexer, ParagraphMap } from '../parameter/ParagraphMap';
 
 /**
  * Represents a range selection used for cache. We store the start and end insert point here instead of range itself
@@ -48,6 +49,11 @@ export interface CachePluginState {
      * When reuse Content Model is allowed, we cache the Content Model object here after created
      */
     cachedModel?: ContentModelDocument;
+
+    /**
+     * A helper class that manages a mapping from paragraph marker to paragraph object.
+     */
+    paragraphMap?: ParagraphMap & ParagraphIndexer;
 
     /**
      * @optional Indexer for CachePlugin, to help build backward relationship from DOM node to Content Model


### PR DESCRIPTION
Sometimes we want to find a paragraph and then call some service or any other async call, then update the paragraph using the result. At this point there is no way to find back the paragraph since content model could be recreated.

So in this PR I'm adding a marker to paragraph in both content model and DOM, then allow caller to find latest paragraph model using a previous one. Here is an example how to use it:

```ts
let para: ReadonlyContentModelParagraph;

editor.formatContentModel(model => {
   para = getSelectedParagraphs(model)[0]; // Now store the paragraph here
   return false;
});

await someAsyncCall(); // This may take a long time, and content can be changed by user while it is waiting

editor.formatContentModel((model, context) => {
   if (para) {
      // use paragraphIndexer under `FormatContentModelContext` to get the latest paragraph
      const updatedPara = context.paragraphIndexer?.getParagraphFromMarker(para);

      // Now you can use updatedPara to do whatever you want
      const mutablePara = updatedPara && mutateBlock(updatePara);
     
     if (mutablePara) {
       // ...
       return true;
     }
   }

   // Updated paragraph not found, could be deleted by user, so no op
   return false;
});
```
  

