### PR TITLE
Fix type error when continuing list

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/list/getListTypeStyle.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/list/getListTypeStyle.ts
@@ -52,7 +52,6 @@ export function getListTypeStyle(
             return { listType: 'UL', styleType: bulletType };
         } else if (shouldSearchForNumbering) {
             const { previousList, hasSpaceBetween } = getPreviousListLevel(model, paragraph);
-
             const previousIndex = getPreviousListIndex(model, previousList);
             const previousListStyle = getPreviousListStyle(previousList);
             const numberingType = getNumberingListStyle(

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/list/getListTypeStyleTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/list/getListTypeStyleTest.ts
@@ -1408,7 +1408,7 @@ describe('getListTypeStyle', () => {
         runTest(model, {
             listType: 'OL',
             styleType: NumberingListType.Decimal,
-            index: 1,
+            index: undefined,
         });
     });
 });


### PR DESCRIPTION
When starting a list after a list, check if the list has levels, when look for the list type. I could not find the scenario where a list cannot have levels, but since there is a spike of these errors, a check to verify list levels was added. 