### PR TITLE
Improve table selection

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -559,6 +559,10 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
 
             range.setStart(posStart.node, posStart.offset);
             range.setEnd(posEnd.node, posEnd.offset);
+
+            if (range.toString() === '') {
+                range.collapse(true /* toStart */);
+            }
         } else {
             // Get deepest editable position in the cell
             const { node, offset } = normalizePos(cell, nodeOffset);

--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -177,9 +177,7 @@ export class EditPlugin implements EditorPlugin {
         ) {
             const selection = this.editor.getDOMSelection();
             const startContainer =
-                selection?.type == 'range' && selection.range.collapsed
-                    ? selection.range.startContainer
-                    : null;
+                selection?.type == 'range' ? selection.range.startContainer : null;
             const table = startContainer
                 ? this.editor.getDOMHelper().findClosestElementAncestor(startContainer, 'table')
                 : null;


### PR DESCRIPTION
1. In table, when press TAB key to move focus to the next cell, if the cell is empty, collapse the selection
2. In last table cell, when press TAB key, no matter if there is text selected, always create a new table row

Before:
![before](https://github.com/user-attachments/assets/7257e191-2424-4c07-9c00-8dc0c18018c7)

After:
![after](https://github.com/user-attachments/assets/b48edcc9-2a97-4d78-8aad-ec30732b86d0)
