### PR TITLE
Toggle blockquote in Format Container

### DIFF
--- a/packages/roosterjs-content-model-api/lib/modelApi/block/toggleModelBlockQuote.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/block/toggleModelBlockQuote.ts
@@ -33,7 +33,9 @@ export function toggleModelBlockQuote(
 
     const paragraphOfQuote = getOperationalBlocks<
         ContentModelFormatContainer | ContentModelListItem
-    >(model, ['FormatContainer', 'ListItem'], ['TableCell'], true /*deepFirst*/);
+    >(model, ['FormatContainer', 'ListItem'], ['TableCell'], true /*deepFirst*/, block => {
+        return block.blockGroupType == 'FormatContainer' ? block.tagName == 'blockquote' : true;
+    });
 
     if (areAllBlockQuotes(paragraphOfQuote)) {
         // All selections are already in quote, we need to unquote them
@@ -52,16 +54,8 @@ export function toggleModelBlockQuote(
             canMergeQuote(target, current?.format || (isRtl ? formatRtl : formatLtr));
 
         paragraphOfQuote.forEach(({ block, parent }) => {
-            if (isBlockGroupOfType<ContentModelFormatContainer>(block, 'FormatContainer')) {
-                if (block.tagName !== 'blockquote') {
-                    const paragraphsToWrap = block.blocks.filter(
-                        b => b.blockType == 'Paragraph' && b.segments.some(s => s.isSelected)
-                    );
-
-                    paragraphsToWrap.forEach(b => {
-                        wrapBlockStep1(step1Results, block, b, creator, canMerge);
-                    });
-                }
+            if (isQuote(block)) {
+                // Already in quote, no op
             } else {
                 wrapBlockStep1(step1Results, parent, block, creator, canMerge);
             }

--- a/packages/roosterjs-content-model-api/lib/modelApi/block/toggleModelBlockQuote.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/block/toggleModelBlockQuote.ts
@@ -53,7 +53,7 @@ export function toggleModelBlockQuote(
 
         paragraphOfQuote.forEach(({ block, parent }) => {
             if (isBlockGroupOfType<ContentModelFormatContainer>(block, 'FormatContainer')) {
-                if (block.tagName !== 'blockquote' && !!block.format.id) {
+                if (block.tagName !== 'blockquote') {
                     const paragraphsToWrap = block.blocks.filter(
                         b => b.blockType == 'Paragraph' && b.segments.some(s => s.isSelected)
                     );
@@ -61,8 +61,6 @@ export function toggleModelBlockQuote(
                     paragraphsToWrap.forEach(b => {
                         wrapBlockStep1(step1Results, block, b, creator, canMerge);
                     });
-                } else if (block.tagName !== 'blockquote') {
-                    wrapBlockStep1(step1Results, parent, block, creator, canMerge);
                 }
             } else {
                 wrapBlockStep1(step1Results, parent, block, creator, canMerge);

--- a/packages/roosterjs-content-model-api/test/modelApi/block/toggleModelBlockQuoteTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/block/toggleModelBlockQuoteTest.ts
@@ -807,7 +807,6 @@ describe('toggleModelBlockQuote', () => {
         const container = createFormatContainer('div', {
             id: 'TestId',
         });
-        text1.isSelected = true;
 
         para1.segments.push(text1);
         para2.segments.push(text2);
@@ -838,22 +837,13 @@ describe('toggleModelBlockQuote', () => {
                                     format: {},
                                 },
                             ],
-                            segmentFormat: {},
                             blockType: 'Paragraph',
                             format: {},
                         },
                         {
                             tagName: 'blockquote',
                             blockType: 'BlockGroup',
-                            format: {
-                                marginTop: '1em',
-                                marginBottom: '1em',
-                                marginLeft: '40px',
-                                marginRight: '40px',
-                                paddingLeft: '10px',
-                                borderLeft: '3px solid rgb(200, 200, 200)',
-                                textColor: 'rgb(102, 102, 102)',
-                            },
+                            format: {},
                             blockGroupType: 'FormatContainer',
                             blocks: [
                                 {
@@ -861,11 +851,116 @@ describe('toggleModelBlockQuote', () => {
                                         {
                                             text: 'test2',
                                             segmentType: 'Text',
-                                            isSelected: true,
                                             format: {},
+                                            isSelected: true,
                                         },
                                     ],
-                                    segmentFormat: {},
+
+                                    blockType: 'Paragraph',
+                                    format: {},
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
+    });
+
+    it('Quote only selected segments in a FormatContainer - multi selected segments', () => {
+        const doc = createContentModelDocument();
+        const para1 = createParagraph();
+        const text1 = createText('test1');
+        const para2 = createParagraph();
+        const text2 = createText('test2');
+        const para3 = createParagraph();
+        const text3 = createText('test3');
+        const para4 = createParagraph();
+        const text4 = createText('test4');
+
+        const container = createFormatContainer('div', {
+            id: 'TestId',
+        });
+
+        para1.segments.push(text1);
+        para2.segments.push(text2);
+        para3.segments.push(text3);
+        para4.segments.push(text4);
+        container.blocks.push(para1);
+        container.blocks.push(para2);
+        container.blocks.push(para3);
+        container.blocks.push(para4);
+        doc.blocks.push(container);
+
+        text2.isSelected = true;
+        text3.isSelected = true;
+        text4.isSelected = true;
+
+        toggleModelBlockQuote(doc, {}, {});
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    tagName: 'div',
+                    blockType: 'BlockGroup',
+                    format: {
+                        id: 'TestId',
+                    },
+                    blockGroupType: 'FormatContainer',
+                    blocks: [
+                        {
+                            segments: [
+                                {
+                                    text: 'test1',
+                                    segmentType: 'Text',
+                                    format: {},
+                                },
+                            ],
+                            blockType: 'Paragraph',
+                            format: {},
+                        },
+                        {
+                            tagName: 'blockquote',
+                            blockType: 'BlockGroup',
+                            format: {},
+                            blockGroupType: 'FormatContainer',
+                            blocks: [
+                                {
+                                    segments: [
+                                        {
+                                            text: 'test2',
+                                            segmentType: 'Text',
+                                            format: {},
+                                            isSelected: true,
+                                        },
+                                    ],
+                                    blockType: 'Paragraph',
+                                    format: {},
+                                },
+                                {
+                                    segments: [
+                                        {
+                                            text: 'test3',
+                                            segmentType: 'Text',
+                                            format: {},
+                                            isSelected: true,
+                                        },
+                                    ],
+                                    blockType: 'Paragraph',
+                                    format: {},
+                                },
+                                {
+                                    segments: [
+                                        {
+                                            text: 'test4',
+                                            segmentType: 'Text',
+                                            format: {},
+                                            isSelected: true,
+                                        },
+                                    ],
                                     blockType: 'Paragraph',
                                     format: {},
                                 },

--- a/packages/roosterjs-content-model-api/test/modelApi/block/toggleModelBlockQuoteTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/block/toggleModelBlockQuoteTest.ts
@@ -797,4 +797,85 @@ describe('toggleModelBlockQuote', () => {
         expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
         expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
     });
+
+    it('Quote only selected segments in a FormatContainer', () => {
+        const doc = createContentModelDocument();
+        const para1 = createParagraph();
+        const text1 = createText('test1');
+        const para2 = createParagraph();
+        const text2 = createText('test2');
+        const container = createFormatContainer('div', {
+            id: 'TestId',
+        });
+        text1.isSelected = true;
+
+        para1.segments.push(text1);
+        para2.segments.push(text2);
+        container.blocks.push(para1);
+        container.blocks.push(para2);
+        doc.blocks.push(container);
+
+        text2.isSelected = true;
+
+        toggleModelBlockQuote(doc, {}, {});
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    tagName: 'div',
+                    blockType: 'BlockGroup',
+                    format: {
+                        id: 'TestId',
+                    },
+                    blockGroupType: 'FormatContainer',
+                    blocks: [
+                        {
+                            segments: [
+                                {
+                                    text: 'test1',
+                                    segmentType: 'Text',
+                                    format: {},
+                                },
+                            ],
+                            segmentFormat: {},
+                            blockType: 'Paragraph',
+                            format: {},
+                        },
+                        {
+                            tagName: 'blockquote',
+                            blockType: 'BlockGroup',
+                            format: {
+                                marginTop: '1em',
+                                marginBottom: '1em',
+                                marginLeft: '40px',
+                                marginRight: '40px',
+                                paddingLeft: '10px',
+                                borderLeft: '3px solid rgb(200, 200, 200)',
+                                textColor: 'rgb(102, 102, 102)',
+                            },
+                            blockGroupType: 'FormatContainer',
+                            blocks: [
+                                {
+                                    segments: [
+                                        {
+                                            text: 'test2',
+                                            segmentType: 'Text',
+                                            isSelected: true,
+                                            format: {},
+                                        },
+                                    ],
+                                    segmentFormat: {},
+                                    blockType: 'Paragraph',
+                                    format: {},
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledTimes(1);
+        expect(splitSelectedParagraphByBrSpy).toHaveBeenCalledWith(doc);
+    });
 });

--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/getClosestAncestorBlockGroupIndex.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/getClosestAncestorBlockGroupIndex.ts
@@ -10,16 +10,21 @@ import type {
  * @param path The block group path, from the closest one to root
  * @param blockGroupTypes The expected block group types
  * @param stopTypes @optional Block group types that will cause stop searching
+ * @param isValidTarget @optional An additional callback to validate whether a matching block group is a valid target
  */
 export function getClosestAncestorBlockGroupIndex<T extends ContentModelBlockGroup>(
     path: ReadonlyContentModelBlockGroup[],
     blockGroupTypes: TypeOfBlockGroup<T>[],
-    stopTypes: ContentModelBlockGroupType[] = []
+    stopTypes: ContentModelBlockGroupType[] = [],
+    isValidTarget?: (block: ReadonlyContentModelBlockGroup) => boolean
 ): number {
     for (let i = 0; i < path.length; i++) {
         const group = path[i];
 
-        if ((blockGroupTypes as string[]).indexOf(group.blockGroupType) >= 0) {
+        if (
+            (blockGroupTypes as string[]).indexOf(group.blockGroupType) >= 0 &&
+            (!isValidTarget || isValidTarget(group))
+        ) {
             return i;
         } else if (stopTypes.indexOf(group.blockGroupType) >= 0) {
             // Do not go across boundary specified by stopTypes.

--- a/packages/roosterjs-content-model-dom/lib/modelApi/selection/collectSelections.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/selection/collectSelections.ts
@@ -237,12 +237,14 @@ export function getSelectedParagraphs(
  * @param blockGroupTypes The expected block group types
  * @param stopTypes Block group types that will stop searching when hit
  * @param deepFirst True means search in deep first, otherwise wide first
+ * @param isValidTarget @optional An additional callback to validate whether a matching block group is a valid target
  */
 export function getOperationalBlocks<T extends ContentModelBlockGroup>(
     group: ContentModelBlockGroup,
     blockGroupTypes: TypeOfBlockGroup<T>[],
     stopTypes: ContentModelBlockGroupType[],
-    deepFirst?: boolean
+    deepFirst?: boolean,
+    isValidTarget?: (block: ReadonlyContentModelBlockGroup) => boolean
 ): OperationalBlocks<T>[];
 
 /**
@@ -251,19 +253,22 @@ export function getOperationalBlocks<T extends ContentModelBlockGroup>(
  * @param blockGroupTypes The expected block group types
  * @param stopTypes Block group types that will stop searching when hit
  * @param deepFirst True means search in deep first, otherwise wide first
+ * @param isValidTarget @optional An additional callback to validate whether a matching block group is a valid target
  */
 export function getOperationalBlocks<T extends ReadonlyContentModelBlockGroup>(
     group: ReadonlyContentModelBlockGroup,
     blockGroupTypes: TypeOfBlockGroup<T>[],
     stopTypes: ContentModelBlockGroupType[],
-    deepFirst?: boolean
+    deepFirst?: boolean,
+    isValidTarget?: (block: ReadonlyContentModelBlockGroup) => boolean
 ): ReadonlyOperationalBlocks<T>[];
 
 export function getOperationalBlocks<T extends ContentModelBlockGroup>(
     group: ReadonlyContentModelBlockGroup,
     blockGroupTypes: TypeOfBlockGroup<T>[],
     stopTypes: ContentModelBlockGroupType[],
-    deepFirst?: boolean
+    deepFirst?: boolean,
+    isValidTarget?: (block: ReadonlyContentModelBlockGroup) => boolean
 ): ReadonlyOperationalBlocks<T>[] {
     const result: ReadonlyOperationalBlocks<T>[] = [];
     const findSequence = deepFirst ? blockGroupTypes.map(type => [type]) : [blockGroupTypes];
@@ -276,7 +281,12 @@ export function getOperationalBlocks<T extends ContentModelBlockGroup>(
 
     selections.forEach(({ path, block }) => {
         for (let i = 0; i < findSequence.length; i++) {
-            const groupIndex = getClosestAncestorBlockGroupIndex(path, findSequence[i], stopTypes);
+            const groupIndex = getClosestAncestorBlockGroupIndex(
+                path,
+                findSequence[i],
+                stopTypes,
+                isValidTarget
+            );
 
             if (groupIndex >= 0) {
                 if (result.filter(x => x.block == path[groupIndex]).length <= 0) {


### PR DESCRIPTION
FormatContainer can be used to other elements other than blockquotes. When toggling blockquote in format containers that are not blockquotes, search for the selected elements inside the container and only apply blockquote to theses selected elements. 

Before: 
![ToggleBlockquoteBug](https://github.com/user-attachments/assets/f87a3171-5bf6-41aa-9844-5972029723b4)

After: 
![ToggleBlockquoteFixed](https://github.com/user-attachments/assets/5f2b0d7f-f02c-4084-9b24-5dcfb4972cd8)
