### PR TITLE
Support CloneIndependentRoot feature

### DIFF
--- a/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -66,6 +66,7 @@ const initialState: OptionState = {
         'PersistCache',
         'HandleEnterKey',
         'CustomCopyCut',
+        'CloneIndependentRoot',
     ]),
 };
 

--- a/demo/scripts/controlsV2/sidePane/editorOptions/ExperimentalFeatures.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/ExperimentalFeatures.tsx
@@ -14,6 +14,7 @@ export class ExperimentalFeatures extends React.Component<DefaultFormatProps, {}
                 {this.renderFeature('PersistCache')}
                 {this.renderFeature('HandleEnterKey')}
                 {this.renderFeature('CustomCopyCut')}
+                {this.renderFeature('CloneIndependentRoot')}
             </>
         );
     }

--- a/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
@@ -5,13 +5,15 @@ import type {
     DOMHelper,
 } from 'roosterjs-content-model-types';
 
+/**
+ * @internal
+ */
+export interface DOMHelperImplOption {
+    cloneIndependentRoot?: boolean;
+}
+
 class DOMHelperImpl implements DOMHelper {
-    constructor(
-        private contentDiv: HTMLElement,
-        private options: {
-            cloneIndependentRoot?: boolean;
-        }
-    ) {}
+    constructor(private contentDiv: HTMLElement, private options: DOMHelperImplOption) {}
 
     queryElements(selector: string): HTMLElement[] {
         return toArray(this.contentDiv.querySelectorAll(selector)) as HTMLElement[];
@@ -153,9 +155,7 @@ class DOMHelperImpl implements DOMHelper {
  */
 export function createDOMHelper(
     contentDiv: HTMLElement,
-    options: {
-        cloneIndependentRoot?: boolean;
-    } = {}
+    options: DOMHelperImplOption = {}
 ): DOMHelper {
     return new DOMHelperImpl(contentDiv, options);
 }

--- a/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/DOMHelperImpl.ts
@@ -6,7 +6,12 @@ import type {
 } from 'roosterjs-content-model-types';
 
 class DOMHelperImpl implements DOMHelper {
-    constructor(private contentDiv: HTMLElement) {}
+    constructor(
+        private contentDiv: HTMLElement,
+        private options: {
+            cloneIndependentRoot?: boolean;
+        }
+    ) {}
 
     queryElements(selector: string): HTMLElement[] {
         return toArray(this.contentDiv.querySelectorAll(selector)) as HTMLElement[];
@@ -90,7 +95,14 @@ class DOMHelperImpl implements DOMHelper {
      * Get a deep cloned root element
      */
     getClonedRoot(): HTMLElement {
-        return this.contentDiv.cloneNode(true /*deep*/) as HTMLElement;
+        if (this.options.cloneIndependentRoot) {
+            const doc = this.contentDiv.ownerDocument.implementation.createHTMLDocument();
+            const clone = doc.importNode(this.contentDiv, true /*deep*/);
+
+            return clone;
+        } else {
+            return this.contentDiv.cloneNode(true /*deep*/) as HTMLElement;
+        }
     }
 
     /**
@@ -139,6 +151,11 @@ class DOMHelperImpl implements DOMHelper {
 /**
  * @internal Create new instance of DOMHelper
  */
-export function createDOMHelper(contentDiv: HTMLElement): DOMHelper {
-    return new DOMHelperImpl(contentDiv);
+export function createDOMHelper(
+    contentDiv: HTMLElement,
+    options: {
+        cloneIndependentRoot?: boolean;
+    } = {}
+): DOMHelper {
+    return new DOMHelperImpl(contentDiv, options);
 }

--- a/packages/roosterjs-content-model-core/lib/editor/core/createEditorCore.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/core/createEditorCore.ts
@@ -50,7 +50,9 @@ export function createEditorCore(contentDiv: HTMLDivElement, options: EditorOpti
                 ? options.trustedHTMLHandler
                 : createTrustedHTMLHandler(domCreator),
         domCreator: domCreator,
-        domHelper: createDOMHelper(contentDiv),
+        domHelper: createDOMHelper(contentDiv, {
+            cloneIndependentRoot: options.experimentalFeatures?.includes('CloneIndependentRoot'),
+        }),
         ...getPluginState(corePlugins),
         disposeErrorHandler: options.disposeErrorHandler,
         onFixUpModel: options.onFixUpModel,

--- a/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/core/DOMHelperImplTest.ts
@@ -365,6 +365,31 @@ describe('DOMHelperImpl', () => {
             expect(result).toBe(mockedClone);
             expect(cloneSpy).toHaveBeenCalledWith(true);
         });
+
+        it('getClonedRoot, with CloneIndependentRoot on', () => {
+            const mockedClone = 'CLONE' as any;
+            const cloneSpy = jasmine.createSpy('cloneSpy').and.returnValue(mockedClone);
+            const importNodeSpy = jasmine.createSpy('importNodeSpy').and.returnValue(mockedClone);
+            const mockedDiv: HTMLElement = {
+                cloneNode: cloneSpy,
+                ownerDocument: {
+                    implementation: {
+                        createHTMLDocument: () => ({
+                            importNode: importNodeSpy,
+                        }),
+                    },
+                },
+            } as any;
+            const domHelper = createDOMHelper(mockedDiv, {
+                cloneIndependentRoot: true,
+            });
+
+            const result = domHelper.getClonedRoot();
+
+            expect(result).toBe(mockedClone);
+            expect(cloneSpy).not.toHaveBeenCalled();
+            expect(importNodeSpy).toHaveBeenCalledWith(mockedDiv, true);
+        });
     });
 
     describe('getContainerFormat', () => {

--- a/packages/roosterjs-content-model-types/lib/editor/ExperimentalFeature.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/ExperimentalFeature.ts
@@ -35,4 +35,10 @@ export type ExperimentalFeature =
     /**
      * Export editor content as HTML using HTMLFast option
      */
-    | 'ExportHTMLFast';
+    | 'ExportHTMLFast'
+
+    /**
+     * Get cloned root element from an independent HTML document instead of current document.
+     * So any operation to the cloned root won't trigger network request for resources like images
+     */
+    | 'CloneIndependentRoot';


### PR DESCRIPTION
Today when we extract HTML from editor using ExportHTMLFast feature, we first clone a DOM tree, then pass it to plugins to do clean up. However, if plugin wants to set src of image, it will trigger an image downloading service call. This is a browser behavior.

In this change, I create a new experimental feature `CloneIndependentRoot`, when set, we will create an independent HTML document using `document.implementation.createHTMLDocument()`, then call `importNode()` to clone the DOM tree, this makes the cloned tree to be under this independent document context, so setting src of IMG won't really download it.