### PR TITLE
Do not enable paragraph map by default

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/CachePlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/CachePlugin.ts
@@ -25,16 +25,22 @@ class CachePlugin implements PluginWithState<CachePluginState> {
      * @param contentDiv The editor content DIV
      */
     constructor(option: EditorOptions, contentDiv: HTMLDivElement) {
-        this.state = option.disableCache
-            ? {}
-            : {
-                  domIndexer: new DomIndexerImpl(
-                      option.experimentalFeatures &&
-                          option.experimentalFeatures.indexOf('PersistCache') >= 0
-                  ),
-                  textMutationObserver: createTextMutationObserver(contentDiv, this.onMutation),
-                  paragraphMap: createParagraphMap(),
-              };
+        this.state = {};
+
+        if (!option.disableCache) {
+            this.state.domIndexer = new DomIndexerImpl(
+                option.experimentalFeatures &&
+                    option.experimentalFeatures.indexOf('PersistCache') >= 0
+            );
+            this.state.textMutationObserver = createTextMutationObserver(
+                contentDiv,
+                this.onMutation
+            );
+        }
+
+        if (option.enableParagraphMap) {
+            this.state.paragraphMap = createParagraphMap();
+        }
     }
 
     /**

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/CachePluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/CachePluginTest.ts
@@ -76,7 +76,7 @@ describe('CachePlugin', () => {
             expect(plugin.getState()).toEqual({});
         });
 
-        it('initialize with cache', () => {
+        it('initialize without paragraph map', () => {
             const startObservingSpy = jasmine.createSpy('startObserving');
             const stopObservingSpy = jasmine.createSpy('stopObserving');
             const mockedObserver = {
@@ -88,6 +88,29 @@ describe('CachePlugin', () => {
             );
             init({
                 disableCache: false,
+            });
+            expect(addEventListenerSpy).toHaveBeenCalledWith('selectionchange', jasmine.anything());
+            expect(plugin.getState()).toEqual({
+                domIndexer: new DomIndexerImpl(),
+                textMutationObserver: mockedObserver,
+            });
+            expect(resetMapSpy).not.toHaveBeenCalled();
+            expect(startObservingSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('initialize with cache and paragraph map', () => {
+            const startObservingSpy = jasmine.createSpy('startObserving');
+            const stopObservingSpy = jasmine.createSpy('stopObserving');
+            const mockedObserver = {
+                startObserving: startObservingSpy,
+                stopObserving: stopObservingSpy,
+            } as any;
+            spyOn(textMutationObserver, 'createTextMutationObserver').and.returnValue(
+                mockedObserver
+            );
+            init({
+                disableCache: false,
+                enableParagraphMap: true,
             });
             expect(addEventListenerSpy).toHaveBeenCalledWith('selectionchange', jasmine.anything());
             expect(plugin.getState()).toEqual({
@@ -115,7 +138,9 @@ describe('CachePlugin', () => {
                 'createTextMutationObserver'
             ).and.returnValue(mockedObserver);
 
-            init({});
+            init({
+                enableParagraphMap: true,
+            });
 
             const state = plugin.getState();
 
@@ -371,7 +396,7 @@ describe('CachePlugin', () => {
 
     describe('ContentChanged', () => {
         beforeEach(() => {
-            init({ disableCache: true });
+            init({ disableCache: true, enableParagraphMap: true });
         });
         afterEach(() => {
             plugin.dispose();
@@ -392,9 +417,10 @@ describe('CachePlugin', () => {
             expect(state).toEqual({
                 cachedModel: undefined,
                 cachedSelection: undefined,
+                paragraphMap: mockedParagraphMap,
             });
             expect(reconcileSelectionSpy).not.toHaveBeenCalled();
-            expect(resetMapSpy).toHaveBeenCalledTimes(0);
+            expect(resetMapSpy).toHaveBeenCalledTimes(1);
         });
 
         it('No domIndexer, has model in event', () => {
@@ -418,9 +444,10 @@ describe('CachePlugin', () => {
             expect(state).toEqual({
                 cachedModel: undefined,
                 cachedSelection: undefined,
+                paragraphMap: mockedParagraphMap,
             });
             expect(reconcileSelectionSpy).not.toHaveBeenCalled();
-            expect(resetMapSpy).toHaveBeenCalledTimes(0);
+            expect(resetMapSpy).toHaveBeenCalledTimes(1);
         });
 
         it('Has domIndexer, has model in event', () => {
@@ -446,6 +473,7 @@ describe('CachePlugin', () => {
                 cachedModel: model,
                 cachedSelection: newRangeEx,
                 domIndexer,
+                paragraphMap: mockedParagraphMap,
             });
             expect(reconcileSelectionSpy).not.toHaveBeenCalled();
             expect(resetMapSpy).toHaveBeenCalledTimes(0);
@@ -479,7 +507,7 @@ describe('CachePlugin', () => {
                 }
             );
 
-            init({});
+            init({ enableParagraphMap: true });
 
             mockedIndexer = {
                 reconcileSelection: reconcileSelectionSpy,

--- a/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/EditorOptions.ts
@@ -174,6 +174,12 @@ export interface EditorBaseOptions {
      * @returns A template string to announce, use placeholder such as "{0}" for variables if necessary
      */
     announcerStringGetter?: (key: KnownAnnounceStrings) => string;
+
+    /**
+     * Whether to enable paragraph map. Default value is false.
+     * Paragraph map is used to save a marker for paragraphs so it can be found even content is changed from a previous marked paragraph.
+     */
+    enableParagraphMap?: boolean;
 }
 
 /**


### PR DESCRIPTION
In a previous change (#2975 ) I added paragraph map feature. However I found that this has some side effect to test code that causes paragraph has a marker value which is order-sensitive. So in this change I'm adding an option for this feature and by default it is off.