### PR TITLE
Fix auto-capitalization for iOS 

### DIFF
--- a/packages/roosterjs-content-model-core/lib/editor/core/createEditorCore.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/createEditorCore.ts
@@ -71,7 +71,7 @@ function createEditorEnvironment(
         modelToDomSettings: createModelToDomSettings(options),
         isMac: appVersion.indexOf('Mac') != -1,
         isAndroid: /android/i.test(userAgent),
-        isIOS: /iPad|iPhone|iPod/.test(userAgent),
+        isIOS: /iPad|iPhone/.test(userAgent),
         isSafari:
             userAgent.indexOf('Safari') >= 0 &&
             userAgent.indexOf('Chrome') < 0 &&

--- a/packages/roosterjs-content-model-core/lib/editor/core/createEditorCore.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/createEditorCore.ts
@@ -71,6 +71,7 @@ function createEditorEnvironment(
         modelToDomSettings: createModelToDomSettings(options),
         isMac: appVersion.indexOf('Mac') != -1,
         isAndroid: /android/i.test(userAgent),
+        isIOS: /iPad|iPhone|iPod/.test(userAgent),
         isSafari:
             userAgent.indexOf('Safari') >= 0 &&
             userAgent.indexOf('Chrome') < 0 &&

--- a/packages/roosterjs-content-model-core/test/editor/core/createEditorCoreTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/createEditorCoreTest.ts
@@ -85,6 +85,7 @@ describe('createEditorCore', () => {
             environment: {
                 isMac: false,
                 isAndroid: false,
+                isIOS: false,
                 isSafari: false,
                 isMobileOrTablet: false,
                 domToModelSettings: mockedDomToModelSettings,
@@ -218,6 +219,7 @@ describe('createEditorCore', () => {
             environment: {
                 isMac: false,
                 isAndroid: true,
+                isIOS: false,
                 isSafari: false,
                 isMobileOrTablet: true,
                 domToModelSettings: mockedDomToModelSettings,
@@ -252,6 +254,7 @@ describe('createEditorCore', () => {
             environment: {
                 isMac: false,
                 isAndroid: true,
+                isIOS: false,
                 isSafari: false,
                 isMobileOrTablet: true,
                 domToModelSettings: mockedDomToModelSettings,
@@ -286,6 +289,7 @@ describe('createEditorCore', () => {
             environment: {
                 isMac: true,
                 isAndroid: false,
+                isIOS: false,
                 isSafari: false,
                 isMobileOrTablet: false,
                 domToModelSettings: mockedDomToModelSettings,
@@ -320,6 +324,7 @@ describe('createEditorCore', () => {
             environment: {
                 isMac: false,
                 isAndroid: false,
+                isIOS: false,
                 isSafari: true,
                 isMobileOrTablet: false,
                 domToModelSettings: mockedDomToModelSettings,
@@ -354,6 +359,7 @@ describe('createEditorCore', () => {
             environment: {
                 isMac: false,
                 isAndroid: false,
+                isIOS: false,
                 isSafari: false,
                 isMobileOrTablet: false,
                 domToModelSettings: mockedDomToModelSettings,
@@ -368,4 +374,41 @@ describe('createEditorCore', () => {
             undefined
         );
     });
+
+    it('iOS iPhone Safari', () => {
+        const mockedDiv = {
+            ownerDocument: {
+                defaultView: {
+                    navigator: {
+                        userAgent:
+                            'Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+                    },
+                },
+            },
+            attributes: {
+                a: 'b',
+            },
+        } as any;
+        const mockedOptions = {} as any;
+
+        runTest(mockedDiv, mockedOptions, {
+            environment: {
+                isMac: false,
+                isAndroid: false,
+                isIOS: true,
+                isSafari: false,
+                isMobileOrTablet: true,
+                domToModelSettings: mockedDomToModelSettings,
+                modelToDomSettings: mockedModelToDomSettings,
+            },
+        });
+
+        expect(DarkColorHandlerImpl.createDarkColorHandler).toHaveBeenCalledWith(
+            mockedDiv,
+            getDarkColorFallback,
+            undefined,
+            undefined
+        );
+    });
 });
+

--- a/packages/roosterjs-content-model-core/test/editor/core/createEditorCoreTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/createEditorCoreTest.ts
@@ -411,4 +411,3 @@ describe('createEditorCore', () => {
         );
     });
 });
-

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -41,7 +41,14 @@ export function keyboardDelete(
     let handled = false;
     const selection = editor.getDOMSelection();
 
-    if (shouldDeleteWithContentModel(selection, rawEvent, handleExpandedSelection, editor)) {
+    if (
+        shouldDeleteWithContentModel(
+            selection,
+            rawEvent,
+            handleExpandedSelection,
+            editor.getEnvironment().isIOS ?? false
+        )
+    ) {
         editor.formatContentModel(
             (model, context) => {
                 const result = deleteSelection(
@@ -93,7 +100,7 @@ function shouldDeleteWithContentModel(
     selection: DOMSelection | null,
     rawEvent: KeyboardEvent,
     handleExpandedSelection: boolean,
-    editor: IEditor
+    isIOS: boolean
 ) {
     if (!selection) {
         return false; // Nothing to delete
@@ -122,20 +129,19 @@ function shouldDeleteWithContentModel(
         return !(
             isNodeOfType(startContainer, 'TEXT_NODE') &&
             !isModifierKey(rawEvent) &&
-            (canDeleteBefore(rawEvent, startContainer, startOffset, editor) ||
+            (canDeleteBefore(rawEvent, startContainer, startOffset, isIOS) ||
                 canDeleteAfter(rawEvent, startContainer, startOffset))
         );
     }
 }
 
-function canDeleteBefore(rawEvent: KeyboardEvent, text: Text, offset: number, editor: IEditor) {
+function canDeleteBefore(rawEvent: KeyboardEvent, text: Text, offset: number, isIOS: boolean) {
     if (rawEvent.key != 'Backspace') {
         return false;
     }
     if (offset <= 1) {
-        const { isAndroid, isMobileOrTablet } = editor.getEnvironment();
         // For iOS, allow browser to handle deletion of first character on iOS to preserve auto-capitalization
-        return offset === 1 && isMobileOrTablet && !isAndroid;
+        return offset === 1 && isIOS;
     }
 
     const length = text.nodeValue?.length ?? 0;

--- a/packages/roosterjs-content-model-plugins/test/edit/keyboardDeleteTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/keyboardDeleteTest.ts
@@ -536,6 +536,7 @@ describe('keyboardDelete', () => {
                 type: 'range',
                 range: { collapsed: false },
             }),
+            getEnvironment: () => ({}),
         } as any) as IEditor;
         const event = {
             which: Delete,
@@ -559,6 +560,7 @@ describe('keyboardDelete', () => {
                 type: 'range',
                 range: { collapsed: false },
             }),
+            getEnvironment: () => ({}),
         } as any;
         const which = Backspace;
         const event = {
@@ -589,6 +591,7 @@ describe('keyboardDelete', () => {
         const editor = {
             formatContentModel: formatWithContentModelSpy,
             getDOMSelection: () => range,
+            getEnvironment: () => ({}),
         } as any;
 
         keyboardDelete(editor, rawEvent);
@@ -611,6 +614,7 @@ describe('keyboardDelete', () => {
         const editor = {
             formatContentModel: formatWithContentModelSpy,
             getDOMSelection: () => range,
+            getEnvironment: () => ({}),
         } as any;
 
         keyboardDelete(editor, rawEvent);
@@ -636,6 +640,7 @@ describe('keyboardDelete', () => {
         const editor = {
             formatContentModel: formatWithContentModelSpy,
             getDOMSelection: () => range,
+            getEnvironment: () => ({}),
         } as any;
 
         keyboardDelete(editor, rawEvent, false /* handleExpandedSelectionOnDelete */);
@@ -659,6 +664,7 @@ describe('keyboardDelete', () => {
         const editor = {
             formatContentModel: formatWithContentModelSpy,
             getDOMSelection: () => range,
+            getEnvironment: () => ({}),
         } as any;
 
         keyboardDelete(editor, rawEvent);
@@ -682,6 +688,7 @@ describe('keyboardDelete', () => {
         const editor = {
             formatContentModel: formatWithContentModelSpy,
             getDOMSelection: () => range,
+            getEnvironment: () => ({}),
         } as any;
 
         keyboardDelete(editor, rawEvent);
@@ -707,6 +714,7 @@ describe('keyboardDelete', () => {
         const editor = {
             formatContentModel: formatWithContentModelSpy,
             getDOMSelection: () => range,
+            getEnvironment: () => ({}),
         } as any;
 
         keyboardDelete(editor, rawEvent, false /* handleExpandedSelectionOnDelete */);
@@ -740,6 +748,7 @@ describe('keyboardDelete', () => {
         const editor = {
             formatContentModel: formatWithContentModelSpy,
             getDOMSelection: () => range,
+            getEnvironment: () => ({}),
         } as any;
 
         keyboardDelete(editor, rawEvent, false /* handleExpandedSelectionOnDelete */);

--- a/packages/roosterjs-content-model-types/lib/parameter/EditorEnvironment.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/EditorEnvironment.ts
@@ -40,6 +40,11 @@ export interface EditorEnvironment {
     readonly isAndroid?: boolean;
 
     /**
+     * Whether editor is running on iOS
+     */
+    readonly isIOS?: boolean;
+
+    /**
      * Whether editor is running on Safari browser
      */
     readonly isSafari?: boolean;


### PR DESCRIPTION
Fix auto-capitalization for iOS by allowing browser to handle first character deletion

## Root Cause

The Content Model intercepts delete detection when deleting the first character, which prevents the system browser from applying keyboard auto-capitalization.

### Solution
When deleting the first character (i.e., offset = 1) on iOS, allow the browser to handle the deletion.
When offset = 0, delete detection is still handled by the Content Model. In my testing, other styles can still be cleared correctly by the Content Model at that point.

### Preview
![Screen Recording 2025-08-29 at 14 53 10](https://github.com/user-attachments/assets/fbe49120-69d8-4de7-81bb-b303416af5c4)


#3111 #3081 