### PR TITLE
Fix 341291: Enter key does not work after an inline entity under a list

### DIFF
--- a/packages/roosterjs-content-model-core/test/corePlugin/entity/entityDelimiterUtilsTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/entity/entityDelimiterUtilsTest.ts
@@ -1148,8 +1148,9 @@ describe('handleEnterInlineEntity', () => {
             format: {},
         };
 
-        DelimiterFile.handleEnterInlineEntity(model, <any>{});
+        const result = DelimiterFile.handleEnterInlineEntity(model, <any>{});
 
+        expect(result).toBeTrue();
         expect(model).toEqual({
             blockGroupType: 'Document',
             blocks: [
@@ -1195,6 +1196,123 @@ describe('handleEnterInlineEntity', () => {
         });
     });
 
+    it('handle after entity under list item', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    format: {},
+                    formatHolder: {
+                        format: {},
+                        segmentType: 'SelectionMarker',
+                    },
+                    levels: [
+                        {
+                            dataset: {},
+                            listType: 'UL',
+                            format: {},
+                        },
+                    ],
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: '_',
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'Entity',
+                                    blockType: 'Entity',
+                                    format: {},
+                                    entityFormat: {
+                                        entityType: '',
+                                        isReadonly: true,
+                                    },
+                                    wrapper: <any>{},
+                                },
+                                {
+                                    segmentType: 'SelectionMarker',
+                                    isSelected: true,
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'Text',
+                                    text: '_',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+            format: {},
+        };
+
+        const result = DelimiterFile.handleEnterInlineEntity(model, <any>{});
+
+        expect(result).toBeFalse();
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    format: {},
+                    formatHolder: {
+                        format: {},
+                        segmentType: 'SelectionMarker',
+                    },
+                    levels: [
+                        {
+                            dataset: {},
+                            listType: 'UL',
+                            format: {},
+                        },
+                    ],
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: '_',
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'Entity',
+                                    blockType: 'Entity',
+                                    format: {},
+                                    entityFormat: {
+                                        entityType: '',
+                                        isReadonly: true,
+                                    },
+                                    wrapper: <any>{},
+                                },
+                                {
+                                    segmentType: 'SelectionMarker',
+                                    isSelected: true,
+                                    format: {},
+                                },
+                                {
+                                    segmentType: 'Text',
+                                    text: '_',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                },
+            ],
+            format: {},
+        });
+    });
+
     it('handle before entity', () => {
         const model: ContentModelDocument = {
             blockGroupType: 'Document',
@@ -1234,8 +1352,9 @@ describe('handleEnterInlineEntity', () => {
             format: {},
         };
 
-        DelimiterFile.handleEnterInlineEntity(model, <any>{});
+        const result = DelimiterFile.handleEnterInlineEntity(model, <any>{});
 
+        expect(result).toBeTrue();
         expect(model).toEqual({
             blockGroupType: 'Document',
             blocks: [
@@ -1315,8 +1434,9 @@ describe('handleEnterInlineEntity', () => {
             format: {},
         };
 
-        DelimiterFile.handleEnterInlineEntity(model, <any>{});
+        const result = DelimiterFile.handleEnterInlineEntity(model, <any>{});
 
+        expect(result).toBeTrue();
         expect(model).toEqual({
             blockGroupType: 'Document',
             blocks: [
@@ -1394,8 +1514,9 @@ describe('handleEnterInlineEntity', () => {
             format: {},
         };
 
-        DelimiterFile.handleEnterInlineEntity(model, <any>{});
+        const result = DelimiterFile.handleEnterInlineEntity(model, <any>{});
 
+        expect(result).toBeTrue();
         expect(model).toEqual({
             blockGroupType: 'Document',
             blocks: [


### PR DESCRIPTION
Repro:

```html
<ol start="1"><li><div style="margin: 0px;">test <span class="entityDelimiterBefore" style="font-family: Calibri; font-size: 11pt; color: rgb(0, 0, 0);">​</span><span class="_Entity _EType_OWALink _EId_OWALink _EReadonly_1" contenteditable="false"><span>ENTITY</span></span><span class="entityDelimiterAfter" style="font-family: Calibri; font-size: 11pt; color: rgb(0, 0, 0);">​</span></div></li></ol><!--{"type":"range","start":[1],"end":[1],"isReverted":false,"isDarkMode":false}-->
```

Press ENTER.

Expect: Go to next line and generate list item "2."
Actual: Nothing happens

This is in entityDelimiter code, it incorrectly retrieve the parent block using a wrong index.
Actually, when parent block group type is ListItem, we should not handle it since it will be handled by common enter handler code