### PR TITLE
Keep implicit paragraph when pressing Enter at the start of it.

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/inputSteps/handleEnterOnParagraph.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/inputSteps/handleEnterOnParagraph.ts
@@ -10,7 +10,7 @@ export const handleEnterOnParagraph: DeleteSelectionStep = context => {
     const paraIndex = path[0]?.blocks.indexOf(paragraph) ?? -1;
 
     if (context.deleteResult == 'notDeleted' && paraIndex >= 0) {
-        const newPara = splitParagraph(context.insertPoint);
+        const newPara = splitParagraph(context.insertPoint, true /* preserveImplicitParagraph */);
 
         mutateBlock(path[0]).blocks.splice(paraIndex + 1, 0, newPara);
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/inputSteps/handleEnterOnParagraph.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/inputSteps/handleEnterOnParagraph.ts
@@ -10,7 +10,7 @@ export const handleEnterOnParagraph: DeleteSelectionStep = context => {
     const paraIndex = path[0]?.blocks.indexOf(paragraph) ?? -1;
 
     if (context.deleteResult == 'notDeleted' && paraIndex >= 0) {
-        const newPara = splitParagraph(context.insertPoint, true /* preserveImplicitParagraph */);
+        const newPara = splitParagraph(context.insertPoint, false /* removeImplicitParagraph */);
 
         mutateBlock(path[0]).blocks.splice(paraIndex + 1, 0, newPara);
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/utils/splitParagraph.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/utils/splitParagraph.ts
@@ -42,9 +42,12 @@ export function splitParagraph(
 
     newParagraph.segments.push(...segments);
 
-    if (paragraph.segments.length == 0 && (!paragraph.isImplicit || !removeImplicitParagraph)) {
+    const isEmptyParagraph = paragraph.segments.length == 0;
+    const shouldPreserveImplicitParagraph = !paragraph.isImplicit || !removeImplicitParagraph;
+
+    if (isEmptyParagraph && shouldPreserveImplicitParagraph) {
         paragraph.segments.push(createBr(marker.format));
-    } else if (paragraph.segments.length > 0) {
+    } else if (!isEmptyParagraph) {
         setParagraphNotImplicit(paragraph);
     }
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/utils/splitParagraph.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/utils/splitParagraph.ts
@@ -16,10 +16,15 @@ import type {
  * Split the given paragraph from insert point into two paragraphs,
  * and move the selection marker to the beginning of the second paragraph
  * @param insertPoint The input insert point which includes the paragraph and selection marker
- * @param formatKeys The format that needs to be copied from the splitted paragraph, if not specified,  some default format will be copied
+ * @param removeImplicitParagraph Whether to remove the implicit paragraph if it becomes empty after split
+ * * If set to false, the implicit paragraph will be preserved even if it becomes empty
+ * * If set to true, the implicit paragraph will be removed if it becomes empty
  * @returns The new paragraph it created
  */
-export function splitParagraph(insertPoint: InsertPoint) {
+export function splitParagraph(
+    insertPoint: InsertPoint,
+    removeImplicitParagraph: boolean = true
+): ShallowMutableContentModelParagraph {
     const { paragraph, marker } = insertPoint;
     const newParagraph: ShallowMutableContentModelParagraph = createParagraph(
         false /*isImplicit*/,
@@ -37,7 +42,7 @@ export function splitParagraph(insertPoint: InsertPoint) {
 
     newParagraph.segments.push(...segments);
 
-    if (paragraph.segments.length == 0 && !paragraph.isImplicit) {
+    if (paragraph.segments.length == 0 && (!paragraph.isImplicit || !removeImplicitParagraph)) {
         paragraph.segments.push(createBr(marker.format));
     } else if (paragraph.segments.length > 0) {
         setParagraphNotImplicit(paragraph);

--- a/packages/roosterjs-content-model-plugins/test/edit/utils/splitParagraphTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/utils/splitParagraphTest.ts
@@ -186,4 +186,48 @@ describe('splitParagraph', () => {
             path: [group],
         });
     });
+
+    it('Implicit paragraph with selection marker only and removeImplicitParagraph false', () => {
+        const group = createContentModelDocument();
+        const paragraph = createParagraph(true);
+        const marker = createSelectionMarker();
+
+        paragraph.segments.push(marker);
+        group.blocks.push(paragraph);
+
+        const ip: InsertPoint = {
+            marker: marker,
+            paragraph: paragraph,
+            path: [group],
+        };
+
+        const result = splitParagraph(ip, false /* removeImplicitParagraph */);
+
+        expect(result).toEqual({
+            blockType: 'Paragraph',
+            segments: [marker],
+            format: {},
+        });
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Br', format: {} }],
+                    format: {},
+                    isImplicit: true,
+                },
+            ],
+        });
+        expect(ip).toEqual({
+            marker: marker,
+            paragraph: {
+                blockType: 'Paragraph',
+                segments: [marker],
+                format: {},
+            },
+            path: [group],
+        });
+    });
 });


### PR DESCRIPTION
If Enter is pressed at the start of a implicit paragraph, the content does not do anything.
And user will need to press enter again to see change happen.

The reason is that since we remove all the segments of the implicit paragraph, content model will not write back to DOM that empty implicit element.
To fix, add a param to keep the implicit paragraph and use it in the Enter scenario.

Before 
![2222](https://github.com/user-attachments/assets/9d57ec59-0940-497d-a73d-ac8e8a00411d)

After
![22222](https://github.com/user-attachments/assets/b0b101c9-e7bc-44f0-bf2b-4559b2867e24)
