### PR TITLE
Fix clipboard text handling for plain text pasting

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/paste/createPasteFragment.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/createPasteFragment.ts
@@ -14,7 +14,7 @@ export function createPasteFragment(
     pasteType: PasteType,
     root: HTMLElement | undefined
 ): DocumentFragment {
-    if (!clipboardData.text && pasteType == 'asPlainText' && root) {
+    if (!clipboardData.text && pasteType === 'asPlainText' && root) {
         clipboardData.text = root.textContent || clipboardData.text;
     }
 

--- a/packages/roosterjs-content-model-core/lib/command/paste/createPasteFragment.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/createPasteFragment.ts
@@ -14,6 +14,10 @@ export function createPasteFragment(
     pasteType: PasteType,
     root: HTMLElement | undefined
 ): DocumentFragment {
+    if (!clipboardData.text && pasteType == 'asPlainText' && root) {
+        clipboardData.text = root.textContent || clipboardData.text;
+    }
+
     const { imageDataUri, text } = clipboardData;
     const fragment = document.createDocumentFragment();
 

--- a/packages/roosterjs-content-model-core/test/command/paste/createPasteFragmentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/createPasteFragmentTest.ts
@@ -126,7 +126,7 @@ describe('createPasteFragment', () => {
                 imageDataUri: 'test',
             },
             'asPlainText',
-            '',
+            'HTML',
             false
         );
     });


### PR DESCRIPTION
When there is no text in the clipboard data but here is html, get the text content of the root element and correctly set the text prop of the clipboard data,

Otherwise paste in this scenario would be no-op.
Fix 279830