### PR TITLE
Fix #3063: focus to editor when click format painter button

### DIFF
--- a/demo/scripts/controlsV2/demoButtons/formatPainterButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/formatPainterButton.ts
@@ -12,8 +12,9 @@ export function createFormatPainterButton(
         key: 'formatPainter',
         unlocalizedText: 'Format painter',
         iconName: 'Brush',
-        onClick: () => {
+        onClick: editor => {
             handler.startFormatPainter();
+            editor.focus();
         },
     };
 }


### PR DESCRIPTION
The original issue (#3063) can happen to any button that does not focus into editor in Firefox. So add a focus call in the button handler in demo site code.