### PR TITLE
[AutoFormat] Handle input exclusively

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/AutoFormatPlugin.ts
@@ -124,7 +124,6 @@ export class AutoFormatPlugin implements EditorPlugin {
 
     willHandleEventExclusively(event: PluginEvent) {
         if (this.editor) {
-            console.log(event);
             switch (event.eventType) {
                 case 'input':
                     return this.shouldHandleInputEventExclusively(this.editor, event);

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/link/isLastWordUrl.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/link/isLastWordUrl.ts
@@ -4,7 +4,9 @@ import { matchLink } from 'roosterjs-content-model-api';
  * @internal
  */
 export const isLastWordUrl = (text: string): boolean => {
-    if (!text) return false;
+    if (!text) {
+        return false;
+    }
 
     const words = text.trim().split(/\s+/);
     const lastWord = words[words.length - 1];
@@ -12,6 +14,11 @@ export const isLastWordUrl = (text: string): boolean => {
     const isMailto = lastWord.toLowerCase().startsWith('mailto:');
     const isTel = lastWord.toLowerCase().startsWith('tel:');
 
+    if (isMailto || isTel) {
+        const protocolLength = isMailto ? 7 : 4; // 'mailto:' = 7, 'tel:' = 4
+        return lastWord.length > protocolLength;
+    }
+
     // Use matchLink for other URL types
-    return !!matchLink(lastWord)?.normalizedUrl || isMailto || isTel;
+    return !!matchLink(lastWord)?.normalizedUrl;
 };

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/link/isLastWordUrl.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/link/isLastWordUrl.ts
@@ -1,0 +1,13 @@
+import { matchLink } from 'roosterjs-content-model-api';
+
+/**
+ * @internal
+ */
+export const isLastWordUrl = (text: string): boolean => {
+    if (!text) return false;
+
+    const words = text.trim().split(/\s+/);
+    const lastWord = words[words.length - 1];
+
+    return !!matchLink(lastWord)?.normalizedUrl;
+};

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/link/isLastWordUrl.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/link/isLastWordUrl.ts
@@ -9,5 +9,9 @@ export const isLastWordUrl = (text: string): boolean => {
     const words = text.trim().split(/\s+/);
     const lastWord = words[words.length - 1];
 
-    return !!matchLink(lastWord)?.normalizedUrl;
+    const isMailto = lastWord.toLowerCase().startsWith('mailto:');
+    const isTel = lastWord.toLowerCase().startsWith('tel:');
+
+    // Use matchLink for other URL types
+    return !!matchLink(lastWord)?.normalizedUrl || isMailto || isTel;
 };

--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/list/isLetterFollowedByMarker.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/list/isLetterFollowedByMarker.ts
@@ -1,0 +1,18 @@
+/**
+ * @internal
+ */
+export const isLetterFollowedByMarker = (text: string): boolean => {
+    if (!text || text.length !== 2) {
+        return false;
+    }
+
+    // Check if the string ends with ), . or -
+    const lastChar = text[text.length - 1];
+    if (lastChar !== ')' && lastChar !== '.' && lastChar !== '-') {
+        return false;
+    }
+
+    // Check if the first character is a single letter
+    const firstChar = text[0];
+    return /^[a-zA-Z]$/.test(firstChar);
+};

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/link/isLastWordUrlTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/link/isLastWordUrlTest.ts
@@ -1,0 +1,86 @@
+import { isLastWordUrl } from '../../../lib/autoFormat/link/isLastWordUrl';
+
+describe('isLastWordUrl', () => {
+    it('should return true for valid HTTP URLs as last word', () => {
+        expect(isLastWordUrl('Check out https://example.com')).toBe(true);
+        expect(isLastWordUrl('Visit https://www.google.com')).toBe(true);
+        expect(isLastWordUrl('Go to http://localhost:3000')).toBe(true);
+        expect(isLastWordUrl('https://github.com')).toBe(true);
+    });
+
+    it('should return true for valid HTTPS URLs as last word', () => {
+        expect(isLastWordUrl('Check https://secure.example.com')).toBe(true);
+        expect(isLastWordUrl('Visit https://api.github.com/users')).toBe(true);
+        expect(isLastWordUrl('https://example.com/path?query=value')).toBe(true);
+    });
+
+    it('should return true for www URLs as last word', () => {
+        expect(isLastWordUrl('Visit www.example.com')).toBe(true);
+        expect(isLastWordUrl('Go to www.google.com')).toBe(true);
+        expect(isLastWordUrl('Check www.github.com')).toBe(true);
+    });
+
+    it('should return true for FTP URLs as last word', () => {
+        expect(isLastWordUrl('Download from ftp://files.example.com')).toBe(true);
+        expect(isLastWordUrl('ftp://ftp.gnu.org/gnu')).toBe(true);
+    });
+
+    it('should return true for mailto URLs as last word', () => {
+        expect(isLastWordUrl('Contact mailto:test@example.com')).toBe(true);
+        expect(isLastWordUrl('Email mailto:support@company.com')).toBe(true);
+    });
+
+    it('should return true for tel URLs as last word', () => {
+        expect(isLastWordUrl('Call tel:+1234567890')).toBe(true);
+        expect(isLastWordUrl('Phone tel:555-0123')).toBe(true);
+    });
+
+    it('should return false for empty or null input', () => {
+        expect(isLastWordUrl('')).toBe(false);
+        expect(isLastWordUrl(null as any)).toBe(false);
+        expect(isLastWordUrl(undefined as any)).toBe(false);
+    });
+
+    it('should return false when last word is not a URL', () => {
+        expect(isLastWordUrl('This is normal text')).toBe(false);
+        expect(isLastWordUrl('No URL here word')).toBe(false);
+        expect(isLastWordUrl('Just a sentence')).toBe(false);
+    });
+
+    it('should return false when URL is not the last word', () => {
+        expect(isLastWordUrl('Visit https://example.com today')).toBe(false);
+        expect(isLastWordUrl('Check www.google.com for more info')).toBe(false);
+        expect(isLastWordUrl('Email mailto:test@example.com now')).toBe(false);
+    });
+
+    it('should return false for incomplete URLs', () => {
+        expect(isLastWordUrl('Just http')).toBe(false);
+        expect(isLastWordUrl('Only https')).toBe(false);
+        expect(isLastWordUrl('Just www')).toBe(false);
+        expect(isLastWordUrl('Only ftp')).toBe(false);
+    });
+
+    it('should return false for URLs with spaces', () => {
+        expect(isLastWordUrl('https://example .com')).toBe(false);
+        expect(isLastWordUrl('www.example .com')).toBe(false);
+    });
+
+    it('should handle URLs with complex paths and parameters', () => {
+        expect(
+            isLastWordUrl('Visit https://example.com/path/to/resource?param1=value1&param2=value2')
+        ).toBe(true);
+        expect(isLastWordUrl('Check www.example.com/search?q=test&type=all')).toBe(true);
+    });
+
+    it('should handle single word URLs', () => {
+        expect(isLastWordUrl('https://example.com')).toBe(true);
+        expect(isLastWordUrl('www.google.com')).toBe(true);
+        expect(isLastWordUrl('mailto:test@example.com')).toBe(true);
+    });
+
+    it('should be case insensitive for protocol', () => {
+        expect(isLastWordUrl('Visit HTTPS://EXAMPLE.COM')).toBe(true);
+        expect(isLastWordUrl('Go to HTTP://LOCALHOST')).toBe(true);
+        expect(isLastWordUrl('Email MAILTO:TEST@EXAMPLE.COM')).toBe(true);
+    });
+});

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/link/isLastWordUrlTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/link/isLastWordUrlTest.ts
@@ -20,11 +20,6 @@ describe('isLastWordUrl', () => {
         expect(isLastWordUrl('Check www.github.com')).toBe(true);
     });
 
-    it('should return true for FTP URLs as last word', () => {
-        expect(isLastWordUrl('Download from ftp://files.example.com')).toBe(true);
-        expect(isLastWordUrl('ftp://ftp.gnu.org/gnu')).toBe(true);
-    });
-
     it('should return true for mailto URLs as last word', () => {
         expect(isLastWordUrl('Contact mailto:test@example.com')).toBe(true);
         expect(isLastWordUrl('Email mailto:support@company.com')).toBe(true);
@@ -33,6 +28,26 @@ describe('isLastWordUrl', () => {
     it('should return true for tel URLs as last word', () => {
         expect(isLastWordUrl('Call tel:+1234567890')).toBe(true);
         expect(isLastWordUrl('Phone tel:555-0123')).toBe(true);
+        expect(isLastWordUrl('Contact tel:(555)123-4567')).toBe(true);
+    });
+
+    it('should return true for case-insensitive mailto and tel', () => {
+        expect(isLastWordUrl('Email MAILTO:TEST@EXAMPLE.COM')).toBe(true);
+        expect(isLastWordUrl('Call TEL:+1234567890')).toBe(true);
+        expect(isLastWordUrl('Contact Mailto:Support@Company.Com')).toBe(true);
+        expect(isLastWordUrl('Phone Tel:555-0123')).toBe(true);
+    });
+
+    it('should return false for incomplete mailto/tel URLs', () => {
+        expect(isLastWordUrl('Just mailto:')).toBe(false);
+        expect(isLastWordUrl('Only tel:')).toBe(false);
+        expect(isLastWordUrl('Email MAILTO:')).toBe(false);
+        expect(isLastWordUrl('Phone TEL:')).toBe(false);
+    });
+
+    it('should return false for mailto/tel without content', () => {
+        expect(isLastWordUrl('Contact mailto: ')).toBe(false);
+        expect(isLastWordUrl('Call tel: ')).toBe(false);
     });
 
     it('should return false for empty or null input', () => {
@@ -58,6 +73,8 @@ describe('isLastWordUrl', () => {
         expect(isLastWordUrl('Only https')).toBe(false);
         expect(isLastWordUrl('Just www')).toBe(false);
         expect(isLastWordUrl('Only ftp')).toBe(false);
+        expect(isLastWordUrl('Just mailto')).toBe(false);
+        expect(isLastWordUrl('Only tel')).toBe(false);
     });
 
     it('should return false for URLs with spaces', () => {
@@ -82,5 +99,19 @@ describe('isLastWordUrl', () => {
         expect(isLastWordUrl('Visit HTTPS://EXAMPLE.COM')).toBe(true);
         expect(isLastWordUrl('Go to HTTP://LOCALHOST')).toBe(true);
         expect(isLastWordUrl('Email MAILTO:TEST@EXAMPLE.COM')).toBe(true);
+        expect(isLastWordUrl('Call TEL:+1234567890')).toBe(true);
+    });
+
+    it('should handle valid mailto formats', () => {
+        expect(isLastWordUrl('Email mailto:user@domain.com')).toBe(true);
+        expect(isLastWordUrl('Contact mailto:first.last+tag@example.co.uk')).toBe(true);
+        expect(isLastWordUrl('Send mailto:test123@sub.domain.org')).toBe(true);
+    });
+
+    it('should handle valid tel formats', () => {
+        expect(isLastWordUrl('Call tel:+1-555-123-4567')).toBe(true);
+        expect(isLastWordUrl('Phone tel:555.123.4567')).toBe(true);
+        expect(isLastWordUrl('Contact tel:15551234567')).toBe(true);
+        expect(isLastWordUrl('Dial tel:+44-20-7946-0958')).toBe(true);
     });
 });

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/list/isLetterFollowedByMarkerTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/list/isLetterFollowedByMarkerTest.ts
@@ -1,0 +1,70 @@
+import { isLetterFollowedByMarker } from '../../../lib/autoFormat/list/isLetterFollowedByMarker';
+
+describe('isLetterFollowedByMarker', () => {
+    it('should return true for valid letter followed by )', () => {
+        expect(isLetterFollowedByMarker('a)')).toBe(true);
+        expect(isLetterFollowedByMarker('B)')).toBe(true);
+        expect(isLetterFollowedByMarker('z)')).toBe(true);
+        expect(isLetterFollowedByMarker('Z)')).toBe(true);
+    });
+
+    it('should return true for valid letter followed by .', () => {
+        expect(isLetterFollowedByMarker('a.')).toBe(true);
+        expect(isLetterFollowedByMarker('B.')).toBe(true);
+        expect(isLetterFollowedByMarker('z.')).toBe(true);
+        expect(isLetterFollowedByMarker('Z.')).toBe(true);
+    });
+
+    it('should return true for valid letter followed by -', () => {
+        expect(isLetterFollowedByMarker('a-')).toBe(true);
+        expect(isLetterFollowedByMarker('B-')).toBe(true);
+        expect(isLetterFollowedByMarker('z-')).toBe(true);
+        expect(isLetterFollowedByMarker('Z-')).toBe(true);
+    });
+
+    it('should return false for empty or null input', () => {
+        expect(isLetterFollowedByMarker('')).toBe(false);
+        expect(isLetterFollowedByMarker(null as any)).toBe(false);
+        expect(isLetterFollowedByMarker(undefined as any)).toBe(false);
+    });
+
+    it('should return false for strings that are too short', () => {
+        expect(isLetterFollowedByMarker('a')).toBe(false);
+        expect(isLetterFollowedByMarker('.')).toBe(false);
+        expect(isLetterFollowedByMarker(')')).toBe(false);
+        expect(isLetterFollowedByMarker('-')).toBe(false);
+    });
+
+    it('should return false for strings that are too long', () => {
+        expect(isLetterFollowedByMarker('ab.')).toBe(false);
+        expect(isLetterFollowedByMarker('abc)')).toBe(false);
+        expect(isLetterFollowedByMarker('test-')).toBe(false);
+    });
+
+    it('should return false for numbers followed by markers', () => {
+        expect(isLetterFollowedByMarker('1.')).toBe(false);
+        expect(isLetterFollowedByMarker('2)')).toBe(false);
+        expect(isLetterFollowedByMarker('9-')).toBe(false);
+    });
+
+    it('should return false for letters followed by invalid markers', () => {
+        expect(isLetterFollowedByMarker('a!')).toBe(false);
+        expect(isLetterFollowedByMarker('b?')).toBe(false);
+        expect(isLetterFollowedByMarker('c:')).toBe(false);
+        expect(isLetterFollowedByMarker('d;')).toBe(false);
+        expect(isLetterFollowedByMarker('e,')).toBe(false);
+    });
+
+    it('should return false for special characters followed by markers', () => {
+        expect(isLetterFollowedByMarker('*.')).toBe(false);
+        expect(isLetterFollowedByMarker('#)')).toBe(false);
+        expect(isLetterFollowedByMarker('@-')).toBe(false);
+        expect(isLetterFollowedByMarker('$.')).toBe(false);
+    });
+
+    it('should return false for mixed cases', () => {
+        expect(isLetterFollowedByMarker('1a.')).toBe(false);
+        expect(isLetterFollowedByMarker('a1.')).toBe(false);
+        expect(isLetterFollowedByMarker('a b.')).toBe(false);
+    });
+});


### PR DESCRIPTION
After inputting a link URL or characters that triggers a list, handle the input event exclusively to avoid auto capitalization, when AutoCorrect Plugin is enabled.  