### PR TITLE
Support 'HTMLFast' mode when get HTML

### DIFF
--- a/demo/scripts/controlsV2/demoButtons/exportContentButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/exportContentButton.ts
@@ -9,6 +9,7 @@ import type { RibbonButton } from 'roosterjs-react';
 export type ExportButtonStringKey =
     | 'buttonNameExport'
     | 'menuNameExportHTML'
+    | 'menuNameExportHTMLFast'
     | 'menuNameExportText';
 
 const callbacks: ModelToTextCallbacks = {
@@ -26,6 +27,7 @@ export const exportContentButton: RibbonButton<ExportButtonStringKey> = {
     dropDownMenu: {
         items: {
             menuNameExportHTML: 'as HTML',
+            menuNameExportHTMLFast: 'as HTML (fast version)',
             menuNameExportText: 'as Plain Text',
         },
     },
@@ -45,6 +47,8 @@ export const exportContentButton: RibbonButton<ExportButtonStringKey> = {
                     },
                 }) +
                 '</body></html>';
+        } else if (key == 'menuNameExportHTMLFast') {
+            html = exportContent(editor, 'HTMLFast');
         } else if (key == 'menuNameExportText') {
             html = `<pre>${exportContent(editor, 'PlainText', callbacks)}</pre>`;
         }

--- a/packages/roosterjs-content-model-core/lib/command/exportContent/exportContent.ts
+++ b/packages/roosterjs-content-model-core/lib/command/exportContent/exportContent.ts
@@ -15,7 +15,7 @@ import type {
 /**
  * Export HTML content. If there are entities, this will cause EntityOperation event with option = 'replaceTemporaryContent' to get a dehydrated entity
  * @param editor The editor to get content from
- * @param mode Specify HTML to get plain text result. This is the default option
+ * @param mode Specify HTML to get HTML. This is the default option
  * @param options @optional Options for Model to DOM conversion
  */
 export function exportContent(editor: IEditor, mode?: 'HTML', options?: ModelToDomOption): string;
@@ -24,7 +24,7 @@ export function exportContent(editor: IEditor, mode?: 'HTML', options?: ModelToD
  * Export HTML content. If there are entities, this will cause EntityOperation event with option = 'replaceTemporaryContent' to get a dehydrated entity.
  * This is a fast version, it retrieve HTML content directly from editor without going through content model conversion.
  * @param editor The editor to get content from
- * @param mode Specify HTML to get plain text result. This is the default option
+ * @param mode Specify HTMLFast to get HTML result.
  */
 export function exportContent(editor: IEditor, mode: 'HTMLFast'): string;
 
@@ -48,9 +48,11 @@ export function exportContent(
  */
 export function exportContent(editor: IEditor, mode: 'PlainTextFast'): string;
 
+// Here I didn't add 'HTMLFast' to ExportContentMode type because it will make this a breaking change and EditorAdapter will see build time error without bumping version
+// Once we are confident that 'HTMLFast' is stable, we can fully switch 'HTML' to use the 'HTMLFast' approach
 export function exportContent(
     editor: IEditor,
-    mode: ExportContentMode = 'HTML',
+    mode: ExportContentMode | 'HTMLFast' = 'HTML',
     optionsOrCallbacks?: ModelToDomOption | ModelToTextCallbacks
 ): string {
     let model: ContentModelDocument;
@@ -67,7 +69,22 @@ export function exportContent(
                 optionsOrCallbacks as ModelToTextCallbacks
             );
 
+        case 'HTMLFast':
+            const clonedRoot = editor.getDOMHelper().getClonedRoot();
+
+            if (editor.isDarkMode()) {
+                transformColor(
+                    clonedRoot,
+                    false /*includeSelf*/,
+                    'darkToLight',
+                    editor.getColorManager()
+                );
+            }
+
+            return getHTMLFromDOM(editor, clonedRoot);
+
         case 'HTML':
+        default:
             model = editor.getContentModelCopy('clean');
 
             const doc = editor.getDocument();
@@ -84,19 +101,6 @@ export function exportContent(
             );
 
             return getHTMLFromDOM(editor, div);
-        case 'HTMLFast':
-            const clonedRoot = editor.getDOMHelper().getClonedRoot();
-
-            if (editor.isDarkMode()) {
-                transformColor(
-                    clonedRoot,
-                    false /*includeSelf*/,
-                    'darkToLight',
-                    editor.getColorManager()
-                );
-            }
-
-            return getHTMLFromDOM(editor, clonedRoot);
     }
 }
 

--- a/packages/roosterjs-content-model-core/test/command/exportContent/exportContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/exportContent/exportContentTest.ts
@@ -1,6 +1,7 @@
 import * as contentModelToDom from 'roosterjs-content-model-dom/lib/modelToDom/contentModelToDom';
 import * as contentModelToText from 'roosterjs-content-model-dom/lib/modelToText/contentModelToText';
 import * as createModelToDomContext from 'roosterjs-content-model-dom/lib/modelToDom/context/createModelToDomContext';
+import * as transformColor from 'roosterjs-content-model-dom/lib/domUtils/style/transformColor';
 import { exportContent } from '../../../lib/command/exportContent/exportContent';
 import { IEditor } from 'roosterjs-content-model-types';
 
@@ -150,6 +151,84 @@ describe('exportContent', () => {
             'extractContentWithDom',
             { clonedRoot: mockedDiv },
             true
+        );
+    });
+
+    it('HTMLFast in light mode', () => {
+        const mockedHTML = 'HTML';
+        const mockedClonedRoot = {
+            innerHTML: mockedHTML,
+        };
+        const mockedDOMHelper = {
+            getClonedRoot: () => mockedClonedRoot,
+        } as any;
+        const getDOMHelperSpy = jasmine.createSpy('getDOMHelper').and.returnValue(mockedDOMHelper);
+        const mockedDiv = {} as any;
+        const mockedDoc = {
+            createElement: () => mockedDiv,
+        } as any;
+        const triggerEventSpy = jasmine.createSpy('triggerEvent');
+        const editor: IEditor = {
+            getDocument: () => mockedDoc,
+            triggerEvent: triggerEventSpy,
+            getDOMHelper: getDOMHelperSpy,
+            isDarkMode: () => false,
+        } as any;
+
+        const html = exportContent(editor, 'HTMLFast');
+
+        expect(html).toBe(mockedHTML);
+        expect(getDOMHelperSpy).toHaveBeenCalledWith();
+        expect(triggerEventSpy).toHaveBeenCalledWith(
+            'extractContentWithDom',
+            { clonedRoot: mockedClonedRoot },
+            true
+        );
+    });
+
+    it('HTMLFast in dark mode', () => {
+        const mockedColorManager = 'COLOR_MANAGER' as any;
+        const transformedHTML = 'Transformed HTML';
+        const transformColorSpy = spyOn(transformColor, 'transformColor').and.callFake(
+            (rootNode: any) => {
+                rootNode.innerHTML = transformedHTML;
+            }
+        );
+        const mockedHTML = 'HTML';
+        const mockedClonedRoot = {
+            innerHTML: mockedHTML,
+        } as any;
+        const mockedDOMHelper = {
+            getClonedRoot: () => mockedClonedRoot,
+        } as any;
+        const getDOMHelperSpy = jasmine.createSpy('getDOMHelper').and.returnValue(mockedDOMHelper);
+        const mockedDiv = {} as any;
+        const mockedDoc = {
+            createElement: () => mockedDiv,
+        } as any;
+        const triggerEventSpy = jasmine.createSpy('triggerEvent');
+        const editor: IEditor = {
+            getDocument: () => mockedDoc,
+            triggerEvent: triggerEventSpy,
+            getDOMHelper: getDOMHelperSpy,
+            isDarkMode: () => true,
+            getColorManager: () => mockedColorManager,
+        } as any;
+
+        const html = exportContent(editor, 'HTMLFast');
+
+        expect(html).toBe(transformedHTML);
+        expect(getDOMHelperSpy).toHaveBeenCalledWith();
+        expect(triggerEventSpy).toHaveBeenCalledWith(
+            'extractContentWithDom',
+            { clonedRoot: mockedClonedRoot },
+            true
+        );
+        expect(transformColorSpy).toHaveBeenCalledWith(
+            mockedClonedRoot,
+            false,
+            'darkToLight',
+            mockedColorManager
         );
     });
 });

--- a/packages/roosterjs-content-model-types/lib/enum/ExportContentMode.ts
+++ b/packages/roosterjs-content-model-types/lib/enum/ExportContentMode.ts
@@ -8,12 +8,6 @@ export type ExportContentMode =
     | 'HTML'
 
     /**
-     * Export to clean HTML in light color mode with dehydrated entities.
-     * This is a fast version, it retrieve HTML content directly from editor without going through content model conversion.
-     */
-    | 'HTMLFast'
-
-    /**
      * Export to plain text
      */
     | 'PlainText'

--- a/packages/roosterjs-content-model-types/lib/enum/ExportContentMode.ts
+++ b/packages/roosterjs-content-model-types/lib/enum/ExportContentMode.ts
@@ -8,6 +8,12 @@ export type ExportContentMode =
     | 'HTML'
 
     /**
+     * Export to clean HTML in light color mode with dehydrated entities.
+     * This is a fast version, it retrieve HTML content directly from editor without going through content model conversion.
+     */
+    | 'HTMLFast'
+
+    /**
      * Export to plain text
      */
     | 'PlainText'


### PR DESCRIPTION
Today in `exportContent` API, we support 3 modes:
- `HTML`
- `PlainText`
- `PlainTextFast`

For `HTML`, we need to clone a content model and then convert it to DOM, then get HTML. When content is long enough, this will be slow.

In this PR I'm adding a new mode `HTMLFast`, it directly clone the existing DOM tree from editor then pass it to plugins, and do dark mode transform if need. This is the same process with roosterjs v8. In theory this can replace the default `HTML` mode unless there is special output options. So add this one to be coexisting with `HTML` mode so we can test it and run it with a flight.