### PR TITLE
Use FormatContainer to represent DIV with id

### DIFF
--- a/packages/roosterjs-content-model-api/test/publicApi/format/getFormatStateTest.ts
+++ b/packages/roosterjs-content-model-api/test/publicApi/format/getFormatStateTest.ts
@@ -148,26 +148,22 @@ describe('getFormatState', () => {
                 blockGroupType: 'Document',
                 blocks: [
                     {
-                        blockType: 'Paragraph',
-                        format: {},
-                        segments: [
+                        blockType: 'BlockGroup',
+                        blockGroupType: 'FormatContainer',
+                        tagName: 'div',
+                        blocks: [
                             {
-                                segmentType: 'Text',
+                                blockType: 'Paragraph',
+                                segments: [{ segmentType: 'Text', text: 'line1', format: {} }],
                                 format: {},
-                                text: 'line1',
+                            },
+                            {
+                                blockType: 'Paragraph',
+                                segments: [{ segmentType: 'Text', text: 'line2', format: {} }],
+                                format: {},
                             },
                         ],
-                    },
-                    {
-                        blockType: 'Paragraph',
-                        format: {},
-                        segments: [
-                            {
-                                segmentType: 'Text',
-                                format: {},
-                                text: 'line2',
-                            },
-                        ],
+                        format: { id: 'Selected' },
                     },
                 ],
             },

--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/knownElementProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/knownElementProcessor.ts
@@ -30,6 +30,7 @@ const FormatContainerTriggerStyles: (keyof CSSStyleDeclaration)[] = [
     'minWidth',
     'minHeight',
 ];
+const FormatContainerTriggerAttributes = ['id'];
 const ByPassFormatContainerTags = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'P', 'A'];
 const SegmentDecoratorTags = ['A', 'CODE'];
 
@@ -115,7 +116,8 @@ function shouldUseFormatContainer(element: HTMLElement, context: DomToModelConte
     if (
         FormatContainerTriggerStyles.some(
             key => parseInt((style[key] as string) || (defaultStyle[key] as string) || '') > 0
-        )
+        ) ||
+        FormatContainerTriggerAttributes.some(attr => element.hasAttribute(attr))
     ) {
         return true;
     }

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
@@ -208,7 +208,7 @@ export const defaultFormatKeysPerCategory: {
     code: ['fontFamily', 'display'],
     dataset: ['dataset'],
     divider: [...sharedBlockFormats, ...sharedContainerFormats, 'display', 'size', 'htmlAlign'],
-    container: [...sharedContainerFormats, 'htmlAlign', 'size', 'display'],
+    container: [...sharedContainerFormats, 'htmlAlign', 'size', 'display', 'id'],
     entity: ['entity'],
     general: ['textColor', 'backgroundColor'], // General model still need to do color transformation in dark mode
 };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/formatContainerProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/formatContainerProcessorTest.ts
@@ -375,4 +375,78 @@ describe('formatContainerProcessor', () => {
             ],
         });
     });
+
+    it('div with id', () => {
+        const group = createContentModelDocument();
+        const div = document.createElement('div');
+
+        div.id = 'testId';
+        div.appendChild(document.createTextNode('test'));
+
+        formatContainerProcessor(group, div, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                        },
+                    ],
+                    format: {
+                        id: 'testId',
+                    } as ContentModelBlockFormat,
+                    isImplicit: false,
+                },
+                { blockType: 'Paragraph', segments: [], format: {}, isImplicit: true },
+            ],
+        });
+    });
+
+    it('div with id, multiple children', () => {
+        const group = createContentModelDocument();
+        const div = document.createElement('div');
+        const child = document.createElement('div');
+
+        div.id = 'testId';
+        div.appendChild(document.createTextNode('test'));
+        div.appendChild(child);
+
+        child.appendChild(document.createTextNode('test2'));
+
+        formatContainerProcessor(group, div, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'FormatContainer',
+                    tagName: 'div',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [{ segmentType: 'Text', text: 'test', format: {} }],
+                            format: {},
+                            isImplicit: true,
+                        },
+                        {
+                            blockType: 'Paragraph',
+                            segments: [{ segmentType: 'Text', text: 'test2', format: {} }],
+                            format: {},
+                        },
+                        { blockType: 'Paragraph', segments: [], format: {}, isImplicit: true },
+                    ],
+                    format: {
+                        id: 'testId',
+                    },
+                },
+                { blockType: 'Paragraph', segments: [], format: {}, isImplicit: true },
+            ],
+        });
+    });
 });

--- a/packages/roosterjs-content-model-dom/test/endToEndTest.ts
+++ b/packages/roosterjs-content-model-dom/test/endToEndTest.ts
@@ -2379,4 +2379,99 @@ describe('End to end test for DOM => Model => DOM/TEXT', () => {
             '<table><tbody><tr><th>test</th></tr></tbody></table>'
         );
     });
+
+    it('div with id, no child', () => {
+        runTest(
+            '<div id="test"></div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'BlockGroup',
+                        blockGroupType: 'FormatContainer',
+                        tagName: 'div',
+                        blocks: [],
+                        format: { id: 'test' },
+                    },
+                ],
+            },
+            '',
+            '<div id="test"></div>'
+        );
+    });
+
+    it('div with id, 1 child', () => {
+        runTest(
+            '<div id="test"><div>test</div></div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'BlockGroup',
+                        blockGroupType: 'FormatContainer',
+                        tagName: 'div',
+                        blocks: [
+                            {
+                                blockType: 'Paragraph',
+                                segments: [
+                                    {
+                                        segmentType: 'Text',
+                                        text: 'test',
+                                        format: {},
+                                    },
+                                ],
+                                format: {},
+                            },
+                        ],
+                        format: { id: 'test' },
+                    },
+                ],
+            },
+            'test',
+            '<div id="test"><div>test</div></div>'
+        );
+    });
+
+    it('div with id, 2 child', () => {
+        runTest(
+            '<div id="test"><div>test1</div><div>test2</div></div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'BlockGroup',
+                        blockGroupType: 'FormatContainer',
+                        tagName: 'div',
+                        blocks: [
+                            {
+                                blockType: 'Paragraph',
+                                segments: [
+                                    {
+                                        segmentType: 'Text',
+                                        text: 'test1',
+                                        format: {},
+                                    },
+                                ],
+                                format: {},
+                            },
+                            {
+                                blockType: 'Paragraph',
+                                segments: [
+                                    {
+                                        segmentType: 'Text',
+                                        text: 'test2',
+                                        format: {},
+                                    },
+                                ],
+                                format: {},
+                            },
+                        ],
+                        format: { id: 'test' },
+                    },
+                ],
+            },
+            'test1\r\ntest2',
+            '<div id="test"><div>test1</div><div>test2</div></div>'
+        );
+    });
 });

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelBlockFormat.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelBlockFormat.ts
@@ -2,6 +2,7 @@ import type { BackgroundColorFormat } from './formatParts/BackgroundColorFormat'
 import type { BorderFormat } from './formatParts/BorderFormat';
 import type { DirectionFormat } from './formatParts/DirectionFormat';
 import type { HtmlAlignFormat } from './formatParts/HtmlAlignFormat';
+import type { IdFormat } from './formatParts/IdFormat';
 import type { LineHeightFormat } from './formatParts/LineHeightFormat';
 import type { MarginFormat } from './formatParts/MarginFormat';
 import type { PaddingFormat } from './formatParts/PaddingFormat';
@@ -21,4 +22,5 @@ export type ContentModelBlockFormat = BackgroundColorFormat &
     LineHeightFormat &
     WhiteSpaceFormat &
     BorderFormat &
-    TextIndentFormat;
+    TextIndentFormat &
+    IdFormat;


### PR DESCRIPTION
When DIV has id, use `FormatContainer` instead of `Paragraph` to represent it in Content Model.

- If there is only one sub paragraph under format container, it will fallback to paragraph with id
- If there are multiple child blocks under format container, keep format container with id so id won't lose or duplicated.