### PR TITLE
Prevent Enter on crop

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -269,7 +269,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                 }
                 this.cleanInfo();
             } else {
-                if (event.rawEvent.key == 'Enter') {
+                if (event.rawEvent.key == 'Enter' && this.isCropMode) {
                     event.rawEvent.preventDefault();
                 }
                 this.applyFormatWithContentModel(
@@ -657,6 +657,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
             this.editor.focus(); // Safari will keep the selection when click crop, then the focus() call should not be called
         }
         const selection = this.editor.getDOMSelection();
+
         if (selection?.type == 'image') {
             this.applyFormatWithContentModel(
                 this.editor,

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -269,6 +269,9 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                 }
                 this.cleanInfo();
             } else {
+                if (event.rawEvent.key == 'Enter') {
+                    event.rawEvent.preventDefault();
+                }
                 this.applyFormatWithContentModel(
                     editor,
                     this.isCropMode,

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -190,6 +190,35 @@ describe('ImageEditPlugin', () => {
         plugin.dispose();
     });
 
+    it('keyDown - ENTER - CROP', () => {
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
+        };
+        const plugin = new TestPlugin();
+        plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        const image = createImage('');
+        const paragraph = createParagraph();
+        paragraph.segments.push(image);
+        plugin.cropImage();
+        const preventDefaultSpy = jasmine.createSpy('preventDefault');
+        plugin.onPluginEvent({
+            eventType: 'keyDown',
+            rawEvent: {
+                key: 'Enter',
+                target: mockedImage,
+                preventDefault: preventDefaultSpy,
+            } as any,
+        });
+        expect(preventDefaultSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(2);
+        plugin.dispose();
+    });
+
     it('keyDown - DELETE', () => {
         const mockedImage = {
             getAttribute: getAttributeSpy,


### PR DESCRIPTION
In OWA, pressing the Enter key while editing an image in crop mode used to remove the image. To prevent this, a check was implemented to stop the default behavior of the Enter key in crop mode.
![preventCrop](https://github.com/user-attachments/assets/aa032690-3b92-45fd-8861-28fbdb7e50e7)
