### PR TITLE
Fix 276282

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/mergeModel.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/mergeModel.ts
@@ -256,7 +256,7 @@ function mergeList(markerPosition: InsertPoint, newList: ContentModelListItem) {
 
     const { path, paragraph } = markerPosition;
 
-    const listItemIndex = getClosestAncestorBlockGroupIndex(path, ['ListItem']);
+    const listItemIndex = getClosestAncestorBlockGroupIndex(path, ['ListItem'], ['TableCell']);
     const listItem = path[listItemIndex] as ContentModelListItem;
     const listParent = path[listItemIndex + 1]; // It is ok here when index is -1, that means there is no list and we just insert a new paragraph and use path[0] as its parent
     const blockIndex = listParent.blocks.indexOf(listItem || paragraph);

--- a/packages/roosterjs-content-model-dom/test/modelApi/editing/mergeModelTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/editing/mergeModelTest.ts
@@ -854,6 +854,240 @@ describe('mergeModel', () => {
         });
     });
 
+    it('list to list with table', () => {
+        const majorModel = createContentModelDocument();
+        const sourceModel = createContentModelDocument();
+
+        const br = createBr();
+        const marker = createSelectionMarker();
+        const para = createParagraph();
+
+        para.segments.push(marker, br);
+
+        const td = createTableCell();
+
+        td.blocks.push(para);
+
+        const table = createTable(1);
+        table.rows[0].cells.push(td);
+
+        const list1 = createListItem([createListLevel('OL')]);
+
+        list1.blocks.push(table);
+
+        majorModel.blocks.push(list1);
+
+        const newPara1 = createParagraph();
+        const newText1 = createText('newText1');
+        const newPara2 = createParagraph();
+        const newText2 = createText('newText2');
+        const newList1 = createListItem([
+            createListLevel(
+                'UL',
+                {},
+                { editingInfo: JSON.stringify({ startNumberOverride: 3, unorderedStyleType: 4 }) }
+            ),
+        ]);
+        const newList2 = createListItem([
+            createListLevel(
+                'UL',
+                {},
+                { editingInfo: JSON.stringify({ startNumberOverride: 3, unorderedStyleType: 4 }) }
+            ),
+            createListLevel(
+                'UL',
+                {},
+                { editingInfo: JSON.stringify({ startNumberOverride: 5, unorderedStyleType: 6 }) }
+            ),
+        ]);
+
+        newPara1.segments.push(newText1);
+        newPara2.segments.push(newText2);
+
+        newList1.blocks.push(newPara1);
+        newList2.blocks.push(newPara2);
+
+        sourceModel.blocks.push(newList1);
+        sourceModel.blocks.push(newList2);
+
+        const result = mergeModel(majorModel, sourceModel, {
+            newEntities: [],
+            deletedEntities: [],
+            newImages: [],
+        });
+
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [table],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: false,
+                        format: {},
+                    },
+                    format: {},
+                },
+            ],
+        });
+        expect(majorModel).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Table',
+                            rows: [
+                                {
+                                    height: 0,
+                                    format: {},
+                                    cells: [
+                                        {
+                                            blockGroupType: 'TableCell',
+                                            blocks: [
+                                                {
+                                                    blockType: 'BlockGroup',
+                                                    blockGroupType: 'ListItem',
+                                                    blocks: [
+                                                        {
+                                                            blockType: 'Paragraph',
+                                                            segments: [
+                                                                {
+                                                                    segmentType: 'Text',
+                                                                    text: 'newText1',
+                                                                    format: {},
+                                                                },
+                                                            ],
+                                                            format: {},
+                                                        },
+                                                    ],
+                                                    levels: [
+                                                        {
+                                                            listType: 'UL',
+                                                            format: {},
+                                                            dataset: {
+                                                                editingInfo:
+                                                                    '{"startNumberOverride":3,"unorderedStyleType":4}',
+                                                            },
+                                                        },
+                                                    ],
+                                                    formatHolder: {
+                                                        segmentType: 'SelectionMarker',
+                                                        isSelected: false,
+                                                        format: {},
+                                                    },
+                                                    format: {},
+                                                },
+                                                {
+                                                    blockType: 'BlockGroup',
+                                                    blockGroupType: 'ListItem',
+                                                    blocks: [
+                                                        {
+                                                            blockType: 'Paragraph',
+                                                            segments: [
+                                                                {
+                                                                    segmentType: 'Text',
+                                                                    text: 'newText2',
+                                                                    format: {},
+                                                                },
+                                                            ],
+                                                            format: {},
+                                                        },
+                                                    ],
+                                                    levels: [
+                                                        {
+                                                            listType: 'UL',
+                                                            format: {},
+                                                            dataset: {
+                                                                editingInfo:
+                                                                    '{"startNumberOverride":3,"unorderedStyleType":4}',
+                                                            },
+                                                        },
+                                                        {
+                                                            listType: 'UL',
+                                                            format: {},
+                                                            dataset: {
+                                                                editingInfo:
+                                                                    '{"startNumberOverride":5,"unorderedStyleType":6}',
+                                                            },
+                                                        },
+                                                    ],
+                                                    formatHolder: {
+                                                        segmentType: 'SelectionMarker',
+                                                        isSelected: false,
+                                                        format: {},
+                                                    },
+                                                    format: {},
+                                                },
+                                                {
+                                                    blockType: 'Paragraph',
+                                                    segments: [
+                                                        {
+                                                            segmentType: 'SelectionMarker',
+                                                            isSelected: true,
+                                                            format: {},
+                                                        },
+                                                        { segmentType: 'Br', format: {} },
+                                                    ],
+                                                    format: {},
+                                                },
+                                            ],
+                                            format: {},
+                                            spanLeft: false,
+                                            spanAbove: false,
+                                            isHeader: false,
+                                            dataset: {},
+                                        },
+                                    ],
+                                },
+                            ],
+                            format: {},
+                            widths: [],
+                            dataset: {},
+                        },
+                    ],
+                    levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                    formatHolder: { segmentType: 'SelectionMarker', isSelected: false, format: {} },
+                    format: {},
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            marker,
+            paragraph: {
+                blockType: 'Paragraph',
+                segments: [
+                    {
+                        segmentType: 'SelectionMarker',
+                        isSelected: true,
+                        format: {},
+                    },
+                    { segmentType: 'Br', format: {} },
+                ],
+                format: {},
+            },
+            path: [td, list1, majorModel],
+            tableContext: {
+                table,
+                rowIndex: 0,
+                colIndex: 0,
+                isWholeTableSelected: false,
+            },
+        });
+    });
+
     it('table to text', () => {
         const majorModel = createContentModelDocument();
         const sourceModel = createContentModelDocument();


### PR DESCRIPTION
[Bug 276282](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/276282): [Format]Unable to paste text into table when both text and table are set numbering/bullets

When paste list and try to merge with existing list, do not search beyond table.