### PR TITLE
Update ContextMenuProvider to accept event parameter and adjust relat…

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/contextMenu/ContextMenuPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/contextMenu/ContextMenuPlugin.ts
@@ -87,7 +87,7 @@ class ContextMenuPlugin implements PluginWithState<ContextMenuPluginState> {
 
             if (targetNode) {
                 this.state.contextMenuProviders.forEach(provider => {
-                    const items = provider.getContextMenuItems(targetNode) ?? [];
+                    const items = provider.getContextMenuItems(targetNode, mouseEvent) ?? [];
                     if (items?.length > 0) {
                         if (allItems.length > 0) {
                             allItems.push(null);

--- a/packages/roosterjs-content-model-core/test/corePlugin/contextMenu/ContextMenuPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/contextMenu/ContextMenuPluginTest.ts
@@ -105,8 +105,8 @@ describe('ContextMenu handle other event', () => {
         expect(collapseSpy).not.toHaveBeenCalled();
         expect(getDOMSelectionSpy).not.toHaveBeenCalled();
         expect(getSelectionRootNodeSpy).not.toHaveBeenCalled();
-        expect(getContextMenuItemSpy1).toHaveBeenCalledWith(mockedTarget);
-        expect(getContextMenuItemSpy2).toHaveBeenCalledWith(mockedTarget);
+        expect(getContextMenuItemSpy1).toHaveBeenCalledWith(mockedTarget, mockedEvent);
+        expect(getContextMenuItemSpy2).toHaveBeenCalledWith(mockedTarget, mockedEvent);
         expect(triggerEventSpy).toHaveBeenCalledWith('contextMenu', {
             rawEvent: mockedEvent,
             items: ['Item1', 'Item2', null, 'Item3', 'Item4'],
@@ -159,8 +159,8 @@ describe('ContextMenu handle other event', () => {
         expect(collapseSpy).toHaveBeenCalledWith(true);
         expect(getDOMSelectionSpy).toHaveBeenCalledWith();
         expect(getSelectionRootNodeSpy).toHaveBeenCalledWith(mockedSelection);
-        expect(getContextMenuItemSpy1).toHaveBeenCalledWith(mockedNode);
-        expect(getContextMenuItemSpy2).toHaveBeenCalledWith(mockedNode);
+        expect(getContextMenuItemSpy1).toHaveBeenCalledWith(mockedNode, mockedEvent);
+        expect(getContextMenuItemSpy2).toHaveBeenCalledWith(mockedNode, mockedEvent);
         expect(triggerEventSpy).toHaveBeenCalledWith('contextMenu', {
             rawEvent: mockedEvent,
             items: ['Item1', 'Item2', null, 'Item3', 'Item4'],

--- a/packages/roosterjs-content-model-types/lib/editor/ContextMenuProvider.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/ContextMenuProvider.ts
@@ -9,5 +9,5 @@ export interface ContextMenuProvider<T> extends EditorPlugin {
      * @param target Target node that triggered a ContextMenu event
      * @returns An array of context menu items, or null means no items needed
      */
-    getContextMenuItems: (target: Node) => T[] | null;
+    getContextMenuItems: (target: Node, event?: Event) => T[] | null;
 }


### PR DESCRIPTION
Pass in the event to getContextMenuItems function, so we can add or not add items based on the information of the event.