### PR TITLE
Do not add undo snapshot from ImageEdit plugin if image is not changed

### DIFF
--- a/packages/roosterjs-content-model-api/test/publicApi/link/insertLinkTest.ts
+++ b/packages/roosterjs-content-model-api/test/publicApi/link/insertLinkTest.ts
@@ -392,6 +392,7 @@ describe('insertLink', () => {
             contentModel: jasmine.anything(),
             selection: jasmine.anything(),
             changedEntities: [],
+            skipUndo: false,
         });
 
         document.body.removeChild(div);

--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -80,6 +80,9 @@ export const formatContentModel: FormatContentModel = (
                 data: options?.getChangeData?.(),
                 formatApiName: options?.apiName,
                 changedEntities: getChangedEntities(context, rawEvent),
+                skipUndo:
+                    !(shouldMarkNewContent || shouldAddSnapshot) ||
+                    options?.changeSource == ChangeSource.Keyboard, // Keyboard changes will be handled separately in undo plugin, so we need to skip handling it again
             };
 
             core.api.triggerEvent(core, eventData, true /*broadcast*/);

--- a/packages/roosterjs-content-model-core/lib/corePlugin/undo/UndoPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/undo/UndoPlugin.ts
@@ -1,5 +1,5 @@
-import { ChangeSource, isCursorMovingKey } from 'roosterjs-content-model-dom';
 import { createSnapshotsManager } from './SnapshotsManagerImpl';
+import { isCursorMovingKey } from 'roosterjs-content-model-dom';
 import { undo } from '../../command/undo/undo';
 import type {
     ContentChangedEvent,
@@ -211,14 +211,7 @@ class UndoPlugin implements PluginWithState<UndoPluginState> {
     }
 
     private onContentChanged(event: ContentChangedEvent) {
-        if (
-            !(
-                this.state.isRestoring ||
-                event.source == ChangeSource.SwitchToDarkMode ||
-                event.source == ChangeSource.SwitchToLightMode ||
-                event.source == ChangeSource.Keyboard
-            )
-        ) {
+        if (!this.state.isRestoring && !event.skipUndo) {
             this.clearRedoForInput();
         }
     }

--- a/packages/roosterjs-content-model-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/Editor.ts
@@ -319,6 +319,7 @@ export class Editor implements IEditor {
                     source: isDarkMode
                         ? ChangeSource.SwitchToDarkMode
                         : ChangeSource.SwitchToLightMode,
+                    skipUndo: true,
                 },
                 true
             );

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -119,6 +119,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -156,6 +157,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -194,6 +196,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -232,6 +235,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -270,6 +274,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -308,6 +313,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: true,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -342,6 +348,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: 'TEST',
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -384,6 +391,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: 'TEST',
+                    skipUndo: false,
                     data: returnData,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -423,6 +431,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -475,6 +484,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [
@@ -536,6 +546,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: mockedData,
                     formatApiName: apiName,
                     changedEntities: [
@@ -580,6 +591,7 @@ describe('formatContentModel', () => {
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
+                    skipUndo: false,
                 },
                 true
             );
@@ -610,6 +622,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -647,6 +660,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -679,6 +693,7 @@ describe('formatContentModel', () => {
                     contentModel: undefined,
                     selection: undefined,
                     source: ChangeSource.Format,
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: apiName,
                     changedEntities: [],
@@ -1100,6 +1115,20 @@ describe('formatContentModel', () => {
                 },
                 isNested: false,
             } as any);
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: 'contentChanged',
+                    contentModel: mockedModel,
+                    selection: mockedSelection,
+                    source: ChangeSource.Format,
+                    data: undefined,
+                    formatApiName: undefined,
+                    changedEntities: [],
+                    skipUndo: false,
+                },
+                true
+            );
         });
 
         it('trigger addUndoSnapshot when has entityStates', () => {
@@ -1123,6 +1152,20 @@ describe('formatContentModel', () => {
                 isNested: false,
                 snapshotsManager: {},
             } as any);
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: 'contentChanged',
+                    contentModel: mockedModel,
+                    selection: mockedSelection,
+                    source: ChangeSource.Format,
+                    data: undefined,
+                    formatApiName: undefined,
+                    changedEntities: [],
+                    skipUndo: false,
+                },
+                true
+            );
         });
 
         it('trigger addUndoSnapshot when has canUndoByBackspace', () => {
@@ -1145,6 +1188,20 @@ describe('formatContentModel', () => {
                 isNested: false,
                 snapshotsManager: {},
             } as any);
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: 'contentChanged',
+                    contentModel: mockedModel,
+                    selection: mockedSelection,
+                    source: ChangeSource.Format,
+                    data: undefined,
+                    formatApiName: undefined,
+                    changedEntities: [],
+                    skipUndo: false,
+                },
+                true
+            );
         });
 
         it('trigger addUndoSnapshot when has canUndoByBackspace and has valid range selection', () => {
@@ -1154,14 +1211,15 @@ describe('formatContentModel', () => {
                     context.canUndoByBackspace = true;
                     return true;
                 });
-
-            setContentModel.and.returnValue({
+            const newSelection = {
                 type: 'range',
                 range: {
                     startContainer: mockedContainer,
                     startOffset: mockedOffset,
                 },
-            });
+            };
+
+            setContentModel.and.returnValue(newSelection);
 
             formatContentModel(core, callback);
 
@@ -1178,6 +1236,20 @@ describe('formatContentModel', () => {
                     offset: mockedOffset,
                 },
             } as any);
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: 'contentChanged',
+                    contentModel: mockedModel,
+                    selection: newSelection,
+                    source: ChangeSource.Format,
+                    data: undefined,
+                    formatApiName: undefined,
+                    changedEntities: [],
+                    skipUndo: false,
+                },
+                true
+            );
         });
 
         it('Do not trigger addUndoSnapshot when isNested', () => {
@@ -1195,6 +1267,53 @@ describe('formatContentModel', () => {
                 isNested: true,
                 snapshotsManager: {},
             } as any);
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: 'contentChanged',
+                    contentModel: mockedModel,
+                    selection: mockedSelection,
+                    source: ChangeSource.Format,
+                    data: undefined,
+                    formatApiName: undefined,
+                    changedEntities: [],
+                    skipUndo: true,
+                },
+                true
+            );
+        });
+
+        it('Do not trigger addUndoSnapshot when change from Keyboard', () => {
+            core.undo.isNested = true;
+
+            const callback = jasmine.createSpy('callback').and.returnValue(true);
+
+            formatContentModel(core, callback, {
+                changeSource: ChangeSource.Keyboard,
+            });
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(addUndoSnapshot).toHaveBeenCalledTimes(0);
+            expect(setContentModel).toHaveBeenCalledTimes(1);
+            expect(setContentModel).toHaveBeenCalledWith(core, mockedModel, undefined, undefined);
+            expect(core.undo).toEqual({
+                isNested: true,
+                snapshotsManager: {},
+            } as any);
+            expect(triggerEvent).toHaveBeenCalledWith(
+                core,
+                {
+                    eventType: 'contentChanged',
+                    contentModel: mockedModel,
+                    selection: mockedSelection,
+                    source: ChangeSource.Keyboard,
+                    data: undefined,
+                    formatApiName: undefined,
+                    changedEntities: [],
+                    skipUndo: true,
+                },
+                true
+            );
         });
     });
 
@@ -1257,6 +1376,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: 'Format',
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: 'mockedApi',
                     changedEntities: [],
@@ -1308,6 +1428,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: 'Format',
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: 'mockedApi',
                     changedEntities: [
@@ -1360,6 +1481,7 @@ describe('formatContentModel', () => {
                     contentModel: mockedModel,
                     selection: mockedSelection,
                     source: 'Format',
+                    skipUndo: false,
                     data: undefined,
                     formatApiName: 'mockedApi',
                     changedEntities: undefined,

--- a/packages/roosterjs-content-model-core/test/corePlugin/undo/UndoPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/undo/UndoPluginTest.ts
@@ -1,6 +1,5 @@
 import * as SnapshotsManagerImpl from '../../../lib/corePlugin/undo/SnapshotsManagerImpl';
 import * as undo from '../../../lib/command/undo/undo';
-import { ChangeSource } from 'roosterjs-content-model-dom';
 import { createUndoPlugin } from '../../../lib/corePlugin/undo/UndoPlugin';
 import {
     IEditor,
@@ -102,7 +101,7 @@ describe('UndoPlugin', () => {
         });
 
         it('Not handled exclusively for EditorReady event', () => {
-            const result = plugin.willHandleEventExclusively({
+            const result = plugin.willHandleEventExclusively!({
                 eventType: 'editorReady',
                 addedBlockElements: [],
                 removedBlockElements: [],
@@ -114,7 +113,7 @@ describe('UndoPlugin', () => {
         });
 
         it('Not handled exclusively for ContentChanged event', () => {
-            const result = plugin.willHandleEventExclusively({
+            const result = plugin.willHandleEventExclusively!({
                 eventType: 'contentChanged',
             } as any);
 
@@ -124,7 +123,7 @@ describe('UndoPlugin', () => {
         });
 
         it('Not handled exclusively for MouseDown event', () => {
-            const result = plugin.willHandleEventExclusively({
+            const result = plugin.willHandleEventExclusively!({
                 eventType: 'mouseDown',
             } as any);
 
@@ -134,7 +133,7 @@ describe('UndoPlugin', () => {
         });
 
         it('Not handled exclusively for KeyDown event with Enter key', () => {
-            const result = plugin.willHandleEventExclusively({
+            const result = plugin.willHandleEventExclusively!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Enter',
@@ -147,7 +146,7 @@ describe('UndoPlugin', () => {
         });
 
         it('Not handled exclusively for KeyDown event with Ctrl key', () => {
-            const result = plugin.willHandleEventExclusively({
+            const result = plugin.willHandleEventExclusively!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Backspace',
@@ -163,7 +162,7 @@ describe('UndoPlugin', () => {
         it('Not handled exclusively for KeyDown event, canUndoAutoComplete returns false', () => {
             canUndoAutoCompleteSpy.and.returnValue(false);
 
-            const result = plugin.willHandleEventExclusively({
+            const result = plugin.willHandleEventExclusively!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Backspace',
@@ -181,7 +180,7 @@ describe('UndoPlugin', () => {
                 type: 'image',
             });
 
-            const result = plugin.willHandleEventExclusively({
+            const result = plugin.willHandleEventExclusively!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Backspace',
@@ -202,7 +201,7 @@ describe('UndoPlugin', () => {
                 },
             });
 
-            const result = plugin.willHandleEventExclusively({
+            const result = plugin.willHandleEventExclusively!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Backspace',
@@ -229,7 +228,7 @@ describe('UndoPlugin', () => {
                 },
             });
 
-            const result = plugin.willHandleEventExclusively({
+            const result = plugin.willHandleEventExclusively!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Backspace',
@@ -256,7 +255,7 @@ describe('UndoPlugin', () => {
                 },
             });
 
-            const result = plugin.willHandleEventExclusively({
+            const result = plugin.willHandleEventExclusively!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Backspace',
@@ -285,7 +284,7 @@ describe('UndoPlugin', () => {
             canMoveSpy.and.returnValue(false);
             plugin.getState().snapshotsManager.hasNewContent = false;
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'editorReady',
                 addedBlockElements: [],
                 removedBlockElements: [],
@@ -308,7 +307,7 @@ describe('UndoPlugin', () => {
             canMoveSpy.and.callFake((step: number) => step < 0);
             plugin.getState().snapshotsManager.hasNewContent = false;
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'editorReady',
                 addedBlockElements: [],
                 removedBlockElements: [],
@@ -331,7 +330,7 @@ describe('UndoPlugin', () => {
             canMoveSpy.and.callFake((step: number) => step > 0);
             plugin.getState().snapshotsManager.hasNewContent = false;
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'editorReady',
                 addedBlockElements: [],
                 removedBlockElements: [],
@@ -367,7 +366,7 @@ describe('UndoPlugin', () => {
 
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Backspace',
@@ -400,7 +399,7 @@ describe('UndoPlugin', () => {
                 type: 'image',
             });
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Backspace',
@@ -429,7 +428,7 @@ describe('UndoPlugin', () => {
 
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Delete',
@@ -458,7 +457,7 @@ describe('UndoPlugin', () => {
 
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Up',
@@ -490,7 +489,7 @@ describe('UndoPlugin', () => {
 
             state.snapshotsManager.hasNewContent = true;
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'Up',
@@ -523,7 +522,7 @@ describe('UndoPlugin', () => {
             state.snapshotsManager.hasNewContent = true;
             state.lastKeyPress = 'Backspace';
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'A',
@@ -552,7 +551,7 @@ describe('UndoPlugin', () => {
 
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyDown',
                 rawEvent: {
                     key: 'A',
@@ -587,7 +586,7 @@ describe('UndoPlugin', () => {
                 },
             });
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyPress',
                 rawEvent: {
                     key: 'Enter',
@@ -621,7 +620,7 @@ describe('UndoPlugin', () => {
                 },
             });
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyPress',
                 rawEvent: {
                     key: 'A',
@@ -651,7 +650,7 @@ describe('UndoPlugin', () => {
 
             state.lastKeyPress = 'A';
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyPress',
                 rawEvent: {
                     key: ' ',
@@ -681,7 +680,7 @@ describe('UndoPlugin', () => {
 
             state.lastKeyPress = ' ';
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyPress',
                 rawEvent: {
                     key: ' ',
@@ -708,7 +707,7 @@ describe('UndoPlugin', () => {
         it('KeyPress event, Enter key', () => {
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyPress',
                 rawEvent: {
                     key: 'Enter',
@@ -735,7 +734,7 @@ describe('UndoPlugin', () => {
         it('KeyPress event, other key', () => {
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'keyPress',
                 rawEvent: {
                     key: 'A',
@@ -762,7 +761,7 @@ describe('UndoPlugin', () => {
         it('CompositionEnd event', () => {
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'compositionEnd',
                 rawEvent: {
                     key: 'Test',
@@ -789,7 +788,7 @@ describe('UndoPlugin', () => {
 
             state.isRestoring = true;
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'contentChanged',
                 source: 'Test',
             } as any);
@@ -808,56 +807,13 @@ describe('UndoPlugin', () => {
             expect(clearRedoSpy).toHaveBeenCalledTimes(0);
         });
 
-        it('onContentChanged event, SwitchToDarkMode', () => {
+        it('onContentChanged event, skip undo', () => {
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'contentChanged',
-                source: ChangeSource.SwitchToDarkMode,
-            } as any);
-
-            expect(takeSnapshotSpy).toHaveBeenCalledTimes(0);
-            expect(preventDefaultSpy).toHaveBeenCalledTimes(0);
-            expect(undoSpy).toHaveBeenCalledTimes(0);
-            expect(plugin.getState()).toEqual({
-                snapshotsManager: mockedSnapshotsManager,
-                isRestoring: false,
-                isNested: false,
-                autoCompleteInsertPoint: null,
-                lastKeyPress: null,
-            });
-            expect(mockedSnapshotsManager.hasNewContent).toBeFalsy();
-            expect(clearRedoSpy).toHaveBeenCalledTimes(0);
-        });
-
-        it('onContentChanged event, SwitchToLightMode', () => {
-            const preventDefaultSpy = jasmine.createSpy('preventDefault');
-
-            plugin.onPluginEvent({
-                eventType: 'contentChanged',
-                source: ChangeSource.SwitchToLightMode,
-            } as any);
-
-            expect(takeSnapshotSpy).toHaveBeenCalledTimes(0);
-            expect(preventDefaultSpy).toHaveBeenCalledTimes(0);
-            expect(undoSpy).toHaveBeenCalledTimes(0);
-            expect(plugin.getState()).toEqual({
-                snapshotsManager: mockedSnapshotsManager,
-                isRestoring: false,
-                isNested: false,
-                autoCompleteInsertPoint: null,
-                lastKeyPress: null,
-            });
-            expect(mockedSnapshotsManager.hasNewContent).toBeFalsy();
-            expect(clearRedoSpy).toHaveBeenCalledTimes(0);
-        });
-
-        it('onContentChanged event, Keyboard', () => {
-            const preventDefaultSpy = jasmine.createSpy('preventDefault');
-
-            plugin.onPluginEvent({
-                eventType: 'contentChanged',
-                source: ChangeSource.Keyboard,
+                source: 'Test',
+                skipUndo: true,
             } as any);
 
             expect(takeSnapshotSpy).toHaveBeenCalledTimes(0);
@@ -877,7 +833,7 @@ describe('UndoPlugin', () => {
         it('onContentChanged event, other source', () => {
             const preventDefaultSpy = jasmine.createSpy('preventDefault');
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'contentChanged',
                 source: 'Test',
             } as any);
@@ -902,7 +858,7 @@ describe('UndoPlugin', () => {
 
             state.lastKeyPress = 'A';
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'beforeKeyboardEditing',
                 rawEvent: {
                     key: 'B',
@@ -929,7 +885,7 @@ describe('UndoPlugin', () => {
 
             state.lastKeyPress = 'A';
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'beforeKeyboardEditing',
                 rawEvent: {
                     key: 'A',
@@ -953,7 +909,7 @@ describe('UndoPlugin', () => {
         it('MouseDown addUndoSnapshot if there is new content', () => {
             const state = plugin.getState();
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'mouseDown',
             } as any);
 
@@ -961,7 +917,7 @@ describe('UndoPlugin', () => {
 
             state.snapshotsManager.hasNewContent = true;
 
-            plugin.onPluginEvent({
+            plugin.onPluginEvent!({
                 eventType: 'mouseDown',
             } as any);
 

--- a/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
@@ -1016,6 +1016,7 @@ describe('Editor', () => {
             {
                 eventType: 'contentChanged',
                 source: ChangeSource.SwitchToDarkMode,
+                skipUndo: true,
             },
             true
         );
@@ -1036,6 +1037,7 @@ describe('Editor', () => {
             {
                 eventType: 'contentChanged',
                 source: ChangeSource.SwitchToLightMode,
+                skipUndo: true,
             },
             true
         );

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -346,7 +346,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         const selection = editor.getDOMSelection();
 
         editor.formatContentModel(
-            model => {
+            (model, context) => {
                 const editingImage = getSelectedImage(model);
                 const previousSelectedImage = isApiOperation
                     ? editingImage
@@ -426,6 +426,9 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                         result = true;
                     }
                 }
+
+                // Skip adding undo snapshot since image wrapper change should not be treated as user's action
+                context.skipUndoSnapshot = 'SkipAll';
 
                 return result;
             },

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/applyChange.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/applyChange.ts
@@ -2,6 +2,7 @@ import { checkEditInfoState } from './checkEditInfoState';
 import { generateDataURL } from './generateDataURL';
 import { getGeneratedImageSize } from './generateImageSize';
 import { updateImageEditInfo } from './updateImageEditInfo';
+import type { ImageEditInfoState } from './checkEditInfoState';
 import type {
     ContentModelImage,
     IEditor,
@@ -26,7 +27,7 @@ export function applyChange(
     previousSrc: string,
     wasResizedOrCropped: boolean,
     editingImage?: HTMLImageElement
-) {
+): ImageEditInfoState {
     let newSrc = '';
     const imageEditing = editingImage ?? image;
     const initEditInfo = updateImageEditInfo(contentModelImage, imageEditing) ?? undefined;
@@ -74,14 +75,15 @@ export function applyChange(
 
     // Write back the change to image, and set its new size
     const generatedImageSize = getGeneratedImageSize(editInfo);
-    if (!generatedImageSize) {
-        return;
+
+    if (generatedImageSize) {
+        contentModelImage.src = newSrc;
+
+        if (wasResizedOrCropped || state == 'FullyChanged') {
+            contentModelImage.format.width = generatedImageSize.targetWidth + 'px';
+            contentModelImage.format.height = generatedImageSize.targetHeight + 'px';
+        }
     }
 
-    contentModelImage.src = newSrc;
-
-    if (wasResizedOrCropped || state == 'FullyChanged') {
-        contentModelImage.format.width = generatedImageSize.targetWidth + 'px';
-        contentModelImage.format.height = generatedImageSize.targetHeight + 'px';
-    }
+    return state;
 }

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/checkEditInfoState.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/checkEditInfoState.ts
@@ -77,8 +77,7 @@ export function checkEditInfoState(
         return 'ResizeOnly';
     } else if (
         compareTo &&
-        ROTATE_KEYS.every(key => areSameNumber(editInfo[key], 0)) &&
-        ROTATE_KEYS.every(key => areSameNumber(compareTo[key], 0)) &&
+        ROTATE_KEYS.every(key => areSameNumber(editInfo[key], compareTo[key])) &&
         CROP_KEYS.every(key => areSameNumber(editInfo[key], compareTo[key])) &&
         compareTo.flippedHorizontal === editInfo.flippedHorizontal &&
         compareTo.flippedVertical === editInfo.flippedVertical

--- a/packages/roosterjs-content-model-types/lib/event/ContentChangedEvent.ts
+++ b/packages/roosterjs-content-model-types/lib/event/ContentChangedEvent.ts
@@ -71,7 +71,12 @@ export interface ContentChangedEvent extends BasePluginEvent<'contentChanged'> {
     readonly formatApiName?: string;
 
     /**
-     * @deprecated Call editor.announce(announceData) directly insteaad
+     * When set to true, the change will not be added to the undo stack
+     */
+    readonly skipUndo?: boolean;
+
+    /**
+     * @deprecated Call editor.announce(announceData) directly instead
      */
     readonly announceData?: AnnounceData;
 }


### PR DESCRIPTION
1. Add a new property `skipUndo` in `ContentChangedEvent`
2. When this property is true, UndoPlugin will not add undo snapshot / set has new content for this event
3. When ContentChangedEvent is triggered due to the following reasons, set this property to true
   - Switch color mode
   - Keyboard input (to follow the existing behavior)
4. When add image editing border, set this property to true, so no need to add undo snapshot for image editing border
5. When remove image editing border, check if image is edited since current border is added. If not, do not add undo snapshot