### PR TITLE
Revert "Improve handleParagraph function"

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/setContentModel/setContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setContentModel/setContentModel.ts
@@ -41,7 +41,7 @@ export const setContentModel: SetContentModel = (
     core.onFixUpModel?.(model);
 
     const selection = contentModelToDom(
-        core.logicalRoot.ownerDocument.implementation.createHTMLDocument(),
+        core.logicalRoot.ownerDocument,
         core.logicalRoot,
         model,
         modelToDomContext

--- a/packages/roosterjs-content-model-core/test/coreApi/setContentModel/setContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setContentModel/setContentModelTest.ts
@@ -4,9 +4,11 @@ import * as updateCache from '../../../lib/corePlugin/cache/updateCache';
 import { ContentModelDocument, EditorCore, ModelToDomContext } from 'roosterjs-content-model-types';
 import { setContentModel } from '../../../lib/coreApi/setContentModel/setContentModel';
 
+const mockedDoc = 'DOCUMENT' as any;
 const mockedModel = 'MODEL' as any;
 const mockedEditorContext = 'EDITORCONTEXT' as any;
 const mockedContext = { name: 'CONTEXT', rewriteFromModel: {} } as any;
+const mockedDiv = { ownerDocument: mockedDoc } as any;
 const mockedConfig = 'CONFIG' as any;
 
 describe('setContentModel', () => {
@@ -20,19 +22,8 @@ describe('setContentModel', () => {
     let flushMutationsSpy: jasmine.Spy;
     let updateCacheSpy: jasmine.Spy;
     let triggerEventSpy: jasmine.Spy;
-    let mockedDiv: HTMLElement;
-    let doc: Document;
 
     beforeEach(() => {
-        doc = document.implementation.createHTMLDocument('test');
-
-        mockedDiv = {
-            ownerDocument: {
-                implementation: {
-                    createHTMLDocument: () => doc,
-                },
-            },
-        } as any;
         contentModelToDomSpy = spyOn(contentModelToDom, 'contentModelToDom');
         createEditorContext = jasmine
             .createSpy('createEditorContext')
@@ -88,7 +79,7 @@ describe('setContentModel', () => {
             mockedEditorContext
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            jasmine.anything(),
+            mockedDoc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -112,7 +103,7 @@ describe('setContentModel', () => {
             mockedEditorContext
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            doc,
+            mockedDoc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -142,7 +133,7 @@ describe('setContentModel', () => {
             additionalOption
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            doc,
+            mockedDoc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -167,7 +158,7 @@ describe('setContentModel', () => {
             mockedEditorContext
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            doc,
+            mockedDoc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -199,7 +190,7 @@ describe('setContentModel', () => {
             }
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            doc,
+            mockedDoc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -233,7 +224,7 @@ describe('setContentModel', () => {
             }
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            doc,
+            mockedDoc,
             mockedDiv,
             mockedModel,
             mockedContext
@@ -262,7 +253,7 @@ describe('setContentModel', () => {
             }
         );
         expect(contentModelToDomSpy).toHaveBeenCalledWith(
-            doc,
+            mockedDoc,
             mockedDiv,
             mockedModel,
             mockedContext

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
@@ -39,9 +39,10 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
                       ...paragraph.segmentFormat,
                   }
                 : {};
-            const prevRefNode = refNode?.previousSibling;
 
             container = doc.createElement(paragraph.decorator?.tagName || DefaultParagraphTag);
+
+            parent.insertBefore(container, refNode);
 
             context.regularSelection.current = {
                 block: needParagraphWrapper ? container : container.parentNode,
@@ -107,14 +108,7 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
             // since this paragraph it is implicit. In that case container.nextSibling will become original
             // inline entity's next sibling. So reset refNode to its real next sibling (after change) here
             // to make sure the value is correct.
-            refNode =
-                prevRefNode === undefined // When refNode is not passed in
-                    ? null
-                    : prevRefNode === null // When refNode is the first child of parent
-                    ? parent.firstChild
-                    : prevRefNode.nextSibling; // Normal case
-
-            parent.insertBefore(container, refNode);
+            refNode = container.nextSibling;
 
             if (container) {
                 context.onNodeCreated?.(paragraph, container);


### PR DESCRIPTION
Reverts microsoft/roosterjs#3130

This change causes the following issues:

1. For implicit paragraph, the parent block is not correctly assigned into context.regularSelection when convert model to dom
2. Because we delay appending paragraph container after handling all segments, in onNodeCreated for segment, if it wants to read computed styles, it will not work correctly

Given the above issues, I decide to revert this change.