### PR TITLE
Fix 380860

### DIFF
--- a/packages/roosterjs-content-model-api/lib/modelApi/list/setListType.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/list/setListType.ts
@@ -54,6 +54,13 @@ export function setListType(
 
             if (!alreadyInExpectedType && level) {
                 level.listType = listType;
+
+                updateListMetadata(level, metadata =>
+                    Object.assign({}, metadata, {
+                        applyListStyleFromLevel: true,
+                    })
+                );
+
                 block.levels.push(level);
             } else if (block.blocks.length == 1) {
                 setParagraphNotImplicit(block.blocks[0]);

--- a/packages/roosterjs-content-model-api/test/modelApi/list/setListTypeTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/list/setListTypeTest.ts
@@ -207,7 +207,13 @@ describe('indent', () => {
                 {
                     blockGroupType: 'ListItem',
                     blockType: 'BlockGroup',
-                    levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {},
+                            dataset: { editingInfo: '{"applyListStyleFromLevel":true}' },
+                        },
+                    ],
                     blocks: [para],
                     formatHolder: { segmentType: 'SelectionMarker', format: {}, isSelected: false },
                     format: {},
@@ -356,7 +362,13 @@ describe('indent', () => {
                 {
                     blockGroupType: 'ListItem',
                     blockType: 'BlockGroup',
-                    levels: [{ listType: 'OL', dataset: {}, format: {} }],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            dataset: { editingInfo: '{"applyListStyleFromLevel":true}' },
+                            format: {},
+                        },
+                    ],
                     blocks: [para1],
                     formatHolder: { segmentType: 'SelectionMarker', format: {}, isSelected: false },
                     format: {},
@@ -366,7 +378,11 @@ describe('indent', () => {
                     blockType: 'BlockGroup',
                     levels: [
                         { listType: 'OL', dataset: {}, format: {} },
-                        { listType: 'OL', dataset: {}, format: {} },
+                        {
+                            listType: 'OL',
+                            dataset: { editingInfo: '{"applyListStyleFromLevel":true}' },
+                            format: {},
+                        },
                     ],
                     blocks: [para2],
                     formatHolder: { segmentType: 'SelectionMarker', format: {}, isSelected: false },
@@ -781,7 +797,13 @@ describe('indent', () => {
                     blockType: 'BlockGroup',
                     blockGroupType: 'ListItem',
                     blocks: [para1],
-                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            format: {},
+                            dataset: { editingInfo: '{"applyListStyleFromLevel":true}' },
+                        },
+                    ],
                     formatHolder: { segmentType: 'SelectionMarker', isSelected: false, format: {} },
                     format: {},
                 },


### PR DESCRIPTION
[Bug 380860](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/380860): Re: Monarch Feedback 🐞 - Mail - In mail editor, list buttons behave unexpectedly. If my IP is in a bulleted list and I press the numbering button, it removes...

When switch list type, we should let the list use the list type according to its list level. So let's set the property `applyListStyleFromLevel` onto list level metadata then further code will update format from metadata and change list style.