### PR TITLE
Crop image in context menu

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -104,7 +104,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         this.disposer = editor.attachDomEvent({
             blur: {
                 beforeDispatch: () => {
-                    if (this.editor) {
+                    if (this.editor && this.imageEditInfo) {
                         this.applyFormatWithContentModel(
                             this.editor,
                             this.isCropMode,
@@ -219,7 +219,8 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         if (
             this.isEditing &&
             this.isImageSelection(event.rawEvent.target as Node) &&
-            event.rawEvent.button !== MouseRightButton
+            event.rawEvent.button !== MouseRightButton &&
+            !this.isCropMode
         ) {
             this.applyFormatWithContentModel(
                 editor,

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -524,6 +524,32 @@ describe('ImageEditPlugin', () => {
         plugin.dispose();
     });
 
+    it('mouseDown  on crop mode', () => {
+        const target = {
+            contains: () => true,
+        };
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
+        };
+        const plugin = new TestPlugin();
+        plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        plugin.cropImage();
+        plugin.onPluginEvent({
+            eventType: 'mouseDown',
+            rawEvent: {
+                button: 0,
+                target: target,
+            } as any,
+        });
+        expect(formatContentModelSpy).toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
+        plugin.dispose();
+    });
+
     it('dragImage', () => {
         const mockedImage = {
             id: 'image_0',

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -200,9 +200,6 @@ describe('ImageEditPlugin', () => {
             type: 'image',
             image: mockedImage,
         });
-        const image = createImage('');
-        const paragraph = createParagraph();
-        paragraph.segments.push(image);
         plugin.cropImage();
         const preventDefaultSpy = jasmine.createSpy('preventDefault');
         plugin.onPluginEvent({


### PR DESCRIPTION
When cropping an image do not handle mouse down event, since the user can click at the overlay of the cropped image making image be edited twice and lose the correct selection. Also verify if there is an image being edited before applying the format when the editor loses focus. 

Before: 
![ContextMenuCropBug](https://github.com/user-attachments/assets/5ad84479-7afd-4838-8586-f5b77fc6e2b1)

After: 
![ContextMenuCropFix](https://github.com/user-attachments/assets/cafa6c06-10df-4530-a3bc-a89b5ffdf36f)
