### PR TITLE
Add focus handling in formatTableWithContentModel and its tests

### DIFF
--- a/packages/roosterjs-content-model-api/lib/publicApi/utils/formatTableWithContentModel.ts
+++ b/packages/roosterjs-content-model-api/lib/publicApi/utils/formatTableWithContentModel.ts
@@ -29,6 +29,7 @@ export function formatTableWithContentModel(
     callback: (tableModel: ShallowMutableContentModelTable) => void,
     selectionOverride?: TableSelection
 ) {
+    editor.focus();
     editor.formatContentModel(
         model => {
             const [readonlyTableModel, path] = getFirstSelectedTable(model);

--- a/packages/roosterjs-content-model-api/test/publicApi/utils/formatTableWithContentModelTest.ts
+++ b/packages/roosterjs-content-model-api/test/publicApi/utils/formatTableWithContentModelTest.ts
@@ -13,6 +13,7 @@ import {
 describe('formatTableWithContentModel', () => {
     let editor: IEditor;
     let formatContentModelSpy: jasmine.Spy;
+    let focusSpy: jasmine.Spy;
     let model: ContentModelDocument;
     let formatResult: boolean | undefined;
 
@@ -31,8 +32,11 @@ describe('formatTableWithContentModel', () => {
             .and.callFake((callback: Function) => {
                 formatResult = callback(model);
             });
+        focusSpy = jasmine.createSpy('focus').and.callFake(() => {});
+
         editor = {
             formatContentModel: formatContentModelSpy,
+            focus: focusSpy,
         } as any;
     });
 
@@ -54,6 +58,7 @@ describe('formatTableWithContentModel', () => {
             }
         );
         expect(formatResult).toBeFalse();
+        expect(focusSpy).toHaveBeenCalled();
     });
 
     it('Model with table but not selected', () => {
@@ -81,6 +86,7 @@ describe('formatTableWithContentModel', () => {
         );
         expect(formatResult).toBeFalse();
         expect(table.cachedElement).toBeDefined();
+        expect(focusSpy).toHaveBeenCalled();
     });
 
     it('Model with selected table, has selection in block, no metadata', () => {
@@ -120,6 +126,7 @@ describe('formatTableWithContentModel', () => {
         expect(applyTableFormat.applyTableFormat).not.toHaveBeenCalled();
         expect(formatResult).toBeTrue();
         expect(table.cachedElement).toBeUndefined();
+        expect(focusSpy).toHaveBeenCalled();
     });
 
     it('Model with selected table, no selection in block, no metadata', () => {
@@ -187,6 +194,7 @@ describe('formatTableWithContentModel', () => {
             dataset: {},
         });
         expect(table.cachedElement).toBeUndefined();
+        expect(focusSpy).toHaveBeenCalled();
     });
 
     it('Model with selected table, no selection in block, has metadata', () => {
@@ -255,6 +263,7 @@ describe('formatTableWithContentModel', () => {
             dataset: {},
         });
         expect(table.cachedElement).toBeUndefined();
+        expect(focusSpy).toHaveBeenCalled();
     });
 
     it('With default format and additional parameters', () => {
@@ -329,5 +338,6 @@ describe('formatTableWithContentModel', () => {
             dataset: {},
         });
         expect(table.cachedElement).toBeUndefined();
+        expect(focusSpy).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
When inserting a Row or column, we used to select the inserted rows and inserted columns, but looks like at some point if the editor did not have focus we do not do it.

So to fix, focus the editor before adding the table rows/columns, so after inserting them we select them.

Before
| Before Inserting | After Inserting |
|---|---|
|![image](https://github.com/user-attachments/assets/c7ee4aae-ea39-4c08-a8b8-aaa80b9deaf5)|![image](https://github.com/user-attachments/assets/622886b8-91eb-4955-85a5-92c7c8df3c50) Focus was moved to the start of content|

After
| Before Inserting | After Inserting |
|---|---|
|![image](https://github.com/user-attachments/assets/c7ee4aae-ea39-4c08-a8b8-aaa80b9deaf5)|![image](https://github.com/user-attachments/assets/c937e5c5-0307-4322-8dd3-ad526f8f166e)|