### PR TITLE
Fix runtime color for dark mode

### DIFF
--- a/packages/roosterjs-content-model-api/lib/publicApi/format/getFormatState.ts
+++ b/packages/roosterjs-content-model-api/lib/publicApi/format/getFormatState.ts
@@ -30,7 +30,9 @@ export function getFormatState(
                 pendingFormat,
                 result,
                 conflictSolution,
-                editor.getDOMHelper()
+                editor.getDOMHelper(),
+                editor.isDarkMode(),
+                editor.getColorManager()
             );
 
             return false;

--- a/packages/roosterjs-content-model-api/test/publicApi/format/getFormatStateTest.ts
+++ b/packages/roosterjs-content-model-api/test/publicApi/format/getFormatStateTest.ts
@@ -28,6 +28,7 @@ describe('getFormatState', () => {
         expectedFormat: ContentModelFormatState
     ) {
         const mockedDOMHelper: DOMHelper = {} as any;
+        const mockedColorManager = {} as any;
         const editor = ({
             getSnapshotsManager: () => ({
                 hasNewContent: false,
@@ -66,6 +67,7 @@ describe('getFormatState', () => {
 
                 callback(model);
             },
+            getColorManager: () => mockedColorManager,
         } as any) as IEditor;
 
         const result = getFormatState(editor);
@@ -80,7 +82,9 @@ describe('getFormatState', () => {
                 isDarkMode: false,
             },
             'remove',
-            mockedDOMHelper
+            mockedDOMHelper,
+            false,
+            mockedColorManager
         );
         expect(result).toEqual(expectedFormat);
     }

--- a/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
@@ -1,5 +1,9 @@
-import { isNodeOfType, parseValueWithUnit, toArray } from 'roosterjs-content-model-dom';
-import type { ContentModelSegmentFormat, DOMHelper } from 'roosterjs-content-model-types';
+import { getColor, isNodeOfType, parseValueWithUnit, toArray } from 'roosterjs-content-model-dom';
+import type {
+    ContentModelSegmentFormat,
+    DarkColorHandler,
+    DOMHelper,
+} from 'roosterjs-content-model-types';
 
 class DOMHelperImpl implements DOMHelper {
     constructor(private contentDiv: HTMLElement) {}
@@ -91,8 +95,13 @@ class DOMHelperImpl implements DOMHelper {
 
     /**
      * Get format of the container element
+     * @param isInDarkMode Optional flag to indicate if the environment is in dark mode
+     * @param darkColorHandler Optional DarkColorHandler to retrieve dark mode colors
      */
-    getContainerFormat(): ContentModelSegmentFormat {
+    getContainerFormat(
+        isInDarkMode?: boolean,
+        darkColorHandler?: DarkColorHandler
+    ): ContentModelSegmentFormat {
         const window = this.contentDiv.ownerDocument.defaultView;
 
         const style = window?.getComputedStyle(this.contentDiv);
@@ -102,8 +111,20 @@ class DOMHelperImpl implements DOMHelper {
                   fontSize: style.fontSize,
                   fontFamily: style.fontFamily,
                   fontWeight: style.fontWeight,
-                  textColor: style.color,
-                  backgroundColor: style.backgroundColor,
+                  textColor: getColor(
+                      this.contentDiv,
+                      false /*isBackgroundColor*/,
+                      !!isInDarkMode,
+                      darkColorHandler,
+                      style.color
+                  ),
+                  backgroundColor: getColor(
+                      this.contentDiv,
+                      true /*isBackgroundColor*/,
+                      !!isInDarkMode,
+                      darkColorHandler,
+                      style.backgroundColor
+                  ),
                   italic: style.fontStyle == 'italic',
                   letterSpacing: style.letterSpacing,
                   lineHeight: style.lineHeight,

--- a/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
@@ -386,6 +386,8 @@ describe('DOMHelperImpl', () => {
                         }),
                     },
                 },
+                style: {},
+                getAttribute: (): null => null,
             } as any;
             const domHelper = createDOMHelper(mockedDiv);
 
@@ -397,6 +399,49 @@ describe('DOMHelperImpl', () => {
                 fontWeight: 'bold',
                 textColor: 'red',
                 backgroundColor: 'blue',
+                italic: true,
+                letterSpacing: '1px',
+                lineHeight: '1.5',
+                strikethrough: true,
+                superOrSubScriptSequence: 'super',
+                underline: true,
+            });
+        });
+
+        it('getContainerFormat use style color', () => {
+            const mockedDiv: HTMLDivElement = {
+                ownerDocument: {
+                    defaultView: {
+                        getComputedStyle: () => ({
+                            fontSize: '12px',
+                            fontFamily: 'Arial',
+                            fontWeight: 'bold',
+                            color: 'red',
+                            backgroundColor: 'blue',
+                            fontStyle: 'italic',
+                            letterSpacing: '1px',
+                            lineHeight: '1.5',
+                            textDecoration: 'line-through underline',
+                            verticalAlign: 'super',
+                        }),
+                    },
+                },
+                style: {
+                    color: 'style-color',
+                    backgroundColor: 'style-bg-color',
+                },
+                getAttribute: (): null => null,
+            } as any;
+            const domHelper = createDOMHelper(mockedDiv);
+
+            const result = domHelper.getContainerFormat();
+
+            expect(result).toEqual({
+                fontSize: '12px',
+                fontFamily: 'Arial',
+                fontWeight: 'bold',
+                textColor: 'style-color',
+                backgroundColor: 'style-bg-color',
                 italic: true,
                 letterSpacing: '1px',
                 lineHeight: '1.5',

--- a/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
@@ -450,5 +450,92 @@ describe('DOMHelperImpl', () => {
                 underline: true,
             });
         });
+
+        it('getContainerFormat use style color in dark mode', () => {
+            const mockedDiv: HTMLDivElement = {
+                ownerDocument: {
+                    defaultView: {
+                        getComputedStyle: () => ({
+                            fontSize: '12px',
+                            fontFamily: 'Arial',
+                            fontWeight: 'bold',
+                            color: 'red',
+                            backgroundColor: 'blue',
+                            fontStyle: 'italic',
+                            letterSpacing: '1px',
+                            lineHeight: '1.5',
+                            textDecoration: 'line-through underline',
+                            verticalAlign: 'super',
+                        }),
+                    },
+                },
+                style: {
+                    color: 'var(--darkColor, lightColor)',
+                    backgroundColor: 'var(--darkBgColor, lightBgColor)',
+                },
+                getAttribute: (): null => null,
+            } as any;
+            const mockDarkHandler = {} as any;
+
+            const domHelper = createDOMHelper(mockedDiv);
+
+            const result = domHelper.getContainerFormat(true, mockDarkHandler);
+
+            expect(result).toEqual({
+                fontSize: '12px',
+                fontFamily: 'Arial',
+                fontWeight: 'bold',
+                textColor: 'lightColor',
+                backgroundColor: 'lightBgColor',
+                italic: true,
+                letterSpacing: '1px',
+                lineHeight: '1.5',
+                strikethrough: true,
+                superOrSubScriptSequence: 'super',
+                underline: true,
+            });
+        });
+
+        it('getContainerFormat use runtime color in dark mode', () => {
+            const mockedDiv: HTMLDivElement = {
+                ownerDocument: {
+                    defaultView: {
+                        getComputedStyle: () => ({
+                            fontSize: '12px',
+                            fontFamily: 'Arial',
+                            fontWeight: 'bold',
+                            color: 'var(--darkColor, lightColor)',
+                            backgroundColor: 'var(--darkBgColor, lightBgColor)',
+                            fontStyle: 'italic',
+                            letterSpacing: '1px',
+                            lineHeight: '1.5',
+                            textDecoration: 'line-through underline',
+                            verticalAlign: 'super',
+                        }),
+                    },
+                },
+                style: {},
+                getAttribute: (): null => null,
+            } as any;
+            const mockDarkHandler = {} as any;
+
+            const domHelper = createDOMHelper(mockedDiv);
+
+            const result = domHelper.getContainerFormat(true, mockDarkHandler);
+
+            expect(result).toEqual({
+                fontSize: '12px',
+                fontFamily: 'Arial',
+                fontWeight: 'bold',
+                textColor: 'lightColor',
+                backgroundColor: 'lightBgColor',
+                italic: true,
+                letterSpacing: '1px',
+                lineHeight: '1.5',
+                strikethrough: true,
+                superOrSubScriptSequence: 'super',
+                underline: true,
+            });
+        });
     });
 });

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/utils/color.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/utils/color.ts
@@ -50,17 +50,19 @@ const COLOR_VAR_PREFIX = '--darkColor';
  * @param isBackground True to get background color, false to get text color
  * @param isDarkMode Whether element is in dark mode now
  * @param darkColorHandler @optional The dark color handler object to help manager dark mode color
+ * @param fallback @optional Fallback color to use if no color is found from the element
  */
 export function getColor(
     element: HTMLElement,
     isBackground: boolean,
     isDarkMode: boolean,
-    darkColorHandler?: DarkColorHandler
+    darkColorHandler?: DarkColorHandler,
+    fallback?: string
 ): string | undefined {
     let color =
         (isBackground ? element.style.backgroundColor : element.style.color) ||
         element.getAttribute(isBackground ? 'bgcolor' : 'color') ||
-        undefined;
+        fallback;
 
     if (color && DeprecatedColors.indexOf(color) > -1) {
         color = isBackground ? undefined : BlackColor;

--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/retrieveModelFormatState.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/retrieveModelFormatState.ts
@@ -18,6 +18,7 @@ import type {
     ReadonlyContentModelListItem,
     ReadonlyContentModelDocument,
     DOMHelper,
+    DarkColorHandler,
 } from 'roosterjs-content-model-types';
 
 /**
@@ -26,13 +27,19 @@ import type {
  * @param pendingFormat Existing pending format, if any
  * @param formatState Existing format state object, used for receiving the result
  * @param conflictSolution The strategy for handling format conflicts
+ * @param domHelper Optional DOMHelper to retrieve container format
+ * @param isInDarkMode Optional flag to indicate if the environment is in dark mode
+ * @param colorHandler Optional DarkColorHandler to handle dark mode colors
+ *
  */
 export function retrieveModelFormatState(
     model: ReadonlyContentModelDocument,
     pendingFormat: ContentModelSegmentFormat | null,
     formatState: ContentModelFormatState,
     conflictSolution: ConflictFormatSolution = 'remove',
-    domHelper?: DOMHelper
+    domHelper?: DOMHelper,
+    isInDarkMode?: boolean,
+    colorHandler?: DarkColorHandler
 ) {
     let firstTableContext: ReadonlyTableSelectionContext | undefined;
     let firstBlock: ReadonlyContentModelBlock | undefined;
@@ -84,7 +91,9 @@ export function retrieveModelFormatState(
                         // to make sure the current format contains all required format.
                         if (!hasAllRequiredFormat(currentFormat)) {
                             if (!containerFormat) {
-                                containerFormat = domHelper?.getContainerFormat() ?? modelFormat;
+                                containerFormat =
+                                    domHelper?.getContainerFormat(isInDarkMode, colorHandler) ??
+                                    modelFormat;
                             }
 
                             currentFormat = Object.assign({}, containerFormat, currentFormat);

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/utils/colorTest.ts
@@ -274,6 +274,20 @@ describe('getColor with darkColorHandler', () => {
         expect(backDark).toBeUndefined();
         expect(textDark).toBe('rgb(0, 0, 0)');
     });
+
+    it('has fallback color', () => {
+        const div = document.createElement('div');
+
+        const backLight = getColor(div, true, false, darkColorHandler, 'fallbackBack');
+        const textLight = getColor(div, false, false, darkColorHandler, 'fallbackText');
+        const backDark = getColor(div, true, true, darkColorHandler, 'fallbackBack');
+        const textDark = getColor(div, false, true, darkColorHandler, 'fallbackText');
+
+        expect(backLight).toBe('fallbackBack');
+        expect(textLight).toBe('fallbackText');
+        expect(backDark).toBe('');
+        expect(textDark).toBe('');
+    });
 });
 
 describe('setColor without darkColorHandler', () => {

--- a/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
@@ -1,5 +1,5 @@
 import type { ContentModelSegmentFormat } from '../contentModel/format/ContentModelSegmentFormat';
-import type { DarkColorHandler } from 'roosterjs-content-model-types';
+import type { DarkColorHandler } from '../context/DarkColorHandler';
 
 /**
  * A helper class to provide DOM access APIs

--- a/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/DOMHelper.ts
@@ -1,4 +1,5 @@
 import type { ContentModelSegmentFormat } from '../contentModel/format/ContentModelSegmentFormat';
+import type { DarkColorHandler } from 'roosterjs-content-model-types';
 
 /**
  * A helper class to provide DOM access APIs
@@ -102,6 +103,11 @@ export interface DOMHelper {
 
     /**
      * Get format of the container element
+     * @param isInDarkMode Optional flag to indicate if the environment is in dark mode
+     * @param darkColorHandler Optional DarkColorHandler to retrieve dark mode colors
      */
-    getContainerFormat(): ContentModelSegmentFormat;
+    getContainerFormat(
+        isInDarkMode?: boolean,
+        darkColorHandler?: DarkColorHandler
+    ): ContentModelSegmentFormat;
 }


### PR DESCRIPTION
With PR #2998, `getFormatState()` now retrieves styles from the container when the current element lacks the required style. This introduces an issue in dark mode: if the current element has no specified color, it inherits the runtime color from the editor container, which is a dark color. However, we expect it to return the light mode color, even when the editor is in dark mode. As a result, when using the format painter, the painted content ends up with an incorrect color.

To address this issue, we now call getColor() with isInDarkMode and darkColorHandler to correctly parse the color value. The color is retrieved in the following order: first from the container’s CSS style, then from its HTML attribute, and finally falling back to its runtime color. getColor() parses the value, and if it detects a dark mode color, it converts it back to the corresponding light mode color before returning it.