### PR TITLE
Edit plugin Options

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -68,7 +68,9 @@ export class EditPlugin implements EditorPlugin {
      * @param options An optional parameter that takes in an object of type EditOptions, which includes the following properties:
      * handleTabKey: A boolean that enables or disables Tab key handling. Defaults to true.
      */
-    constructor(private options: EditOptions = DefaultOptions) {}
+    constructor(private options: EditOptions = DefaultOptions) {
+        this.options = { ...DefaultOptions, ...options };
+    }
 
     private createNormalEnterChecker(result: boolean) {
         return result ? () => true : () => false;


### PR DESCRIPTION
Combine the options of the Edit Plugin with the Default options. The Default options will only be disabled if explicitly set to false.