### PR TITLE
Fix regression: If font family already has single quote, keep it

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/domUtils/style/normalizeFontFamily.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/style/normalizeFontFamily.ts
@@ -5,7 +5,7 @@
  * @returns The normalized font family string
  */
 export function normalizeFontFamily(fontFamily: string): string {
-    const existingQuotedFontsRegex = /".*?"/g;
+    const existingQuotedFontsRegex = /(".*?")|('.*?')/g;
     let match = existingQuotedFontsRegex.exec(fontFamily);
     let start = 0;
     const result: string[] = [];

--- a/packages/roosterjs-content-model-dom/test/domUtils/style/normalizeFontFamilyTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domUtils/style/normalizeFontFamilyTest.ts
@@ -125,4 +125,16 @@ describe('normalizeFontFamily', () => {
     it('font family with dots', () => {
         expect(normalizeFontFamily('A.B')).toBe('"A.B"');
     });
+
+    it('font family has single quote', () => {
+        expect(normalizeFontFamily("'Corbel','Skia',sans-serif")).toBe(
+            "'Corbel', 'Skia', sans-serif"
+        );
+    });
+
+    it('mixed single quoted and double quoted font families', () => {
+        expect(normalizeFontFamily('"Corbel",\'Skia\',sans-serif')).toBe(
+            '"Corbel", \'Skia\', sans-serif'
+        );
+    });
 });


### PR DESCRIPTION
In #3038, I'm add quotes to font names if need. However, it only check double quote for existing quote in font family, and missed single quotes. Here is a fix to check single quote as well. It can fix the case if font is like
```
'Corbel','Skia',sans-serif
```