### PR TITLE
Add callback for Table CellResizer

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/TableEditor.ts
+++ b/packages/roosterjs-content-model-plugins/lib/tableEdit/editors/TableEditor.ts
@@ -256,7 +256,8 @@ export class TableEditor {
                 true /*isHorizontal*/,
                 this.onStartCellResize,
                 this.onFinishEditing,
-                this.anchorContainer
+                this.anchorContainer,
+                this.onTableEditorCreated
             );
             this.verticalResizer = createCellResizer(
                 this.editor,
@@ -266,7 +267,8 @@ export class TableEditor {
                 false /*isHorizontal*/,
                 this.onStartCellResize,
                 this.onFinishEditing,
-                this.anchorContainer
+                this.anchorContainer,
+                this.onTableEditorCreated
             );
         }
     }


### PR DESCRIPTION
Add callback for Table CellResizer similar to other TableEditFeature.

With this, client will have more control over how they can define the resizer component and action.