### PR TITLE
Check editor disposed before executing function when on blur

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -104,7 +104,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         this.disposer = editor.attachDomEvent({
             blur: {
                 beforeDispatch: () => {
-                    if (this.imageEditInfo && this.editor && !this.editor.isDisposed()) {
+                    if (this.isEditing && this.editor && !this.editor.isDisposed()) {
                         this.applyFormatWithContentModel(
                             this.editor,
                             this.isCropMode,

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -104,7 +104,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         this.disposer = editor.attachDomEvent({
             blur: {
                 beforeDispatch: () => {
-                    if (this.editor) {
+                    if (this.imageEditInfo && this.editor && !this.editor.isDisposed()) {
                         this.applyFormatWithContentModel(
                             this.editor,
                             this.isCropMode,
@@ -142,13 +142,13 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
      * called, plugin should not call to any editor method since it will result in error.
      */
     dispose() {
-        this.editor = null;
-        this.isEditing = false;
-        this.cleanInfo();
         if (this.disposer) {
             this.disposer();
             this.disposer = null;
         }
+        this.isEditing = false;
+        this.cleanInfo();
+        this.editor = null;
     }
 
     /**


### PR DESCRIPTION
When onBlur event happens, check if the editor is disposed and if the image is in editing state, before applying format to image