### PR TITLE
Avoid "undefined" in HTML to Markdown generated content

### DIFF
--- a/packages/roosterjs-content-model-markdown/lib/modelToMarkdown/creators/createMarkdownParagraph.ts
+++ b/packages/roosterjs-content-model-markdown/lib/modelToMarkdown/creators/createMarkdownParagraph.ts
@@ -23,7 +23,7 @@ export function createMarkdownParagraph(
                 markdownString += textProcessor(segment);
                 break;
             case 'Image':
-                markdownString += `![${segment.alt}](${segment.src})`;
+                markdownString += `![${segment.alt || 'image'}](${segment.src})`;
                 break;
             case 'Br':
                 if (!context?.ignoreLineBreaks) {

--- a/packages/roosterjs-content-model-markdown/test/modelToMarkdown/convertContentModelToMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/modelToMarkdown/convertContentModelToMarkdownTest.ts
@@ -114,4 +114,12 @@ describe('convertContentModelToMarkdown', () => {
         const md = convertContentModelToMarkdown(model).trim();
         expect(md).toEqual(markdown);
     });
+
+    it('should set a default alt to images', () => {
+        const markdown = '![image](https://www.example.com/image)';
+        const model = createModelFromHtml("<img src='https://www.example.com/image'>");
+        console.log(model);
+        const md = convertContentModelToMarkdown(model).trim();
+        expect(md).toEqual(markdown);
+    });
 });


### PR DESCRIPTION
This PR <ins>partly</ins> fixes issue https://github.com/microsoft/roosterjs/issues/3040

## Issues fixed
Currently the simple example bellow generates an `undefined` at the beggining of the resulting markdown:
```typescript
    const model = createModelFromHtml("<p>hello <b>world</b> how are you?</p>")
    const md = convertContentModelToMarkdown(model);
    console.log(md)// Generates => undefinedhello **world** how are you?
```
_(it basically adds an `undefined` before every paragraphs that are not Headings)_

Also, images without ALT would generate "undefined" as the default ALT:
```typescript
    const model = createModelFromHtml("<img src='https://www.example.com/image'>")
    const md = convertContentModelToMarkdown(model);
    console.log(md)// Generates => ![undefined](https://www.example.com/image)
```

## Changes
This PR avoids `undefined` before every paragraphs.
It also sets a default "`image`" ALT for <img> tags instead of "`undefined`".  
If language is an issue for the default ALT value then setting it to an empty string might be preferable.

2 unit tests have been added to specifically test those 2 issues.