### PR TITLE
Fix #3085 Implement the `disableSideResize` option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,6 +63,7 @@
         "Polski",
         "Popout",
         "Resizer",
+        "resizers",
         "roosterjs",
         "rowspan",
         "saturationv",

--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -106,7 +106,6 @@ export class MainPane extends React.Component<{}, MainPaneState> {
     private formatPainterPlugin: FormatPainterPlugin;
     private samplePickerPlugin: SamplePickerPlugin;
     private snapshots: Snapshots;
-    private imageEditPlugin: ImageEditPlugin;
     private markdownPanePlugin: MarkdownPanePlugin;
 
     protected sidePane = React.createRef<SidePane>();
@@ -145,7 +144,6 @@ export class MainPane extends React.Component<{}, MainPaneState> {
         this.ribbonPlugin = createRibbonPlugin();
         this.formatPainterPlugin = new FormatPainterPlugin();
         this.samplePickerPlugin = new SamplePickerPlugin();
-        this.imageEditPlugin = new ImageEditPlugin();
         this.markdownPanePlugin = new MarkdownPanePlugin();
 
         this.state = {
@@ -167,13 +165,22 @@ export class MainPane extends React.Component<{}, MainPaneState> {
 
     render() {
         const theme = getTheme(this.state.isDarkMode);
+
+        const imageEditPlugin = this.state.initState.pluginList.imageEditPlugin
+            ? new ImageEditPlugin({
+                  disableSideResize: this.state.initState.disableSideResize,
+              })
+            : null;
+
         return (
             <ThemeProvider applyTo="body" theme={theme} className={styles.mainPane}>
                 {this.renderTitleBar()}
                 {!this.state.popoutWindow && this.renderTabs()}
-                {!this.state.popoutWindow && this.renderRibbon()}
+                {!this.state.popoutWindow && this.renderRibbon(imageEditPlugin)}
                 <div className={styles.body + ' ' + (this.state.isDarkMode ? 'dark' : '')}>
-                    {this.state.popoutWindow ? this.renderPopout() : this.renderMainPane()}
+                    {this.state.popoutWindow
+                        ? this.renderPopout(imageEditPlugin)
+                        : this.renderMainPane(imageEditPlugin)}
                 </div>
             </ThemeProvider>
         );
@@ -303,13 +310,13 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             </div>
         );
     }
-    private renderRibbon() {
+    private renderRibbon(imageEditPlugin: ImageEditPlugin | undefined) {
         return (
             <Ribbon
                 buttons={getButtons(
                     this.state.activeTab,
                     this.formatPainterPlugin,
-                    this.imageEditPlugin
+                    imageEditPlugin
                 )}
                 plugin={this.ribbonPlugin}
                 dir={this.state.isRtl ? 'rtl' : 'ltr'}
@@ -337,7 +344,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
         });
     }
 
-    private renderEditor() {
+    private renderEditor(imageEditPlugin: ImageEditPlugin | undefined) {
         // Set preset if found
         const search = new URLSearchParams(document.location.search);
         const hasPreset = search.get('preset');
@@ -355,7 +362,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             this.ribbonPlugin,
             this.formatPainterPlugin,
             this.samplePickerPlugin,
-            ...this.getToggleablePlugins(),
+            ...this.getToggleablePlugins(imageEditPlugin),
             this.contentModelPanePlugin.getInnerRibbonPlugin(),
             this.updateContentPlugin,
         ];
@@ -396,10 +403,10 @@ export class MainPane extends React.Component<{}, MainPaneState> {
         );
     }
 
-    private renderMainPane() {
+    private renderMainPane(imageEditPlugin: ImageEditPlugin | undefined) {
         return (
             <>
-                {this.renderEditor()}
+                {this.renderEditor(imageEditPlugin)}
                 {this.state.showSidePane ? (
                     <>
                         <div className={styles.resizer} onMouseDown={this.onMouseDown} />
@@ -425,7 +432,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
         );
     }
 
-    private renderPopout() {
+    private renderPopout(imageEditPlugin: ImageEditPlugin | undefined) {
         return (
             <>
                 {this.renderSidePane(true /*fullWidth*/)}
@@ -434,8 +441,10 @@ export class MainPane extends React.Component<{}, MainPaneState> {
                         <ThemeProvider applyTo="body" theme={getTheme(this.state.isDarkMode)}>
                             <div className={styles.mainPane}>
                                 {this.renderTabs()}
-                                {this.renderRibbon()}
-                                <div className={styles.body}>{this.renderEditor()}</div>
+                                {this.renderRibbon(imageEditPlugin)}
+                                <div className={styles.body}>
+                                    {this.renderEditor(imageEditPlugin)}
+                                </div>
                             </div>
                         </ThemeProvider>
                     </WindowProvider>,
@@ -501,7 +510,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
         ];
     }
 
-    private getToggleablePlugins(): EditorPlugin[] {
+    private getToggleablePlugins(imageEditPlugin: ImageEditPlugin | undefined): EditorPlugin[] {
         const {
             pluginList,
             allowExcelNoBorderTable,
@@ -515,6 +524,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             customReplacements,
             editPluginOptions,
         } = this.state.initState;
+
         return [
             pluginList.autoFormat && new AutoFormatPlugin(autoFormatOptions),
             pluginList.edit && new EditPlugin(editPluginOptions),
@@ -523,7 +533,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             pluginList.tableEdit && new TableEditPlugin(),
             pluginList.watermark && new WatermarkPlugin(watermarkText),
             pluginList.markdown && new MarkdownPlugin(markdownOptions),
-            pluginList.imageEditPlugin && this.imageEditPlugin,
+            imageEditPlugin,
             pluginList.emoji && createEmojiPlugin(),
             pluginList.pasteOption && createPasteOptionPlugin(),
             pluginList.sampleEntity && new SampleEntityPlugin(),
@@ -531,8 +541,9 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             pluginList.contextMenu && listMenu && createListEditMenuProvider(),
             pluginList.contextMenu && tableMenu && createTableEditMenuProvider(),
             pluginList.contextMenu &&
+                imageEditPlugin &&
                 imageMenu &&
-                createImageEditMenuProvider(this.imageEditPlugin),
+                createImageEditMenuProvider(imageEditPlugin),
             pluginList.hyperlink &&
                 new HyperlinkPlugin(
                     linkTitle?.indexOf(UrlPlaceholder) >= 0

--- a/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -61,6 +61,7 @@ const initialState: OptionState = {
         handleTabKey: true,
     },
     customReplacements: emojiReplacements,
+    disableSideResize: false,
     experimentalFeatures: new Set<ExperimentalFeature>([
         'PersistCache',
         'HandleEnterKey',

--- a/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
@@ -38,6 +38,7 @@ export interface OptionState {
     markdownOptions: MarkdownOptions;
     customReplacements: CustomReplace[];
     editPluginOptions: EditOptions;
+    disableSideResize: boolean;
 
     // Legacy plugin options
     defaultFormat: ContentModelSegmentFormat;

--- a/demo/scripts/controlsV2/sidePane/editorOptions/OptionsPane.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/OptionsPane.tsx
@@ -141,6 +141,7 @@ export class OptionsPane extends React.Component<OptionPaneProps, OptionState> {
             customReplacements: this.state.customReplacements,
             experimentalFeatures: this.state.experimentalFeatures,
             editPluginOptions: { ...this.state.editPluginOptions },
+            disableSideResize: this.state.disableSideResize,
         };
 
         if (callback) {

--- a/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
@@ -120,6 +120,7 @@ export class Plugins extends PluginsBase<keyof BuildInPluginList> {
     private markdownStrikethrough = React.createRef<HTMLInputElement>();
     private markdownCode = React.createRef<HTMLInputElement>();
     private linkTitle = React.createRef<HTMLInputElement>();
+    private disableSideResize = React.createRef<HTMLInputElement>();
 
     render(): JSX.Element {
         return (
@@ -314,7 +315,18 @@ export class Plugins extends PluginsBase<keyof BuildInPluginList> {
                         )
                     )}
                     {this.renderPluginItem('customReplace', 'Custom Replace')}
-                    {this.renderPluginItem('imageEditPlugin', 'ImageEditPlugin')}
+                    {this.renderPluginItem(
+                        'imageEditPlugin',
+                        'ImageEditPlugin',
+                        <>
+                            {this.renderCheckBox(
+                                'Disable side resize',
+                                this.disableSideResize,
+                                this.props.state.disableSideResize,
+                                (state, value) => (state.disableSideResize = value)
+                            )}
+                        </>
+                    )}
                     {this.renderPluginItem('hiddenProperty', 'Hidden Property')}
                 </tbody>
             </table>

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -84,8 +84,11 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
     private zoomScale: number = 1;
     private disposer: (() => void) | null = null;
     protected isEditing = false;
+    protected options: ImageEditOptions;
 
-    constructor(protected options: ImageEditOptions = DefaultOptions) {}
+    constructor(options?: ImageEditOptions) {
+        this.options = { ...DefaultOptions, ...options };
+    }
 
     /**
      * Get name of this plugin
@@ -587,7 +590,8 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                                     this.selectedImage,
                                     this.wrapper,
                                     this.rotators,
-                                    this.imageEditInfo?.angleRad
+                                    this.imageEditInfo?.angleRad,
+                                    !!this.options?.disableSideResize
                                 );
                             }
                         },
@@ -610,7 +614,8 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                     this.selectedImage,
                     this.wrapper,
                     this.rotators,
-                    this.imageEditInfo?.angleRad
+                    this.imageEditInfo?.angleRad,
+                    !!this.options?.disableSideResize
                 );
             }
         }
@@ -621,7 +626,8 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         image: HTMLImageElement,
         wrapper: HTMLSpanElement,
         rotators: HTMLDivElement[],
-        angleRad: number | undefined
+        angleRad: number | undefined,
+        disableSideResize: boolean
     ) {
         const viewport = editor.getVisibleViewport();
         const smallImage = isASmallImage(image.width, image.height);
@@ -638,7 +644,8 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                     wrapper,
                     rotator,
                     rotatorHandle,
-                    smallImage
+                    smallImage,
+                    disableSideResize
                 );
             }
         }

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/Resizer/createImageResizer.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/Resizer/createImageResizer.ts
@@ -19,11 +19,14 @@ const RESIZE_HANDLE_SIZE = 10;
  */
 export function createImageResizer(
     doc: Document,
+    disableSideResize: boolean,
     onShowResizeHandle?: OnShowResizeHandle
 ): HTMLDivElement[] {
     const cornerElements = getCornerResizeHTML(onShowResizeHandle);
     const sideElements = getSideResizeHTML(onShowResizeHandle);
-    const handles = [...cornerElements, ...sideElements]
+    const handles = disableSideResize ? cornerElements : cornerElements.concat(sideElements);
+
+    return handles
         .map(element => {
             const handle = createElement(element, doc);
             if (isNodeOfType(handle, 'ELEMENT_NODE') && isElementOfType(handle, 'div')) {
@@ -31,7 +34,6 @@ export function createImageResizer(
             }
         })
         .filter(element => !!element) as HTMLDivElement[];
-    return handles;
 }
 
 /**

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/Rotator/createImageRotator.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/Rotator/createImageRotator.ts
@@ -6,6 +6,7 @@ import type { ImageHtmlOptions } from '../types/ImageHtmlOptions';
 import {
     ROTATE_GAP,
     ROTATE_HANDLE_TOP,
+    ROTATE_HANDLE_TOP_NO_SIDE_RESIZE,
     ROTATE_ICON_MARGIN,
     ROTATE_SIZE,
     ROTATE_WIDTH,
@@ -34,13 +35,16 @@ export function createImageRotator(doc: Document, htmlOptions: ImageHtmlOptions)
 function getRotateHTML({
     borderColor,
     rotateHandleBackColor,
+    disableSideResize,
 }: ImageHtmlOptions): CreateElementData[] {
     const handleLeft = ROTATE_SIZE / 2;
     return [
         {
             tag: 'div',
             className: ImageEditElementClass.RotateCenter,
-            style: `position:absolute;left:50%;width:1px;background-color:${borderColor};top:${-ROTATE_HANDLE_TOP}px;height:${ROTATE_GAP}px;margin-left:${-ROTATE_WIDTH}px;`,
+            style: `position:absolute;left:50%;width:1px;background-color:${borderColor};top:${
+                disableSideResize ? -ROTATE_HANDLE_TOP_NO_SIDE_RESIZE : -ROTATE_HANDLE_TOP
+            }px;height:${ROTATE_GAP}px;margin-left:${-ROTATE_WIDTH}px;`,
             children: [
                 {
                     tag: 'div',

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/Rotator/updateRotateHandle.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/Rotator/updateRotateHandle.ts
@@ -12,7 +12,8 @@ export function updateRotateHandle(
     wrapper: HTMLElement,
     rotateCenter: HTMLElement,
     rotateHandle: HTMLElement,
-    isSmallImage: boolean
+    isSmallImage: boolean,
+    disableSideResize: boolean
 ) {
     if (isSmallImage) {
         rotateCenter.style.display = 'none';
@@ -55,7 +56,8 @@ export function updateRotateHandle(
 
             const rotateGap = Math.max(Math.min(ROTATE_GAP, adjustedDistance), 0);
             const rotateTop = Math.max(Math.min(ROTATE_SIZE, adjustedDistance - rotateGap), 0);
-            rotateCenter.style.top = -rotateGap - RESIZE_HANDLE_MARGIN + 'px';
+            rotateCenter.style.top =
+                -rotateGap - (disableSideResize ? 0 : RESIZE_HANDLE_MARGIN) + 'px';
             rotateCenter.style.height = rotateGap + 'px';
             rotateHandle.style.top = -rotateTop + 'px';
         }

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/constants/constants.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/constants/constants.ts
@@ -68,6 +68,11 @@ export const ROTATE_HANDLE_TOP = ROTATE_GAP + RESIZE_HANDLE_MARGIN;
 /**
  * @internal
  */
+export const ROTATE_HANDLE_TOP_NO_SIDE_RESIZE = ROTATE_GAP;
+
+/**
+ * @internal
+ */
 export const CROP_HANDLE_SIZE = 22;
 
 /**

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/types/ImageHtmlOptions.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/types/ImageHtmlOptions.ts
@@ -17,4 +17,9 @@ export interface ImageHtmlOptions {
      * Verify if the area of the image is less than 10000px, if yes, don't insert the side handles
      */
     isSmallImage: boolean;
+
+    /**
+     * Whether side resize handles should be disabled
+     */
+    disableSideResize: boolean;
 }

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
@@ -45,7 +45,7 @@ export function createImageWrapper(
     }
     let resizers: HTMLDivElement[] = [];
     if (operation.indexOf('resize') > -1) {
-        resizers = createImageResizer(doc);
+        resizers = createImageResizer(doc, !!options.disableSideResize);
     }
 
     let croppers: HTMLDivElement[] = [];

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/getHTMLImageOptions.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/getHTMLImageOptions.ts
@@ -22,5 +22,6 @@ export const getHTMLImageOptions = (
             options.borderColor || (editor.isDarkMode() ? DARK_MODE_BGCOLOR : LIGHT_MODE_BGCOLOR),
         rotateHandleBackColor: editor.isDarkMode() ? DARK_MODE_BGCOLOR : LIGHT_MODE_BGCOLOR,
         isSmallImage: isASmallImage(editInfo.widthPx ?? 0, editInfo.heightPx ?? 0),
+        disableSideResize: !!options.disableSideResize,
     };
 };

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/Resizer/createImageResizerTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/Resizer/createImageResizerTest.ts
@@ -9,7 +9,7 @@ import {
 
 describe('createImageResizer', () => {
     it('should create the croppers', () => {
-        const result = createImageResizer(document);
+        const result = createImageResizer(document, false);
         const resizers = [...createCorners(), ...createSides()].filter(element => !!element);
         expect(result).toEqual(resizers);
 

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/Rotator/updateRotateHandleTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/Rotator/updateRotateHandleTest.ts
@@ -31,6 +31,7 @@ xdescribe('updateRotateHandlePosition', () => {
         borderColor: 'blue',
         rotateHandleBackColor: 'blue',
         isSmallImage: false,
+        disableSideResize: false,
     };
 
     function runTest(
@@ -71,7 +72,7 @@ xdescribe('updateRotateHandlePosition', () => {
         editorGetVisibleViewport.and.returnValue(viewport);
         const angleRad = angle / DEG_PER_RAD;
 
-        updateRotateHandle(viewport, angleRad, wrapper, rotateCenter, rotateHandle, false);
+        updateRotateHandle(viewport, angleRad, wrapper, rotateCenter, rotateHandle, false, false);
 
         expect(rotateCenter.style.top).toBe(rotateCenterTop);
         expect(rotateCenter.style.height).toBe(rotateCenterHeight);

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/utils/createImageWrapperTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/utils/createImageWrapperTest.ts
@@ -54,8 +54,9 @@ describe('createImageWrapper', () => {
             borderColor: '#DB626C',
             rotateHandleBackColor: 'white',
             isSmallImage: false,
+            disableSideResize: false,
         };
-        const resizers = createImageResizer(document);
+        const resizers = createImageResizer(document, false);
         const wrapper = createWrapper(editor, image, options, editInfo, resizers);
         const shadowSpan = createShadowSpan(wrapper);
         const imageClone = cloneImage(image, editInfo);
@@ -101,6 +102,7 @@ describe('createImageWrapper', () => {
             borderColor: '#DB626C',
             rotateHandleBackColor: 'white',
             isSmallImage: false,
+            disableSideResize: false,
         };
         const rotator = createImageRotator(document, htmlOptions);
         const wrapper = createWrapper(editor, image, options, editInfo, undefined, rotator);
@@ -148,6 +150,7 @@ describe('createImageWrapper', () => {
             borderColor: '#DB626C',
             rotateHandleBackColor: 'white',
             isSmallImage: false,
+            disableSideResize: false,
         };
         const cropper = createImageCropper(document);
         const wrapper = createWrapper(

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/utils/getHTMLImageOptionsTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/utils/getHTMLImageOptionsTest.ts
@@ -47,6 +47,7 @@ describe('getHTMLImageOptions', () => {
                 borderColor: '#DB626C',
                 rotateHandleBackColor: 'white',
                 isSmallImage: false,
+                disableSideResize: false,
             }
         );
     });
@@ -79,6 +80,7 @@ describe('getHTMLImageOptions', () => {
                 borderColor: '#DB626C',
                 rotateHandleBackColor: '#333',
                 isSmallImage: true,
+                disableSideResize: false,
             }
         );
     });

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/utils/updateWrapperTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/utils/updateWrapperTest.ts
@@ -30,6 +30,7 @@ describe('updateWrapper', () => {
         borderColor: '#DB626C',
         rotateHandleBackColor: 'white',
         isSmallImage: false,
+        disableSideResize: false,
     };
     const image = document.createElement('img');
     document.body.appendChild(image);


### PR DESCRIPTION
`disableSideResize` option is missed in v9. So in this change I added the support to it, also fix demo site to allow skipping this plugin if it is removed from option pane.

With side resize:
<img width="294" height="310" alt="image" src="https://github.com/user-attachments/assets/4af74448-bd4c-47e3-8faf-3da56de8dcc2" />


Without side resize:
<img width="281" height="294" alt="image" src="https://github.com/user-attachments/assets/a58e06ec-6ae2-4548-9170-58a3e153007b" />


Without ImageEditPlugin:
<img width="291" height="283" alt="image" src="https://github.com/user-attachments/assets/77ab4dba-df32-43ac-b4ee-62b8daf6593e" />
