### PR TITLE
Fix superscript rule 

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
@@ -72,7 +72,8 @@ function getNumericValue(text: string, checkFullText: boolean = false): number |
     const number = checkFullText ? text : text.substring(0, text.length - ORDINAL_LENGTH);
     const isNumber = /^-?\d+$/.test(number);
     if (isNumber) {
-        return parseInt(text);
+        const numericValue = parseInt(number);
+        return numericValue < 20 ? numericValue : parseInt(number.substring(number.length - 1));
     }
     return null;
 }

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
@@ -73,7 +73,9 @@ function getNumericValue(text: string, checkFullText: boolean = false): number |
     const isNumber = /^-?\d+$/.test(number);
     if (isNumber) {
         const numericValue = parseInt(number);
-        return numericValue < 20 ? numericValue : parseInt(number.substring(number.length - 1));
+        return Math.abs(numericValue) < 20
+            ? numericValue
+            : parseInt(number.substring(number.length - 1));
     }
     return null;
 }

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/numbers/transformOrdinalsTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/numbers/transformOrdinalsTest.ts
@@ -97,7 +97,133 @@ describe('transformOrdinals', () => {
             segments: [segment],
             format: {},
         };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
+    });
+
+    it('with 21st', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '21st',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
         runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('with 22nd', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '22nd',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('with 23rd', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '23rd',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('with 11th', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '11th',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('with 12th', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '12th',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('with 13th', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '13th',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('with 11st', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '11st',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
+    });
+
+    it('with 12nd', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '12nd',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
+    });
+
+    it('with 13rd', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '13rd',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
     });
 
     it('with 2th', () => {
@@ -284,7 +410,7 @@ describe('transformOrdinals', () => {
         runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
     });
 
-    it('link - 123th', () => {
+    it('link - 123rd', () => {
         const link: ContentModelText = {
             segmentType: 'Text',
             text: '123',
@@ -298,7 +424,7 @@ describe('transformOrdinals', () => {
         };
         const segment: ContentModelText = {
             segmentType: 'Text',
-            text: 'th',
+            text: 'rd',
             format: {},
         };
         const paragraph: ContentModelParagraph = {

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/numbers/transformOrdinalsTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/numbers/transformOrdinalsTest.ts
@@ -212,6 +212,20 @@ describe('transformOrdinals', () => {
         runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
     });
 
+    it('with -12nd', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '-12nd',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, false);
+    });
+
     it('with 13rd', () => {
         const segment: ContentModelText = {
             segmentType: 'Text',


### PR DESCRIPTION
In English the suffix for ordinal numbers -st, -nd, -rd, and -th are applied based on the last digit of the number, except for 11,12,13. 

- Numbers ending in 1 → -st (except 11 → 11th)
- Numbers ending in 2 → -nd (except 12 → 12th)
- Numbers ending in 3 → -rd (except 13 → 13th)
- All others →-th