### PR TITLE
Retain Excel Table styles if styles get removed due to html comments.

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/convertInlineCss.ts
+++ b/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/convertInlineCss.ts
@@ -1,53 +1,5 @@
 import { toArray } from 'roosterjs-content-model-dom';
-
-/**
- * @internal
- */
-export interface CssRule {
-    selectors: string[];
-    text: string;
-}
-
-/**
- * @internal
- *
- * Splits CSS selectors, avoiding splits within parentheses
- * @param selectorText The CSS selector string
- * @return Array of trimmed selectors
- */
-function splitSelectors(selectorText: string) {
-    const regex = /(?![^(]*\)),/;
-    return selectorText.split(regex).map(s => s.trim());
-}
-
-/**
- * @internal
- */
-export function retrieveCssRules(doc: Document): CssRule[] {
-    const styles = toArray(doc.querySelectorAll('style'));
-    const result: CssRule[] = [];
-
-    styles.forEach(styleNode => {
-        const sheet = styleNode.sheet;
-
-        if (sheet) {
-            for (let ruleIndex = 0; ruleIndex < sheet.cssRules.length; ruleIndex++) {
-                const rule = sheet.cssRules[ruleIndex] as CSSStyleRule;
-
-                if (rule.type == CSSRule.STYLE_RULE && rule.selectorText) {
-                    result.push({
-                        selectors: splitSelectors(rule.selectorText),
-                        text: rule.style.cssText,
-                    });
-                }
-            }
-        }
-
-        styleNode.parentNode?.removeChild(styleNode);
-    });
-
-    return result;
-}
+import type { CssRule } from 'roosterjs-content-model-types';
 
 /**
  * @internal

--- a/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createModelFromHtml.ts
+++ b/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createModelFromHtml.ts
@@ -2,7 +2,7 @@ import { convertInlineCss } from './convertInlineCss';
 import { createDOMCreator } from '../../utils/domCreator';
 import { createDomToModelContextForSanitizing } from './createDomToModelContextForSanitizing';
 import { createEmptyModel, domToContentModel, parseFormat } from 'roosterjs-content-model-dom';
-import { retrieveCssRules } from '../../../../roosterjs-content-model-dom/lib/domUtils/style/retrieveCssRules';
+import { retrieveCssRules } from 'roosterjs-content-model-dom';
 import type {
     ContentModelDocument,
     ContentModelSegmentFormat,

--- a/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createModelFromHtml.ts
+++ b/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createModelFromHtml.ts
@@ -1,7 +1,8 @@
-import { convertInlineCss, retrieveCssRules } from './convertInlineCss';
+import { convertInlineCss } from './convertInlineCss';
 import { createDOMCreator } from '../../utils/domCreator';
 import { createDomToModelContextForSanitizing } from './createDomToModelContextForSanitizing';
 import { createEmptyModel, domToContentModel, parseFormat } from 'roosterjs-content-model-dom';
+import { retrieveCssRules } from '../../../../roosterjs-content-model-dom/lib/domUtils/style/retrieveCssRules';
 import type {
     ContentModelDocument,
     ContentModelSegmentFormat,

--- a/packages/roosterjs-content-model-core/lib/command/paste/generatePasteOptionFromPlugins.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/generatePasteOptionFromPlugins.ts
@@ -37,6 +37,7 @@ export function generatePasteOptionFromPlugins(
         pasteType: pasteType,
         domToModelOption,
         containsBlockElements: !!htmlFromClipboard.containsBlockElements,
+        cssRulesToBeConverted: [],
     };
 
     return editor.triggerEvent('beforePaste', event, true /* broadcast */);

--- a/packages/roosterjs-content-model-core/lib/command/paste/paste.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/paste.ts
@@ -65,7 +65,10 @@ export function paste(
     );
 
     // 5. Convert global CSS to inline CSS
-    convertInlineCss(eventResult.fragment, htmlFromClipboard.globalCssRules);
+    convertInlineCss(
+        eventResult.fragment,
+        htmlFromClipboard.globalCssRules.concat(eventResult.cssRulesToBeConverted || [])
+    );
 
     // 6. Merge pasted content into main Content Model
     mergePasteContent(editor, eventResult, isFirstPaste);

--- a/packages/roosterjs-content-model-core/lib/command/paste/retrieveHtmlInfo.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/retrieveHtmlInfo.ts
@@ -1,7 +1,10 @@
-import { isBlockElement, isNodeOfType, toArray } from 'roosterjs-content-model-dom';
-import { retrieveCssRules } from '../createModelFromHtml/convertInlineCss';
-import type { ClipboardData } from 'roosterjs-content-model-types';
-import type { CssRule } from '../createModelFromHtml/convertInlineCss';
+import {
+    isBlockElement,
+    isNodeOfType,
+    toArray,
+    retrieveCssRules,
+} from 'roosterjs-content-model-dom';
+import type { CssRule, ClipboardData } from 'roosterjs-content-model-types';
 
 const START_FRAGMENT = '<!--StartFragment-->';
 const END_FRAGMENT = '<!--EndFragment-->';

--- a/packages/roosterjs-content-model-core/test/command/createModelFromHtml/convertInlineCssTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/createModelFromHtml/convertInlineCssTest.ts
@@ -1,7 +1,5 @@
-import {
-    convertInlineCss,
-    CssRule,
-} from '../../../lib/command/createModelFromHtml/convertInlineCss';
+import { convertInlineCss } from '../../../lib/command/createModelFromHtml/convertInlineCss';
+import { CssRule } from 'roosterjs-content-model-types';
 
 describe('convertInlineCss', () => {
     it('Empty DOM, empty CSS', () => {

--- a/packages/roosterjs-content-model-core/test/command/createModelFromHtml/createModelFromHtmlTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/createModelFromHtml/createModelFromHtmlTest.ts
@@ -2,6 +2,7 @@ import * as convertInlineCss from '../../../lib/command/createModelFromHtml/conv
 import * as createDomToModelContextForSanitizing from '../../../lib/command/createModelFromHtml/createDomToModelContextForSanitizing';
 import * as domToContentModel from 'roosterjs-content-model-dom/lib/domToModel/domToContentModel';
 import * as parseFormat from 'roosterjs-content-model-dom/lib/domToModel/utils/parseFormat';
+import * as retrieveCssRules from 'roosterjs-content-model-dom/lib/domUtils/style/retrieveCssRules';
 import { createModelFromHtml } from '../../../lib/command/createModelFromHtml/createModelFromHtml';
 import {
     ContentModelGeneralBlock,
@@ -108,7 +109,7 @@ describe('createModelFromHtml', () => {
             mockedDoc
         );
         const mockedRules = 'RULES' as any;
-        const retrieveCssRulesSpy = spyOn(convertInlineCss, 'retrieveCssRules').and.returnValue(
+        const retrieveCssRulesSpy = spyOn(retrieveCssRules, 'retrieveCssRules').and.returnValue(
             mockedRules
         );
         const convertInlineCssSpy = spyOn(convertInlineCss, 'convertInlineCss');
@@ -170,7 +171,7 @@ describe('createModelFromHtml', () => {
             mockedDoc
         );
         const mockedRules = 'RULES' as any;
-        const retrieveCssRulesSpy = spyOn(convertInlineCss, 'retrieveCssRules').and.returnValue(
+        const retrieveCssRulesSpy = spyOn(retrieveCssRules, 'retrieveCssRules').and.returnValue(
             mockedRules
         );
         const convertInlineCssSpy = spyOn(convertInlineCss, 'convertInlineCss');

--- a/packages/roosterjs-content-model-core/test/command/paste/generatePasteOptionFromPluginsTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/generatePasteOptionFromPluginsTest.ts
@@ -56,6 +56,7 @@ describe('generatePasteOptionFromPlugins', () => {
             htmlAfter,
             htmlAttributes: mockedMetadata,
             containsBlockElements: false,
+            cssRulesToBeConverted: [],
         } as any);
         expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
         expect(originalEvent).toEqual({
@@ -76,6 +77,7 @@ describe('generatePasteOptionFromPlugins', () => {
                 attributeSanitizers: {},
             },
             containsBlockElements: false,
+            cssRulesToBeConverted: [],
         });
         expect(triggerPluginEventSpy).toHaveBeenCalledWith(
             'beforePaste',
@@ -89,6 +91,7 @@ describe('generatePasteOptionFromPlugins', () => {
                 pasteType: 'TypeResult',
                 domToModelOption: 'OptionResult',
                 containsBlockElements: false,
+                cssRulesToBeConverted: [],
             },
             true
         );
@@ -130,6 +133,7 @@ describe('generatePasteOptionFromPlugins', () => {
             htmlAfter,
             htmlAttributes: mockedMetadata,
             containsBlockElements: false,
+            cssRulesToBeConverted: [],
         } as any);
         expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
         expect(triggerPluginEventSpy).toHaveBeenCalledWith(
@@ -145,6 +149,7 @@ describe('generatePasteOptionFromPlugins', () => {
                 domToModelOption: 'OptionResult',
                 customizedMerge: mockedCustomizedMerge,
                 containsBlockElements: false,
+                cssRulesToBeConverted: [],
             },
             true
         );
@@ -180,6 +185,7 @@ describe('generatePasteOptionFromPlugins', () => {
             htmlAfter: '',
             htmlAttributes: mockedMetadata,
             containsBlockElements: false,
+            cssRulesToBeConverted: [],
         } as any);
         expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
         expect(triggerPluginEventSpy).toHaveBeenCalledWith(
@@ -194,6 +200,7 @@ describe('generatePasteOptionFromPlugins', () => {
                 pasteType: 'TypeResult',
                 domToModelOption: 'OptionResult',
                 containsBlockElements: false,
+                cssRulesToBeConverted: [],
             },
             true
         );
@@ -214,6 +221,7 @@ describe('generatePasteOptionFromPlugins', () => {
                 styleSanitizers: {},
                 attributeSanitizers: {},
             },
+            cssRulesToBeConverted: [],
             containsBlockElements: false,
         });
     });
@@ -247,6 +255,7 @@ describe('generatePasteOptionFromPlugins', () => {
             pasteType: 'TypeResult' as any,
             domToModelOption: 'OptionResult' as any,
             containsBlockElements: false,
+            cssRulesToBeConverted: [],
         });
         expect(triggerPluginEventSpy).toHaveBeenCalledTimes(1);
     });

--- a/packages/roosterjs-content-model-dom/lib/domUtils/style/retrieveCssRules.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/style/retrieveCssRules.ts
@@ -1,0 +1,44 @@
+import { toArray } from '../toArray';
+import type { CssRule } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ *
+ * Splits CSS selectors, avoiding splits within parentheses
+ * @param selectorText The CSS selector string
+ * @return Array of trimmed selectors
+ */
+function splitSelectors(selectorText: string) {
+    const regex = /(?![^(]*\)),/;
+    return selectorText.split(regex).map(s => s.trim());
+}
+
+/**
+ * Retrieves CSS rules from a document's style elements.
+ * @param doc The document to retrieve CSS rules from
+ */
+export function retrieveCssRules(doc: Document): CssRule[] {
+    const styles = toArray(doc.querySelectorAll('style'));
+    const result: CssRule[] = [];
+
+    styles.forEach(styleNode => {
+        const sheet = styleNode.sheet;
+
+        if (sheet) {
+            for (let ruleIndex = 0; ruleIndex < sheet.cssRules.length; ruleIndex++) {
+                const rule = sheet.cssRules[ruleIndex] as CSSStyleRule;
+
+                if (rule.type == CSSRule.STYLE_RULE && rule.selectorText) {
+                    result.push({
+                        selectors: splitSelectors(rule.selectorText),
+                        text: rule.style.cssText,
+                    });
+                }
+            }
+        }
+
+        styleNode.parentNode?.removeChild(styleNode);
+    });
+
+    return result;
+}

--- a/packages/roosterjs-content-model-dom/lib/index.ts
+++ b/packages/roosterjs-content-model-dom/lib/index.ts
@@ -101,6 +101,7 @@ export {
 } from './modelToDom/context/createModelToDomContext';
 
 export { isBold } from './domUtils/style/isBold';
+export { retrieveCssRules } from './domUtils/style/retrieveCssRules';
 export { getSelectionRootNode } from './domUtils/selection/getSelectionRootNode';
 export { getDOMInsertPointRect } from './domUtils/selection/getDOMInsertPointRect';
 export { isCharacterValue, isModifierKey, isCursorMovingKey } from './domUtils/event/eventUtils';

--- a/packages/roosterjs-content-model-plugins/test/paste/createBeforePasteEventMock.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/createBeforePasteEventMock.ts
@@ -12,6 +12,7 @@ export function createBeforePasteEventMock(
         htmlAfter: '',
         htmlAttributes: {},
         pasteType: 'normal',
+        cssRulesToBeConverted: [],
         domToModelOption: {
             additionalAllowedTags: [],
             additionalDisallowedTags: [],

--- a/packages/roosterjs-content-model-plugins/test/paste/excel/validateExcelFragmentTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/excel/validateExcelFragmentTest.ts
@@ -27,7 +27,15 @@ describe('validateExcelFragment', () => {
         const htmlAfter = '</table>';
         clipboardData.html = '<tr><td>Test</td></tr></table>';
 
-        validateExcelFragment(fragment, domCreator, htmlBefore, clipboardData, htmlAfter);
+        const ev = <any>{
+            htmlBefore,
+            htmlAfter,
+            clipboardData,
+            fragment,
+            cssRulesToBeConverted: [],
+        };
+
+        validateExcelFragment(ev, domCreator);
 
         expect(fragment.querySelector('table')).not.toBeNull();
         expect(domCreator.htmlToDOM).toHaveBeenCalledWith(
@@ -40,7 +48,15 @@ describe('validateExcelFragment', () => {
         const htmlAfter = '';
         clipboardData.html = '<tr><td>Test</td></tr>';
 
-        validateExcelFragment(fragment, domCreator, htmlBefore, clipboardData, htmlAfter);
+        const ev = <any>{
+            htmlBefore,
+            htmlAfter,
+            clipboardData,
+            cssRulesToBeConverted: [],
+            fragment,
+        };
+
+        validateExcelFragment(ev, domCreator);
 
         expect(fragment.querySelector('table')).not.toBeNull();
         expect(domCreator.htmlToDOM).toHaveBeenCalledTimes(2);

--- a/packages/roosterjs-content-model-types/lib/event/BeforePasteEvent.ts
+++ b/packages/roosterjs-content-model-types/lib/event/BeforePasteEvent.ts
@@ -1,3 +1,4 @@
+import type { CssRule } from '../parameter/CssRule';
 import type { DomToModelOptionForSanitizing } from '../context/DomToModelOption';
 import type { PasteType } from '../enum/PasteType';
 import type { ClipboardData } from '../parameter/ClipboardData';
@@ -67,4 +68,11 @@ export interface BeforePasteEvent extends BasePluginEvent<'beforePaste'> {
      * Whether the current clipboard contains at least a block element.
      */
     readonly containsBlockElements?: boolean;
+
+    /**
+     * Additional Css rules to be converted to inline styles.
+     * This property accumulates additional CSS rules extracted from pasted content,
+     * which are then merged with global CSS rules during the inline style conversion process.
+     */
+    cssRulesToBeConverted?: CssRule[];
 }

--- a/packages/roosterjs-content-model-types/lib/index.ts
+++ b/packages/roosterjs-content-model-types/lib/index.ts
@@ -403,6 +403,7 @@ export {
     ContentModelFormatter,
 } from './parameter/FormatContentModelOptions';
 export { ContentModelFormatState } from './parameter/ContentModelFormatState';
+export { CssRule } from './parameter/CssRule';
 export { PasteTypeOrGetter } from './parameter/PasteTypeOrGetter';
 export { ImageFormatState } from './parameter/ImageFormatState';
 export { Border } from './parameter/Border';

--- a/packages/roosterjs-content-model-types/lib/parameter/CssRule.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/CssRule.ts
@@ -1,0 +1,7 @@
+/**
+ * Represents a CSS rule in a style block.
+ */
+export interface CssRule {
+    selectors: string[];
+    text: string;
+}


### PR DESCRIPTION
In OWA, the Excel styles are getting removed due to a custom DOMCreator The reason is that Styles in HEAD are wrapped in html comment tags

So we may need to remove them and add a way to add CSS styles to the BeforePasteEvent. 

Source: 
![image](https://github.com/user-attachments/assets/ecb1d873-015f-45e3-8017-48a1e8c33f6a)

Before![image](https://github.com/user-attachments/assets/e5b228a6-c17b-4cd3-93c8-c1f5fbe7f70c)

After![image](https://github.com/user-attachments/assets/dea86202-761f-4576-b3b4-5a9cbaa84cf5)
