### PR TITLE
Add Markdown Package to Rooster all package

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ There are also some extension packages to provide additional functionalities.
 1. [roosterjs-color-utils](https://microsoft.github.io/roosterjs/docs/modules/roosterjs_color_utils.html):
    Provide color transformation utility to make editor work under dark mode.
 
+2. [roosterjs-content-model-markdown](https://microsoft.github.io/roosterjs/docs/modules/roosterjs_content_model_types.html):
+   Defines public APIs to enable conversions between Markdown and ContentModel
+
 To be compatible with old (8.\*) versions, you can use `EditorAdapter` class from the following package which can act as a 8.\* Editor:
 
 1. [roosterjs-editor-adapter](https://microsoft.github.io/roosterjs/docs/modules/roosterjs_editor_adapter.html):

--- a/packages/roosterjs/lib/index.ts
+++ b/packages/roosterjs/lib/index.ts
@@ -5,3 +5,4 @@ export * from 'roosterjs-content-model-core';
 export * from 'roosterjs-content-model-api';
 export * from 'roosterjs-content-model-plugins';
 export * from 'roosterjs-color-utils';
+export * from 'roosterjs-content-model-markdown';

--- a/packages/roosterjs/package.json
+++ b/packages/roosterjs/package.json
@@ -8,7 +8,8 @@
         "roosterjs-content-model-core": "",
         "roosterjs-content-model-api": "",
         "roosterjs-content-model-plugins": "",
-        "roosterjs-color-utils": ""
+        "roosterjs-color-utils": "",
+        "roosterjs-content-model-markdown": ""
     },
     "version": "0.0.0",
     "main": "./lib/index.ts"

--- a/tools/reference.md
+++ b/tools/reference.md
@@ -35,6 +35,9 @@ There are also some extension packages to provide additional functionalities.
 1. [roosterjs-color-utils](modules/roosterjs_color_utils.html):
    Provide color transformation utility to make editor work under dark mode.
 
+2. [roosterjs-content-model-markdown](https://microsoft.github.io/roosterjs/docs/modules/roosterjs_content_model_types.html):
+   Defines public APIs to enable conversions between Markdown and ContentModel
+
 To be compatible with old (8.\*) versions, you can use `EditorAdapter` class from the following package which can act as a 8.\* Editor:
 
 1. [roosterjs-editor-adapter](modules/roosterjs_editor_adapter.html):

--- a/tools/tsconfig.doc.json
+++ b/tools/tsconfig.doc.json
@@ -26,6 +26,7 @@
             "../packages/roosterjs-content-model-dom/lib/index.ts",
             "../packages/roosterjs-content-model-core/lib/index.ts",
             "../packages/roosterjs-content-model-api/lib/index.ts",
+            "../packages/roosterjs-content-model-markdown/lib/index.ts",
             "../packages/roosterjs-content-model-plugins/lib/index.ts",
             "../packages/roosterjs-editor-adapter/lib/index.ts",
             "../packages/roosterjs/lib/index.ts"


### PR DESCRIPTION
Add new `roosterjs-content-model-markdown` package to the `rooster` package. Then when build rooster package, the markdown conversion APIs will be included fixing the Rooster Demo Site. 