### PR TITLE
Fix #3087 Delete paragraph styles when there is nothing else to be deleted

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteParagraphStyle.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteParagraphStyle.ts
@@ -14,7 +14,7 @@ export const deleteParagraphStyle: DeleteSelectionStep = context => {
             paragraph.segments.every(
                 s => s.segmentType === 'SelectionMarker' || s.segmentType === 'Br'
             ) &&
-            paragraph.segments.filter(s => s.segmentType == 'Br').length <= 1 &&
+            paragraph.segments.filter(s => s.segmentType === 'Br').length <= 1 &&
             Object.keys(paragraph.format).length > 0
         ) {
             paragraph.format = {};

--- a/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteParagraphStyle.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteParagraphStyle.ts
@@ -1,0 +1,24 @@
+import type { DeleteSelectionStep } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ */
+export const deleteParagraphStyle: DeleteSelectionStep = context => {
+    if (context.deleteResult == 'nothingToDelete') {
+        const { insertPoint } = context;
+        const { paragraph } = insertPoint;
+
+        // If the paragraph is empty, we will delete any style in it
+        // This is to ensure the paragraph style is reset to default when there is no content in the paragraph
+        if (
+            paragraph.segments.every(
+                s => s.segmentType == 'SelectionMarker' || s.segmentType == 'Br'
+            ) &&
+            paragraph.segments.filter(s => s.segmentType == 'Br').length <= 1 &&
+            Object.keys(paragraph.format).length > 0
+        ) {
+            paragraph.format = {};
+            context.deleteResult = 'range';
+        }
+    }
+};

--- a/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteParagraphStyle.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteParagraphStyle.ts
@@ -12,7 +12,7 @@ export const deleteParagraphStyle: DeleteSelectionStep = context => {
         // This is to ensure the paragraph style is reset to default when there is no content in the paragraph
         if (
             paragraph.segments.every(
-                s => s.segmentType == 'SelectionMarker' || s.segmentType == 'Br'
+                s => s.segmentType === 'SelectionMarker' || s.segmentType === 'Br'
             ) &&
             paragraph.segments.filter(s => s.segmentType == 'Br').length <= 1 &&
             Object.keys(paragraph.format).length > 0

--- a/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteParagraphStyle.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteParagraphStyle.ts
@@ -4,7 +4,7 @@ import type { DeleteSelectionStep } from 'roosterjs-content-model-types';
  * @internal
  */
 export const deleteParagraphStyle: DeleteSelectionStep = context => {
-    if (context.deleteResult == 'nothingToDelete') {
+    if (context.deleteResult === 'nothingToDelete') {
         const { insertPoint } = context;
         const { paragraph } = insertPoint;
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -1,6 +1,7 @@
 import { deleteAllSegmentBefore } from './deleteSteps/deleteAllSegmentBefore';
 import { deleteEmptyQuote } from './deleteSteps/deleteEmptyQuote';
 import { deleteList } from './deleteSteps/deleteList';
+import { deleteParagraphStyle } from './deleteSteps/deleteParagraphStyle';
 import {
     ChangeSource,
     deleteSelection,
@@ -84,6 +85,7 @@ function getDeleteSteps(rawEvent: KeyboardEvent, isMac: boolean): (DeleteSelecti
         isForward ? null : deleteList,
         deleteCollapsedSelection,
         deleteQuote,
+        deleteParagraphStyle,
     ];
 }
 

--- a/packages/roosterjs-content-model-plugins/test/edit/deleteSteps/deleteParagraphStyleTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/deleteSteps/deleteParagraphStyleTest.ts
@@ -1,0 +1,101 @@
+import { deleteParagraphStyle } from '../../../lib/edit/deleteSteps/deleteParagraphStyle';
+import { ValidDeleteSelectionContext } from 'roosterjs-content-model-types';
+
+describe('deleteParagraphStyle', () => {
+    it('should delete paragraph style when paragraph is empty', () => {
+        const context: ValidDeleteSelectionContext = {
+            deleteResult: 'nothingToDelete',
+            insertPoint: {
+                paragraph: {
+                    segments: [
+                        { segmentType: 'Br' } as any,
+                        { segmentType: 'SelectionMarker' } as any,
+                    ],
+                    format: {
+                        textAlign: 'center',
+                    },
+                    blockType: 'Paragraph',
+                },
+                marker: null!,
+                path: [],
+            },
+        };
+
+        deleteParagraphStyle(context);
+
+        expect(context.deleteResult).toBe('range');
+        expect(context.insertPoint.paragraph.format).toEqual({});
+    });
+
+    it('should not delete paragraph style when paragraph is not empty', () => {
+        const context: ValidDeleteSelectionContext = {
+            deleteResult: 'nothingToDelete',
+            insertPoint: {
+                paragraph: {
+                    segments: [{ segmentType: 'Text', text: 'Hello World' } as any],
+                    format: {
+                        textAlign: 'center',
+                    },
+                    blockType: 'Paragraph',
+                },
+                marker: null!,
+                path: [],
+            },
+        };
+
+        deleteParagraphStyle(context);
+
+        expect(context.deleteResult).toBe('nothingToDelete');
+        expect(context.insertPoint.paragraph.format).toEqual({
+            textAlign: 'center',
+        });
+    });
+
+    it('should not delete paragraph style when paragraph has multiple line breaks', () => {
+        const context: ValidDeleteSelectionContext = {
+            deleteResult: 'nothingToDelete',
+            insertPoint: {
+                paragraph: {
+                    segments: [
+                        { segmentType: 'Br' } as any,
+                        { segmentType: 'Br' } as any,
+                        { segmentType: 'SelectionMarker' } as any,
+                    ],
+                    format: {
+                        textAlign: 'center',
+                    },
+                    blockType: 'Paragraph',
+                },
+                marker: null!,
+                path: [],
+            },
+        };
+
+        deleteParagraphStyle(context);
+
+        expect(context.deleteResult).toBe('nothingToDelete');
+        expect(context.insertPoint.paragraph.format).toEqual({
+            textAlign: 'center',
+        });
+    });
+
+    it('should not delete paragraph style when paragraph has no format', () => {
+        const context: ValidDeleteSelectionContext = {
+            deleteResult: 'nothingToDelete',
+            insertPoint: {
+                paragraph: {
+                    segments: [{ segmentType: 'Text', text: 'Hello World' } as any],
+                    format: {},
+                    blockType: 'Paragraph',
+                },
+                marker: null!,
+                path: [],
+            },
+        };
+
+        deleteParagraphStyle(context);
+
+        expect(context.deleteResult).toBe('nothingToDelete');
+        expect(context.insertPoint.paragraph.format).toEqual({});
+    });
+});

--- a/packages/roosterjs-content-model-plugins/test/edit/keyboardDeleteTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/keyboardDeleteTest.ts
@@ -5,6 +5,7 @@ import { ContentModelDocument, DOMSelection, IEditor } from 'roosterjs-content-m
 import { deleteAllSegmentBefore } from '../../lib/edit/deleteSteps/deleteAllSegmentBefore';
 import { deleteEmptyQuote } from '../../lib/edit/deleteSteps/deleteEmptyQuote';
 import { deleteList } from '../../lib/edit/deleteSteps/deleteList';
+import { deleteParagraphStyle } from '../../lib/edit/deleteSteps/deleteParagraphStyle';
 import { DeleteResult, DeleteSelectionStep } from 'roosterjs-content-model-types';
 import { editingTestCommon } from './editingTestCommon';
 import { keyboardDelete } from '../../lib/edit/keyboardDelete';
@@ -90,7 +91,7 @@ describe('keyboardDelete', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            [null!, null!, null!, forwardDeleteCollapsedSelection, null!],
+            [null!, null!, null!, forwardDeleteCollapsedSelection, null!, deleteParagraphStyle],
             'notDeleted',
             true,
             0
@@ -108,7 +109,14 @@ describe('keyboardDelete', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            [null!, null!, deleteList, backwardDeleteCollapsedSelection, deleteEmptyQuote],
+            [
+                null!,
+                null!,
+                deleteList,
+                backwardDeleteCollapsedSelection,
+                deleteEmptyQuote,
+                deleteParagraphStyle,
+            ],
             'notDeleted',
             true,
             0
@@ -128,7 +136,14 @@ describe('keyboardDelete', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            [null!, forwardDeleteWordSelection, null!, forwardDeleteCollapsedSelection, null!],
+            [
+                null!,
+                forwardDeleteWordSelection,
+                null!,
+                forwardDeleteCollapsedSelection,
+                null!,
+                deleteParagraphStyle,
+            ],
             'notDeleted',
             true,
             0
@@ -154,6 +169,7 @@ describe('keyboardDelete', () => {
                 deleteList,
                 backwardDeleteCollapsedSelection,
                 deleteEmptyQuote,
+                deleteParagraphStyle,
             ],
             'notDeleted',
             true,
@@ -174,7 +190,7 @@ describe('keyboardDelete', () => {
                 blockGroupType: 'Document',
                 blocks: [],
             },
-            [null!, null!, null!, forwardDeleteCollapsedSelection, null!],
+            [null!, null!, null!, forwardDeleteCollapsedSelection, null!, deleteParagraphStyle],
             'notDeleted',
             true,
             0
@@ -200,6 +216,7 @@ describe('keyboardDelete', () => {
                 deleteList,
                 backwardDeleteCollapsedSelection,
                 deleteEmptyQuote,
+                deleteParagraphStyle,
             ],
             'notDeleted',
             true,
@@ -242,7 +259,7 @@ describe('keyboardDelete', () => {
                     },
                 ],
             },
-            [null!, null!, null!, forwardDeleteCollapsedSelection, null!],
+            [null!, null!, null!, forwardDeleteCollapsedSelection, null!, deleteParagraphStyle],
             'notDeleted',
             true,
             0
@@ -284,7 +301,14 @@ describe('keyboardDelete', () => {
                     },
                 ],
             },
-            [null!, null!, deleteList, backwardDeleteCollapsedSelection, deleteEmptyQuote],
+            [
+                null!,
+                null!,
+                deleteList,
+                backwardDeleteCollapsedSelection,
+                deleteEmptyQuote,
+                deleteParagraphStyle,
+            ],
             'notDeleted',
             true,
             0
@@ -336,7 +360,7 @@ describe('keyboardDelete', () => {
                     },
                 ],
             },
-            [null!, null!, null!, forwardDeleteCollapsedSelection, null!],
+            [null!, null!, null!, forwardDeleteCollapsedSelection, null!, deleteParagraphStyle],
             'singleChar',
             false,
             1
@@ -388,7 +412,14 @@ describe('keyboardDelete', () => {
                     },
                 ],
             },
-            [null!, null!, deleteList, backwardDeleteCollapsedSelection, deleteEmptyQuote],
+            [
+                null!,
+                null!,
+                deleteList,
+                backwardDeleteCollapsedSelection,
+                deleteEmptyQuote,
+                deleteParagraphStyle,
+            ],
             'singleChar',
             false,
             1
@@ -482,7 +513,14 @@ describe('keyboardDelete', () => {
                     },
                 ],
             },
-            [null!, null!, deleteList, backwardDeleteCollapsedSelection, deleteEmptyQuote],
+            [
+                null!,
+                null!,
+                deleteList,
+                backwardDeleteCollapsedSelection,
+                deleteEmptyQuote,
+                deleteParagraphStyle,
+            ],
             'singleChar',
             false,
             1


### PR DESCRIPTION
Sometimes when paste some content that has styles on paragraph, it is hard to remove those styles. This change handles delete operation, and at the last, check if nothing is deleted, try to delete styles on current paragraph if any, so that those styles can be deleted.

![deleteparagraphstyle](https://github.com/user-attachments/assets/4f5794be-b6e2-47e8-8ec4-0a2af4c13003)
