### PR TITLE
Improve handleParagraph function

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/setContentModel/setContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setContentModel/setContentModel.ts
@@ -41,7 +41,7 @@ export const setContentModel: SetContentModel = (
     core.onFixUpModel?.(model);
 
     const selection = contentModelToDom(
-        core.logicalRoot.ownerDocument,
+        core.logicalRoot.ownerDocument.implementation.createHTMLDocument(),
         core.logicalRoot,
         model,
         modelToDomContext

--- a/packages/roosterjs-content-model-core/test/coreApi/setContentModel/setContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setContentModel/setContentModelTest.ts
@@ -4,11 +4,9 @@ import * as updateCache from '../../../lib/corePlugin/cache/updateCache';
 import { ContentModelDocument, EditorCore, ModelToDomContext } from 'roosterjs-content-model-types';
 import { setContentModel } from '../../../lib/coreApi/setContentModel/setContentModel';
 
-const mockedDoc = 'DOCUMENT' as any;
 const mockedModel = 'MODEL' as any;
 const mockedEditorContext = 'EDITORCONTEXT' as any;
 const mockedContext = { name: 'CONTEXT', rewriteFromModel: {} } as any;
-const mockedDiv = { ownerDocument: mockedDoc } as any;
 const mockedConfig = 'CONFIG' as any;
 
 describe('setContentModel', () => {
@@ -22,8 +20,19 @@ describe('setContentModel', () => {
     let flushMutationsSpy: jasmine.Spy;
     let updateCacheSpy: jasmine.Spy;
     let triggerEventSpy: jasmine.Spy;
+    let mockedDiv: HTMLElement;
+    let doc: Document;
 
     beforeEach(() => {
+        doc = document.implementation.createHTMLDocument('test');
+
+        mockedDiv = {
+            ownerDocument: {
+                implementation: {
+                    createHTMLDocument: () => doc,
+                },
+            },
+        } as any;
         contentModelToDomSpy = spyOn(contentModelToDom, 'contentModelToDom');
         createEditorContext = jasmine
             .createSpy('createEditorContext')
@@ -79,7 +88,7 @@ describe('setContentModel', () => {
             mockedEditorContext
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            mockedDoc,
+            jasmine.anything(),
             mockedDiv,
             mockedModel,
             mockedContext
@@ -103,7 +112,7 @@ describe('setContentModel', () => {
             mockedEditorContext
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            mockedDoc,
+            doc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -133,7 +142,7 @@ describe('setContentModel', () => {
             additionalOption
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            mockedDoc,
+            doc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -158,7 +167,7 @@ describe('setContentModel', () => {
             mockedEditorContext
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            mockedDoc,
+            doc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -190,7 +199,7 @@ describe('setContentModel', () => {
             }
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            mockedDoc,
+            doc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -224,7 +233,7 @@ describe('setContentModel', () => {
             }
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            mockedDoc,
+            doc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -253,7 +262,7 @@ describe('setContentModel', () => {
             }
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            mockedDoc,
+            doc,
             mockedDiv,
             mockedModel,
             mockedContext

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
@@ -39,10 +39,9 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
                       ...paragraph.segmentFormat,
                   }
                 : {};
+            const prevRefNode = refNode?.previousSibling;
 
             container = doc.createElement(paragraph.decorator?.tagName || DefaultParagraphTag);
-
-            parent.insertBefore(container, refNode);
 
             context.regularSelection.current = {
                 block: needParagraphWrapper ? container : container.parentNode,
@@ -108,7 +107,14 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
             // since this paragraph it is implicit. In that case container.nextSibling will become original
             // inline entity's next sibling. So reset refNode to its real next sibling (after change) here
             // to make sure the value is correct.
-            refNode = container.nextSibling;
+            refNode =
+                prevRefNode === undefined // When refNode is not passed in
+                    ? null
+                    : prevRefNode === null // When refNode is the first child of parent
+                    ? parent.firstChild
+                    : prevRefNode.nextSibling; // Normal case
+
+            parent.insertBefore(container, refNode);
 
             if (container) {
                 context.onNodeCreated?.(paragraph, container);


### PR DESCRIPTION
1. When convert model to DOM, use independent document to create element. We are expecting this can reduce some cost of operating DOM elements before it is appended into the main DOM tree body
2. When handle paragraph, first prepare the whole paragraph element and make it is ready, and finally insert into DOM tree. This can reduce the count of DOM mutation 