### PR TITLE
Touch - Fix selection range collapsed issue when pressing touch on a word

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/contextMenu/ContextMenuPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/contextMenu/ContextMenuPlugin.ts
@@ -46,7 +46,8 @@ class ContextMenuPlugin implements PluginWithState<ContextMenuPluginState> {
             { [P in keyof HTMLElementEventMap]: DOMEventRecord<HTMLElementEventMap[P]> }
         > = {
             contextmenu: {
-                beforeDispatch: e => this.onContextMenuEvent(e),
+                beforeDispatch: (event: MouseEvent | PointerEvent) =>
+                    this.onContextMenuEvent(event),
             },
         };
         this.disposer = this.editor.attachDomEvent(<Record<string, DOMEventRecord>>eventHandlers);
@@ -68,10 +69,11 @@ class ContextMenuPlugin implements PluginWithState<ContextMenuPluginState> {
         return this.state;
     }
 
-    private onContextMenuEvent = (e: PointerEvent) => {
+    private onContextMenuEvent = (e: MouseEvent | PointerEvent) => {
         if (this.editor) {
             const allItems: any[] = [];
             const mouseEvent = e as MouseEvent;
+            const pointerEvent = e as PointerEvent;
 
             // ContextMenu event can be triggered from mouse right click or keyboard (e.g. Shift+F10 on Windows)
             // Need to check if this is from keyboard, we need to get target node from selection because in that case
@@ -79,8 +81,8 @@ class ContextMenuPlugin implements PluginWithState<ContextMenuPluginState> {
             const targetNode =
                 mouseEvent.button == ContextMenuButton
                     ? (mouseEvent.target as Node)
-                    : e.pointerType === 'touch' || e.pointerType === 'pen'
-                    ? (e.target as Node)
+                    : pointerEvent?.pointerType === 'touch' || pointerEvent?.pointerType === 'pen'
+                    ? (pointerEvent.target as Node)
                     : this.getFocusedNode(this.editor);
 
             if (targetNode) {


### PR DESCRIPTION
Issue: When pressing onto a word by touch or pen, it selects the entire word and trigger context menu event, but then move cursor to the beginning of the word.

Recording showing the wrong behavior
![fix-touch-press-word](https://github.com/user-attachments/assets/0deb4a2b-3275-4617-b1df-7b14f13b2292)

This happens because we collapse the selection range in `getFocusNode` if it is not context menu event triggered by mouse. Add another check for touch to avoid getting into `getFocusNode` to fix it.