### PR TITLE
Ensure image is loaded before creating image wrapper

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -462,7 +462,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
             (this.imageEditInfo.widthPx == 0 || this.imageEditInfo.heightPx == 0) &&
             !image.complete
         ) {
-            // width and height not being set means the image is not loaded yet.
+            // Image dimensions are zero and loading is incomplete, wait for image to load.
             image.onload = () => {
                 this.imageEditInfo = {
                     ...this.imageEditInfo,

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -396,8 +396,11 @@ describe('ImageEditPlugin', () => {
                                 textColor: 'rgb(0, 0, 0)',
                                 id: '0',
                                 maxWidth: '1800px',
+                                maxHeight: '1800px',
                             },
-                            dataset: {},
+                            dataset: {
+                                editingInfo: '{"widthPx":100,"heightPx":100}',
+                            },
                             isSelectedAsImageSelection: true,
                             isSelected: true,
                         },
@@ -419,6 +422,18 @@ describe('ImageEditPlugin', () => {
         const plugin = new ImageEditPlugin();
         const editor = initEditor('image_edit', [plugin], modelWithUnsupportedId);
         spyOn(editor, 'setEditorStyle').and.callThrough();
+        (plugin as any).imageEditInfo = {
+            src: 'test',
+            widthPx: 100,
+            heightPx: 100,
+            naturalWidth: 200,
+            naturalHeight: 200,
+            leftPercent: 0,
+            rightPercent: 0,
+            topPercent: 0,
+            bottomPercent: 0,
+            angleRad: 0,
+        };
 
         plugin.initialize(editor);
         plugin.flipImage('horizontal');
@@ -691,6 +706,18 @@ describe('ImageEditPlugin', () => {
         spyOn(editor, 'setEditorStyle').and.callThrough();
 
         plugin.initialize(editor);
+        (plugin as any).imageEditInfo = {
+            src: 'test',
+            widthPx: 100,
+            heightPx: 100,
+            naturalWidth: 200,
+            naturalHeight: 200,
+            leftPercent: 0,
+            rightPercent: 0,
+            topPercent: 0,
+            bottomPercent: 0,
+            angleRad: 0,
+        };
         plugin.flipImage('horizontal');
         plugin.dispose();
 
@@ -885,7 +912,14 @@ describe('ImageEditPlugin - applyFormatWithContentModel', () => {
         const mockedImage = document.createElement('img');
         document.body.appendChild(mockedImage);
         mockedImage.src = 'test';
-        plugin.setEditingInfo(mockedImage);
+        const mockImageWithWidth: any = {
+            clientWidth: 100,
+            clientHeight: 100,
+            naturalWidth: 200,
+            naturalHeight: 200,
+            getAttribute: () => 'test',
+        };
+        plugin.setEditingInfo(mockImageWithWidth);
         plugin.startRotateAndResize(editor, mockedImage);
         plugin.setIsEditing(isEditing);
         plugin.applyFormatWithContentModel(editor, isCropMode, shouldSelectImage, isApiOperation);
@@ -2030,5 +2064,212 @@ describe('ImageEditPlugin - applyFormatWithContentModel', () => {
             setImageStyle: true,
             removeImageStyle: true,
         });
+    });
+
+    it('Image not loaded', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    formatHolder: {
+                        isSelected: false,
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                    },
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo:
+                                    '{"applyListStyleFromLevel":false,"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    blockType: 'BlockGroup',
+                    format: {},
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            segments: [
+                                {
+                                    src: 'test',
+                                    segmentType: 'Image',
+                                    format: {
+                                        imageState: 'isEditing',
+                                    },
+                                    dataset: {},
+                                    isSelectedAsImageSelection: undefined,
+                                    isSelected: undefined,
+                                },
+                            ],
+                            segmentFormat: {},
+                            blockType: 'Paragraph',
+                            format: {},
+                        },
+                    ],
+                },
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {},
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+
+        const plugin = new TestPlugin();
+        spyOn(plugin as any, 'startEditingInternal').and.callFake(() => {});
+        let editor: IEditor | null = initEditor('image_edit', [plugin], model);
+
+        plugin.initialize(editor!);
+
+        const mockedImage = {} as any;
+        mockedImage.src = 'Test';
+        mockedImage.getAttribute = (name: string) => {
+            if (name == 'src') {
+                return 'Test';
+            }
+            return null;
+        };
+        mockedImage.complete = false;
+        mockedImage.clientWidth = 0;
+        mockedImage.clientHeight = 0;
+        mockedImage.naturalWidth = 0;
+        mockedImage.naturalHeight = 0;
+
+        plugin.setEditingInfo(mockedImage);
+        (plugin as any).startEditing(editor!, mockedImage, ['resize', 'rotate']);
+
+        expect(mockedImage.onload).toBeDefined('onload');
+        expect(mockedImage.onerror).toBeDefined('onError');
+
+        expect((plugin as any).startEditingInternal).not.toHaveBeenCalled();
+
+        mockedImage.clientWidth = 100;
+        mockedImage.clientHeight = 100;
+        mockedImage.naturalWidth = 100;
+        mockedImage.naturalHeight = 100;
+        mockedImage.style = {};
+
+        mockedImage.onload();
+        expect((plugin as any).startEditingInternal).toHaveBeenCalledWith(editor, mockedImage, [
+            'resize',
+            'rotate',
+        ]);
+        expect(mockedImage.onload).toBeNull();
+        expect(mockedImage.onerror).toBeNull();
+    });
+
+    it('Image not loaded but size defined.', () => {
+        const model: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    formatHolder: {
+                        isSelected: false,
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                    },
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {
+                                startNumberOverride: 1,
+                                listStyleType: 'decimal',
+                            },
+                            dataset: {
+                                editingInfo:
+                                    '{"applyListStyleFromLevel":false,"orderedStyleType":1}',
+                            },
+                        },
+                    ],
+                    blockType: 'BlockGroup',
+                    format: {},
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            segments: [
+                                {
+                                    src: 'test',
+                                    segmentType: 'Image',
+                                    format: {
+                                        imageState: 'isEditing',
+                                    },
+                                    dataset: {},
+                                    isSelectedAsImageSelection: undefined,
+                                    isSelected: undefined,
+                                },
+                            ],
+                            segmentFormat: {},
+                            blockType: 'Paragraph',
+                            format: {},
+                        },
+                    ],
+                },
+                {
+                    segments: [
+                        {
+                            src: 'test',
+                            segmentType: 'Image',
+                            format: {},
+                            dataset: {},
+                            isSelectedAsImageSelection: true,
+                            isSelected: true,
+                        },
+                    ],
+                    segmentFormat: undefined,
+                    blockType: 'Paragraph',
+                    format: {},
+                },
+            ],
+            format: {},
+        };
+
+        const plugin = new TestPlugin();
+        spyOn(plugin as any, 'startEditingInternal').and.callFake(() => {});
+        let editor: IEditor | null = initEditor('image_edit', [plugin], model);
+
+        plugin.initialize(editor!);
+
+        const mockedImage = {} as any;
+        mockedImage.getAttribute = (name: string) => {
+            if (name == 'src') {
+                return 'Test';
+            }
+            return null;
+        };
+        mockedImage.src = 'Test';
+        mockedImage.complete = false; // Simulate image not loaded
+        mockedImage.clientWidth = 200;
+        mockedImage.clientHeight = 200;
+        mockedImage.naturalWidth = 200;
+        mockedImage.naturalHeight = 200;
+        mockedImage.onload = null;
+        mockedImage.onerror = null;
+        mockedImage.style = {};
+
+        plugin.setEditingInfo(mockedImage);
+        (plugin as any).startEditing(editor!, mockedImage, ['resize', 'rotate']);
+
+        expect(mockedImage.onload).toBeNull();
+        expect(mockedImage.onerror).toBeNull();
+
+        expect((plugin as any).startEditingInternal).toHaveBeenCalled();
+        expect(mockedImage.onload).toBeNull();
+        expect(mockedImage.onerror).toBeNull();
     });
 });


### PR DESCRIPTION
If the editing image have a src pointing to a server host, if we try to wrap the image the clientWidth and clientHeight will be 0, as the image is still not loaded.

To fix, if the image is not completing loading and the size is 0, add an event handler for onload to wait until the image is loaded to be able to wrap it.

Image to test
`<img src='https://res.df.onecdn.static.microsoft/assets/eventify/themeImages/16_9/000.jpg' />`

Before
![AfterBefore](https://github.com/user-attachments/assets/1f6944cc-929e-42cf-9f1f-9ca0d533bb6c)


After
![AfterImage](https://github.com/user-attachments/assets/cb26ec91-907f-4496-99fd-2750ced5e7a8)

