### PR TITLE
Do not parse negative number in ListStyles

### DIFF
--- a/packages/roosterjs-content-model-core/lib/override/listMetadataApplier.ts
+++ b/packages/roosterjs-content-model-core/lib/override/listMetadataApplier.ts
@@ -85,10 +85,14 @@ export const listLevelMetadataApplier: MetadataApplier<
 
             if (listStyleType !== undefined) {
                 if (!shouldApplyToItem(listStyleType, listType)) {
+                    const listNumber =
+                        context.listFormat.threadItemCounts[depth] > 0
+                            ? context.listFormat.threadItemCounts[depth]
+                            : 1;
                     const listStyleTypeFormat = getListStyleValue(
                         listType,
                         listStyleType,
-                        context.listFormat.threadItemCounts[depth]
+                        listNumber
                     );
 
                     if (listStyleTypeFormat) {

--- a/packages/roosterjs-content-model-core/test/overrides/listMetadataApplierTest.ts
+++ b/packages/roosterjs-content-model-core/test/overrides/listMetadataApplierTest.ts
@@ -462,6 +462,33 @@ describe('listItemMetadataApplier', () => {
             runTest(BulletListType.Hyphen, '"— "');
         });
     });
+
+    describe('invalid scenarios - no thread counts', () => {
+        function runTest(formatNum: number) {
+            context.listFormat.nodeStack = [
+                {
+                    node: {} as Node,
+                },
+                {
+                    node: {} as Node,
+                },
+            ];
+            context.listFormat.threadItemCounts = [];
+
+            listItemMetadataApplier.applierFunction(
+                {
+                    orderedStyleType: formatNum,
+                },
+                format,
+                context
+            );
+
+            expect(format).toEqual({});
+        }
+        it('Roman Numbers', () => {
+            runTest(NumberingListType.UpperRoman);
+        });
+    });
 });
 
 describe('listLevelMetadataApplier', () => {


### PR DESCRIPTION
If the thread items count does not count the list depth, parse the list number as 1, so it does not return negative number as listNumber. 
[369096](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/369096)