### PR TITLE
Include ImageMetadata in FormatState

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/retrieveModelFormatState.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/retrieveModelFormatState.ts
@@ -1,5 +1,6 @@
 import { extractBorderValues } from '../../domUtils/style/borderValues';
 import { getClosestAncestorBlockGroupIndex } from './getClosestAncestorBlockGroupIndex';
+import { getImageMetadata } from '../metadata/updateImageMetadata';
 import { getTableMetadata } from '../metadata/updateTableMetadata';
 import { isBold } from '../../domUtils/style/isBold';
 import { iterateSelections } from '../selection/iterateSelections';
@@ -124,6 +125,7 @@ export function retrieveModelFormatState(
                             isFirstImage = false;
                         } else {
                             formatState.imageFormat = undefined;
+                            formatState.imageEditingMetadata = undefined;
                         }
                     }
                 });
@@ -257,6 +259,7 @@ function retrieveImageFormat(image: ReadonlyContentModelImage, result: ContentMo
     const borderColor = extractedBorder.color;
     const borderWidth = extractedBorder.width;
     const borderStyle = extractedBorder.style;
+
     result.imageFormat = {
         borderColor,
         borderWidth,
@@ -264,6 +267,7 @@ function retrieveImageFormat(image: ReadonlyContentModelImage, result: ContentMo
         boxShadow: format.boxShadow,
         borderRadius: format.borderRadius,
     };
+    result.imageEditingMetadata = getImageMetadata(image);
 }
 
 function mergeValue<K extends keyof ContentModelFormatState>(

--- a/packages/roosterjs-content-model-dom/test/modelApi/editing/retrieveModelFormatStateTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/editing/retrieveModelFormatStateTest.ts
@@ -18,6 +18,7 @@ import {
     ContentModelFormatState,
     ContentModelSegmentFormat,
     DOMHelper,
+    ImageMetadataFormat,
 } from 'roosterjs-content-model-types';
 
 describe('retrieveModelFormatState', () => {
@@ -649,6 +650,49 @@ describe('retrieveModelFormatState', () => {
                 boxShadow: undefined,
                 borderRadius: undefined,
             },
+            imageEditingMetadata: null,
+        });
+    });
+
+    it('With selection under image that has metadata', () => {
+        const model = createContentModelDocument();
+        const result: ContentModelFormatState = {};
+        const para = createParagraph();
+        const image = createImage('test', {
+            borderTop: 'solid 2px red',
+        });
+        const mockedMetadata: ImageMetadataFormat = {
+            src: 'test',
+        };
+
+        image.dataset = { editingInfo: JSON.stringify(mockedMetadata) };
+        image.isSelected = true;
+
+        para.segments.push(image);
+
+        spyOn(iterateSelections, 'iterateSelections').and.callFake((path: any, callback) => {
+            callback([path], undefined, para, [image]);
+            return false;
+        });
+
+        retrieveModelFormatState(model, null, result);
+
+        expect(result).toEqual({
+            isBlockQuote: false,
+            isBold: false,
+            isSuperscript: false,
+            isSubscript: false,
+            isCodeInline: false,
+            canUnlink: false,
+            canAddImageAltText: true,
+            imageFormat: {
+                borderColor: 'red',
+                borderWidth: '2px',
+                borderStyle: 'solid',
+                boxShadow: undefined,
+                borderRadius: undefined,
+            },
+            imageEditingMetadata: mockedMetadata,
         });
     });
 
@@ -683,6 +727,7 @@ describe('retrieveModelFormatState', () => {
             canUnlink: false,
             canAddImageAltText: true,
             imageFormat: undefined,
+            imageEditingMetadata: undefined,
         });
     });
 

--- a/packages/roosterjs-content-model-types/lib/parameter/ContentModelFormatState.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/ContentModelFormatState.ts
@@ -1,3 +1,4 @@
+import type { ImageMetadataFormat } from '../contentModel/format/metadata/ImageMetadataFormat';
 import type { TableMetadataFormat } from '../contentModel/format/metadata/TableMetadataFormat';
 import type { ImageFormatState } from './ImageFormatState';
 
@@ -151,9 +152,14 @@ export interface ContentModelFormatState {
     fontWeight?: string;
 
     /**
-     * Format of image, if there is table at cursor position
+     * Format of image, if there is image at cursor position
      */
     imageFormat?: ImageFormatState;
+
+    /**
+     * Editing metadata of image, if there is image at cursor position
+     */
+    imageEditingMetadata?: ImageMetadataFormat | null;
 
     /**
      * Letter spacing


### PR DESCRIPTION
Include ImageMetadata for image editing into FormatState, so we can directly get image editing info from format state without additional operations.