### PR TITLE
Fix 338766

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/features/TableMover.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/features/TableMover.ts
@@ -345,14 +345,15 @@ export function onDragEnd(
                             const finalTable = getFirstSelectedTable(model)[0] ?? initValue.cmTable;
                             if (finalTable) {
                                 // Add selection marker to the first cell of the table
-                                const FirstCell = finalTable.rows[0].cells[0];
-                                const markerParagraph = FirstCell?.blocks[0];
+                                const firstCell = finalTable.rows[0].cells[0];
+                                const markerParagraph = firstCell?.blocks[0];
+
                                 if (markerParagraph?.blockType == 'Paragraph') {
                                     const marker = createSelectionMarker(model.format);
 
                                     mutateBlock(markerParagraph).segments.unshift(marker);
                                     setParagraphNotImplicit(markerParagraph);
-                                    setSelection(FirstCell, marker);
+                                    setSelection(model, marker);
                                 }
                             }
                         }


### PR DESCRIPTION
[Bug 338766](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/338766): [Mail] Font/Font size should not be displayed blank after dragging a table or picture

This change fix the table part. For dragging a picture, it need to be covered by the whole drag-and-drop design, which is not in plan yet.

For table, after drop, we already put a selection marker in the first cell, so we just need to correctly select it.