### PR TITLE
Add margin-inline-start to watermark styles to fix #3030

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/watermark/WatermarkPlugin.ts
@@ -135,7 +135,7 @@ export class WatermarkPlugin implements EditorPlugin {
     }
 
     private applyWatermarkStyle(editor: IEditor) {
-        let rule = `position: absolute; pointer-events: none; content: "${this.watermark}";`;
+        let rule = `position: absolute; pointer-events: none; margin-inline-start: 1px; content: "${this.watermark}";`;
         const format = {
             ...this.format,
             textColor: editor.isDarkMode() ? this.darkTextColor : this.format.textColor,

--- a/packages/roosterjs-content-model-plugins/test/watermark/WatermarkPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/watermark/WatermarkPluginTest.ts
@@ -55,7 +55,7 @@ describe('WatermarkPlugin', () => {
         expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
         expect(setEditorStyleSpy).toHaveBeenCalledWith(
             '_WatermarkContent',
-            'position: absolute; pointer-events: none; content: "test";font-size: 14px!important;color: #AAAAAA!important;',
+            'position: absolute; pointer-events: none; margin-inline-start: 1px; content: "test";font-size: 14px!important;color: #AAAAAA!important;',
             'before'
         );
 
@@ -98,7 +98,7 @@ describe('WatermarkPlugin', () => {
         expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
         expect(setEditorStyleSpy).toHaveBeenCalledWith(
             '_WatermarkContent',
-            'position: absolute; pointer-events: none; content: "test";font-size: 14px!important;color: #AAAAAA!important;',
+            'position: absolute; pointer-events: none; margin-inline-start: 1px; content: "test";font-size: 14px!important;color: #AAAAAA!important;',
             'before'
         );
     });
@@ -124,7 +124,7 @@ describe('WatermarkPlugin', () => {
         expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
         expect(setEditorStyleSpy).toHaveBeenCalledWith(
             '_WatermarkContent',
-            'position: absolute; pointer-events: none; content: "test";font-family: Arial!important;font-size: 20pt!important;color: red!important;',
+            'position: absolute; pointer-events: none; margin-inline-start: 1px; content: "test";font-family: Arial!important;font-size: 20pt!important;color: red!important;',
             'before'
         );
 
@@ -161,7 +161,7 @@ describe('WatermarkPlugin', () => {
         expect(setEditorStyleSpy).toHaveBeenCalledTimes(1);
         expect(setEditorStyleSpy).toHaveBeenCalledWith(
             '_WatermarkContent',
-            'position: absolute; pointer-events: none; content: "test";font-family: Arial!important;font-size: 20pt!important;color: red!important;',
+            'position: absolute; pointer-events: none; margin-inline-start: 1px; content: "test";font-family: Arial!important;font-size: 20pt!important;color: red!important;',
             'before'
         );
 
@@ -220,8 +220,8 @@ describe('WatermarkPlugin dark mode', () => {
             fontSize: '20pt',
             textColor: textColor,
         });
-        const darkModeStyles = `position: absolute; pointer-events: none; content: "test";font-family: Arial!important;font-size: 20pt!important;color: ${DEFAULT_DARK_COLOR_SUFFIX_COLOR}${textColor}!important;`;
-        const lightModeStyles = `position: absolute; pointer-events: none; content: "test";font-family: Arial!important;font-size: 20pt!important;color: red!important;`;
+        const darkModeStyles = `position: absolute; pointer-events: none; margin-inline-start: 1px; content: "test";font-family: Arial!important;font-size: 20pt!important;color: ${DEFAULT_DARK_COLOR_SUFFIX_COLOR}${textColor}!important;`;
+        const lightModeStyles = `position: absolute; pointer-events: none; margin-inline-start: 1px; content: "test";font-family: Arial!important;font-size: 20pt!important;color: red!important;`;
 
         plugin.initialize(editor);
 


### PR DESCRIPTION
Fix #3030 

Looks like in Contrast themes, the watermark ::before element content hides the cursor. So add margin at the start of the line so it is visible:

Before
![image](https://github.com/user-attachments/assets/52ebf0f8-383a-4f6d-9de3-6b109c65f86d)


After
![image](https://github.com/user-attachments/assets/743a00e3-a21e-44bf-ab3b-44dfd7cf528a)
