### PR TITLE
Support different options for empty line mode in mark down

### DIFF
--- a/packages/roosterjs-content-model-markdown/lib/index.ts
+++ b/packages/roosterjs-content-model-markdown/lib/index.ts
@@ -1,3 +1,4 @@
 export { convertMarkdownToContentModel } from './markdownToModel/convertMarkdownToContentModel';
 export { convertContentModelToMarkdown } from './modelToMarkdown/convertContentModelToMarkdown';
 export { MarkdownLineBreaks } from '../lib/constants/markdownLineBreaks';
+export { MarkdownToModelOptions } from './markdownToModel/types/MarkdownToModelOptions';

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/convertMarkdownToContentModel.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/convertMarkdownToContentModel.ts
@@ -1,5 +1,5 @@
 import { markdownProcessor } from './processor/markdownProcessor';
-import type { MarkdownOptions } from './types/MarkdownOptions';
+import type { MarkdownToModelOptions } from './types/MarkdownToModelOptions';
 import type { ContentModelDocument } from 'roosterjs-content-model-types';
 
 /**
@@ -21,14 +21,14 @@ export function convertMarkdownToContentModel(
  */
 export function convertMarkdownToContentModel(
     text: string,
-    options?: MarkdownOptions
+    options?: MarkdownToModelOptions
 ): ContentModelDocument;
 
 export function convertMarkdownToContentModel(
     text: string,
-    splitLinesPatternOrOptions?: string | MarkdownOptions
+    splitLinesPatternOrOptions?: string | MarkdownToModelOptions
 ): ContentModelDocument {
-    const options: MarkdownOptions =
+    const options: MarkdownToModelOptions =
         (typeof splitLinesPatternOrOptions === 'string'
             ? {
                   splitLinesPattern: splitLinesPatternOrOptions,

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/convertMarkdownToContentModel.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/convertMarkdownToContentModel.ts
@@ -1,9 +1,9 @@
 import { markdownProcessor } from './processor/markdownProcessor';
+import type { MarkdownOptions } from './types/MarkdownOptions';
 import type { ContentModelDocument } from 'roosterjs-content-model-types';
 
 /**
  * Convert the whole content to ContentModel with the given plain text
- * @param editor The editor instance
  * @param text The markdown text
  * @param splitLinesPattern The pattern to split lines. Default is /\r\n|\r|\\n|\n/
  * @returns The ContentModelDocument
@@ -11,7 +11,29 @@ import type { ContentModelDocument } from 'roosterjs-content-model-types';
 export function convertMarkdownToContentModel(
     text: string,
     splitLinesPattern?: string
+): ContentModelDocument;
+
+/**
+ * Convert the whole content to ContentModel with the given plain text
+ * @param text The markdown text
+ * @param options The markdown options
+ * @returns The ContentModelDocument
+ */
+export function convertMarkdownToContentModel(
+    text: string,
+    options?: MarkdownOptions
+): ContentModelDocument;
+
+export function convertMarkdownToContentModel(
+    text: string,
+    splitLinesPatternOrOptions?: string | MarkdownOptions
 ): ContentModelDocument {
-    const pattern = splitLinesPattern || /\r\n|\r|\\n|\n/;
-    return markdownProcessor(text, pattern);
+    const options: MarkdownOptions =
+        (typeof splitLinesPatternOrOptions === 'string'
+            ? {
+                  splitLinesPattern: splitLinesPatternOrOptions,
+              }
+            : splitLinesPatternOrOptions) ?? {};
+
+    return markdownProcessor(text, options);
 }

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/processor/markdownProcessor.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/processor/markdownProcessor.ts
@@ -4,7 +4,7 @@ import { createParagraphFromMarkdown } from '../creators/createParagraphFromMark
 import { createTableFromMarkdown } from '../creators/createTableFromMarkdown';
 import { isMarkdownTable } from '../utils/isMarkdownTable';
 
-import type { MarkdownOptions } from '../types/MarkdownOptions';
+import type { MarkdownToModelOptions } from '../types/MarkdownToModelOptions';
 import type {
     ContentModelBlockType,
     ContentModelDocument,
@@ -50,7 +50,10 @@ const MarkdownBlockType: Record<string, ContentModelBlockType> = {
  * @returns The ContentModelDocument
  */
 
-export function markdownProcessor(text: string, options: MarkdownOptions): ContentModelDocument {
+export function markdownProcessor(
+    text: string,
+    options: MarkdownToModelOptions
+): ContentModelDocument {
     const splitLinesPattern = options.splitLinesPattern || /\r\n|\r|\\n|\n/;
     const emptyLine = options.emptyLine ?? 'merge';
     const markdownText = text.split(splitLinesPattern);
@@ -79,7 +82,7 @@ function addMarkdownBlockToModel(
     markdown: string,
     patternName: string,
     markdownContext: MarkdownContext,
-    options: MarkdownOptions
+    options: MarkdownToModelOptions
 ) {
     if (
         blockType !== 'Table' &&
@@ -196,7 +199,7 @@ function addMarkdownBlockToModel(
 function convertMarkdownText(
     model: ContentModelDocument,
     lines: string[],
-    options: MarkdownOptions
+    options: MarkdownToModelOptions
 ): ContentModelDocument {
     const markdownContext: MarkdownContext = {
         lastQuote: undefined,

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/types/MarkdownOptions.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/types/MarkdownOptions.ts
@@ -1,0 +1,18 @@
+/**
+ * Options for processing markdown text.
+ */
+export interface MarkdownOptions {
+    /**
+     * The pattern to split lines in the markdown text.
+     */
+    splitLinesPattern?: string;
+
+    /**
+     * Specify how should we process empty lines in the markdown text.
+     * - 'preserve': Keep empty lines as they are.
+     * - 'remove': Remove empty lines.
+     * - 'merge': Merge empty lines with adjacent paragraphs.
+     * @default 'merge'
+     */
+    emptyLine?: 'preserve' | 'remove' | 'merge';
+}

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/types/MarkdownToModelOptions.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/types/MarkdownToModelOptions.ts
@@ -1,7 +1,7 @@
 /**
  * Options for processing markdown text.
  */
-export interface MarkdownOptions {
+export interface MarkdownToModelOptions {
     /**
      * The pattern to split lines in the markdown text.
      */

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/convertMarkdownToContentModelTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/convertMarkdownToContentModelTest.ts
@@ -3,8 +3,7 @@ import { convertMarkdownToContentModel } from '../../lib/markdownToModel/convert
 
 describe('convertMarkdownToContentModel', () => {
     function runTest(markdown: string, expectedContentModel: ContentModelDocument) {
-        convertMarkdownToContentModel(markdown);
-        const actualContentModel = convertMarkdownToContentModel(markdown);
+        const actualContentModel = convertMarkdownToContentModel(markdown, { emptyLine: 'remove' });
         expect(actualContentModel).toEqual(expectedContentModel);
     }
 

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/processor/markdownProcessorTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/processor/markdownProcessorTest.ts
@@ -7,10 +7,1780 @@ import {
     createText,
 } from 'roosterjs-content-model-dom';
 
-describe('markdownProcessor', () => {
+describe('markdownProcessor: removeEmptyLines', () => {
     function runTest(test: string, expected: ContentModelDocument) {
         // Act
-        const result = markdownProcessor(test, /\r\n|\r|\\n|\n/);
+        const result = markdownProcessor(test, { emptyLine: 'remove' });
+
+        // Assert
+        expect(result).toEqual(expected);
+    }
+
+    it('should return document with paragraph for text', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest('text', document);
+    });
+
+    it('should return document with paragraph for text and image', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text and image ',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                        {
+                            alt: 'image of a dog',
+                            src: 'https://www.example.com/image',
+                            format: {},
+                            segmentType: 'Image',
+                            dataset: {},
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest('text and image ![image of a dog](https://www.example.com/image) ', document);
+    });
+
+    it('should return document with paragraph for text and link', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text ',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                        {
+                            text: 'link',
+                            format: {},
+                            link: {
+                                dataset: {},
+                                format: {
+                                    href: 'https://www.example.com',
+                                    underline: true,
+                                },
+                            },
+                            segmentType: 'Text',
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest('text [link](https://www.example.com) ', document);
+    });
+
+    it('should return document with paragraph for text and bold', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text ',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                        {
+                            text: 'bold ',
+                            format: {
+                                fontWeight: 'bold',
+                            },
+                            segmentType: 'Text',
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest('text **bold** ', document);
+    });
+
+    it('should return document with paragraph for text and italic', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text ',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                        {
+                            text: 'italic ',
+                            format: {
+                                italic: true,
+                            },
+                            segmentType: 'Text',
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest('text *italic* ', document);
+    });
+
+    it('should return document with paragraph for text, link and image', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text ',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                        {
+                            text: 'link',
+                            format: {},
+                            link: {
+                                dataset: {},
+                                format: {
+                                    href: 'https://www.example.com',
+                                    underline: true,
+                                },
+                            },
+                            segmentType: 'Text',
+                        },
+                        {
+                            alt: 'image of a dog',
+                            src: 'https://www.example.com/image',
+                            format: {},
+                            segmentType: 'Image',
+                            dataset: {},
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest(
+            'text [link](https://www.example.com) ![image of a dog](https://www.example.com/image) ',
+            document
+        );
+    });
+
+    it('should return document with list item for ordered_list', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+            ],
+        };
+        runTest('1. text', document);
+    });
+
+    it('should return document with list item for unordered_list | *', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+            ],
+        };
+        runTest('* text', document);
+    });
+
+    it('should return document with list item for unordered_list | -', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+            ],
+        };
+        runTest('- text', document);
+    });
+
+    it('should return document with list item for unordered_list | +', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+            ],
+        };
+        runTest('+ text', document);
+    });
+
+    it('should return document with list item for ordered_list with Heading 1 | +', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                            decorator: {
+                                tagName: 'h1',
+                                format: {
+                                    fontSize: '2em',
+                                    fontWeight: 'bold',
+                                },
+                            },
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+            ],
+        };
+        runTest('+ # text', document);
+    });
+
+    it(' should return a document with a table with two rows and one column', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [],
+                    blockType: 'Table',
+                    rows: [
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text1',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                        backgroundColor: '#ABABAB',
+                                        fontWeight: 'bold',
+                                    },
+                                    isHeader: true,
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text2',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    isHeader: false,
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                    },
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                    ],
+                    format: {
+                        borderCollapse: true,
+                    },
+                    dataset: {
+                        editingInfo:
+                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
+                    },
+                },
+            ],
+        };
+        runTest('|text1|\n|----|\n|text2|', document);
+    });
+
+    it('should return a table with two rows and two columns', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [],
+                    blockType: 'Table',
+                    rows: [
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text1',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                        backgroundColor: '#ABABAB',
+                                        fontWeight: 'bold',
+                                    },
+                                    isHeader: true,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text2',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                        backgroundColor: '#ABABAB',
+                                        fontWeight: 'bold',
+                                    },
+                                    isHeader: true,
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text3',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                    },
+                                    isHeader: false,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text4',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                    },
+                                    isHeader: false,
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                    ],
+                    format: {
+                        borderCollapse: true,
+                    },
+                    dataset: {
+                        editingInfo:
+                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
+                    },
+                },
+            ],
+        };
+        runTest('|text1|text2|\n|----|----|\n|text3|text4|', document);
+    });
+
+    it('paragraph after list', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {
+                                displayForDummyItem: 'block',
+                            },
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Text', text: 'paragraph', format: {} }],
+                    format: {},
+                },
+            ],
+        };
+        runTest('- text\ntext\n\nparagraph', document);
+    });
+
+    it('paragraph after blockquote ', () => {
+        const doc = createContentModelDocument();
+        const blockquote = createFormatContainer('blockquote');
+        const paragraph1 = createParagraph();
+        blockquote.format = {
+            borderLeft: '3px solid rgb(200, 200, 200)',
+            textColor: 'rgb(102, 102, 102)',
+            marginTop: '1em',
+            marginBottom: '1em',
+            marginLeft: '40px',
+            marginRight: '40px',
+            paddingLeft: '10px',
+        };
+        const text1 = createText(' text');
+        const paragraph2 = createParagraph();
+        const text2 = createText('text');
+        paragraph1.segments.push(text1);
+        paragraph2.segments.push(text2);
+        blockquote.blocks.push(paragraph1, paragraph2);
+        doc.blocks.push(blockquote);
+        const paragraph3 = createParagraph();
+        const text3 = createText('paragraph');
+        paragraph3.segments.push(text3);
+        doc.blocks.push(paragraph3);
+        runTest('> text\ntext\n\nparagraph', doc);
+    });
+
+    it('should return a table with two rows and two columns with alignment', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [],
+                    blockType: 'Table',
+                    rows: [
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text1',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                        backgroundColor: '#ABABAB',
+                                        fontWeight: 'bold',
+                                    },
+                                    isHeader: true,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text2',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'end',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                        backgroundColor: '#ABABAB',
+                                        fontWeight: 'bold',
+                                    },
+                                    isHeader: true,
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text3',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                    },
+                                    isHeader: false,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text4',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'end',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                    },
+                                    isHeader: false,
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                    ],
+                    format: {
+                        borderCollapse: true,
+                    },
+                    dataset: {
+                        editingInfo:
+                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
+                    },
+                },
+            ],
+        };
+        runTest('|text1|text2|\n|:----:|----:|\n|text3|text4|', document);
+    });
+});
+
+describe('markdownProcessor: mergeEmptyLines', () => {
+    function runTest(test: string, expected: ContentModelDocument) {
+        // Act
+        const result = markdownProcessor(test, { emptyLine: 'merge' });
+
+        // Assert
+        expect(result).toEqual(expected);
+    }
+
+    it('should return document with paragraph for text', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest('text', document);
+    });
+
+    it('should return document with paragraph for text and image', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text and image ',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                        {
+                            alt: 'image of a dog',
+                            src: 'https://www.example.com/image',
+                            format: {},
+                            segmentType: 'Image',
+                            dataset: {},
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest('text and image ![image of a dog](https://www.example.com/image) ', document);
+    });
+
+    it('should return document with paragraph for text and link', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text ',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                        {
+                            text: 'link',
+                            format: {},
+                            link: {
+                                dataset: {},
+                                format: {
+                                    href: 'https://www.example.com',
+                                    underline: true,
+                                },
+                            },
+                            segmentType: 'Text',
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest('text [link](https://www.example.com) ', document);
+    });
+
+    it('should return document with paragraph for text and bold', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text ',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                        {
+                            text: 'bold ',
+                            format: {
+                                fontWeight: 'bold',
+                            },
+                            segmentType: 'Text',
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest('text **bold** ', document);
+    });
+
+    it('should return document with paragraph for text and italic', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text ',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                        {
+                            text: 'italic ',
+                            format: {
+                                italic: true,
+                            },
+                            segmentType: 'Text',
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest('text *italic* ', document);
+    });
+
+    it('should return document with paragraph for text, link and image', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            text: 'text ',
+                            format: {},
+                            segmentType: 'Text',
+                        },
+                        {
+                            text: 'link',
+                            format: {},
+                            link: {
+                                dataset: {},
+                                format: {
+                                    href: 'https://www.example.com',
+                                    underline: true,
+                                },
+                            },
+                            segmentType: 'Text',
+                        },
+                        {
+                            alt: 'image of a dog',
+                            src: 'https://www.example.com/image',
+                            format: {},
+                            segmentType: 'Image',
+                            dataset: {},
+                        },
+                    ],
+
+                    format: {},
+                },
+            ],
+        };
+        runTest(
+            'text [link](https://www.example.com) ![image of a dog](https://www.example.com/image) ',
+            document
+        );
+    });
+
+    it('should return document with list item for ordered_list', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+            ],
+        };
+        runTest('1. text', document);
+    });
+
+    it('should return document with list item for unordered_list | *', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+            ],
+        };
+        runTest('* text', document);
+    });
+
+    it('should return document with list item for unordered_list | -', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+            ],
+        };
+        runTest('- text', document);
+    });
+
+    it('should return document with list item for unordered_list | +', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+            ],
+        };
+        runTest('+ text', document);
+    });
+
+    it('should return document with list item for ordered_list with Heading 1 | +', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                            decorator: {
+                                tagName: 'h1',
+                                format: {
+                                    fontSize: '2em',
+                                    fontWeight: 'bold',
+                                },
+                            },
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+            ],
+        };
+        runTest('+ # text', document);
+    });
+
+    it(' should return a document with a table with two rows and one column', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [],
+                    blockType: 'Table',
+                    rows: [
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text1',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                        backgroundColor: '#ABABAB',
+                                        fontWeight: 'bold',
+                                    },
+                                    isHeader: true,
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text2',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    isHeader: false,
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                    },
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                    ],
+                    format: {
+                        borderCollapse: true,
+                    },
+                    dataset: {
+                        editingInfo:
+                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
+                    },
+                },
+            ],
+        };
+        runTest('|text1|\n|----|\n|text2|', document);
+    });
+
+    it('should return a table with two rows and two columns', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [],
+                    blockType: 'Table',
+                    rows: [
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text1',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                        backgroundColor: '#ABABAB',
+                                        fontWeight: 'bold',
+                                    },
+                                    isHeader: true,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text2',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                        backgroundColor: '#ABABAB',
+                                        fontWeight: 'bold',
+                                    },
+                                    isHeader: true,
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text3',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                    },
+                                    isHeader: false,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text4',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'start',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                    },
+                                    isHeader: false,
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                    ],
+                    format: {
+                        borderCollapse: true,
+                    },
+                    dataset: {
+                        editingInfo:
+                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
+                    },
+                },
+            ],
+        };
+        runTest('|text1|text2|\n|----|----|\n|text3|text4|', document);
+    });
+
+    it('paragraph after list', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    text: 'text',
+                                    format: {},
+                                    segmentType: 'Text',
+                                },
+                            ],
+
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'UL',
+                            dataset: {},
+                            format: {
+                                displayForDummyItem: 'block',
+                            },
+                        },
+                    ],
+                    format: {},
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        format: {},
+                        isSelected: false,
+                    },
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Text', text: 'paragraph', format: {} }],
+                    format: {},
+                },
+            ],
+        };
+        runTest('- text\ntext\n\nparagraph', document);
+    });
+
+    it('paragraph after blockquote ', () => {
+        const doc = createContentModelDocument();
+        const blockquote = createFormatContainer('blockquote');
+        const paragraph1 = createParagraph();
+        blockquote.format = {
+            borderLeft: '3px solid rgb(200, 200, 200)',
+            textColor: 'rgb(102, 102, 102)',
+            marginTop: '1em',
+            marginBottom: '1em',
+            marginLeft: '40px',
+            marginRight: '40px',
+            paddingLeft: '10px',
+        };
+        const text1 = createText(' text');
+        const paragraph2 = createParagraph();
+        const text2 = createText('text');
+        paragraph1.segments.push(text1);
+        paragraph2.segments.push(text2);
+        blockquote.blocks.push(paragraph1, paragraph2);
+        doc.blocks.push(blockquote);
+        const paragraph3 = createParagraph();
+        const text3 = createText('paragraph');
+        paragraph3.segments.push(text3);
+        doc.blocks.push(paragraph3);
+        runTest('> text\ntext\n\nparagraph', doc);
+    });
+
+    it('should return a table with two rows and two columns with alignment', () => {
+        const document: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    widths: [],
+                    blockType: 'Table',
+                    rows: [
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text1',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                        backgroundColor: '#ABABAB',
+                                        fontWeight: 'bold',
+                                    },
+                                    isHeader: true,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text2',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'end',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                        backgroundColor: '#ABABAB',
+                                        fontWeight: 'bold',
+                                    },
+                                    isHeader: true,
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                        {
+                            cells: [
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text3',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'center',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                    },
+                                    isHeader: false,
+                                },
+                                {
+                                    spanAbove: false,
+                                    spanLeft: false,
+                                    dataset: {},
+                                    blockGroupType: 'TableCell',
+                                    blocks: [
+                                        {
+                                            segments: [
+                                                {
+                                                    text: 'text4',
+                                                    format: {},
+                                                    segmentType: 'Text',
+                                                },
+                                            ],
+                                            format: {},
+                                            blockType: 'Paragraph',
+                                        },
+                                    ],
+                                    format: {
+                                        textAlign: 'end',
+                                        borderTop: '1px solid #ABABAB',
+                                        borderRight: '1px solid #ABABAB',
+                                        borderBottom: '1px solid #ABABAB',
+                                        borderLeft: '1px solid #ABABAB',
+                                    },
+                                    isHeader: false,
+                                },
+                            ],
+                            height: 0,
+                            format: {},
+                        },
+                    ],
+                    format: {
+                        borderCollapse: true,
+                    },
+                    dataset: {
+                        editingInfo:
+                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
+                    },
+                },
+            ],
+        };
+        runTest('|text1|text2|\n|:----:|----:|\n|text3|text4|', document);
+    });
+});
+
+describe('markdownProcessor: preserveEmptyLines', () => {
+    function runTest(test: string, expected: ContentModelDocument) {
+        // Act
+        const result = markdownProcessor(test, { emptyLine: 'preserve' });
 
         // Assert
         expect(result).toEqual(expected);

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/processor/markdownProcessorTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/processor/markdownProcessorTest.ts
@@ -62,7 +62,7 @@ describe('markdownProcessor: removeEmptyLines', () => {
                 },
             ],
         };
-        runTest('text and image ![image of a dog](https://www.example.com/image) ', document);
+        runTest('text and image ![image of a dog](https://www.example.com/image)', document);
     });
 
     it('should return document with paragraph for text and link', () => {
@@ -95,7 +95,7 @@ describe('markdownProcessor: removeEmptyLines', () => {
                 },
             ],
         };
-        runTest('text [link](https://www.example.com) ', document);
+        runTest('text [link](https://www.example.com)', document);
     });
 
     it('should return document with paragraph for text and bold', () => {
@@ -123,7 +123,7 @@ describe('markdownProcessor: removeEmptyLines', () => {
                 },
             ],
         };
-        runTest('text **bold** ', document);
+        runTest('text **bold**', document);
     });
 
     it('should return document with paragraph for text and italic', () => {
@@ -151,7 +151,7 @@ describe('markdownProcessor: removeEmptyLines', () => {
                 },
             ],
         };
-        runTest('text *italic* ', document);
+        runTest('text *italic*', document);
     });
 
     it('should return document with paragraph for text, link and image', () => {
@@ -192,7 +192,7 @@ describe('markdownProcessor: removeEmptyLines', () => {
             ],
         };
         runTest(
-            'text [link](https://www.example.com) ![image of a dog](https://www.example.com/image) ',
+            'text [link](https://www.example.com) ![image of a dog](https://www.example.com/image)',
             document
         );
     });
@@ -947,7 +947,7 @@ describe('markdownProcessor: mergeEmptyLines', () => {
                 },
             ],
         };
-        runTest('text and image ![image of a dog](https://www.example.com/image) ', document);
+        runTest('text and image ![image of a dog](https://www.example.com/image)', document);
     });
 
     it('should return document with paragraph for text and link', () => {
@@ -980,7 +980,7 @@ describe('markdownProcessor: mergeEmptyLines', () => {
                 },
             ],
         };
-        runTest('text [link](https://www.example.com) ', document);
+        runTest('text [link](https://www.example.com)', document);
     });
 
     it('should return document with paragraph for text and bold', () => {
@@ -1036,7 +1036,7 @@ describe('markdownProcessor: mergeEmptyLines', () => {
                 },
             ],
         };
-        runTest('text *italic* ', document);
+        runTest('text *italic*', document);
     });
 
     it('should return document with paragraph for text, link and image', () => {
@@ -1077,7 +1077,7 @@ describe('markdownProcessor: mergeEmptyLines', () => {
             ],
         };
         runTest(
-            'text [link](https://www.example.com) ![image of a dog](https://www.example.com/image) ',
+            'text [link](https://www.example.com) ![image of a dog](https://www.example.com/image)',
             document
         );
     });
@@ -1832,7 +1832,7 @@ describe('markdownProcessor: preserveEmptyLines', () => {
                 },
             ],
         };
-        runTest('text and image ![image of a dog](https://www.example.com/image) ', document);
+        runTest('text and image ![image of a dog](https://www.example.com/image)', document);
     });
 
     it('should return document with paragraph for text and link', () => {
@@ -1865,7 +1865,7 @@ describe('markdownProcessor: preserveEmptyLines', () => {
                 },
             ],
         };
-        runTest('text [link](https://www.example.com) ', document);
+        runTest('text [link](https://www.example.com)', document);
     });
 
     it('should return document with paragraph for text and bold', () => {
@@ -1893,7 +1893,7 @@ describe('markdownProcessor: preserveEmptyLines', () => {
                 },
             ],
         };
-        runTest('text **bold** ', document);
+        runTest('text **bold**', document);
     });
 
     it('should return document with paragraph for text and italic', () => {
@@ -1921,7 +1921,7 @@ describe('markdownProcessor: preserveEmptyLines', () => {
                 },
             ],
         };
-        runTest('text *italic* ', document);
+        runTest('text *italic*', document);
     });
 
     it('should return document with paragraph for text, link and image', () => {
@@ -1962,7 +1962,7 @@ describe('markdownProcessor: preserveEmptyLines', () => {
             ],
         };
         runTest(
-            'text [link](https://www.example.com) ![image of a dog](https://www.example.com/image) ',
+            'text [link](https://www.example.com) ![image of a dog](https://www.example.com/image)',
             document
         );
     });

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/processor/markdownProcessorTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/processor/markdownProcessorTest.ts
@@ -67,7 +67,7 @@ describe('markdownProcessor: removeEmptyLines', () => {
                 },
             ],
         };
-        runTest('text and image ![image of a dog](https://www.example.com/image)', document);
+        runTest('text and image ![image of a dog](https://www.example.com/image) ', document);
     });
 
     it('should return document with paragraph for text and link', () => {
@@ -133,7 +133,7 @@ describe('markdownProcessor: removeEmptyLines', () => {
                 },
             ],
         };
-        runTest('text **bold**', document);
+        runTest('text **bold** ', document);
     });
 
     it('should return document with paragraph for text and italic', () => {
@@ -166,7 +166,7 @@ describe('markdownProcessor: removeEmptyLines', () => {
                 },
             ],
         };
-        runTest('text *italic*', document);
+        runTest('text *italic* ', document);
     });
 
     it('should return document with paragraph for text, link and image', () => {
@@ -921,189 +921,98 @@ describe('markdownProcessor: mergeEmptyLines', () => {
         expect(result).toEqual(expected);
     }
 
-    it('should return document with paragraph for text', () => {
-        const document: ContentModelDocument = {
+    it('Single empty line', () => {
+        runTest('\n', {
+            blockGroupType: 'Document',
+            blocks: [],
+        });
+    });
+
+    it('Single empty line with text', () => {
+        runTest('a\nb', {
             blockGroupType: 'Document',
             blocks: [
                 {
-                    blockType: 'Paragraph',
                     segments: [
                         {
-                            text: 'text',
+                            text: 'a',
                             format: {},
                             segmentType: 'Text',
                         },
                     ],
-
                     format: {},
-                },
-            ],
-        };
-        runTest('text', document);
-    });
-
-    it('should return document with paragraph for text and image', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
                     blockType: 'Paragraph',
+                },
+                {
                     segments: [
                         {
-                            text: 'text and image ',
+                            text: 'b',
                             format: {},
                             segmentType: 'Text',
                         },
-                        {
-                            alt: 'image of a dog',
-                            src: 'https://www.example.com/image',
-                            format: {},
-                            segmentType: 'Image',
-                            dataset: {},
-                        },
                     ],
-
                     format: {},
+                    blockType: 'Paragraph',
                 },
             ],
-        };
-        runTest('text and image ![image of a dog](https://www.example.com/image)', document);
+        });
     });
 
-    it('should return document with paragraph for text and link', () => {
-        const document: ContentModelDocument = {
+    it('Multiple empty lines with text', () => {
+        runTest('a\n\n\nb', {
             blockGroupType: 'Document',
             blocks: [
                 {
-                    blockType: 'Paragraph',
                     segments: [
                         {
-                            text: 'text ',
+                            text: 'a',
                             format: {},
-                            segmentType: 'Text',
-                        },
-                        {
-                            text: 'link',
-                            format: {},
-                            link: {
-                                dataset: {},
-                                format: {
-                                    href: 'https://www.example.com',
-                                    underline: true,
-                                },
-                            },
                             segmentType: 'Text',
                         },
                     ],
-
                     format: {},
-                },
-            ],
-        };
-        runTest('text [link](https://www.example.com)', document);
-    });
-
-    it('should return document with paragraph for text and bold', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
                     blockType: 'Paragraph',
+                },
+                {
                     segments: [
                         {
-                            text: 'text ',
+                            segmentType: 'Br',
                             format: {},
-                            segmentType: 'Text',
-                        },
-                        {
-                            text: 'bold ',
-                            format: {
-                                fontWeight: 'bold',
-                            },
-                            segmentType: 'Text',
                         },
                     ],
-
                     format: {},
-                },
-            ],
-        };
-        runTest('text **bold** ', document);
-    });
-
-    it('should return document with paragraph for text and italic', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
                     blockType: 'Paragraph',
+                },
+                {
                     segments: [
                         {
-                            text: 'text ',
+                            text: 'b',
                             format: {},
                             segmentType: 'Text',
                         },
-                        {
-                            text: 'italic ',
-                            format: {
-                                italic: true,
-                            },
-                            segmentType: 'Text',
-                        },
                     ],
-
                     format: {},
+                    blockType: 'Paragraph',
                 },
             ],
-        };
-        runTest('text *italic*', document);
+        });
     });
 
-    it('should return document with paragraph for text, link and image', () => {
-        const document: ContentModelDocument = {
+    it('Empty lines with spaces', () => {
+        runTest('\n   \n  \n', {
             blockGroupType: 'Document',
             blocks: [
                 {
                     blockType: 'Paragraph',
-                    segments: [
-                        {
-                            text: 'text ',
-                            format: {},
-                            segmentType: 'Text',
-                        },
-                        {
-                            text: 'link',
-                            format: {},
-                            link: {
-                                dataset: {},
-                                format: {
-                                    href: 'https://www.example.com',
-                                    underline: true,
-                                },
-                            },
-                            segmentType: 'Text',
-                        },
-                        {
-                            alt: 'image of a dog',
-                            src: 'https://www.example.com/image',
-                            format: {},
-                            segmentType: 'Image',
-                            dataset: {},
-                        },
-                    ],
-
+                    segments: [{ segmentType: 'Text', text: '   ', format: {} }],
                     format: {},
                 },
             ],
-        };
-        runTest(
-            'text [link](https://www.example.com) ![image of a dog](https://www.example.com/image)',
-            document
-        );
+        });
     });
 
-    it('should return document with list item for ordered_list', () => {
-        const document: ContentModelDocument = {
+    it('Empty line right after list', () => {
+        runTest('\n- item 1\n- item 2\n\n', {
             blockGroupType: 'Document',
             blocks: [
                 {
@@ -1112,38 +1021,42 @@ describe('markdownProcessor: mergeEmptyLines', () => {
                     blocks: [
                         {
                             blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
+                            segments: [{ segmentType: 'Text', text: 'item 1', format: {} }],
                             format: {},
                         },
                     ],
-                    levels: [
-                        {
-                            listType: 'OL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
-                    format: {},
+                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
                     formatHolder: {
                         segmentType: 'SelectionMarker',
-                        format: {},
                         isSelected: false,
+                        format: {},
                     },
+                    format: {},
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [{ segmentType: 'Text', text: 'item 2', format: {} }],
+                            format: {},
+                        },
+                    ],
+                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: false,
+                        format: {},
+                    },
+                    format: {},
                 },
             ],
-        };
-        runTest('1. text', document);
+        });
     });
 
-    it('should return document with list item for unordered_list | *', () => {
-        const document: ContentModelDocument = {
+    it('Multiple empty lines right after list', () => {
+        runTest('\n- item 1\n- item 2\n\n\na', {
             blockGroupType: 'Document',
             blocks: [
                 {
@@ -1152,433 +1065,17 @@ describe('markdownProcessor: mergeEmptyLines', () => {
                     blocks: [
                         {
                             blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
+                            segments: [{ segmentType: 'Text', text: 'item 1', format: {} }],
                             format: {},
                         },
                     ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
-                    format: {},
+                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
                     formatHolder: {
                         segmentType: 'SelectionMarker',
-                        format: {},
                         isSelected: false,
+                        format: {},
                     },
-                },
-            ],
-        };
-        runTest('* text', document);
-    });
-
-    it('should return document with list item for unordered_list | -', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
-                        {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
                     format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
-                },
-            ],
-        };
-        runTest('- text', document);
-    });
-
-    it('should return document with list item for unordered_list | +', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
-                        {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
-                    format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
-                },
-            ],
-        };
-        runTest('+ text', document);
-    });
-
-    it('should return document with list item for ordered_list with Heading 1 | +', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
-                        {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                            decorator: {
-                                tagName: 'h1',
-                                format: {
-                                    fontSize: '2em',
-                                    fontWeight: 'bold',
-                                },
-                            },
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
-                    format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
-                },
-            ],
-        };
-        runTest('+ # text', document);
-    });
-
-    it(' should return a document with a table with two rows and one column', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    widths: [],
-                    blockType: 'Table',
-                    rows: [
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text1',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                        backgroundColor: '#ABABAB',
-                                        fontWeight: 'bold',
-                                    },
-                                    isHeader: true,
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text2',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    isHeader: false,
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                    },
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                    ],
-                    format: {
-                        borderCollapse: true,
-                    },
-                    dataset: {
-                        editingInfo:
-                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
-                    },
-                },
-            ],
-        };
-        runTest('|text1|\n|----|\n|text2|', document);
-    });
-
-    it('should return a table with two rows and two columns', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    widths: [],
-                    blockType: 'Table',
-                    rows: [
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text1',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                        backgroundColor: '#ABABAB',
-                                        fontWeight: 'bold',
-                                    },
-                                    isHeader: true,
-                                },
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text2',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                        backgroundColor: '#ABABAB',
-                                        fontWeight: 'bold',
-                                    },
-                                    isHeader: true,
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text3',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                    },
-                                    isHeader: false,
-                                },
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text4',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                    },
-                                    isHeader: false,
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                    ],
-                    format: {
-                        borderCollapse: true,
-                    },
-                    dataset: {
-                        editingInfo:
-                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
-                    },
-                },
-            ],
-        };
-        runTest('|text1|text2|\n|----|----|\n|text3|text4|', document);
-    });
-
-    it('paragraph after list', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
-                        {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
-                    format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
                 },
                 {
                     blockType: 'BlockGroup',
@@ -1586,214 +1083,25 @@ describe('markdownProcessor: mergeEmptyLines', () => {
                     blocks: [
                         {
                             blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
+                            segments: [{ segmentType: 'Text', text: 'item 2', format: {} }],
                             format: {},
                         },
                     ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {
-                                displayForDummyItem: 'block',
-                            },
-                        },
-                    ],
-                    format: {},
+                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
                     formatHolder: {
                         segmentType: 'SelectionMarker',
-                        format: {},
                         isSelected: false,
+                        format: {},
                     },
+                    format: {},
                 },
                 {
                     blockType: 'Paragraph',
-                    segments: [{ segmentType: 'Text', text: 'paragraph', format: {} }],
+                    segments: [{ segmentType: 'Text', text: 'a', format: {} }],
                     format: {},
                 },
             ],
-        };
-        runTest('- text\ntext\n\nparagraph', document);
-    });
-
-    it('paragraph after blockquote ', () => {
-        const doc = createContentModelDocument();
-        const blockquote = createFormatContainer('blockquote');
-        const paragraph1 = createParagraph();
-        blockquote.format = {
-            borderLeft: '3px solid rgb(200, 200, 200)',
-            textColor: 'rgb(102, 102, 102)',
-            marginTop: '1em',
-            marginBottom: '1em',
-            marginLeft: '40px',
-            marginRight: '40px',
-            paddingLeft: '10px',
-        };
-        const text1 = createText(' text');
-        const paragraph2 = createParagraph();
-        const text2 = createText('text');
-        paragraph1.segments.push(text1);
-        paragraph2.segments.push(text2);
-        blockquote.blocks.push(paragraph1, paragraph2);
-        doc.blocks.push(blockquote);
-        const paragraph3 = createParagraph();
-        const text3 = createText('paragraph');
-        paragraph3.segments.push(text3);
-        doc.blocks.push(paragraph3);
-        runTest('> text\ntext\n\nparagraph', doc);
-    });
-
-    it('should return a table with two rows and two columns with alignment', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    widths: [],
-                    blockType: 'Table',
-                    rows: [
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text1',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'center',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                        backgroundColor: '#ABABAB',
-                                        fontWeight: 'bold',
-                                    },
-                                    isHeader: true,
-                                },
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text2',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'end',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                        backgroundColor: '#ABABAB',
-                                        fontWeight: 'bold',
-                                    },
-                                    isHeader: true,
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text3',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'center',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                    },
-                                    isHeader: false,
-                                },
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text4',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'end',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                    },
-                                    isHeader: false,
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                    ],
-                    format: {
-                        borderCollapse: true,
-                    },
-                    dataset: {
-                        editingInfo:
-                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
-                    },
-                },
-            ],
-        };
-        runTest('|text1|text2|\n|:----:|----:|\n|text3|text4|', document);
+        });
     });
 });
 
@@ -1806,878 +1114,272 @@ describe('markdownProcessor: preserveEmptyLines', () => {
         expect(result).toEqual(expected);
     }
 
-    it('should return document with paragraph for text', () => {
-        const document: ContentModelDocument = {
+    it('Single empty line', () => {
+        runTest('\n', {
             blockGroupType: 'Document',
             blocks: [
                 {
                     blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Br', format: {} }],
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Br', format: {} }],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('Single empty line with text', () => {
+        runTest('a\nb', {
+            blockGroupType: 'Document',
+            blocks: [
+                {
                     segments: [
                         {
-                            text: 'text',
+                            text: 'a',
                             format: {},
                             segmentType: 'Text',
                         },
                     ],
-
                     format: {},
-                },
-            ],
-        };
-        runTest('text', document);
-    });
-
-    it('should return document with paragraph for text and image', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
                     blockType: 'Paragraph',
+                },
+                {
                     segments: [
                         {
-                            text: 'text and image ',
+                            text: 'b',
                             format: {},
                             segmentType: 'Text',
                         },
-                        {
-                            alt: 'image of a dog',
-                            src: 'https://www.example.com/image',
-                            format: {},
-                            segmentType: 'Image',
-                            dataset: {},
-                        },
                     ],
-
                     format: {},
+                    blockType: 'Paragraph',
                 },
             ],
-        };
-        runTest('text and image ![image of a dog](https://www.example.com/image)', document);
+        });
     });
 
-    it('should return document with paragraph for text and link', () => {
-        const document: ContentModelDocument = {
+    it('Multiple empty lines with text', () => {
+        runTest('a\n\n\nb', {
             blockGroupType: 'Document',
             blocks: [
                 {
-                    blockType: 'Paragraph',
                     segments: [
                         {
-                            text: 'text ',
+                            text: 'a',
                             format: {},
-                            segmentType: 'Text',
-                        },
-                        {
-                            text: 'link',
-                            format: {},
-                            link: {
-                                dataset: {},
-                                format: {
-                                    href: 'https://www.example.com',
-                                    underline: true,
-                                },
-                            },
                             segmentType: 'Text',
                         },
                     ],
-
                     format: {},
-                },
-            ],
-        };
-        runTest('text [link](https://www.example.com)', document);
-    });
-
-    it('should return document with paragraph for text and bold', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
                     blockType: 'Paragraph',
+                },
+                {
                     segments: [
                         {
-                            text: 'text ',
+                            segmentType: 'Br',
                             format: {},
-                            segmentType: 'Text',
-                        },
-                        {
-                            text: 'bold ',
-                            format: {
-                                fontWeight: 'bold',
-                            },
-                            segmentType: 'Text',
                         },
                     ],
-
                     format: {},
-                },
-            ],
-        };
-        runTest('text **bold**', document);
-    });
-
-    it('should return document with paragraph for text and italic', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
                     blockType: 'Paragraph',
+                },
+                {
                     segments: [
                         {
-                            text: 'text ',
+                            segmentType: 'Br',
                             format: {},
-                            segmentType: 'Text',
-                        },
-                        {
-                            text: 'italic ',
-                            format: {
-                                italic: true,
-                            },
-                            segmentType: 'Text',
                         },
                     ],
-
                     format: {},
-                },
-            ],
-        };
-        runTest('text *italic*', document);
-    });
-
-    it('should return document with paragraph for text, link and image', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
                     blockType: 'Paragraph',
+                },
+                {
                     segments: [
                         {
-                            text: 'text ',
+                            text: 'b',
                             format: {},
                             segmentType: 'Text',
                         },
-                        {
-                            text: 'link',
-                            format: {},
-                            link: {
-                                dataset: {},
-                                format: {
-                                    href: 'https://www.example.com',
-                                    underline: true,
-                                },
-                            },
-                            segmentType: 'Text',
-                        },
-                        {
-                            alt: 'image of a dog',
-                            src: 'https://www.example.com/image',
-                            format: {},
-                            segmentType: 'Image',
-                            dataset: {},
-                        },
                     ],
-
                     format: {},
+                    blockType: 'Paragraph',
                 },
             ],
-        };
-        runTest(
-            'text [link](https://www.example.com) ![image of a dog](https://www.example.com/image)',
-            document
-        );
+        });
     });
 
-    it('should return document with list item for ordered_list', () => {
-        const document: ContentModelDocument = {
+    it('Empty lines with spaces', () => {
+        runTest('\n   \n  \n', {
             blockGroupType: 'Document',
             blocks: [
                 {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
+                    segments: [
                         {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'OL',
-                            dataset: {},
+                            segmentType: 'Br',
                             format: {},
                         },
                     ],
                     format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
-                },
-            ],
-        };
-        runTest('1. text', document);
-    });
-
-    it('should return document with list item for unordered_list | *', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
-                        {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
-                    format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
-                },
-            ],
-        };
-        runTest('* text', document);
-    });
-
-    it('should return document with list item for unordered_list | -', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
-                        {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
-                    format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
-                },
-            ],
-        };
-        runTest('- text', document);
-    });
-
-    it('should return document with list item for unordered_list | +', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
-                        {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
-                    format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
-                },
-            ],
-        };
-        runTest('+ text', document);
-    });
-
-    it('should return document with list item for ordered_list with Heading 1 | +', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
-                        {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                            decorator: {
-                                tagName: 'h1',
-                                format: {
-                                    fontSize: '2em',
-                                    fontWeight: 'bold',
-                                },
-                            },
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
-                    format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
-                },
-            ],
-        };
-        runTest('+ # text', document);
-    });
-
-    it(' should return a document with a table with two rows and one column', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    widths: [],
-                    blockType: 'Table',
-                    rows: [
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text1',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                        backgroundColor: '#ABABAB',
-                                        fontWeight: 'bold',
-                                    },
-                                    isHeader: true,
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text2',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    isHeader: false,
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                    },
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                    ],
-                    format: {
-                        borderCollapse: true,
-                    },
-                    dataset: {
-                        editingInfo:
-                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
-                    },
-                },
-            ],
-        };
-        runTest('|text1|\n|----|\n|text2|', document);
-    });
-
-    it('should return a table with two rows and two columns', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    widths: [],
-                    blockType: 'Table',
-                    rows: [
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text1',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                        backgroundColor: '#ABABAB',
-                                        fontWeight: 'bold',
-                                    },
-                                    isHeader: true,
-                                },
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text2',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                        backgroundColor: '#ABABAB',
-                                        fontWeight: 'bold',
-                                    },
-                                    isHeader: true,
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text3',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                    },
-                                    isHeader: false,
-                                },
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text4',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'start',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                    },
-                                    isHeader: false,
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                    ],
-                    format: {
-                        borderCollapse: true,
-                    },
-                    dataset: {
-                        editingInfo:
-                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
-                    },
-                },
-            ],
-        };
-        runTest('|text1|text2|\n|----|----|\n|text3|text4|', document);
-    });
-
-    it('paragraph after list', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
-                {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
-                        {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {},
-                        },
-                    ],
-                    format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
-                },
-                {
-                    blockType: 'BlockGroup',
-                    blockGroupType: 'ListItem',
-                    blocks: [
-                        {
-                            blockType: 'Paragraph',
-                            segments: [
-                                {
-                                    text: 'text',
-                                    format: {},
-                                    segmentType: 'Text',
-                                },
-                            ],
-
-                            format: {},
-                        },
-                    ],
-                    levels: [
-                        {
-                            listType: 'UL',
-                            dataset: {},
-                            format: {
-                                displayForDummyItem: 'block',
-                            },
-                        },
-                    ],
-                    format: {},
-                    formatHolder: {
-                        segmentType: 'SelectionMarker',
-                        format: {},
-                        isSelected: false,
-                    },
+                    blockType: 'Paragraph',
                 },
                 {
                     blockType: 'Paragraph',
-                    segments: [{ segmentType: 'Text', text: 'paragraph', format: {} }],
+                    segments: [{ segmentType: 'Text', text: '   ', format: {} }],
                     format: {},
                 },
-            ],
-        };
-        runTest('- text\ntext\n\nparagraph', document);
-    });
-
-    it('paragraph after blockquote ', () => {
-        const doc = createContentModelDocument();
-        const blockquote = createFormatContainer('blockquote');
-        const paragraph1 = createParagraph();
-        blockquote.format = {
-            borderLeft: '3px solid rgb(200, 200, 200)',
-            textColor: 'rgb(102, 102, 102)',
-            marginTop: '1em',
-            marginBottom: '1em',
-            marginLeft: '40px',
-            marginRight: '40px',
-            paddingLeft: '10px',
-        };
-        const text1 = createText(' text');
-        const paragraph2 = createParagraph();
-        const text2 = createText('text');
-        paragraph1.segments.push(text1);
-        paragraph2.segments.push(text2);
-        blockquote.blocks.push(paragraph1, paragraph2);
-        doc.blocks.push(blockquote);
-        const paragraph3 = createParagraph();
-        const text3 = createText('paragraph');
-        paragraph3.segments.push(text3);
-        doc.blocks.push(paragraph3);
-        runTest('> text\ntext\n\nparagraph', doc);
-    });
-
-    it('should return a table with two rows and two columns with alignment', () => {
-        const document: ContentModelDocument = {
-            blockGroupType: 'Document',
-            blocks: [
                 {
-                    widths: [],
-                    blockType: 'Table',
-                    rows: [
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Text', text: '  ', format: {} }],
+                    format: {},
+                },
+                {
+                    segments: [
                         {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text1',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'center',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                        backgroundColor: '#ABABAB',
-                                        fontWeight: 'bold',
-                                    },
-                                    isHeader: true,
-                                },
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text2',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'end',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                        backgroundColor: '#ABABAB',
-                                        fontWeight: 'bold',
-                                    },
-                                    isHeader: true,
-                                },
-                            ],
-                            height: 0,
-                            format: {},
-                        },
-                        {
-                            cells: [
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text3',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'center',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                    },
-                                    isHeader: false,
-                                },
-                                {
-                                    spanAbove: false,
-                                    spanLeft: false,
-                                    dataset: {},
-                                    blockGroupType: 'TableCell',
-                                    blocks: [
-                                        {
-                                            segments: [
-                                                {
-                                                    text: 'text4',
-                                                    format: {},
-                                                    segmentType: 'Text',
-                                                },
-                                            ],
-                                            format: {},
-                                            blockType: 'Paragraph',
-                                        },
-                                    ],
-                                    format: {
-                                        textAlign: 'end',
-                                        borderTop: '1px solid #ABABAB',
-                                        borderRight: '1px solid #ABABAB',
-                                        borderBottom: '1px solid #ABABAB',
-                                        borderLeft: '1px solid #ABABAB',
-                                    },
-                                    isHeader: false,
-                                },
-                            ],
-                            height: 0,
+                            segmentType: 'Br',
                             format: {},
                         },
                     ],
-                    format: {
-                        borderCollapse: true,
-                    },
-                    dataset: {
-                        editingInfo:
-                            '{"topBorderColor":"#ABABAB","bottomBorderColor":"#ABABAB","verticalBorderColor":"#ABABAB","hasHeaderRow":true,"hasFirstColumn":false,"hasBandedRows":false,"hasBandedColumns":false,"bgColorEven":null,"bgColorOdd":"#ABABAB20","headerRowColor":"#ABABAB","tableBorderFormat":0,"verticalAlign":null}',
-                    },
+                    format: {},
+                    blockType: 'Paragraph',
                 },
             ],
-        };
-        runTest('|text1|text2|\n|:----:|----:|\n|text3|text4|', document);
+        });
+    });
+
+    it('Empty line right after list', () => {
+        runTest('\n- item 1\n- item 2\n\n', {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    segments: [
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    blockType: 'Paragraph',
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [{ segmentType: 'Text', text: 'item 1', format: {} }],
+                            format: {},
+                        },
+                    ],
+                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: false,
+                        format: {},
+                    },
+                    format: {},
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [{ segmentType: 'Text', text: 'item 2', format: {} }],
+                            format: {},
+                        },
+                    ],
+                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: false,
+                        format: {},
+                    },
+                    format: {},
+                },
+                {
+                    segments: [
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    blockType: 'Paragraph',
+                },
+            ],
+        });
+    });
+
+    it('Multiple empty lines right after list', () => {
+        runTest('\n- item 1\n- item 2\n\n\na', {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    segments: [
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    blockType: 'Paragraph',
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [{ segmentType: 'Text', text: 'item 1', format: {} }],
+                            format: {},
+                        },
+                    ],
+                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: false,
+                        format: {},
+                    },
+                    format: {},
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [{ segmentType: 'Text', text: 'item 2', format: {} }],
+                            format: {},
+                        },
+                    ],
+                    levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: false,
+                        format: {},
+                    },
+                    format: {},
+                },
+                {
+                    segments: [
+                        {
+                            segmentType: 'Br',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    blockType: 'Paragraph',
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [{ segmentType: 'Text', text: 'a', format: {} }],
+                    format: {},
+                },
+            ],
+        });
     });
 });


### PR DESCRIPTION
Current markdown parser will always ignore empty lines. But actually if there are multiple empty lines, we should keep one.

This change introduces 3 empty line modes:
- preserve: Preserve empty lines, unless it is right next to list, quote, table
- remove: Remove all empty lines (current behavior)
- merge: If there are multiple empty lines, keep one (default)