### PR TITLE
Add mailto scheme check when only email address was entered

### DIFF
--- a/packages/roosterjs-content-model-api/lib/modelApi/link/getLinkUrl.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/link/getLinkUrl.ts
@@ -28,8 +28,8 @@ function matchMailTo(text: string) {
         return text.toLocaleLowerCase();
     }
 
-    // Only add 'mailto:' if text matches COMMON_REGEX and EMAIlADDRESS_REGEX
-    if (text.match(COMMON_REGEX) && text.match(EMAIlADDRESS_REGEX)) {
+    // Only add 'mailto:' if text matches EMAIlADDRESS_REGEX
+    if (text.match(EMAIlADDRESS_REGEX)) {
         const prefixed = 'mailto:' + text;
         if (prefixed.match(MAILTO_REGEX)) {
             return prefixed.toLocaleLowerCase();

--- a/packages/roosterjs-content-model-api/lib/modelApi/link/getLinkUrl.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/link/getLinkUrl.ts
@@ -22,5 +22,17 @@ function matchTel(text: string) {
 }
 
 function matchMailTo(text: string) {
-    return text.match(MAILTO_REGEX) ? text.toLocaleLowerCase() : undefined;
+    // Check if text matches MAILTO_REGEX directly
+    if (text.match(MAILTO_REGEX)) {
+        return text.toLocaleLowerCase();
+    }
+
+    // Only add 'mailto:' if text matches COMMON_REGEX
+    if (text.match(COMMON_REGEX)) {
+        const prefixed = 'mailto:' + text;
+        if (prefixed.match(MAILTO_REGEX)) {
+            return prefixed.toLocaleLowerCase();
+        }
+    }
+    return undefined;
 }

--- a/packages/roosterjs-content-model-api/lib/modelApi/link/getLinkUrl.ts
+++ b/packages/roosterjs-content-model-api/lib/modelApi/link/getLinkUrl.ts
@@ -4,6 +4,7 @@ import type { AutoLinkOptions } from 'roosterjs-content-model-types';
 const COMMON_REGEX = `[\s]*[a-zA-Z0-9+][\s]*`;
 const TELEPHONE_REGEX = `(T|t)el:${COMMON_REGEX}`;
 const MAILTO_REGEX = `(M|m)ailto:${COMMON_REGEX}`;
+const EMAIlADDRESS_REGEX = /^[\w.%+-]+@/i;
 
 /**
  * @internal
@@ -27,8 +28,8 @@ function matchMailTo(text: string) {
         return text.toLocaleLowerCase();
     }
 
-    // Only add 'mailto:' if text matches COMMON_REGEX
-    if (text.match(COMMON_REGEX)) {
+    // Only add 'mailto:' if text matches COMMON_REGEX and EMAIlADDRESS_REGEX
+    if (text.match(COMMON_REGEX) && text.match(EMAIlADDRESS_REGEX)) {
         const prefixed = 'mailto:' + text;
         if (prefixed.match(MAILTO_REGEX)) {
             return prefixed.toLocaleLowerCase();

--- a/packages/roosterjs-content-model-api/test/modelApi/link/getLinkUrlTest.ts
+++ b/packages/roosterjs-content-model-api/test/modelApi/link/getLinkUrlTest.ts
@@ -50,4 +50,12 @@ describe('getLinkUrl', () => {
     it('invalid mailto', () => {
         runTest('mailtos:test', { autoMailto: true }, undefined);
     });
+
+    it('valid mailto', () => {
+        runTest('test@test.com', { autoMailto: true }, 'mailto:test@test.com');
+    });
+
+    it('Invalid email address', () => {
+        runTest('test@test', { autoMailto: true }, undefined);
+    });
 });


### PR DESCRIPTION
When user enters email address in editor without the mailto scheme, anchor element was not added. This is to add check if mailto is needed to be added for auto link url.