### PR TITLE
Fix suffix check

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/retrieveModelFormatState.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/retrieveModelFormatState.ts
@@ -276,10 +276,13 @@ function mergeValue<K extends keyof ContentModelFormatState>(
 }
 
 function px2Pt(px: string) {
-    if (px && px.indexOf('px') == px.length - 2) {
-        // Edge may not handle the floating computing well which causes the calculated value is a little less than actual value
-        // So add 0.05 to fix it
-        return Math.round(parseFloat(px) * 75 + 0.05) / 100 + 'pt';
+    if (px) {
+        let index = px.indexOf('px');
+        if (index !== -1 && index === px.length - 2) {
+            // Edge may not handle the floating computing well which causes the calculated value to be a little less than the actual value
+            // So add 0.05 to fix it
+            return Math.round(parseFloat(px) * 75 + 0.05) / 100 + 'pt';
+        }
     }
     return px;
 }

--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/retrieveModelFormatState.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/retrieveModelFormatState.ts
@@ -277,7 +277,7 @@ function mergeValue<K extends keyof ContentModelFormatState>(
 
 function px2Pt(px: string) {
     if (px) {
-        let index = px.indexOf('px');
+        const index = px.indexOf('px');
         if (index !== -1 && index === px.length - 2) {
             // Edge may not handle the floating computing well which causes the calculated value to be a little less than the actual value
             // So add 0.05 to fix it


### PR DESCRIPTION
Fixes the suffix check in cases where to avoid situations where `px.indexOf('px')` might return -1 making the test pass in a wrong scenario.