### PR TITLE
Restore iOS auto-capitalization by delegating Backspace to the browser

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -275,6 +275,7 @@ export class EditPlugin implements EditorPlugin {
         switch (rawEvent.inputType) {
             case 'deleteContentBackward':
                 if (!this.shouldBrowserHandleBackspace(editor)) {
+                    // This logic is Android specific. It's because some Android keyboard doesn't support key and keycode, the value of them is always Unidentified, so we have to manually create a new one.
                     handled = keyboardDelete(
                         editor,
                         new KeyboardEvent('keydown', {

--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -313,7 +313,7 @@ export class EditPlugin implements EditorPlugin {
         const opt = this.options.shouldHandleBackspaceKey;
         switch (typeof opt) {
             case 'function':
-                return Boolean(opt(editor));
+                return opt(editor);
             case 'boolean':
                 return opt;
             default:

--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -320,4 +320,3 @@ export class EditPlugin implements EditorPlugin {
         }
     }
 }
-

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardDelete.ts
@@ -41,14 +41,7 @@ export function keyboardDelete(
     let handled = false;
     const selection = editor.getDOMSelection();
 
-    if (
-        shouldDeleteWithContentModel(
-            selection,
-            rawEvent,
-            handleExpandedSelection,
-            editor.getEnvironment().isIOS ?? false
-        )
-    ) {
+    if (shouldDeleteWithContentModel(selection, rawEvent, handleExpandedSelection)) {
         editor.formatContentModel(
             (model, context) => {
                 const result = deleteSelection(
@@ -99,8 +92,7 @@ function getDeleteSteps(rawEvent: KeyboardEvent, isMac: boolean): (DeleteSelecti
 function shouldDeleteWithContentModel(
     selection: DOMSelection | null,
     rawEvent: KeyboardEvent,
-    handleExpandedSelection: boolean,
-    isIOS: boolean
+    handleExpandedSelection: boolean
 ) {
     if (!selection) {
         return false; // Nothing to delete
@@ -129,19 +121,15 @@ function shouldDeleteWithContentModel(
         return !(
             isNodeOfType(startContainer, 'TEXT_NODE') &&
             !isModifierKey(rawEvent) &&
-            (canDeleteBefore(rawEvent, startContainer, startOffset, isIOS) ||
+            (canDeleteBefore(rawEvent, startContainer, startOffset) ||
                 canDeleteAfter(rawEvent, startContainer, startOffset))
         );
     }
 }
 
-function canDeleteBefore(rawEvent: KeyboardEvent, text: Text, offset: number, isIOS: boolean) {
-    if (rawEvent.key != 'Backspace') {
+function canDeleteBefore(rawEvent: KeyboardEvent, text: Text, offset: number) {
+    if (rawEvent.key != 'Backspace' || offset <= 1) {
         return false;
-    }
-    if (offset <= 1) {
-        // For iOS, allow browser to handle deletion of first character on iOS to preserve auto-capitalization
-        return offset === 1 && isIOS;
     }
 
     const length = text.nodeValue?.length ?? 0;

--- a/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
@@ -137,7 +137,6 @@ describe('EditPlugin', () => {
             expect(keyboardTabSpy).not.toHaveBeenCalled();
         });
 
-
         it('handleExpandedSelectionOnDelete disabled', () => {
             plugin = new EditPlugin({ handleExpandedSelectionOnDelete: false });
             const rawEvent = { key: 'Delete' } as any;

--- a/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
@@ -120,6 +120,24 @@ describe('EditPlugin', () => {
             expect(keyboardDeleteSpy).toHaveBeenCalledWith(editor, rawEvent, true);
         });
 
+        it('Backspace with shouldHandleBackspaceKey boolean true', () => {
+            plugin = new EditPlugin({ shouldHandleBackspaceKey: true });
+            const rawEvent = { key: 'Backspace' } as any;
+
+            plugin.initialize(editor);
+
+            plugin.onPluginEvent({
+                eventType: 'keyDown',
+                rawEvent,
+            });
+
+            expect(keyboardDeleteSpy).not.toHaveBeenCalled();
+            expect(keyboardInputSpy).not.toHaveBeenCalled();
+            expect(keyboardEnterSpy).not.toHaveBeenCalled();
+            expect(keyboardTabSpy).not.toHaveBeenCalled();
+        });
+
+
         it('handleExpandedSelectionOnDelete disabled', () => {
             plugin = new EditPlugin({ handleExpandedSelectionOnDelete: false });
             const rawEvent = { key: 'Delete' } as any;


### PR DESCRIPTION
# Summary
We’ve observed that iOS maintains internal text-input state (e.g., keyboard auto-capitalization). When we intercept Backspace with preventDefault(), that state can incorrectly. 

# Code changes
1. Adding a callback to delegate Backspace to the browser.


# Issue
Our previous PR already fixed the issue where the system didn’t handle backspace when 'offset == 1'. However, since 'offset == 0' is still handled by the Content Model, the system’s internal state becomes inconsistent, which leads to auto-capitalization being triggered incorrectly.

![Simulator Screen Recording - 15PRO(MailUIKIT Test) - 2025-09-16 at 15 12 54](https://github.com/user-attachments/assets/c4b783f2-3381-4d77-af4b-c7a963df6190)

