### PR TITLE
Remove default style from P list

### DIFF
--- a/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
@@ -4,7 +4,9 @@ import { expectEqual } from '../e2e/testUtils';
 import { processPastedContentFromWordDesktop } from '../../../lib/paste/WordDesktop/processPastedContentFromWordDesktop';
 import { WordMetadata } from '../../../lib/paste/WordDesktop/WordMetadata';
 import {
+    contentModelToDom,
     createDomToModelContext,
+    createModelToDomContext,
     domToContentModel,
     moveChildNodes,
 } from 'roosterjs-content-model-dom';
@@ -44,6 +46,12 @@ describe('processPastedContentFromWordDesktopTest', () => {
                 expect(model).toEqual(expectedModel);
             }
         }
+
+        const div = document.createElement('div');
+        contentModelToDom(document, div, model, createModelToDomContext());
+
+        document.body.appendChild(div);
+        document.body.removeChild(div);
     }
 
     it('Remove Comment | mso-element:comment-list', () => {
@@ -334,10 +342,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             isSelected: false,
                             format: {},
                         },
-                        format: {
-                            marginTop: '1em',
-                            marginBottom: '1em',
-                        },
+                        format: {},
                     },
                     {
                         blockType: 'BlockGroup',
@@ -426,10 +431,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             isSelected: false,
                             format: {},
                         },
-                        format: {
-                            marginTop: '1em',
-                            marginBottom: '1em',
-                        },
+                        format: {},
                     },
                     {
                         blockType: 'BlockGroup',
@@ -527,10 +529,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             isSelected: false,
                             format: {},
                         },
-                        format: {
-                            marginTop: '1em',
-                            marginBottom: '1em',
-                        },
+                        format: {},
                     },
                     {
                         blockType: 'BlockGroup',
@@ -635,10 +634,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             isSelected: false,
                             format: {},
                         },
-                        format: {
-                            marginTop: '1em',
-                            marginBottom: '1em',
-                        },
+                        format: {},
                     },
                     {
                         blockType: 'BlockGroup',
@@ -792,7 +788,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                                     isSelected: false,
                                                     format: {},
                                                 },
-                                                format: { marginTop: '1em', marginBottom: '1em' },
+                                                format: {},
                                             },
                                             {
                                                 blockType: 'BlockGroup',
@@ -845,7 +841,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                                     isSelected: false,
                                                     format: {},
                                                 },
-                                                format: { marginTop: '1em', marginBottom: '1em' },
+                                                format: {},
                                             },
                                             {
                                                 blockType: 'BlockGroup',
@@ -889,7 +885,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                                     isSelected: false,
                                                     format: {},
                                                 },
-                                                format: { marginTop: '1em', marginBottom: '1em' },
+                                                format: {},
                                             },
                                             {
                                                 blockType: 'BlockGroup',
@@ -960,7 +956,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                                     isSelected: false,
                                                     format: {},
                                                 },
-                                                format: { marginTop: '1em', marginBottom: '1em' },
+                                                format: {},
                                             },
                                         ],
                                         format: {},
@@ -1138,8 +1134,6 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             ],
                             blockType: 'BlockGroup',
                             format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
                                 marginLeft: '1.5in',
                             },
                             blockGroupType: 'ListItem',
@@ -1403,7 +1397,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 isSelected: false,
                                 format: {},
                             },
-                            format: { marginTop: '1em', marginBottom: '1em' },
+                            format: {},
                         },
                         {
                             blockType: 'BlockGroup',
@@ -1439,7 +1433,7 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 isSelected: false,
                                 format: {},
                             },
-                            format: { marginTop: '1em', marginBottom: '1em' },
+                            format: {},
                         },
                     ],
                 }
@@ -1487,11 +1481,34 @@ describe('processPastedContentFromWordDesktopTest', () => {
                     blockGroupType: 'Document',
                     blocks: [
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: '123123',
+                                            format: {
+                                                underline: true,
+                                                textColor: 'rgb(70, 120, 134)',
+                                            },
+                                            link: {
+                                                format: {
+                                                    name: 'OLE_LINK3',
+                                                },
+                                                dataset: {},
+                                            },
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                    segmentFormat: {
+                                        textColor: 'rgb(70, 120, 134)',
+                                    },
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -1505,43 +1522,38 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
-                                marginTop: '1em',
                                 marginBottom: '0in',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: '123123',
                                             segmentType: 'Text',
+                                            text: '123123',
                                             format: {
                                                 underline: true,
                                                 textColor: 'rgb(70, 120, 134)',
                                             },
-                                            link: {
-                                                format: { name: 'OLE_LINK3' },
-                                                dataset: {},
-                                            },
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                     segmentFormat: {
                                         textColor: 'rgb(70, 120, 134)',
                                     },
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -1554,39 +1566,38 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
-                                marginTop: '1em',
                                 marginBottom: '0in',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: '123123',
                                             segmentType: 'Text',
+                                            text: '123123',
                                             format: {
                                                 underline: true,
                                                 textColor: 'rgb(70, 120, 134)',
                                             },
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                     segmentFormat: {
                                         textColor: 'rgb(70, 120, 134)',
                                     },
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -1599,51 +1610,41 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
-                                marginTop: '1em',
                                 marginBottom: '0in',
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: '123123',
-                                            segmentType: 'Text',
-                                            format: {
-                                                underline: true,
-                                                textColor: 'rgb(70, 120, 134)',
-                                            },
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                    segmentFormat: {
-                                        textColor: 'rgb(70, 120, 134)',
-                                    },
-                                },
-                            ],
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: '123123123',
                                     segmentType: 'Text',
+                                    text: '123123123',
                                     format: {
                                         underline: true,
                                         textColor: 'rgb(70, 120, 134)',
                                     },
                                 },
                                 {
-                                    text: '',
                                     segmentType: 'Text',
-                                    format: { underline: true, textColor: 'rgb(70, 120, 134)' },
-                                    link: { format: { name: 'OLE_LINK2' }, dataset: {} },
+                                    text: '',
+                                    format: {
+                                        underline: true,
+                                        textColor: 'rgb(70, 120, 134)',
+                                    },
+                                    link: {
+                                        format: {
+                                            name: 'OLE_LINK2',
+                                        },
+                                        dataset: {},
+                                    },
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '0in',
@@ -1654,11 +1655,28 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: '123123',
+                                            format: {
+                                                underline: true,
+                                                textColor: 'rgb(70, 120, 134)',
+                                            },
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                    segmentFormat: {
+                                        textColor: 'rgb(70, 120, 134)',
+                                    },
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -1672,39 +1690,38 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
-                                marginTop: '1em',
                                 marginBottom: '0in',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: '123123',
                                             segmentType: 'Text',
+                                            text: '12123',
                                             format: {
                                                 underline: true,
                                                 textColor: 'rgb(70, 120, 134)',
                                             },
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                     segmentFormat: {
                                         textColor: 'rgb(70, 120, 134)',
                                     },
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -1717,45 +1734,27 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
-                                marginTop: '1em',
                                 marginBottom: '0in',
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: '12123',
-                                            segmentType: 'Text',
-                                            format: {
-                                                underline: true,
-                                                textColor: 'rgb(70, 120, 134)',
-                                            },
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                    segmentFormat: {
-                                        textColor: 'rgb(70, 120, 134)',
-                                    },
-                                },
-                            ],
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: ' ',
                                     segmentType: 'Text',
+                                    text: ' ',
                                     format: {
                                         fontSize: '11pt',
                                         lineHeight: '116%',
                                     },
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '0in',
@@ -1766,14 +1765,14 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: ' ',
                                     segmentType: 'Text',
+                                    text: ' ',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -1784,11 +1783,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: '123',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -1802,33 +1812,30 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
+                            format: {},
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: '123',
                                             segmentType: 'Text',
+                                            text: ' ',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -1841,33 +1848,30 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
+                            format: {},
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: ' ',
                                             segmentType: 'Text',
+                                            text: '123',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -1881,33 +1885,30 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
+                            format: {},
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: '123',
                                             segmentType: 'Text',
+                                            text: ' ',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -1920,36 +1921,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: ' ',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
+                            format: {},
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: ' ',
                                     segmentType: 'Text',
+                                    text: ' ',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -1960,11 +1947,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: '123',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -1978,33 +1976,30 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
+                            format: {},
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: '123',
                                             segmentType: 'Text',
+                                            text: ' ',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -2017,36 +2012,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: ' ',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
+                            format: {},
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: ' ',
                                     segmentType: 'Text',
+                                    text: ' ',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -2057,11 +2038,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: '123',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -2075,33 +2067,30 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
+                            format: {},
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: '123',
                                             segmentType: 'Text',
+                                            text: ' ',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -2114,36 +2103,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: ' ',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
+                            format: {},
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: ' ',
                                     segmentType: 'Text',
+                                    text: ' ',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -2154,11 +2129,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: '123',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -2172,33 +2158,30 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
+                            format: {},
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: '123',
                                             segmentType: 'Text',
+                                            text: ' ',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -2211,36 +2194,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: ' ',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
+                            format: {},
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: ' ',
                                     segmentType: 'Text',
+                                    text: ' ',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -2251,51 +2220,59 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
-                            levels: [
-                                {
-                                    listType: 'OL',
-                                    format: {
-                                        marginTop: '1em',
-                                        wordList: 'l9',
-                                        startNumberOverride: 1,
-                                    },
-                                    dataset: {
-                                        editingInfo: '{"orderedStyleType":1}',
-                                    },
-                                },
-                            ],
                             blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
-                            },
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
+                                            segmentType: 'Text',
                                             text: '123',
-                                            segmentType: 'Text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
+                            levels: [
+                                {
+                                    listType: 'OL',
+                                    format: {
+                                        marginTop: '1em',
+                                        wordList: 'l9',
+                                        startNumberOverride: 1,
+                                    },
+                                    dataset: {
+                                        editingInfo: '{"orderedStyleType":1}',
+                                    },
+                                },
+                            ],
                             formatHolder: {
-                                isSelected: false,
                                 segmentType: 'SelectionMarker',
+                                isSelected: false,
                                 format: {},
                             },
+                            format: {},
+                        },
+                        {
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: ' ',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -2308,36 +2285,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: ' ',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
+                            format: {},
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: ' ',
                                     segmentType: 'Text',
+                                    text: ' ',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -2348,51 +2311,59 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
-                            levels: [
-                                {
-                                    listType: 'OL',
-                                    format: {
-                                        marginTop: '1em',
-                                        wordList: 'l3',
-                                        startNumberOverride: 1,
-                                    },
-                                    dataset: {
-                                        editingInfo: '{"orderedStyleType":13}',
-                                    },
-                                },
-                            ],
                             blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
-                            },
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
+                                            segmentType: 'Text',
                                             text: 'Asd',
-                                            segmentType: 'Text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
+                            levels: [
+                                {
+                                    listType: 'OL',
+                                    format: {
+                                        marginTop: '1em',
+                                        wordList: 'l3',
+                                        startNumberOverride: 1,
+                                    },
+                                    dataset: {
+                                        editingInfo: '{"orderedStyleType":13}',
+                                    },
+                                },
+                            ],
                             formatHolder: {
-                                isSelected: false,
                                 segmentType: 'SelectionMarker',
+                                isSelected: false,
                                 format: {},
                             },
+                            format: {},
+                        },
+                        {
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: ' ',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -2405,36 +2376,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: ' ',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
+                            format: {},
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: ' ',
                                     segmentType: 'Text',
+                                    text: ' ',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -2445,11 +2402,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: 'Asd',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -2463,26 +2431,12 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: 'Asd',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
+                            format: {},
                         },
                     ],
                 },
@@ -4223,21 +4177,20 @@ describe('processPastedContentFromWordDesktopTest', () => {
         it('Multiple lists with the same mso-list', () => {
             const htmlBefore =
                 '<html xmlns:o="urn:schemas-microsoft-com:office:office"\r\nxmlns:w="urn:schemas-microsoft-com:office:word"\r\nxmlns:m="http://schemas.microsoft.com/office/2004/12/omml"\r\nxmlns="http://www.w3.org/TR/REC-html40">\r\n\r\n<head>\r\n<meta http-equiv=Content-Type content="text/html; charset=utf-8">\r\n<meta name=ProgId content=Word.Document>\r\n<meta name=Generator content="Microsoft Word 15">\r\n<meta name=Originator content="Microsoft Word 15">\r\n<link rel=File-List\r\nhref="file:///C:/Users/BVALVE~1/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">\r\n\x3C!--[if gte mso 9]><xml>\r\n <o:OfficeDocumentSettings>\r\n  <o:AllowPNG/>\r\n </o:OfficeDocumentSettings>\r\n</xml><![endif]-->\r\n<link rel=themeData\r\nhref="file:///C:/Users/BVALVE~1/AppData/Local/Temp/msohtmlclip1/01/clip_themedata.thmx">\r\n<link rel=colorSchemeMapping\r\nhref="file:///C:/Users/BVALVE~1/AppData/Local/Temp/msohtmlclip1/01/clip_colorschememapping.xml">\r\n\x3C!--[if gte mso 9]><xml>\r\n <w:WordDocument>\r\n  <w:View>Normal</w:View>\r\n  <w:Zoom>0</w:Zoom>\r\n  <w:TrackMoves/>\r\n  <w:TrackFormatting/>\r\n  <w:PunctuationKerning/>\r\n  <w:ValidateAgainstSchemas/>\r\n  <w:SaveIfXMLInvalid>false</w:SaveIfXMLInvalid>\r\n  <w:IgnoreMixedContent>false</w:IgnoreMixedContent>\r\n  <w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>\r\n  <w:DoNotPromoteQF/>\r\n  <w:LidThemeOther>EN-US</w:LidThemeOther>\r\n  <w:LidThemeAsian>JA</w:LidThemeAsian>\r\n  <w:LidThemeComplexScript>X-NONE</w:LidThemeComplexScript>\r\n  <w:Compatibility>\r\n   <w:BreakWrappedTables/>\r\n   <w:SnapToGridInCell/>\r\n   <w:WrapTextWithPunct/>\r\n   <w:UseAsianBreakRules/>\r\n   <w:DontGrowAutofit/>\r\n   <w:SplitPgBreakAndParaMark/>\r\n   <w:EnableOpenTypeKerning/>\r\n   <w:DontFlipMirrorIndents/>\r\n   <w:OverrideTableStyleHps/>\r\n  </w:Compatibility>\r\n  <m:mathPr>\r\n   <m:mathFont m:val="Cambria Math"/>\r\n   <m:brkBin m:val="before"/>\r\n   <m:brkBinSub m:val="&#45;-"/>\r\n   <m:smallFrac m:val="off"/>\r\n   <m:dispDef/>\r\n   <m:lMargin m:val="0"/>\r\n   <m:rMargin m:val="0"/>\r\n   <m:defJc m:val="centerGroup"/>\r\n   <m:wrapIndent m:val="1440"/>\r\n   <m:intLim m:val="subSup"/>\r\n   <m:naryLim m:val="undOvr"/>\r\n  </m:mathPr></w:WordDocument>\r\n</xml><![endif]-->\x3C!--[if gte mso 9]><xml>\r\n <w:LatentStyles DefLockedState="false" DefUnhideWhenUsed="false"\r\n  DefSemiHidden="false" DefQFormat="false" DefPriority="99"\r\n  LatentStyleCount="376">\r\n  <w:LsdException Locked="false" Priority="0" QFormat="true" Name="Normal"/>\r\n  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 1"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 2"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 3"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 4"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 5"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 6"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 7"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 8"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 9"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 6"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 7"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 8"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 9"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 1"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 2"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 3"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 4"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 5"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 6"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 7"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 8"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 9"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Normal Indent"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="footnote text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="annotation text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="header"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="footer"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index heading"/>\r\n  <w:LsdException Locked="false" Priority="35" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="caption"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="table of figures"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="envelope address"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="envelope return"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="footnote reference"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="annotation reference"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="line number"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="page number"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="endnote reference"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="endnote text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="table of authorities"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="macro"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="toa heading"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Bullet"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Number"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Bullet 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Bullet 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Bullet 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Bullet 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Number 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Number 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Number 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Number 5"/>\r\n  <w:LsdException Locked="false" Priority="10" QFormat="true" Name="Title"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Closing"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Signature"/>\r\n  <w:LsdException Locked="false" Priority="1" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="Default Paragraph Font"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text Indent"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Continue"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Continue 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Continue 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Continue 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Continue 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Message Header"/>\r\n  <w:LsdException Locked="false" Priority="11" QFormat="true" Name="Subtitle"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Salutation"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Date"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text First Indent"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text First Indent 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Note Heading"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text Indent 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text Indent 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Block Text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Hyperlink"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="FollowedHyperlink"/>\r\n  <w:LsdException Locked="false" Priority="22" QFormat="true" Name="Strong"/>\r\n  <w:LsdException Locked="false" Priority="20" QFormat="true" Name="Emphasis"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Document Map"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Plain Text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="E-mail Signature"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Top of Form"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Bottom of Form"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Normal (Web)"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Acronym"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Address"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Cite"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Code"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Definition"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Keyboard"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Preformatted"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Sample"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Typewriter"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Variable"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Normal Table"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="annotation subject"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="No List"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Outline List 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Outline List 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Outline List 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Simple 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Simple 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Simple 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Classic 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Classic 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Classic 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Classic 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Colorful 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Colorful 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Colorful 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Columns 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Columns 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Columns 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Columns 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Columns 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 6"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 7"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 8"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 6"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 7"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 8"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table 3D effects 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table 3D effects 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table 3D effects 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Contemporary"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Elegant"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Professional"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Subtle 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Subtle 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Web 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Web 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Web 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Balloon Text"/>\r\n  <w:LsdException Locked="false" Priority="39" Name="Table Grid"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Theme"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" Name="Placeholder Text"/>\r\n  <w:LsdException Locked="false" Priority="1" QFormat="true" Name="No Spacing"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" Name="Revision"/>\r\n  <w:LsdException Locked="false" Priority="34" QFormat="true"\r\n   Name="List Paragraph"/>\r\n  <w:LsdException Locked="false" Priority="29" QFormat="true" Name="Quote"/>\r\n  <w:LsdException Locked="false" Priority="30" QFormat="true"\r\n   Name="Intense Quote"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="19" QFormat="true"\r\n   Name="Subtle Emphasis"/>\r\n  <w:LsdException Locked="false" Priority="21" QFormat="true"\r\n   Name="Intense Emphasis"/>\r\n  <w:LsdException Locked="false" Priority="31" QFormat="true"\r\n   Name="Subtle Reference"/>\r\n  <w:LsdException Locked="false" Priority="32" QFormat="true"\r\n   Name="Intense Reference"/>\r\n  <w:LsdException Locked="false" Priority="33" QFormat="true" Name="Book Title"/>\r\n  <w:LsdException Locked="false" Priority="37" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="Bibliography"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="TOC Heading"/>\r\n  <w:LsdException Locked="false" Priority="41" Name="Plain Table 1"/>\r\n  <w:LsdException Locked="false" Priority="42" Name="Plain Table 2"/>\r\n  <w:LsdException Locked="false" Priority="43" Name="Plain Table 3"/>\r\n  <w:LsdException Locked="false" Priority="44" Name="Plain Table 4"/>\r\n  <w:LsdException Locked="false" Priority="45" Name="Plain Table 5"/>\r\n  <w:LsdException Locked="false" Priority="40" Name="Grid Table Light"/>\r\n  <w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark"/>\r\n  <w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful"/>\r\n  <w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="46" Name="List Table 1 Light"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark"/>\r\n  <w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful"/>\r\n  <w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 6"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Mention"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Smart Hyperlink"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Hashtag"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Unresolved Mention"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Smart Link"/>\r\n </w:LatentStyles>\r\n</xml><![endif]-->\r\n<style>\r\n\x3C!--\r\n /* Font Definitions */\r\n @font-face\r\n\t{font-family:"Cambria Math";\r\n\tpanose-1:2 4 5 3 5 4 6 3 2 4;\r\n\tmso-font-charset:0;\r\n\tmso-generic-font-family:roman;\r\n\tmso-font-pitch:variable;\r\n\tmso-font-signature:-536869121 1107305727 33554432 0 415 0;}\r\n@font-face\r\n\t{font-family:Calibri;\r\n\tpanose-1:2 15 5 2 2 2 4 3 2 4;\r\n\tmso-font-charset:0;\r\n\tmso-generic-font-family:swiss;\r\n\tmso-font-pitch:variable;\r\n\tmso-font-signature:-469750017 -1040178053 9 0 511 0;}\r\n@font-face\r\n\t{font-family:"Yu Gothic Light";\r\n\tpanose-1:2 11 3 0 0 0 0 0 0 0;\r\n\tmso-font-alt:"游ゴシック Light";\r\n\tmso-font-charset:128;\r\n\tmso-generic-font-family:swiss;\r\n\tmso-font-pitch:variable;\r\n\tmso-font-signature:-536870145 717749759 22 0 131231 0;}\r\n@font-face\r\n\t{font-family:"Aptos Display";\r\n\tmso-font-charset:0;\r\n\tmso-generic-font-family:swiss;\r\n\tmso-font-pitch:variable;\r\n\tmso-font-signature:536871559 3 0 0 415 0;}\r\n@font-face\r\n\t{font-family:Aptos;\r\n\tmso-font-charset:0;\r\n\tmso-generic-font-family:swiss;\r\n\tmso-font-pitch:variable;\r\n\tmso-font-signature:536871559 3 0 0 415 0;}\r\n@font-face\r\n\t{font-family:"\\@Yu Gothic Light";\r\n\tmso-font-charset:128;\r\n\tmso-generic-font-family:swiss;\r\n\tmso-font-pitch:variable;\r\n\tmso-font-signature:-536870145 717749759 22 0 131231 0;}\r\n /* Style Definitions */\r\n p.MsoNormal, li.MsoNormal, div.MsoNormal\r\n\t{mso-style-unhide:no;\r\n\tmso-style-qformat:yes;\r\n\tmso-style-parent:"";\r\n\tmargin:0in;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-bidi-font-family:Calibri;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;}\r\nh2\r\n\t{mso-style-noshow:yes;\r\n\tmso-style-priority:9;\r\n\tmso-style-qformat:yes;\r\n\tmso-style-link:"Heading 2 Char";\r\n\tmso-style-next:Normal;\r\n\tmargin-top:8.0pt;\r\n\tmargin-right:0in;\r\n\tmargin-bottom:4.0pt;\r\n\tmargin-left:0in;\r\n\tmso-pagination:widow-orphan lines-together;\r\n\tpage-break-after:avoid;\r\n\tmso-outline-level:2;\r\n\tfont-size:16.0pt;\r\n\tfont-family:"Aptos Display",sans-serif;\r\n\tmso-ascii-font-family:"Aptos Display";\r\n\tmso-ascii-theme-font:major-latin;\r\n\tmso-fareast-font-family:"Yu Gothic Light";\r\n\tmso-fareast-theme-font:major-fareast;\r\n\tmso-hansi-font-family:"Aptos Display";\r\n\tmso-hansi-theme-font:major-latin;\r\n\tmso-bidi-font-family:"Times New Roman";\r\n\tmso-bidi-theme-font:major-bidi;\r\n\tcolor:#0F4761;\r\n\tmso-themecolor:accent1;\r\n\tmso-themeshade:191;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;\r\n\tfont-weight:normal;}\r\np.MsoListParagraph, li.MsoListParagraph, div.MsoListParagraph\r\n\t{mso-style-priority:34;\r\n\tmso-style-unhide:no;\r\n\tmso-style-qformat:yes;\r\n\tmargin-top:0in;\r\n\tmargin-right:0in;\r\n\tmargin-bottom:0in;\r\n\tmargin-left:.5in;\r\n\tmso-add-space:auto;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-bidi-font-family:Calibri;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;}\r\np.MsoListParagraphCxSpFirst, li.MsoListParagraphCxSpFirst, div.MsoListParagraphCxSpFirst\r\n\t{mso-style-priority:34;\r\n\tmso-style-unhide:no;\r\n\tmso-style-qformat:yes;\r\n\tmso-style-type:export-only;\r\n\tmargin-top:0in;\r\n\tmargin-right:0in;\r\n\tmargin-bottom:0in;\r\n\tmargin-left:.5in;\r\n\tmso-add-space:auto;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-bidi-font-family:Calibri;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;}\r\np.MsoListParagraphCxSpMiddle, li.MsoListParagraphCxSpMiddle, div.MsoListParagraphCxSpMiddle\r\n\t{mso-style-priority:34;\r\n\tmso-style-unhide:no;\r\n\tmso-style-qformat:yes;\r\n\tmso-style-type:export-only;\r\n\tmargin-top:0in;\r\n\tmargin-right:0in;\r\n\tmargin-bottom:0in;\r\n\tmargin-left:.5in;\r\n\tmso-add-space:auto;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-bidi-font-family:Calibri;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;}\r\np.MsoListParagraphCxSpLast, li.MsoListParagraphCxSpLast, div.MsoListParagraphCxSpLast\r\n\t{mso-style-priority:34;\r\n\tmso-style-unhide:no;\r\n\tmso-style-qformat:yes;\r\n\tmso-style-type:export-only;\r\n\tmargin-top:0in;\r\n\tmargin-right:0in;\r\n\tmargin-bottom:0in;\r\n\tmargin-left:.5in;\r\n\tmso-add-space:auto;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-bidi-font-family:Calibri;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;}\r\nspan.Heading2Char\r\n\t{mso-style-name:"Heading 2 Char";\r\n\tmso-style-noshow:yes;\r\n\tmso-style-priority:9;\r\n\tmso-style-unhide:no;\r\n\tmso-style-locked:yes;\r\n\tmso-style-link:"Heading 2";\r\n\tmso-ansi-font-size:16.0pt;\r\n\tmso-bidi-font-size:16.0pt;\r\n\tfont-family:"Aptos Display",sans-serif;\r\n\tmso-ascii-font-family:"Aptos Display";\r\n\tmso-ascii-theme-font:major-latin;\r\n\tmso-fareast-font-family:"Yu Gothic Light";\r\n\tmso-fareast-theme-font:major-fareast;\r\n\tmso-hansi-font-family:"Aptos Display";\r\n\tmso-hansi-theme-font:major-latin;\r\n\tmso-bidi-font-family:"Times New Roman";\r\n\tmso-bidi-theme-font:major-bidi;\r\n\tcolor:#0F4761;\r\n\tmso-themecolor:accent1;\r\n\tmso-themeshade:191;\r\n\tmso-ligatures:standardcontextual;}\r\n.MsoChpDefault\r\n\t{mso-style-type:export-only;\r\n\tmso-default-props:yes;\r\n\tfont-size:11.0pt;\r\n\tmso-ansi-font-size:11.0pt;\r\n\tmso-bidi-font-size:11.0pt;\r\n\tmso-ascii-font-family:Aptos;\r\n\tmso-ascii-theme-font:minor-latin;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-hansi-font-family:Aptos;\r\n\tmso-hansi-theme-font:minor-latin;\r\n\tmso-bidi-font-family:"Times New Roman";\r\n\tmso-bidi-theme-font:minor-bidi;\r\n\tmso-font-kerning:0pt;\r\n\tmso-ligatures:none;\r\n\tmso-fareast-language:EN-US;}\r\n.MsoPapDefault\r\n\t{mso-style-type:export-only;\r\n\tmargin-bottom:8.0pt;\r\n\tline-height:107%;}\r\n@page WordSection1\r\n\t{size:8.5in 11.0in;\r\n\tmargin:1.0in 1.0in 1.0in 1.0in;\r\n\tmso-header-margin:.5in;\r\n\tmso-footer-margin:.5in;\r\n\tmso-paper-source:0;}\r\ndiv.WordSection1\r\n\t{page:WordSection1;}\r\n /* List Definitions */\r\n @list l0\r\n\t{mso-list-id:549808783;\r\n\tmso-list-type:hybrid;\r\n\tmso-list-template-ids:1093052914 -1 -1 -1 -1 -1 -1 -1 -1 -1;}\r\n@list l0:level1\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level2\r\n\t{mso-level-number-format:bullet;\r\n\tmso-level-text:o;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;\r\n\tfont-family:"Courier New";}\r\n@list l0:level3\r\n\t{mso-level-number-format:bullet;\r\n\tmso-level-text:;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-9.0pt;}\r\n@list l0:level4\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level5\r\n\t{mso-level-number-format:alpha-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level6\r\n\t{mso-level-number-format:roman-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:right;\r\n\ttext-indent:-9.0pt;}\r\n@list l0:level7\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level8\r\n\t{mso-level-number-format:alpha-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level9\r\n\t{mso-level-number-format:roman-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:right;\r\n\ttext-indent:-9.0pt;}\r\n@list l1\r\n\t{mso-list-id:1013996735;\r\n\tmso-list-type:hybrid;\r\n\tmso-list-template-ids:-278866806 -1 -1 67698691 -1 -1 -1 -1 -1 -1;}\r\n@list l1:level1\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l1:level2\r\n\t{mso-level-number-format:bullet;\r\n\tmso-level-text:o;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;\r\n\tfont-family:"Courier New";}\r\n@list l1:level3\r\n\t{mso-level-number-format:bullet;\r\n\tmso-level-text:o;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\tmargin-left:117.0pt;\r\n\ttext-indent:-.25in;\r\n\tfont-family:"Courier New";}\r\n@list l1:level4\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l1:level5\r\n\t{mso-level-number-format:alpha-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l1:level6\r\n\t{mso-level-number-format:roman-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:right;\r\n\ttext-indent:-9.0pt;}\r\n@list l1:level7\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l1:level8\r\n\t{mso-level-number-format:alpha-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l1:level9\r\n\t{mso-level-number-format:roman-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:right;\r\n\ttext-indent:-9.0pt;}\r\n@list l2\r\n\t{mso-list-id:1164933178;\r\n\tmso-list-type:hybrid;\r\n\tmso-list-template-ids:1093052914 249174394 67698691 317858228 -2144320658 1223965924 1127282332 1569479866 -583509990 843376116;}\r\n@list l2:level1\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l2:level2\r\n\t{mso-level-number-format:bullet;\r\n\tmso-level-text:o;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;\r\n\tfont-family:"Courier New";}\r\n@list l2:level3\r\n\t{mso-level-number-format:bullet;\r\n\tmso-level-text:;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-9.0pt;}\r\n@list l2:level4\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l2:level5\r\n\t{mso-level-number-format:alpha-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l2:level6\r\n\t{mso-level-number-format:roman-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:right;\r\n\ttext-indent:-9.0pt;}\r\n@list l2:level7\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l2:level8\r\n\t{mso-level-number-format:alpha-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l2:level9\r\n\t{mso-level-number-format:roman-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:right;\r\n\ttext-indent:-9.0pt;}\r\nol\r\n\t{margin-bottom:0in;}\r\nul\r\n\t{margin-bottom:0in;}\r\n-->\r\n</style>\r\n\x3C!--[if gte mso 10]>\r\n<style>\r\n /* Style Definitions */\r\n table.MsoNormalTable\r\n\t{mso-style-name:"Table Normal";\r\n\tmso-tstyle-rowband-size:0;\r\n\tmso-tstyle-colband-size:0;\r\n\tmso-style-noshow:yes;\r\n\tmso-style-priority:99;\r\n\tmso-style-parent:"";\r\n\tmso-padding-alt:0in 5.4pt 0in 5.4pt;\r\n\tmso-para-margin-top:0in;\r\n\tmso-para-margin-right:0in;\r\n\tmso-para-margin-bottom:8.0pt;\r\n\tmso-para-margin-left:0in;\r\n\tline-height:107%;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-ascii-font-family:Aptos;\r\n\tmso-ascii-theme-font:minor-latin;\r\n\tmso-hansi-font-family:Aptos;\r\n\tmso-hansi-theme-font:minor-latin;\r\n\tmso-fareast-language:EN-US;}\r\n</style>\r\n<![endif]-->\r\n</head>\r\n\r\n<body lang=EN-US style="tab-interval:.5in;word-wrap:break-word">\r\n';
-
             runTest(
                 '\r\n\r\n<h2>Text<b><o:p></o:p></b></h2>\r\n\r\n<p class=MsoListParagraphCxSpFirst style="margin-bottom:8.0pt;mso-add-space:\r\nauto;text-indent:-.25in;line-height:107%;mso-list:l2 level1 lfo1"><a\r\nname="_Hlk155259411"><![if !supportLists]><span style="mso-fareast-font-family:\r\nAptos;mso-bidi-font-family:Aptos"><span style="mso-list:Ignore">1.<span\r\nstyle="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]>text</a>.<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-bottom:8.0pt;mso-add-space:\r\nauto;text-indent:-.25in;line-height:107%;mso-list:l2 level1 lfo1"><![if !supportLists]><span\r\nstyle="mso-fareast-font-family:Aptos;mso-bidi-font-family:Aptos"><span\r\nstyle="mso-list:Ignore">2.<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span></span></span><![endif]>text<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-top:0in;margin-right:0in;\r\nmargin-bottom:8.0pt;margin-left:1.0in;mso-add-space:auto;text-indent:-.25in;\r\nline-height:107%;mso-list:l2 level2 lfo1"><![if !supportLists]><span\r\nstyle="font-family:"Courier New";mso-fareast-font-family:"Courier New""><span\r\nstyle="mso-list:Ignore">o<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;\r\n</span></span></span><![endif]>text <o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-bottom:8.0pt;mso-add-space:\r\nauto;text-indent:-.25in;line-height:107%;mso-list:l2 level1 lfo1"><![if !supportLists]><span\r\nstyle="mso-fareast-font-family:Aptos;mso-bidi-font-family:Aptos"><span\r\nstyle="mso-list:Ignore">3.<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span></span></span><![endif]>text<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-top:0in;margin-right:0in;\r\nmargin-bottom:8.0pt;margin-left:1.0in;mso-add-space:auto;text-indent:-.25in;\r\nline-height:107%;mso-list:l2 level2 lfo1"><![if !supportLists]><span\r\nstyle="font-family:"Courier New";mso-fareast-font-family:"Courier New""><span\r\nstyle="mso-list:Ignore">o<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;\r\n</span></span></span><![endif]>text<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-top:0in;margin-right:0in;\r\nmargin-bottom:8.0pt;margin-left:117.0pt;mso-add-space:auto;text-indent:-.25in;\r\nline-height:107%;mso-list:l1 level3 lfo2"><![if !supportLists]><span\r\nstyle="font-family:"Courier New";mso-fareast-font-family:"Courier New""><span\r\nstyle="mso-list:Ignore">o<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;\r\n</span></span></span><![endif]>text <o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-bottom:8.0pt;mso-add-space:\r\nauto;text-indent:-.25in;line-height:107%;mso-list:l2 level1 lfo1"><![if !supportLists]><span\r\nstyle="mso-fareast-font-family:Aptos;mso-bidi-font-family:Aptos"><span\r\nstyle="mso-list:Ignore">4.<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span></span></span><![endif]>text<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpLast style="margin-top:0in;margin-right:0in;\r\nmargin-bottom:8.0pt;margin-left:1.0in;mso-add-space:auto;text-indent:-.25in;\r\nline-height:107%;mso-list:l2 level2 lfo1"><![if !supportLists]><span\r\nstyle="font-family:"Courier New";mso-fareast-font-family:"Courier New""><span\r\nstyle="mso-list:Ignore">o<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;\r\n</span></span></span><![endif]>text<o:p></o:p></p>\r\n\r\n<p class=MsoNormal><span style="font-size:16.0pt;font-family:"Aptos Display",sans-serif;\r\nmso-ascii-theme-font:major-latin;mso-fareast-font-family:"Yu Gothic Light";\r\nmso-fareast-theme-font:major-fareast;mso-hansi-theme-font:major-latin;\r\nmso-bidi-font-family:"Times New Roman";mso-bidi-theme-font:major-bidi;\r\ncolor:#0F4761;mso-themecolor:accent1;mso-themeshade:191">Text<o:p></o:p></span></p>\r\n\r\n<p class=MsoNormal>text<o:p></o:p></p>\r\n\r\n<p class=MsoNormal>text<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpFirst style="margin-bottom:8.0pt;mso-add-space:\r\nauto;text-indent:-.25in;line-height:107%;mso-list:l0 level1 lfo3"><![if !supportLists]><span\r\nstyle="font-family:"Calibri",sans-serif;mso-fareast-font-family:Calibri"><span\r\nstyle="mso-list:Ignore">1.<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span></span></span><![endif]>text<span style="font-family:"Calibri",sans-serif;\r\nmso-fareast-font-family:Calibri"><o:p></o:p></span></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-top:0in;margin-right:0in;\r\nmargin-bottom:8.0pt;margin-left:1.0in;mso-add-space:auto;text-indent:-.25in;\r\nline-height:105%;mso-list:l0 level2 lfo3"><![if !supportLists]><span\r\nstyle="font-family:"Courier New";mso-fareast-font-family:"Courier New""><span\r\nstyle="mso-list:Ignore">o<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;\r\n</span></span></span><![endif]>text<span style="font-family:"Calibri",sans-serif;\r\nmso-fareast-font-family:Calibri"><o:p></o:p></span></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-bottom:8.0pt;mso-add-space:\r\nauto;text-indent:-.25in;line-height:105%;mso-list:l0 level1 lfo3"><![if !supportLists]><span\r\nstyle="font-family:"Calibri",sans-serif;mso-fareast-font-family:Calibri"><span\r\nstyle="mso-list:Ignore">2.<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span></span></span><![endif]>text<span style="font-family:"Calibri",sans-serif;\r\nmso-fareast-font-family:Calibri"><o:p></o:p></span></p>\r\n\r\n<p class=MsoListParagraphCxSpLast style="margin-top:0in;margin-right:0in;\r\nmargin-bottom:8.0pt;margin-left:1.0in;mso-add-space:auto;text-indent:-.25in;\r\nline-height:105%;mso-list:l0 level2 lfo3"><![if !supportLists]><span\r\nstyle="font-family:"Courier New";mso-fareast-font-family:"Courier New""><span\r\nstyle="mso-list:Ignore">o<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;\r\n</span></span></span><![endif]>text<span style="mso-spacerun:yes">  </span><o:p></o:p></p>\r\n\r\n',
                 {
                     blockGroupType: 'Document',
                     blocks: [
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: 'Text',
                                     segmentType: 'Text',
+                                    text: 'Text',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {},
                             decorator: {
                                 tagName: 'h2',
@@ -4248,11 +4201,33 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: 'text',
+                                            format: {},
+                                            link: {
+                                                format: {
+                                                    name: '_Hlk155259411',
+                                                },
+                                                dataset: {},
+                                            },
+                                        },
+                                        {
+                                            segmentType: 'Text',
+                                            text: '.',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -4266,43 +4241,33 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
                                 lineHeight: '107%',
-                                marginTop: '1em',
                                 marginBottom: '8pt',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
+                                            segmentType: 'Text',
                                             text: 'text',
-                                            segmentType: 'Text',
-                                            format: {},
-                                            link: {
-                                                format: { name: '_Hlk155259411' },
-                                                dataset: {},
-                                            },
-                                        },
-                                        {
-                                            text: '.',
-                                            segmentType: 'Text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -4315,126 +4280,33 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
                                 lineHeight: '107%',
-                                marginTop: '1em',
                                 marginBottom: '8pt',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: 'text',
                                             segmentType: 'Text',
+                                            text: 'text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
-                                },
-                            ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
-                            levels: [
-                                {
-                                    listType: 'OL',
-                                    format: {
-                                        marginTop: '1em',
-                                        wordList: 'l2',
-                                    },
-                                    dataset: {
-                                        editingInfo: '{"orderedStyleType":1}',
-                                    },
-                                },
-                                {
-                                    listType: 'UL',
-                                    format: {
-                                        marginTop: '0in',
-                                        marginRight: '0in',
-                                        paddingLeft: '0px',
-                                        wordList: 'l2',
-                                    },
-                                    dataset: {},
-                                },
-                            ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                lineHeight: '107%',
-                                marginTop: '0in',
-                                marginRight: '0in',
-                                marginBottom: '8pt',
-                                marginLeft: '1in',
-                            },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
                                     isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: 'text',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
-                            levels: [
-                                {
-                                    listType: 'OL',
-                                    format: {
-                                        marginTop: '1em',
-                                        wordList: 'l2',
-                                    },
-                                    dataset: {
-                                        editingInfo: '{"orderedStyleType":1}',
-                                    },
-                                },
-                            ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                lineHeight: '107%',
-                                marginTop: '1em',
-                                marginBottom: '8pt',
-                            },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: 'text',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -4457,7 +4329,11 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     dataset: {},
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
                                 lineHeight: '107%',
                                 marginTop: '0in',
@@ -4465,28 +4341,115 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 marginBottom: '8pt',
                                 marginLeft: '1in',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: 'text',
                                             segmentType: 'Text',
+                                            text: 'text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
+                            levels: [
+                                {
+                                    listType: 'OL',
+                                    format: {
+                                        marginTop: '1em',
+                                        wordList: 'l2',
+                                    },
+                                    dataset: {
+                                        editingInfo: '{"orderedStyleType":1}',
+                                    },
+                                },
+                            ],
                             formatHolder: {
-                                isSelected: false,
                                 segmentType: 'SelectionMarker',
+                                isSelected: false,
                                 format: {},
                             },
+                            format: {
+                                lineHeight: '107%',
+                                marginBottom: '8pt',
+                            },
+                        },
+                        {
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: 'text',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
+                            levels: [
+                                {
+                                    listType: 'OL',
+                                    format: {
+                                        marginTop: '1em',
+                                        wordList: 'l2',
+                                    },
+                                    dataset: {
+                                        editingInfo: '{"orderedStyleType":1}',
+                                    },
+                                },
+                                {
+                                    listType: 'UL',
+                                    format: {
+                                        marginTop: '0in',
+                                        marginRight: '0in',
+                                        paddingLeft: '0px',
+                                        wordList: 'l2',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
+                            format: {
+                                lineHeight: '107%',
+                                marginTop: '0in',
+                                marginRight: '0in',
+                                marginBottom: '8pt',
+                                marginLeft: '1in',
+                            },
+                        },
+                        {
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: 'text',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -4519,7 +4482,11 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     dataset: {},
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
                                 lineHeight: '107%',
                                 marginTop: '0in',
@@ -4527,28 +4494,24 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 marginBottom: '8pt',
                                 marginLeft: '117pt',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: 'text',
                                             segmentType: 'Text',
+                                            text: 'text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -4561,34 +4524,33 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
                                 lineHeight: '107%',
-                                marginTop: '1em',
                                 marginBottom: '8pt',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: 'text',
                                             segmentType: 'Text',
+                                            text: 'text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -4611,7 +4573,11 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     dataset: {},
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
                                 lineHeight: '107%',
                                 marginTop: '0in',
@@ -4619,33 +4585,18 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 marginBottom: '8pt',
                                 marginLeft: '1in',
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: 'text',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: 'Text',
                                     segmentType: 'Text',
+                                    text: 'Text',
                                     format: {
                                         fontSize: '16pt',
                                     },
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -4656,14 +4607,14 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: 'text',
                                     segmentType: 'Text',
+                                    text: 'text',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -4674,14 +4625,14 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: 'text',
                                     segmentType: 'Text',
+                                    text: 'text',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -4692,11 +4643,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: 'text',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -4710,34 +4672,33 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
                                 lineHeight: '107%',
-                                marginTop: '1em',
                                 marginBottom: '8pt',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: 'text',
                                             segmentType: 'Text',
+                                            text: 'text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -4760,7 +4721,11 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     dataset: {},
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
                                 lineHeight: '105%',
                                 marginTop: '0in',
@@ -4768,28 +4733,24 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                 marginBottom: '8pt',
                                 marginLeft: '1in',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: 'text',
                                             segmentType: 'Text',
+                                            text: 'text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -4802,84 +4763,72 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                lineHeight: '105%',
-                                marginTop: '1em',
-                                marginBottom: '8pt',
-                            },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: 'text',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
-                        },
-                        {
                             formatHolder: {
-                                isSelected: false,
                                 segmentType: 'SelectionMarker',
+                                isSelected: false,
                                 format: {},
                             },
-                            levels: [
-                                {
-                                    listType: 'OL',
-                                    format: {
-                                        marginTop: '1em',
-                                        wordList: 'l0',
-                                    },
-                                    dataset: {
-                                        editingInfo: '{"orderedStyleType":1}',
-                                    },
-                                },
-                                {
-                                    listType: 'UL',
-                                    format: {
-                                        marginTop: '0in',
-                                        marginRight: '0in',
-                                        paddingLeft: '0px',
-                                        wordList: 'l0',
-                                    },
-                                    dataset: {},
-                                },
-                            ],
-                            blockType: 'BlockGroup',
                             format: {
                                 lineHeight: '105%',
-                                marginTop: '0in',
-                                marginRight: '0in',
                                 marginBottom: '8pt',
-                                marginLeft: '1in',
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
-                                            text: 'text',
                                             segmentType: 'Text',
+                                            text: 'text',
                                             format: {},
                                         },
                                         {
+                                            segmentType: 'Text',
                                             text: ' ',
-                                            segmentType: 'Text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
+                            levels: [
+                                {
+                                    listType: 'OL',
+                                    format: {
+                                        marginTop: '1em',
+                                        wordList: 'l0',
+                                    },
+                                    dataset: {
+                                        editingInfo: '{"orderedStyleType":1}',
+                                    },
+                                },
+                                {
+                                    listType: 'UL',
+                                    format: {
+                                        marginTop: '0in',
+                                        marginRight: '0in',
+                                        paddingLeft: '0px',
+                                        wordList: 'l0',
+                                    },
+                                    dataset: {},
+                                },
+                            ],
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
+                            format: {
+                                lineHeight: '105%',
+                                marginTop: '0in',
+                                marginRight: '0in',
+                                marginBottom: '8pt',
+                                marginLeft: '1in',
+                            },
                         },
                     ],
                 },
@@ -4897,18 +4846,28 @@ describe('processPastedContentFromWordDesktopTest', () => {
         it('List with dummy list from Word Desktop', () => {
             const htmlBefore =
                 '<html xmlns:o="urn:schemas-microsoft-com:office:office"\r\nxmlns:w="urn:schemas-microsoft-com:office:word"\r\nxmlns:m="http://schemas.microsoft.com/office/2004/12/omml"\r\nxmlns="http://www.w3.org/TR/REC-html40">\r\n\r\n<head>\r\n<meta http-equiv=Content-Type content="text/html; charset=utf-8">\r\n<meta name=ProgId content=Word.Document>\r\n<meta name=Generator content="Microsoft Word 15">\r\n<meta name=Originator content="Microsoft Word 15">\r\n<link rel=File-List\r\nhref="file:///C:/Users/BVALVE~1/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">\r\n\x3C!--[if gte mso 9]><xml>\r\n <o:OfficeDocumentSettings>\r\n  <o:AllowPNG/>\r\n </o:OfficeDocumentSettings>\r\n</xml><![endif]-->\r\n<link rel=themeData\r\nhref="file:///C:/Users/BVALVE~1/AppData/Local/Temp/msohtmlclip1/01/clip_themedata.thmx">\r\n<link rel=colorSchemeMapping\r\nhref="file:///C:/Users/BVALVE~1/AppData/Local/Temp/msohtmlclip1/01/clip_colorschememapping.xml">\r\n\x3C!--[if gte mso 9]><xml>\r\n <w:WordDocument>\r\n  <w:View>Normal</w:View>\r\n  <w:Zoom>0</w:Zoom>\r\n  <w:TrackMoves/>\r\n  <w:TrackFormatting/>\r\n  <w:PunctuationKerning/>\r\n  <w:ValidateAgainstSchemas/>\r\n  <w:SaveIfXMLInvalid>false</w:SaveIfXMLInvalid>\r\n  <w:IgnoreMixedContent>false</w:IgnoreMixedContent>\r\n  <w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>\r\n  <w:DoNotPromoteQF/>\r\n  <w:LidThemeOther>EN-US</w:LidThemeOther>\r\n  <w:LidThemeAsian>JA</w:LidThemeAsian>\r\n  <w:LidThemeComplexScript>X-NONE</w:LidThemeComplexScript>\r\n  <w:Compatibility>\r\n   <w:BreakWrappedTables/>\r\n   <w:SnapToGridInCell/>\r\n   <w:WrapTextWithPunct/>\r\n   <w:UseAsianBreakRules/>\r\n   <w:DontGrowAutofit/>\r\n   <w:SplitPgBreakAndParaMark/>\r\n   <w:EnableOpenTypeKerning/>\r\n   <w:DontFlipMirrorIndents/>\r\n   <w:OverrideTableStyleHps/>\r\n  </w:Compatibility>\r\n  <m:mathPr>\r\n   <m:mathFont m:val="Cambria Math"/>\r\n   <m:brkBin m:val="before"/>\r\n   <m:brkBinSub m:val="&#45;-"/>\r\n   <m:smallFrac m:val="off"/>\r\n   <m:dispDef/>\r\n   <m:lMargin m:val="0"/>\r\n   <m:rMargin m:val="0"/>\r\n   <m:defJc m:val="centerGroup"/>\r\n   <m:wrapIndent m:val="1440"/>\r\n   <m:intLim m:val="subSup"/>\r\n   <m:naryLim m:val="undOvr"/>\r\n  </m:mathPr></w:WordDocument>\r\n</xml><![endif]-->\x3C!--[if gte mso 9]><xml>\r\n <w:LatentStyles DefLockedState="false" DefUnhideWhenUsed="false"\r\n  DefSemiHidden="false" DefQFormat="false" DefPriority="99"\r\n  LatentStyleCount="376">\r\n  <w:LsdException Locked="false" Priority="0" QFormat="true" Name="Normal"/>\r\n  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 1"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 2"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 3"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 4"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 5"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 6"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 7"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 8"/>\r\n  <w:LsdException Locked="false" Priority="9" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="heading 9"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 6"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 7"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 8"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index 9"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 1"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 2"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 3"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 4"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 5"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 6"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 7"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 8"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="toc 9"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Normal Indent"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="footnote text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="annotation text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="header"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="footer"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="index heading"/>\r\n  <w:LsdException Locked="false" Priority="35" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="caption"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="table of figures"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="envelope address"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="envelope return"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="footnote reference"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="annotation reference"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="line number"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="page number"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="endnote reference"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="endnote text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="table of authorities"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="macro"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="toa heading"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Bullet"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Number"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Bullet 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Bullet 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Bullet 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Bullet 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Number 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Number 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Number 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Number 5"/>\r\n  <w:LsdException Locked="false" Priority="10" QFormat="true" Name="Title"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Closing"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Signature"/>\r\n  <w:LsdException Locked="false" Priority="1" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="Default Paragraph Font"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text Indent"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Continue"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Continue 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Continue 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Continue 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="List Continue 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Message Header"/>\r\n  <w:LsdException Locked="false" Priority="11" QFormat="true" Name="Subtitle"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Salutation"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Date"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text First Indent"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text First Indent 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Note Heading"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text Indent 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Body Text Indent 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Block Text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Hyperlink"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="FollowedHyperlink"/>\r\n  <w:LsdException Locked="false" Priority="22" QFormat="true" Name="Strong"/>\r\n  <w:LsdException Locked="false" Priority="20" QFormat="true" Name="Emphasis"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Document Map"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Plain Text"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="E-mail Signature"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Top of Form"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Bottom of Form"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Normal (Web)"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Acronym"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Address"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Cite"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Code"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Definition"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Keyboard"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Preformatted"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Sample"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Typewriter"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="HTML Variable"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Normal Table"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="annotation subject"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="No List"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Outline List 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Outline List 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Outline List 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Simple 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Simple 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Simple 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Classic 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Classic 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Classic 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Classic 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Colorful 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Colorful 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Colorful 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Columns 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Columns 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Columns 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Columns 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Columns 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 6"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 7"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Grid 8"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 4"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 5"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 6"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 7"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table List 8"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table 3D effects 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table 3D effects 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table 3D effects 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Contemporary"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Elegant"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Professional"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Subtle 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Subtle 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Web 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Web 2"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Web 3"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Balloon Text"/>\r\n  <w:LsdException Locked="false" Priority="39" Name="Table Grid"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Table Theme"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" Name="Placeholder Text"/>\r\n  <w:LsdException Locked="false" Priority="1" QFormat="true" Name="No Spacing"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 1"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" Name="Revision"/>\r\n  <w:LsdException Locked="false" Priority="34" QFormat="true"\r\n   Name="List Paragraph"/>\r\n  <w:LsdException Locked="false" Priority="29" QFormat="true" Name="Quote"/>\r\n  <w:LsdException Locked="false" Priority="30" QFormat="true"\r\n   Name="Intense Quote"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="60" Name="Light Shading Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="61" Name="Light List Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="62" Name="Light Grid Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="63" Name="Medium Shading 1 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="64" Name="Medium Shading 2 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="65" Name="Medium List 1 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="66" Name="Medium List 2 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="67" Name="Medium Grid 1 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="68" Name="Medium Grid 2 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="69" Name="Medium Grid 3 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="70" Name="Dark List Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="71" Name="Colorful Shading Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="72" Name="Colorful List Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="73" Name="Colorful Grid Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="19" QFormat="true"\r\n   Name="Subtle Emphasis"/>\r\n  <w:LsdException Locked="false" Priority="21" QFormat="true"\r\n   Name="Intense Emphasis"/>\r\n  <w:LsdException Locked="false" Priority="31" QFormat="true"\r\n   Name="Subtle Reference"/>\r\n  <w:LsdException Locked="false" Priority="32" QFormat="true"\r\n   Name="Intense Reference"/>\r\n  <w:LsdException Locked="false" Priority="33" QFormat="true" Name="Book Title"/>\r\n  <w:LsdException Locked="false" Priority="37" SemiHidden="true"\r\n   UnhideWhenUsed="true" Name="Bibliography"/>\r\n  <w:LsdException Locked="false" Priority="39" SemiHidden="true"\r\n   UnhideWhenUsed="true" QFormat="true" Name="TOC Heading"/>\r\n  <w:LsdException Locked="false" Priority="41" Name="Plain Table 1"/>\r\n  <w:LsdException Locked="false" Priority="42" Name="Plain Table 2"/>\r\n  <w:LsdException Locked="false" Priority="43" Name="Plain Table 3"/>\r\n  <w:LsdException Locked="false" Priority="44" Name="Plain Table 4"/>\r\n  <w:LsdException Locked="false" Priority="45" Name="Plain Table 5"/>\r\n  <w:LsdException Locked="false" Priority="40" Name="Grid Table Light"/>\r\n  <w:LsdException Locked="false" Priority="46" Name="Grid Table 1 Light"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark"/>\r\n  <w:LsdException Locked="false" Priority="51" Name="Grid Table 6 Colorful"/>\r\n  <w:LsdException Locked="false" Priority="52" Name="Grid Table 7 Colorful"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="Grid Table 1 Light Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="Grid Table 2 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="Grid Table 3 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="Grid Table 4 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="Grid Table 5 Dark Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="Grid Table 6 Colorful Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="Grid Table 7 Colorful Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="46" Name="List Table 1 Light"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark"/>\r\n  <w:LsdException Locked="false" Priority="51" Name="List Table 6 Colorful"/>\r\n  <w:LsdException Locked="false" Priority="52" Name="List Table 7 Colorful"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 1"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 2"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 3"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 4"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 5"/>\r\n  <w:LsdException Locked="false" Priority="46"\r\n   Name="List Table 1 Light Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="47" Name="List Table 2 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="48" Name="List Table 3 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="49" Name="List Table 4 Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="50" Name="List Table 5 Dark Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="51"\r\n   Name="List Table 6 Colorful Accent 6"/>\r\n  <w:LsdException Locked="false" Priority="52"\r\n   Name="List Table 7 Colorful Accent 6"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Mention"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Smart Hyperlink"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Hashtag"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Unresolved Mention"/>\r\n  <w:LsdException Locked="false" SemiHidden="true" UnhideWhenUsed="true"\r\n   Name="Smart Link"/>\r\n </w:LatentStyles>\r\n</xml><![endif]-->\r\n<style>\r\n\x3C!--\r\n /* Font Definitions */\r\n @font-face\r\n\t{font-family:"Cambria Math";\r\n\tpanose-1:2 4 5 3 5 4 6 3 2 4;\r\n\tmso-font-charset:0;\r\n\tmso-generic-font-family:roman;\r\n\tmso-font-pitch:variable;\r\n\tmso-font-signature:-536869121 1107305727 33554432 0 415 0;}\r\n@font-face\r\n\t{font-family:Calibri;\r\n\tpanose-1:2 15 5 2 2 2 4 3 2 4;\r\n\tmso-font-charset:0;\r\n\tmso-generic-font-family:swiss;\r\n\tmso-font-pitch:variable;\r\n\tmso-font-signature:-469750017 -1040178053 9 0 511 0;}\r\n@font-face\r\n\t{font-family:Aptos;\r\n\tmso-font-charset:0;\r\n\tmso-generic-font-family:swiss;\r\n\tmso-font-pitch:variable;\r\n\tmso-font-signature:536871559 3 0 0 415 0;}\r\n /* Style Definitions */\r\n p.MsoNormal, li.MsoNormal, div.MsoNormal\r\n\t{mso-style-unhide:no;\r\n\tmso-style-qformat:yes;\r\n\tmso-style-parent:"";\r\n\tmargin:0in;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-bidi-font-family:Calibri;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;}\r\np.MsoListParagraph, li.MsoListParagraph, div.MsoListParagraph\r\n\t{mso-style-priority:34;\r\n\tmso-style-unhide:no;\r\n\tmso-style-qformat:yes;\r\n\tmargin-top:0in;\r\n\tmargin-right:0in;\r\n\tmargin-bottom:0in;\r\n\tmargin-left:.5in;\r\n\tmso-add-space:auto;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-bidi-font-family:Calibri;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;}\r\np.MsoListParagraphCxSpFirst, li.MsoListParagraphCxSpFirst, div.MsoListParagraphCxSpFirst\r\n\t{mso-style-priority:34;\r\n\tmso-style-unhide:no;\r\n\tmso-style-qformat:yes;\r\n\tmso-style-type:export-only;\r\n\tmargin-top:0in;\r\n\tmargin-right:0in;\r\n\tmargin-bottom:0in;\r\n\tmargin-left:.5in;\r\n\tmso-add-space:auto;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-bidi-font-family:Calibri;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;}\r\np.MsoListParagraphCxSpMiddle, li.MsoListParagraphCxSpMiddle, div.MsoListParagraphCxSpMiddle\r\n\t{mso-style-priority:34;\r\n\tmso-style-unhide:no;\r\n\tmso-style-qformat:yes;\r\n\tmso-style-type:export-only;\r\n\tmargin-top:0in;\r\n\tmargin-right:0in;\r\n\tmargin-bottom:0in;\r\n\tmargin-left:.5in;\r\n\tmso-add-space:auto;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-bidi-font-family:Calibri;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;}\r\np.MsoListParagraphCxSpLast, li.MsoListParagraphCxSpLast, div.MsoListParagraphCxSpLast\r\n\t{mso-style-priority:34;\r\n\tmso-style-unhide:no;\r\n\tmso-style-qformat:yes;\r\n\tmso-style-type:export-only;\r\n\tmargin-top:0in;\r\n\tmargin-right:0in;\r\n\tmargin-bottom:0in;\r\n\tmargin-left:.5in;\r\n\tmso-add-space:auto;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-bidi-font-family:Calibri;\r\n\tmso-ligatures:standardcontextual;\r\n\tmso-fareast-language:EN-US;}\r\n.MsoChpDefault\r\n\t{mso-style-type:export-only;\r\n\tmso-default-props:yes;\r\n\tfont-size:11.0pt;\r\n\tmso-ansi-font-size:11.0pt;\r\n\tmso-bidi-font-size:11.0pt;\r\n\tmso-ascii-font-family:Aptos;\r\n\tmso-ascii-theme-font:minor-latin;\r\n\tmso-fareast-font-family:Aptos;\r\n\tmso-fareast-theme-font:minor-latin;\r\n\tmso-hansi-font-family:Aptos;\r\n\tmso-hansi-theme-font:minor-latin;\r\n\tmso-bidi-font-family:"Times New Roman";\r\n\tmso-bidi-theme-font:minor-bidi;\r\n\tmso-font-kerning:0pt;\r\n\tmso-ligatures:none;\r\n\tmso-fareast-language:EN-US;}\r\n.MsoPapDefault\r\n\t{mso-style-type:export-only;\r\n\tmargin-bottom:8.0pt;\r\n\tline-height:107%;}\r\n@page WordSection1\r\n\t{size:8.5in 11.0in;\r\n\tmargin:1.0in 1.0in 1.0in 1.0in;\r\n\tmso-header-margin:.5in;\r\n\tmso-footer-margin:.5in;\r\n\tmso-paper-source:0;}\r\ndiv.WordSection1\r\n\t{page:WordSection1;}\r\n /* List Definitions */\r\n @list l0\r\n\t{mso-list-id:1929538116;\r\n\tmso-list-type:hybrid;\r\n\tmso-list-template-ids:-796745460 1452455558 67698713 67698715 67698703 67698713 67698715 67698703 67698713 67698715;}\r\n@list l0:level1\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level2\r\n\t{mso-level-number-format:alpha-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level3\r\n\t{mso-level-number-format:roman-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:right;\r\n\ttext-indent:-9.0pt;}\r\n@list l0:level4\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level5\r\n\t{mso-level-number-format:alpha-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level6\r\n\t{mso-level-number-format:roman-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:right;\r\n\ttext-indent:-9.0pt;}\r\n@list l0:level7\r\n\t{mso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level8\r\n\t{mso-level-number-format:alpha-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:left;\r\n\ttext-indent:-.25in;}\r\n@list l0:level9\r\n\t{mso-level-number-format:roman-lower;\r\n\tmso-level-tab-stop:none;\r\n\tmso-level-number-position:right;\r\n\ttext-indent:-9.0pt;}\r\nol\r\n\t{margin-bottom:0in;}\r\nul\r\n\t{margin-bottom:0in;}\r\n-->\r\n</style>\r\n\x3C!--[if gte mso 10]>\r\n<style>\r\n /* Style Definitions */\r\n table.MsoNormalTable\r\n\t{mso-style-name:"Table Normal";\r\n\tmso-tstyle-rowband-size:0;\r\n\tmso-tstyle-colband-size:0;\r\n\tmso-style-noshow:yes;\r\n\tmso-style-priority:99;\r\n\tmso-style-parent:"";\r\n\tmso-padding-alt:0in 5.4pt 0in 5.4pt;\r\n\tmso-para-margin-top:0in;\r\n\tmso-para-margin-right:0in;\r\n\tmso-para-margin-bottom:8.0pt;\r\n\tmso-para-margin-left:0in;\r\n\tline-height:107%;\r\n\tmso-pagination:widow-orphan;\r\n\tfont-size:11.0pt;\r\n\tfont-family:"Aptos",sans-serif;\r\n\tmso-ascii-font-family:Aptos;\r\n\tmso-ascii-theme-font:minor-latin;\r\n\tmso-hansi-font-family:Aptos;\r\n\tmso-hansi-theme-font:minor-latin;\r\n\tmso-fareast-language:EN-US;}\r\n</style>\r\n<![endif]-->\r\n</head>\r\n\r\n<body lang=EN-US style="tab-interval:.5in;word-wrap:break-word">\r\n';
-
             runTest(
                 '\r\n\r\n<p class=MsoListParagraphCxSpFirst style="text-indent:-.25in;mso-list:l0 level1 lfo1"><![if !supportLists]><span\r\nstyle="mso-fareast-font-family:Aptos;mso-bidi-font-family:Aptos"><span\r\nstyle="mso-list:Ignore">1.<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span></span></span><![endif]>List 1<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="text-indent:-.25in;mso-list:l0 level1 lfo1"><![if !supportLists]><span\r\nstyle="mso-fareast-font-family:Aptos;mso-bidi-font-family:Aptos"><span\r\nstyle="mso-list:Ignore">2.<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span></span></span><![endif]>List 2<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpLast>List without bullet<o:p></o:p></p>\r\n\r\n<p class=MsoNormal><o:p>&nbsp;</o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpFirst style="text-indent:-.25in;mso-list:l0 level1 lfo1"><![if !supportLists]><span\r\nstyle="mso-fareast-font-family:Aptos;mso-bidi-font-family:Aptos"><span\r\nstyle="mso-list:Ignore">3.<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span></span></span><![endif]>List<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle>Text<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-left:1.0in;mso-add-space:\r\nauto;text-indent:-.25in;mso-list:l0 level2 lfo1"><![if !supportLists]><span\r\nstyle="mso-fareast-font-family:Aptos;mso-bidi-font-family:Aptos"><span\r\nstyle="mso-list:Ignore">a.<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span></span></span><![endif]>List<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-left:1.0in;mso-add-space:\r\nauto">Text<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpMiddle style="margin-left:1.5in;mso-add-space:\r\nauto;text-indent:-1.5in;mso-text-indent-alt:-9.0pt;mso-list:l0 level3 lfo1"><![if !supportLists]><span\r\nstyle="mso-fareast-font-family:Aptos;mso-bidi-font-family:Aptos"><span\r\nstyle="mso-list:Ignore"><span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span>i.<span style="font:7.0pt "Times New Roman"">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\r\n</span></span></span><![endif]>List<o:p></o:p></p>\r\n\r\n<p class=MsoListParagraphCxSpLast style="margin-left:1.5in;mso-add-space:auto">Text<o:p></o:p></p>\r\n\r\n',
                 {
                     blockGroupType: 'Document',
                     blocks: [
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: 'List 1',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -4922,108 +4881,30 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
-                            },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: 'List 1',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
-                        },
-                        {
                             formatHolder: {
-                                isSelected: false,
                                 segmentType: 'SelectionMarker',
+                                isSelected: false,
                                 format: {},
                             },
-                            levels: [
-                                {
-                                    listType: 'OL',
-                                    format: {
-                                        marginTop: '1em',
-                                        wordList: 'l0',
-                                    },
-                                    dataset: {
-                                        editingInfo: '{"orderedStyleType":1}',
-                                    },
-                                },
-                            ],
+                            format: {},
+                        },
+                        {
                             blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
-                            },
                             blockGroupType: 'ListItem',
                             blocks: [
                                 {
-                                    isImplicit: true,
+                                    blockType: 'Paragraph',
                                     segments: [
                                         {
+                                            segmentType: 'Text',
                                             text: 'List 2',
-                                            segmentType: 'Text',
                                             format: {},
                                         },
                                     ],
-                                    blockType: 'Paragraph',
                                     format: {},
+                                    isImplicit: true,
                                 },
                             ],
-                        },
-                        {
-                            segments: [
-                                {
-                                    text: 'List without bullet',
-                                    segmentType: 'Text',
-                                    format: {},
-                                },
-                            ],
-                            blockType: 'Paragraph',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
-                            },
-                            decorator: {
-                                tagName: 'p',
-                                format: {},
-                            },
-                        },
-                        {
-                            segments: [
-                                {
-                                    text: ' ',
-                                    segmentType: 'Text',
-                                    format: {},
-                                },
-                            ],
-                            blockType: 'Paragraph',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
-                            },
-                            decorator: {
-                                tagName: 'p',
-                                format: {},
-                            },
-                        },
-                        {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
                             levels: [
                                 {
                                     listType: 'OL',
@@ -5036,36 +4917,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: 'List',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
+                            format: {},
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: 'Text',
                                     segmentType: 'Text',
+                                    text: 'List without bullet',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -5076,11 +4943,94 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: ' ',
+                                    format: {},
+                                },
+                            ],
+                            format: {
+                                marginTop: '1em',
+                                marginBottom: '1em',
+                            },
+                            decorator: {
+                                tagName: 'p',
                                 format: {},
                             },
+                        },
+                        {
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: 'List',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
+                            levels: [
+                                {
+                                    listType: 'OL',
+                                    format: {
+                                        marginTop: '1em',
+                                        wordList: 'l0',
+                                    },
+                                    dataset: {
+                                        editingInfo: '{"orderedStyleType":1}',
+                                    },
+                                },
+                            ],
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
+                            format: {},
+                        },
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'Text',
+                                    format: {},
+                                },
+                            ],
+                            format: {
+                                marginTop: '1em',
+                                marginBottom: '1em',
+                            },
+                            decorator: {
+                                tagName: 'p',
+                                format: {},
+                            },
+                        },
+                        {
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: 'List',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -5105,37 +5055,24 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
                                 marginLeft: '1in',
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: 'List',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: 'Text',
                                     segmentType: 'Text',
+                                    text: 'Text',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',
@@ -5147,11 +5084,22 @@ describe('processPastedContentFromWordDesktopTest', () => {
                             },
                         },
                         {
-                            formatHolder: {
-                                isSelected: false,
-                                segmentType: 'SelectionMarker',
-                                format: {},
-                            },
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [
+                                        {
+                                            segmentType: 'Text',
+                                            text: 'List',
+                                            format: {},
+                                        },
+                                    ],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
                             levels: [
                                 {
                                     listType: 'OL',
@@ -5187,37 +5135,24 @@ describe('processPastedContentFromWordDesktopTest', () => {
                                     },
                                 },
                             ],
-                            blockType: 'BlockGroup',
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
                             format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
                                 marginLeft: '1.5in',
                             },
-                            blockGroupType: 'ListItem',
-                            blocks: [
-                                {
-                                    isImplicit: true,
-                                    segments: [
-                                        {
-                                            text: 'List',
-                                            segmentType: 'Text',
-                                            format: {},
-                                        },
-                                    ],
-                                    blockType: 'Paragraph',
-                                    format: {},
-                                },
-                            ],
                         },
                         {
+                            blockType: 'Paragraph',
                             segments: [
                                 {
-                                    text: 'Text',
                                     segmentType: 'Text',
+                                    text: 'Text',
                                     format: {},
                                 },
                             ],
-                            blockType: 'Paragraph',
                             format: {
                                 marginTop: '1em',
                                 marginBottom: '1em',

--- a/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
@@ -46,12 +46,6 @@ describe('processPastedContentFromWordDesktopTest', () => {
                 expect(model).toEqual(expectedModel);
             }
         }
-
-        const div = document.createElement('div');
-        contentModelToDom(document, div, model, createModelToDomContext());
-
-        document.body.appendChild(div);
-        document.body.removeChild(div);
     }
 
     it('Remove Comment | mso-element:comment-list', () => {

--- a/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
@@ -4,9 +4,7 @@ import { expectEqual } from '../e2e/testUtils';
 import { processPastedContentFromWordDesktop } from '../../../lib/paste/WordDesktop/processPastedContentFromWordDesktop';
 import { WordMetadata } from '../../../lib/paste/WordDesktop/WordMetadata';
 import {
-    contentModelToDom,
     createDomToModelContext,
-    createModelToDomContext,
     domToContentModel,
     moveChildNodes,
 } from 'roosterjs-content-model-dom';


### PR DESCRIPTION
Word sometimes adds P elements as lists. The problem is that currently when we parseFormat, we set the defaultFormat, because we use the defaultFormatMap to set the style (https://github.com/microsoft/roosterjs/blob/7b655438e9a1d4065bdcccea8572a6b8778d8768/packages/roosterjs-content-model-dom/lib/config/defaultHTMLStyleMap.ts#L81-L85).

This is causing that some list items to contain incorrect MarginTop and MarginBottom styles.

To fix, if the element we are trying to handle as a list is not a LI element, remove the defaultStyle formats.