### PR TITLE
Fix 366527- Support RTL on Table 

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/block/directionFormatHandler.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/block/directionFormatHandler.ts
@@ -1,3 +1,4 @@
+import { isElementOfType } from '../../domUtils/isElementOfType';
 import type { DirectionFormat } from 'roosterjs-content-model-types';
 import type { FormatHandler } from '../FormatHandler';
 
@@ -15,6 +16,10 @@ export const directionFormatHandler: FormatHandler<DirectionFormat> = {
     apply: (format, element) => {
         if (format.direction) {
             element.style.direction = format.direction;
+        }
+
+        if (format.direction == 'rtl' && isElementOfType(element, 'table')) {
+            element.style.justifySelf = 'flex-end';
         }
     },
 };

--- a/packages/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
+++ b/packages/roosterjs-content-model-dom/lib/formatHandlers/defaultFormatHandlers.ts
@@ -178,6 +178,7 @@ export const defaultFormatKeysPerCategory: {
         'size',
         'tableLayout',
         'textColor',
+        'direction',
     ],
     tableBorder: ['borderBox', 'tableSpacing'],
     tableCellBorder: ['borderBox'],

--- a/packages/roosterjs-content-model-dom/test/formatHandlers/block/directionFormatHandlerTest.ts
+++ b/packages/roosterjs-content-model-dom/test/formatHandlers/block/directionFormatHandlerTest.ts
@@ -81,4 +81,13 @@ describe('directionFormatHandler.apply', () => {
         directionFormatHandler.apply(format, div, context);
         expect(div.outerHTML).toBe('<div style="direction: ltr;"></div>');
     });
+
+    it('RTL on table', () => {
+        const table = document.createElement('table');
+        format.direction = 'rtl';
+        directionFormatHandler.apply(format, table, context);
+        expect(table.outerHTML).toBe(
+            '<table style="direction: rtl; justify-self: flex-end;"></table>'
+        );
+    });
 });

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
@@ -534,7 +534,7 @@ describe('handleTable', () => {
         handleTable(document, parent, table, context, null);
 
         expect(parent.innerHTML).toBe(
-            '<table style="direction: rtl; text-align: center; line-height: 2; white-space: pre;"><tbody><tr><td style="width: 100px; height: 200px; direction: ltr; text-align: left; line-height: 1; white-space: normal;"></td></tr></tbody></table>'
+            '<table style="direction: rtl; justify-self: flex-end; text-align: center; line-height: 2; white-space: pre;"><tbody><tr><td style="width: 100px; height: 200px; direction: ltr; text-align: left; line-height: 1; white-space: normal;"></td></tr></tbody></table>'
         );
     });
 

--- a/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelTableFormat.ts
+++ b/packages/roosterjs-content-model-types/lib/contentModel/format/ContentModelTableFormat.ts
@@ -8,6 +8,7 @@ import type { MarginFormat } from './formatParts/MarginFormat';
 import type { SpacingFormat } from './formatParts/SpacingFormat';
 import type { TableLayoutFormat } from './formatParts/TableLayoutFormat';
 import type { SizeFormat } from './formatParts/SizeFormat';
+import type { DirectionFormat } from './formatParts/DirectionFormat';
 
 /**
  * Format of Table
@@ -17,6 +18,7 @@ export type ContentModelTableFormat = ContentModelBlockFormat &
     AriaFormat &
     BorderFormat &
     BorderBoxFormat &
+    DirectionFormat &
     SpacingFormat &
     MarginFormat &
     DisplayFormat &


### PR DESCRIPTION
The style `direction: RTL` does move the table to the right, so use `justifySelf:flex-end`. 
