### PR TITLE
Clean image edit when undo

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -285,7 +285,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
 
     private setContentHandler(editor: IEditor) {
         const selection = editor.getDOMSelection();
-        if (selection?.type == 'image' && selection.image.dataset.isEditing && !this.isEditing) {
+        if (selection?.type == 'image' && selection.image.dataset.isEditing) {
             delete selection.image.dataset.isEditing;
             this.cleanInfo();
             this.isEditing = false;

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -287,6 +287,9 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         const selection = editor.getDOMSelection();
         if (selection?.type == 'image' && selection.image.dataset.isEditing && !this.isEditing) {
             delete selection.image.dataset.isEditing;
+            this.cleanInfo();
+            this.isEditing = false;
+            this.isCropMode = false;
         }
     }
 

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -285,8 +285,10 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
 
     private setContentHandler(editor: IEditor) {
         const selection = editor.getDOMSelection();
-        if (selection?.type == 'image' && selection.image.dataset.isEditing) {
-            delete selection.image.dataset.isEditing;
+        if (selection?.type == 'image') {
+            if (selection.image.dataset.isEditing) {
+                delete selection.image.dataset.isEditing;
+            }
             this.cleanInfo();
             this.isEditing = false;
             this.isCropMode = false;

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -736,6 +736,7 @@ describe('ImageEditPlugin', () => {
             image,
         } as DOMSelection;
         spyOn(editor, 'getDOMSelection').and.returnValue(selection);
+        const cleanInfoSpy = spyOn(plugin, 'cleanInfo');
         const event = {
             eventType: 'contentChanged',
             source: ChangeSource.SetContent,
@@ -744,6 +745,7 @@ describe('ImageEditPlugin', () => {
         const newSelection = editor.getDOMSelection() as ImageSelection;
         expect(newSelection!.type).toBe('image');
         expect(newSelection!.image.dataset.isEditing).toBeUndefined();
+        expect(cleanInfoSpy).toHaveBeenCalled();
         plugin.dispose();
     });
 


### PR DESCRIPTION
When setContent event happens and the selection is an image, clean the image edit state. Therefore, when the undo action happens the styles for hide the cursor will be removed. 
Fix in OWA: 
![UndoImage](https://github.com/user-attachments/assets/f25fb6a7-478c-42b3-87e9-9ac362279166)

