### PR TITLE
Do not indent on TAB

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnParagraph.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/tabUtils/handleTabOnParagraph.ts
@@ -18,7 +18,7 @@ const space = ' ';
  * @internal
  The handleTabOnParagraph function will handle the tab key in following scenarios:
  * 1. When the selection is collapsed and the cursor is at the end of a paragraph, add 4 spaces.
- * 2. When the selection is collapsed and the cursor is at the start of a paragraph, call setModelIndention function to indent the whole paragraph
+ * 2. When the selection is collapsed and the cursor is at the start of a paragraph, add 4 spaces.
  * 3. When the selection is collapsed and the cursor is at the middle of a paragraph, add 4 spaces.
  * 4. When the selection is not collapsed, replace the selected range with a single space.
  * 5. When the selection is not collapsed, but all segments are selected, call setModelIndention function to indent the whole paragraph
@@ -38,8 +38,11 @@ export function handleTabOnParagraph(
     const selectedSegments = paragraph.segments.filter(segment => segment.isSelected);
     const isCollapsed =
         selectedSegments.length === 1 && selectedSegments[0].segmentType === 'SelectionMarker';
-    const isAllSelected = paragraph.segments.every(segment => segment.isSelected);
-    if ((paragraph.segments[0].segmentType === 'SelectionMarker' && isCollapsed) || isAllSelected) {
+    const isAllSelected = paragraph.segments.every(
+        segment =>
+            segment.isSelected || (segment.segmentType == 'Text' && segment.text.trim().length == 0)
+    );
+    if (isAllSelected) {
         const { marginLeft, marginRight, direction } = paragraph.format;
         const isRtl = direction === 'rtl';
         if (
@@ -96,6 +99,9 @@ export function handleTabOnParagraph(
 
                 mutateBlock(paragraph).segments.splice(markerIndex, 0, tabText);
             } else {
+                if (markerIndex <= 0) {
+                    return false;
+                }
                 const tabText = paragraph.segments[markerIndex - 1];
                 const tabSpacesLength = tabSpaces.length;
 

--- a/packages/roosterjs-content-model-plugins/test/edit/keyboardTabTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/keyboardTabTest.ts
@@ -117,7 +117,7 @@ describe('keyboardTab', () => {
             format: {},
         };
 
-        runTest(model, 'indent', false, true);
+        runTest(model, undefined, false, true);
     });
 
     it('tab on empty list', () => {
@@ -1179,6 +1179,11 @@ describe('keyboardTab - handleTabOnParagraph -', () => {
                     blockType: 'Paragraph',
                     segments: [
                         {
+                            segmentType: 'Text',
+                            text: '    ',
+                            format: {},
+                        },
+                        {
                             segmentType: 'SelectionMarker',
                             isSelected: true,
                             format: {},
@@ -1187,6 +1192,57 @@ describe('keyboardTab - handleTabOnParagraph -', () => {
                             segmentType: 'Text',
                             text: 'test',
                             format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+        runTest(input, 'Tab', true, false, expectedResult);
+    });
+
+    it('non collapsed range | tab on the start of paragraph that has space unselected', () => {
+        const input: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: '    ',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+
+        const expectedResult: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: '    ',
+                            format: {},
+                        },
+                        {
+                            segmentType: 'Text',
+                            text: 'test',
+                            format: {},
+                            isSelected: true,
                         },
                     ],
                     format: {
@@ -1297,6 +1353,11 @@ describe('keyboardTab - handleTabOnParagraph -', () => {
                     blockType: 'Paragraph',
                     segments: [
                         {
+                            segmentType: 'Text',
+                            text: '    ',
+                            format: {},
+                        },
+                        {
                             segmentType: 'SelectionMarker',
                             isSelected: true,
                             format: {},
@@ -1307,9 +1368,7 @@ describe('keyboardTab - handleTabOnParagraph -', () => {
                             format: {},
                         },
                     ],
-                    format: {
-                        marginLeft: '40px',
-                    },
+                    format: {},
                 },
             ],
             format: {},
@@ -1332,9 +1391,7 @@ describe('keyboardTab - handleTabOnParagraph -', () => {
                             format: {},
                         },
                     ],
-                    format: {
-                        marginLeft: '0px',
-                    },
+                    format: {},
                 },
             ],
             format: {},

--- a/packages/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnParagraphTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnParagraphTest.ts
@@ -10,7 +10,6 @@ describe('handleTabOnParagraph', () => {
         model: ContentModelDocument,
         paragraph: ContentModelParagraph,
         rawEvent: KeyboardEvent,
-        selection: RangeSelection,
         expectedReturnValue: boolean
     ) {
         // Act
@@ -48,13 +47,8 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: false,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: true,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, true);
+
+        runTest(model, paragraph, rawEvent, true);
     });
 
     it('Outdent - collapsed range should return false when cursor is at the end', () => {
@@ -85,13 +79,8 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: true,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: true,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, false);
+
+        runTest(model, paragraph, rawEvent, false);
     });
 
     it('Indent - collapsed range should return true when cursor is at the start', () => {
@@ -122,13 +111,7 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: false,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: true,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, true);
+        runTest(model, paragraph, rawEvent, true);
     });
 
     it('Outdent - collapsed range should return false when cursor is at the start', () => {
@@ -159,13 +142,8 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: true,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: true,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, false);
+
+        runTest(model, paragraph, rawEvent, false);
     });
 
     it('Outdent - collapsed range should return true when cursor is at the start and exist indentation', () => {
@@ -175,6 +153,11 @@ describe('handleTabOnParagraph', () => {
                 {
                     blockType: 'Paragraph',
                     segments: [
+                        {
+                            segmentType: 'Text',
+                            text: '    ',
+                            format: {},
+                        },
                         {
                             segmentType: 'SelectionMarker',
                             isSelected: true,
@@ -186,9 +169,7 @@ describe('handleTabOnParagraph', () => {
                             format: {},
                         },
                     ],
-                    format: {
-                        marginLeft: '4px',
-                    },
+                    format: {},
                 },
             ],
             format: {},
@@ -198,13 +179,8 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: true,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: true,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, true);
+
+        runTest(model, paragraph, rawEvent, true);
     });
 
     it('Indent - collapsed range should return true when cursor is at the middle', () => {
@@ -240,13 +216,8 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: false,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: true,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, true);
+
+        runTest(model, paragraph, rawEvent, true);
     });
 
     it('Outdent - collapsed range should return true when cursor is at the middle', () => {
@@ -282,13 +253,8 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: true,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: true,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, false);
+
+        runTest(model, paragraph, rawEvent, false);
     });
 
     it('Outdent - Intended - collapsed range should return true when cursor is at the end', () => {
@@ -324,13 +290,8 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: true,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: true,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, true);
+
+        runTest(model, paragraph, rawEvent, true);
     });
 
     it('Outdent - Intended - collapsed range should return true when cursor is at the middle', () => {
@@ -371,13 +332,8 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: true,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: true,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, true);
+
+        runTest(model, paragraph, rawEvent, true);
     });
 
     it('Indent - expanded range should return true', () => {
@@ -414,13 +370,8 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: false,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: false,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, true);
+
+        runTest(model, paragraph, rawEvent, true);
     });
 
     it('outdent - expanded range should return true', () => {
@@ -457,12 +408,7 @@ describe('handleTabOnParagraph', () => {
             key: 'Tab',
             shiftKey: true,
         });
-        const selection = {
-            type: 'range',
-            range: {
-                collapsed: false,
-            },
-        } as RangeSelection;
-        runTest(model, paragraph, rawEvent, selection, true);
+
+        runTest(model, paragraph, rawEvent, true);
     });
 });

--- a/packages/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnParagraphTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/tabUtils/handleTabOnParagraphTest.ts
@@ -1,9 +1,5 @@
+import { ContentModelDocument, ContentModelParagraph } from 'roosterjs-content-model-types';
 import { handleTabOnParagraph } from '../../../lib/edit/tabUtils/handleTabOnParagraph';
-import {
-    ContentModelDocument,
-    ContentModelParagraph,
-    RangeSelection,
-} from 'roosterjs-content-model-types';
 
 describe('handleTabOnParagraph', () => {
     function runTest(


### PR DESCRIPTION
When the selection is collapsed and the cursor is at the start of a paragraph, the `handleTabOnParagraph` function will add 4 spaces instead of calling the `setModelIndention` function. 
![AdjustTab](https://github.com/user-attachments/assets/e73f4c14-a7d9-4442-980f-f3e611d4285d)
