### PR TITLE
Check selection for empty anchor

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/linkProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/linkProcessor.ts
@@ -27,13 +27,16 @@ export const linkProcessor: ElementProcessor<HTMLElement> = (group, element, con
 
             if (isAnchor && !element.firstChild) {
                 // Empty anchor, need to make sure it has some child in model
-                addSegment(
-                    group,
-                    createText('', context.segmentFormat, {
-                        dataset: context.link.dataset,
-                        format: context.link.format,
-                    })
-                );
+                const emptyText = createText('', context.segmentFormat, {
+                    dataset: context.link.dataset,
+                    format: context.link.format,
+                });
+
+                if (context.isInSelection) {
+                    emptyText.isSelected = true;
+                }
+
+                addSegment(group, emptyText);
             } else {
                 knownElementProcessor(group, element, context);
             }

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/linkProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/linkProcessorTest.ts
@@ -359,4 +359,79 @@ describe('linkProcessor', () => {
             dataset: {},
         });
     });
+
+    it('empty anchor', () => {
+        const group = createContentModelDocument();
+        const a = document.createElement('a');
+
+        a.name = 'name';
+
+        linkProcessor(group, a, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    isImplicit: true,
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            link: {
+                                format: { name: 'name' },
+                                dataset: {},
+                            },
+                            text: '',
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(context.link).toEqual({
+            format: {},
+            dataset: {},
+        });
+    });
+
+    it('selected empty anchor', () => {
+        const group = createContentModelDocument();
+        const a = document.createElement('a');
+
+        a.name = 'name';
+
+        context.isInSelection = true;
+
+        linkProcessor(group, a, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    isImplicit: true,
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            isSelected: true,
+                            link: {
+                                format: { name: 'name' },
+                                dataset: {},
+                            },
+                            text: '',
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(context.link).toEqual({
+            format: {},
+            dataset: {},
+        });
+    });
 });


### PR DESCRIPTION
In my previous pr (#2972 ) I added support to empty anchor. However a scenario is missed: if the empty anchor is in selection, we should also mark it as selected. So fix it in this PR.