### PR TITLE
Support table edit with logical root

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/index.ts
+++ b/packages/roosterjs-content-model-plugins/lib/index.ts
@@ -1,6 +1,7 @@
 export { TableEditPlugin } from './tableEdit/TableEditPlugin';
 export { OnTableEditorCreatedCallback } from './tableEdit/OnTableEditorCreatedCallback';
 export { TableEditFeatureName } from './tableEdit/editors/features/TableEditFeatureName';
+export { TableWithRoot } from './tableEdit/TableWithRoot';
 export { PastePlugin } from './paste/PastePlugin';
 export { DefaultSanitizers } from './paste/DefaultSanitizers';
 export { EditPlugin, EditOptions } from './edit/EditPlugin';

--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/TableWithRoot.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/TableWithRoot.ts
@@ -1,0 +1,15 @@
+/**
+ * Represents a table and its container (logical root)
+ */
+export interface TableWithRoot {
+    /**
+     * The table element
+     */
+    table: HTMLTableElement;
+    /**
+     * The logical root element of the table
+     * This is the element that contains the table and all its ancestors
+     * It is used to determine the logical root of the table
+     */
+    logicalRoot: HTMLDivElement | null;
+}

--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/TableEditor.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/TableEditor.ts
@@ -65,6 +65,7 @@ export class TableEditor {
     constructor(
         private editor: IEditor,
         public readonly table: HTMLTableElement,
+        public readonly logicalRoot: HTMLDivElement | null,
         private onChanged: () => void,
         private anchorContainer?: HTMLElement,
         private contentDiv?: EventTarget | null,
@@ -287,7 +288,8 @@ export class TableEditor {
                 this.table,
                 this.isRTL,
                 !!isHorizontal,
-                this.onInserted,
+                this.onBeforeEditTable,
+                this.onAfterInsert,
                 this.anchorContainer,
                 this.onEditorCreated
             );
@@ -362,6 +364,7 @@ export class TableEditor {
     };
 
     private onStartTableMove = () => {
+        this.onBeforeEditTable();
         this.isCurrentlyEditing = true;
         this.disposeTableResizer();
         this.disposeTableInserter();
@@ -369,6 +372,7 @@ export class TableEditor {
     };
 
     private onStartResize() {
+        this.onBeforeEditTable();
         this.isCurrentlyEditing = true;
         const range = this.editor.getDOMSelection();
 
@@ -386,7 +390,11 @@ export class TableEditor {
         return this.onFinishEditing();
     };
 
-    private onInserted = () => {
+    private onBeforeEditTable = () => {
+        this.editor.setLogicalRoot(this.logicalRoot);
+    };
+
+    private onAfterInsert = () => {
         this.disposeTableResizer();
         this.onFinishEditing();
     };

--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/features/TableInserter.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/features/TableInserter.ts
@@ -34,7 +34,8 @@ export function createTableInserter(
     table: HTMLTableElement,
     isRTL: boolean,
     isHorizontal: boolean,
-    onInsert: () => void,
+    onBeforeInsert: () => void,
+    onAfterInserted: () => void,
     anchorContainer?: HTMLElement,
     onTableEditorCreated?: OnTableEditorCreatedCallback
 ): TableEditFeature | null {
@@ -82,7 +83,8 @@ export function createTableInserter(
             table,
             isHorizontal,
             editor,
-            onInsert,
+            onBeforeInsert,
+            onAfterInserted,
             onTableEditorCreated
         );
 
@@ -104,7 +106,8 @@ export class TableInsertHandler implements Disposable {
         private table: HTMLTableElement,
         private isHorizontal: boolean,
         private editor: IEditor,
-        private onInsert: () => void,
+        private onBeforeInsert: () => void,
+        private onAfterInsert: () => void,
         onTableEditorCreated?: OnTableEditorCreatedCallback
     ) {
         this.div.addEventListener('click', this.insertTd);
@@ -133,6 +136,8 @@ export class TableInsertHandler implements Disposable {
             return;
         }
 
+        this.onBeforeInsert();
+
         // Insert row or column
         formatTableWithContentModel(
             this.editor,
@@ -152,7 +157,7 @@ export class TableInsertHandler implements Disposable {
             }
         );
 
-        this.onInsert();
+        this.onAfterInsert();
     };
 }
 


### PR DESCRIPTION
Most features requires that the editing target should be in current logical root, but table edit is an exception. We should still allow showing editing related ui (inserted, resizer, ...) even the table is not in current logical root.

So I'm making this change to allow passing in a callback function to help choose which tables are allowed to be edited, alone with its logical root. Then let each table edit feature set logical root when start to use it (mouse down or click).