### PR TITLE
Remove tslint from recommended extension list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
     "recommendations": [
         "esbenp.prettier-vscode",
-        "ms-vscode.vscode-typescript-tslint-plugin",
         "miclo.sort-typescript-imports",
         "streetsidesoftware.code-spell-checker"
     ]


### PR DESCRIPTION
Remove the extension `ms-vscode.vscode-typescript-tslint-plugin` from the recommended extension list since we don't use it any more.