### PR TITLE
Fix 309357

### DIFF
--- a/demo/scripts/controlsV2/demoButtons/exportContentButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/exportContentButton.ts
@@ -34,14 +34,17 @@ export const exportContentButton: RibbonButton<ExportButtonStringKey> = {
         let html = '';
 
         if (key == 'menuNameExportHTML') {
-            html = exportContent(editor, 'HTML', {
-                defaultContentModelFormatOverride: {
-                    p: {
-                        marginTop: '0',
-                        marginBottom: '0',
+            html =
+                '<html><head><style>p{margin-top:0;margin-bottom:0;}</style></head><body>' +
+                exportContent(editor, 'HTML', {
+                    defaultContentModelFormatOverride: {
+                        p: {
+                            marginTop: '0',
+                            marginBottom: '0',
+                        },
                     },
-                },
-            });
+                }) +
+                '</body></html>';
         } else if (key == 'menuNameExportText') {
             html = `<pre>${exportContent(editor, 'PlainText', callbacks)}</pre>`;
         }

--- a/demo/scripts/controlsV2/demoButtons/exportContentButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/exportContentButton.ts
@@ -1,6 +1,6 @@
+import * as DOMPurify from 'dompurify';
 import { exportContent } from 'roosterjs-content-model-core';
 import { ModelToTextCallbacks } from 'roosterjs-content-model-types';
-import DOMPurify = require('dompurify');
 import type { RibbonButton } from 'roosterjs-react';
 
 /**

--- a/demo/scripts/controlsV2/demoButtons/exportContentButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/exportContentButton.ts
@@ -1,5 +1,6 @@
 import { exportContent } from 'roosterjs-content-model-core';
 import { ModelToTextCallbacks } from 'roosterjs-content-model-types';
+import DOMPurify = require('dompurify');
 import type { RibbonButton } from 'roosterjs-react';
 
 /**
@@ -33,12 +34,27 @@ export const exportContentButton: RibbonButton<ExportButtonStringKey> = {
         let html = '';
 
         if (key == 'menuNameExportHTML') {
-            html = exportContent(editor);
+            html = exportContent(editor, 'HTML', {
+                defaultContentModelFormatOverride: {
+                    p: {
+                        marginTop: '0',
+                        marginBottom: '0',
+                    },
+                },
+            });
         } else if (key == 'menuNameExportText') {
             html = `<pre>${exportContent(editor, 'PlainText', callbacks)}</pre>`;
         }
 
-        win.document.write(editor.getTrustedHTMLHandler()(html));
+        win.document.write(
+            (DOMPurify.sanitize(html, {
+                ADD_TAGS: ['head', 'meta', 'iframe'],
+                ADD_ATTR: ['name', 'content'],
+                WHOLE_DOCUMENT: true,
+                ALLOW_UNKNOWN_PROTOCOLS: true,
+                RETURN_TRUSTED_TYPE: true,
+            }) as any) as string
+        );
     },
     commandBarProperties: {
         buttonStyles: {

--- a/demo/scripts/controlsV2/mainPane/MainPane.scss
+++ b/demo/scripts/controlsV2/mainPane/MainPane.scss
@@ -52,6 +52,11 @@
     top: 0;
     right: 0;
     bottom: 0;
+
+    p {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
 }
 
 .resizer {

--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -5,6 +5,7 @@ import { ApiPlaygroundPlugin } from '../sidePane/apiPlayground/ApiPlaygroundPlug
 import { ContentModelPanePlugin } from '../sidePane/contentModel/ContentModelPanePlugin';
 import { darkModeButton } from '../demoButtons/darkModeButton';
 import { defaultDomToModelOption } from '../options/defaultDomToModelOption';
+import { defaultModelToDomOption } from '../options/defaultModelToDomOption';
 import { Editor } from 'roosterjs-content-model-core';
 import { EditorOptionsPlugin } from '../sidePane/editorOptions/EditorOptionsPlugin';
 import { EventViewPlugin } from '../sidePane/eventViewer/EventViewPlugin';
@@ -389,6 +390,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
                                 this.state.initState.experimentalFeatures
                             )}
                             defaultDomToModelOptions={defaultDomToModelOption}
+                            defaultModelToDomOptions={defaultModelToDomOption}
                         />
                     )}
                 </div>

--- a/demo/scripts/controlsV2/options/defaultModelToDomOption.ts
+++ b/demo/scripts/controlsV2/options/defaultModelToDomOption.ts
@@ -1,0 +1,10 @@
+import { ModelToDomOption } from 'roosterjs-content-model-types';
+
+export const defaultModelToDomOption: ModelToDomOption = {
+    defaultContentModelFormatOverride: {
+        p: {
+            marginTop: '0',
+            marginBottom: '0',
+        },
+    },
+};

--- a/demo/scripts/controlsV2/sidePane/presets/allPresets/allPresets.ts
+++ b/demo/scripts/controlsV2/sidePane/presets/allPresets/allPresets.ts
@@ -1,7 +1,7 @@
 import { allTextFormats } from './textPresets';
+import { htmlParagraphs, mixedParagraphs } from './paragraphPresets';
 import { image64x64Black, image64x64Gradient, image64x64White } from './imagePresets';
 import { mergedTableNoText, simpleTable, simpleTableWithHeader } from './tablePresets';
-import { mixedParagraphs } from './paragraphPresets';
 import { numberedList, simpleList } from './listPresets';
 import { Preset } from './Preset';
 import { undeleteableText } from './undeleteablePresets';
@@ -24,6 +24,7 @@ export const allPresets: Preset[] = [
     simpleList,
     numberedList,
     mixedParagraphs,
+    htmlParagraphs,
     allTextFormats,
     image64x64Gradient,
     image64x64Black,

--- a/demo/scripts/controlsV2/sidePane/presets/allPresets/paragraphPresets.ts
+++ b/demo/scripts/controlsV2/sidePane/presets/allPresets/paragraphPresets.ts
@@ -60,22 +60,6 @@ export const htmlParagraphs: Preset = {
                     format: {},
                 },
             },
-            {
-                isImplicit: true,
-                segments: [
-                    {
-                        isSelected: true,
-                        segmentType: 'SelectionMarker',
-                        format: {
-                            fontFamily: 'Calibri',
-                            fontSize: '11pt',
-                            textColor: 'rgb(0, 0, 0)',
-                        },
-                    },
-                ],
-                blockType: 'Paragraph',
-                format: {},
-            },
         ],
     },
 };

--- a/demo/scripts/controlsV2/sidePane/presets/allPresets/paragraphPresets.ts
+++ b/demo/scripts/controlsV2/sidePane/presets/allPresets/paragraphPresets.ts
@@ -1,5 +1,85 @@
 import { Preset } from './Preset';
 
+export const htmlParagraphs: Preset = {
+    buttonName: 'HTML Paragraphs with margins',
+    id: 'htmlParagraphs',
+    content: {
+        blockGroupType: 'Document',
+        blocks: [
+            {
+                segments: [
+                    {
+                        text: 'line 1',
+                        segmentType: 'Text',
+                        format: {},
+                    },
+                ],
+                blockType: 'Paragraph',
+                format: {
+                    marginTop: '1em',
+                    marginBottom: '1em',
+                },
+                decorator: {
+                    tagName: 'p',
+                    format: {},
+                },
+            },
+            {
+                segments: [
+                    {
+                        text: 'line 2',
+                        segmentType: 'Text',
+                        format: {},
+                    },
+                ],
+                blockType: 'Paragraph',
+                format: {
+                    marginTop: '1em',
+                    marginBottom: '1em',
+                },
+                decorator: {
+                    tagName: 'p',
+                    format: {},
+                },
+            },
+            {
+                segments: [
+                    {
+                        text: 'line 3',
+                        segmentType: 'Text',
+                        format: {},
+                    },
+                ],
+                blockType: 'Paragraph',
+                format: {
+                    marginTop: '1em',
+                    marginBottom: '1em',
+                },
+                decorator: {
+                    tagName: 'p',
+                    format: {},
+                },
+            },
+            {
+                isImplicit: true,
+                segments: [
+                    {
+                        isSelected: true,
+                        segmentType: 'SelectionMarker',
+                        format: {
+                            fontFamily: 'Calibri',
+                            fontSize: '11pt',
+                            textColor: 'rgb(0, 0, 0)',
+                        },
+                    },
+                ],
+                blockType: 'Paragraph',
+                format: {},
+            },
+        ],
+    },
+};
+
 export const mixedParagraphs: Preset = {
     buttonName: 'Mixed Paragraphs',
     id: 'mixedParagraphs',

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext.ts
@@ -1,3 +1,4 @@
+import { defaultContentModelFormatMap } from '../../config/defaultContentModelFormatMap';
 import { defaultContentModelHandlers } from './defaultContentModelHandlers';
 import { getObjectKeys } from '../../domUtils/getObjectKeys';
 import {
@@ -99,6 +100,11 @@ export function createModelToDomConfig(
         defaultModelHandlers: defaultContentModelHandlers,
         defaultFormatAppliers,
         metadataAppliers: Object.assign({}, ...options.map(x => x?.metadataAppliers)),
+        defaultContentModelFormatMap: Object.assign(
+            {},
+            defaultContentModelFormatMap,
+            ...options.map(x => x?.defaultContentModelFormatOverride)
+        ),
     };
 }
 

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/utils/stackFormat.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/utils/stackFormat.ts
@@ -1,4 +1,3 @@
-import { defaultContentModelFormatMap } from '../../config/defaultContentModelFormatMap';
 import type {
     ContentModelBlockFormat,
     ContentModelSegmentFormat,
@@ -15,7 +14,7 @@ export function stackFormat(
 ) {
     const newFormat =
         typeof tagNameOrFormat === 'string'
-            ? defaultContentModelFormatMap[tagNameOrFormat]
+            ? context.defaultContentModelFormatMap[tagNameOrFormat]
             : tagNameOrFormat;
 
     if (newFormat) {

--- a/packages/roosterjs-content-model-dom/test/modelToDom/context/createModelToDomContextTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/context/createModelToDomContextTest.ts
@@ -1,3 +1,4 @@
+import { defaultContentModelFormatMap } from '../../../lib/config/defaultContentModelFormatMap';
 import { defaultContentModelHandlers } from '../../../lib/modelToDom/context/defaultContentModelHandlers';
 import { defaultFormatAppliers } from '../../../lib/formatHandlers/defaultFormatHandlers';
 import { EditorContext } from 'roosterjs-content-model-types';
@@ -31,6 +32,7 @@ describe('createModelToDomContext', () => {
                 addedBlockElements: [],
                 removedBlockElements: [],
             },
+            defaultContentModelFormatMap: defaultContentModelFormatMap,
         });
     });
 
@@ -63,6 +65,7 @@ describe('createModelToDomContext', () => {
                 addedBlockElements: [],
                 removedBlockElements: [],
             },
+            defaultContentModelFormatMap: defaultContentModelFormatMap,
         });
     });
 
@@ -89,6 +92,13 @@ describe('createModelToDomContext', () => {
             {
                 additionalFormatAppliers: {
                     text: [mockedTextApplier2],
+                },
+            },
+            {
+                defaultContentModelFormatOverride: {
+                    p: {
+                        marginTop: '10px',
+                    },
                 },
             }
         );
@@ -125,6 +135,12 @@ describe('createModelToDomContext', () => {
             rewriteFromModel: {
                 addedBlockElements: [],
                 removedBlockElements: [],
+            },
+            defaultContentModelFormatMap: {
+                ...defaultContentModelFormatMap,
+                p: {
+                    marginTop: '10px',
+                },
             },
         });
     });

--- a/packages/roosterjs-content-model-types/lib/context/ModelToDomOption.ts
+++ b/packages/roosterjs-content-model-types/lib/context/ModelToDomOption.ts
@@ -38,11 +38,11 @@ export interface ModelToDomOption {
 
     /**
      * Overrides the default content model formats for specific HTML tags.
-     * 
+     *
      * This property allows you to specify custom formats for both segment and block-level
      * content models for specific tags. The key is the tag name (e.g., 'div', 'span'),
      * and the value is an object containing both segment and block format overrides.
-     * 
+     *
      * Example:
      * ```
      * defaultContentModelFormatOverride: {

--- a/packages/roosterjs-content-model-types/lib/context/ModelToDomOption.ts
+++ b/packages/roosterjs-content-model-types/lib/context/ModelToDomOption.ts
@@ -1,3 +1,5 @@
+import type { ContentModelBlockFormat } from '../contentModel/format/ContentModelBlockFormat';
+import type { ContentModelSegmentFormat } from '../contentModel/format/ContentModelSegmentFormat';
 import type {
     ContentModelHandlerMap,
     FormatAppliers,
@@ -33,4 +35,8 @@ export interface ModelToDomOption {
      * When set to true, selection from content model will not be applied
      */
     ignoreSelection?: boolean;
+
+    defaultContentModelFormatOverride?: {
+        [tagName: string]: ContentModelSegmentFormat & ContentModelBlockFormat;
+    };
 }

--- a/packages/roosterjs-content-model-types/lib/context/ModelToDomOption.ts
+++ b/packages/roosterjs-content-model-types/lib/context/ModelToDomOption.ts
@@ -36,6 +36,28 @@ export interface ModelToDomOption {
      */
     ignoreSelection?: boolean;
 
+    /**
+     * Overrides the default content model formats for specific HTML tags.
+     * 
+     * This property allows you to specify custom formats for both segment and block-level
+     * content models for specific tags. The key is the tag name (e.g., 'div', 'span'),
+     * and the value is an object containing both segment and block format overrides.
+     * 
+     * Example:
+     * ```
+     * defaultContentModelFormatOverride: {
+     *     div: {
+     *         fontSize: '16px',
+     *         textAlign: 'center',
+     *         backgroundColor: 'lightblue',
+     *     },
+     *     span: {
+     *         fontWeight: 'bold',
+     *         color: 'red',
+     *     },
+     * }
+     * ```
+     */
     defaultContentModelFormatOverride?: {
         [tagName: string]: ContentModelSegmentFormat & ContentModelBlockFormat;
     };

--- a/packages/roosterjs-content-model-types/lib/context/ModelToDomSettings.ts
+++ b/packages/roosterjs-content-model-types/lib/context/ModelToDomSettings.ts
@@ -248,7 +248,28 @@ export interface ModelToDomSettings {
     metadataAppliers: MetadataAppliers;
 
     /**
-     * Default format for each tag name used for generating DOM tree from content model
+     * Default format for each tag name used for generating DOM tree from content model.
+     * 
+     * This map defines the default implicit formats for specific HTML tag names. It is used during
+     * the conversion of a content model to a DOM tree to ensure that elements are styled correctly
+     * based on their tag name. Each entry in the map associates a tag name (in lowercase) with a 
+     * combination of segment and block formats.
+     * 
+     * Example:
+     * {
+     *     "p": {
+     *         fontSize: "12px",
+     *         lineHeight: "1.5",
+     *         marginTop: "10px",
+     *         marginBottom: "10px"
+     *     },
+     *     "h1": {
+     *         fontSize: "24px",
+     *         fontWeight: "bold",
+     *         marginTop: "20px",
+     *         marginBottom: "20px"
+     *     }
+     * }
      */
     defaultContentModelFormatMap: {
         [tagName: string]: ContentModelSegmentFormat & ContentModelBlockFormat;

--- a/packages/roosterjs-content-model-types/lib/context/ModelToDomSettings.ts
+++ b/packages/roosterjs-content-model-types/lib/context/ModelToDomSettings.ts
@@ -249,12 +249,12 @@ export interface ModelToDomSettings {
 
     /**
      * Default format for each tag name used for generating DOM tree from content model.
-     * 
+     *
      * This map defines the default implicit formats for specific HTML tag names. It is used during
      * the conversion of a content model to a DOM tree to ensure that elements are styled correctly
-     * based on their tag name. Each entry in the map associates a tag name (in lowercase) with a 
+     * based on their tag name. Each entry in the map associates a tag name (in lowercase) with a
      * combination of segment and block formats.
-     * 
+     *
      * Example:
      * {
      *     "p": {

--- a/packages/roosterjs-content-model-types/lib/context/ModelToDomSettings.ts
+++ b/packages/roosterjs-content-model-types/lib/context/ModelToDomSettings.ts
@@ -248,6 +248,13 @@ export interface ModelToDomSettings {
     metadataAppliers: MetadataAppliers;
 
     /**
+     * Default format for each tag name used for generating DOM tree from content model
+     */
+    defaultContentModelFormatMap: {
+        [tagName: string]: ContentModelSegmentFormat & ContentModelBlockFormat;
+    };
+
+    /**
      * Default Content Model to DOM handlers before overriding.
      * This provides a way to call original handler from an overridden handler function
      */


### PR DESCRIPTION
[Bug 309357](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/309357): HTML emails have inconsistent paragraph spacing when forwarded

It is possible we add some global CSS style after generating HTML from editor. It can cause the HTML style changed by the global CSS. So we need to let editor be aware of such global CSS, so it can generate HTML accordingly.

For example, we can add such CSS to HTML:
```html
<style>
p { margin-top:0; margin-bottom:0}
</style>
```

And inside editor, if we have a `<P>` with the same style, there is no problem. However if there is `<P>` without any style, we expect it to show margins, but the margins will be removed by the CSS above. So in that case we need to explicitly add inline CSS to P to maintain its margins, like:

```html
<p style="margin-top: 1em; margin-bottom: 1em">some text</p>
```

To achieve this, I'm adding a new option to editor options in `defaultModelToDomOptions` parameter, for example:

```ts
const editor = new Editor(div, {
   ...,
   defaultModelToDomOptions: {
        defaultContentModelFormatOverride: {
            p: {
                marginTop: '0',
                marginBottom: '0',
            },
        },
   }
};
```

So that when generate HTML, editor knows that default margin for P will be '0' in this context, when a P has other margin value, it will generate explicit inline CSS to keep its style.