### PR TITLE
[Rooster Markdown] Support RTL

### DIFF
--- a/demo/scripts/controlsV2/sidePane/MarkdownPane/MarkdownPane.tsx
+++ b/demo/scripts/controlsV2/sidePane/MarkdownPane/MarkdownPane.tsx
@@ -16,10 +16,10 @@ export default class MarkdownPane extends React.Component<
     private emptyLinePreserve = React.createRef<HTMLInputElement>();
     private emptyLineRemove = React.createRef<HTMLInputElement>();
     private emptyLineMerge = React.createRef<HTMLInputElement>();
+    private isRTL = React.createRef<HTMLInputElement>();
 
     constructor(props: MarkdownPaneProps) {
         super(props);
-
         this.state = { emptyLine: 'merge' };
     }
 
@@ -32,6 +32,7 @@ export default class MarkdownPane extends React.Component<
                     : this.emptyLineRemove.current.checked
                     ? 'remove'
                     : 'merge',
+                direction: this.isRTL.current.checked ? 'rtl' : 'ltr',
             });
 
             model.blocks = markdownModel.blocks;
@@ -115,6 +116,8 @@ export default class MarkdownPane extends React.Component<
                         onClick={this.onEmptyLineChange}
                     />{' '}
                     <label htmlFor="emptyLineMerge">Merge</label>
+                    <input type="checkbox" name="RTL" id="isRTL" ref={this.isRTL} />{' '}
+                    <label htmlFor="isRTL">RTL</label>
                 </div>
                 <textarea
                     className={styles.textArea}

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createBlockGroupFromMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createBlockGroupFromMarkdown.ts
@@ -5,6 +5,7 @@ import type {
     ContentModelFormatContainer,
     ContentModelListItem,
 } from 'roosterjs-content-model-types';
+import type { MarkdownToModelOptions } from '../types/MarkdownToModelOptions';
 
 const MarkdownBlockGroupType: Record<string, ContentModelBlockGroupType> = {
     unordered_list: 'ListItem',
@@ -18,11 +19,12 @@ const MarkdownBlockGroupType: Record<string, ContentModelBlockGroupType> = {
 export function createBlockGroupFromMarkdown(
     text: string,
     patternName: string,
+    options: MarkdownToModelOptions,
     group?: ContentModelFormatContainer
 ): ContentModelFormatContainer | ContentModelListItem {
     if (MarkdownBlockGroupType[patternName] === 'ListItem') {
-        return createListFromMarkdown(text, patternName === 'ordered_list' ? 'OL' : 'UL');
+        return createListFromMarkdown(text, patternName === 'ordered_list' ? 'OL' : 'UL', options);
     } else {
-        return createBlockQuoteFromMarkdown(text, group);
+        return createBlockQuoteFromMarkdown(text, options, group);
     }
 }

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createBlockQuoteFromMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createBlockQuoteFromMarkdown.ts
@@ -4,6 +4,7 @@ import type {
     ContentModelFormatContainer,
     ContentModelFormatContainerFormat,
 } from 'roosterjs-content-model-types';
+import type { MarkdownToModelOptions } from '../types/MarkdownToModelOptions';
 
 const QuoteFormat: ContentModelFormatContainerFormat = {
     borderLeft: '3px solid rgb(200, 200, 200)',
@@ -20,11 +21,18 @@ const QuoteFormat: ContentModelFormatContainerFormat = {
  */
 export function createBlockQuoteFromMarkdown(
     text: string,
+    options: MarkdownToModelOptions,
     blockquote?: ContentModelFormatContainer
 ): ContentModelFormatContainer {
     text = text.replace('>', '');
-    const paragraph = createParagraphFromMarkdown(text);
-    const quote = blockquote || createFormatContainer('blockquote', QuoteFormat);
+    const paragraph = createParagraphFromMarkdown(text, options);
+    const quote =
+        blockquote ||
+        createFormatContainer(
+            'blockquote',
+            options.direction ? { ...QuoteFormat, direction: options.direction } : QuoteFormat
+        );
+
     quote.blocks.push(paragraph);
     return quote;
 }

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createListFromMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createListFromMarkdown.ts
@@ -1,23 +1,40 @@
 import { createListItem, createListLevel } from 'roosterjs-content-model-dom';
 import { createParagraphFromMarkdown } from './createParagraphFromMarkdown';
 import type { ContentModelListItem } from 'roosterjs-content-model-types';
+import type { MarkdownToModelOptions } from '../types/MarkdownToModelOptions';
 
 /**
  * @internal
  */
-export function createListFromMarkdown(text: string, listType: 'OL' | 'UL'): ContentModelListItem {
+export function createListFromMarkdown(
+    text: string,
+    listType: 'OL' | 'UL',
+    options: MarkdownToModelOptions
+): ContentModelListItem {
     const marker = text.trim().split(' ')[0];
     const isDummy = isDummyListItem(marker);
     const itemText = isDummy ? text : text.trim().substring(marker.length);
-    const paragraph = createParagraphFromMarkdown(itemText.trim());
-    const levels = createLevels(text, listType, isDummy);
+    const paragraph = createParagraphFromMarkdown(itemText.trim(), options);
+    const levels = createLevels(text, listType, isDummy, options);
     const listModel = createListItem(levels);
+    if (options.direction) {
+        listModel.format.direction = options.direction;
+    }
+
     listModel.blocks.push(paragraph);
     return listModel;
 }
 
-function createLevels(text: string, listType: 'OL' | 'UL', isDummy: boolean) {
-    const level = createListLevel(listType);
+function createLevels(
+    text: string,
+    listType: 'OL' | 'UL',
+    isDummy: boolean,
+    options: MarkdownToModelOptions
+) {
+    const level = createListLevel(
+        listType,
+        options.direction ? { direction: options.direction } : undefined
+    );
     if (isDummy) {
         level.format.displayForDummyItem = 'block';
     }

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createParagraphFromMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createParagraphFromMarkdown.ts
@@ -1,14 +1,21 @@
 import { applySegmentFormatting } from '../appliers/applySegmentFormatting';
 import { createParagraph } from 'roosterjs-content-model-dom';
 import { getHeadingDecorator } from '../utils/getHeadingDecorator';
-
+import type { MarkdownToModelOptions } from '../types/MarkdownToModelOptions';
 import type { ContentModelParagraph } from 'roosterjs-content-model-types';
 
 /**
  * @internal
  */
-export function createParagraphFromMarkdown(text: string): ContentModelParagraph {
-    const paragraph = createParagraph();
+export function createParagraphFromMarkdown(
+    text: string,
+    options: MarkdownToModelOptions
+): ContentModelParagraph {
+    const paragraph = createParagraph(
+        undefined /* isImplicit */,
+        options.direction ? { direction: options.direction } : undefined
+    );
+
     const headingType = getHeadingDecorator(text);
     if (headingType) {
         paragraph.decorator = headingType;

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createTableFromMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createTableFromMarkdown.ts
@@ -6,16 +6,26 @@ import {
     createTableCell,
     createTableRow,
 } from 'roosterjs-content-model-dom';
+import type { MarkdownToModelOptions } from '../types/MarkdownToModelOptions';
 
 /**
  * @internal
  */
-export function createTableFromMarkdown(tableLines: string[]): ContentModelTable {
+export function createTableFromMarkdown(
+    tableLines: string[],
+    options: MarkdownToModelOptions
+): ContentModelTable {
     const tableDivider = tableLines[1].split('|').filter(content => content.trim() !== '');
     tableLines.splice(1, 1);
-    const table = createTable(0, { borderCollapse: true });
+    const table = createTable(
+        0,
+        options.direction
+            ? { borderCollapse: true, direction: options.direction }
+            : { borderCollapse: true }
+    );
+
     for (const line of tableLines) {
-        createTableModel(line, table, tableDivider);
+        createTableModel(line, table, tableDivider, options);
     }
     applyTableFormat(table, {
         hasHeaderRow: true,
@@ -23,7 +33,12 @@ export function createTableFromMarkdown(tableLines: string[]): ContentModelTable
     return table;
 }
 
-function createTableModel(markdown: string, table: ContentModelTable, tableDivider: string[]) {
+function createTableModel(
+    markdown: string,
+    table: ContentModelTable,
+    tableDivider: string[],
+    options: MarkdownToModelOptions
+) {
     const contents = markdown.split('|');
     if (contents[0].trim() === '') {
         contents.shift();
@@ -32,15 +47,27 @@ function createTableModel(markdown: string, table: ContentModelTable, tableDivid
         contents.pop();
     }
 
-    addTableRow(table, contents, tableDivider);
+    addTableRow(table, contents, tableDivider, options);
 }
 
-function addTableRow(table: ContentModelTable, contents: string[], tableDivider: string[]) {
-    const row = createTableRow();
+function addTableRow(
+    table: ContentModelTable,
+    contents: string[],
+    tableDivider: string[],
+    options: MarkdownToModelOptions
+) {
+    const row = createTableRow(options.direction ? { direction: options.direction } : undefined);
+
     let index = 0;
     for (const content of contents) {
-        const paragraph = createParagraphFromMarkdown(content);
-        const cell = createTableCell();
+        const paragraph = createParagraphFromMarkdown(content, options);
+        const cell = createTableCell(
+            undefined /* spanLeftOrColSpan */,
+            undefined /* spanAboveOrRowSpan */,
+            undefined /* isHeader */,
+            options.direction ? { direction: options.direction } : undefined
+        );
+
         cell.blocks.push(paragraph);
         if (tableDivider[index]) {
             cell.format.textAlign = getCellAlignment(tableDivider[index]);

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/processor/markdownProcessor.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/processor/markdownProcessor.ts
@@ -95,11 +95,11 @@ function addMarkdownBlockToModel(
             isMarkdownTable(markdownContext.tableLines[1]) &&
             markdownContext.tableLines.length > 1
         ) {
-            const tableModel = createTableFromMarkdown(markdownContext.tableLines);
+            const tableModel = createTableFromMarkdown(markdownContext.tableLines, options);
             model.blocks.push(tableModel);
         } else {
             for (const line of markdownContext.tableLines) {
-                const paragraph = createParagraphFromMarkdown(line);
+                const paragraph = createParagraphFromMarkdown(line, options);
                 model.blocks.push(paragraph);
             }
         }
@@ -163,7 +163,7 @@ function addMarkdownBlockToModel(
 
     switch (blockType) {
         case 'Paragraph':
-            const paragraph = createParagraphFromMarkdown(markdown);
+            const paragraph = createParagraphFromMarkdown(markdown, options);
             model.blocks.push(paragraph);
             break;
         case 'Divider':
@@ -174,6 +174,7 @@ function addMarkdownBlockToModel(
             const blockGroup = createBlockGroupFromMarkdown(
                 markdown,
                 patternName,
+                options,
                 markdownContext.lastQuote
             );
             if (!markdownContext.lastQuote) {

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/types/MarkdownToModelOptions.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/types/MarkdownToModelOptions.ts
@@ -15,4 +15,10 @@ export interface MarkdownToModelOptions {
      * @default 'merge'
      */
     emptyLine?: 'preserve' | 'remove' | 'merge';
+
+    /**
+     * Specify the direction of the converted markdown text
+     * @default 'ltr'
+     */
+    direction?: 'ltr' | 'rtl' | undefined;
 }

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createBlockGroupFromMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createBlockGroupFromMarkdownTest.ts
@@ -1,5 +1,6 @@
 import { ContentModelFormatContainer, ContentModelListItem } from 'roosterjs-content-model-types';
 import { createBlockGroupFromMarkdown } from '../../../lib/markdownToModel/creators/createBlockGroupFromMarkdown';
+import { MarkdownToModelOptions } from '../../../lib/markdownToModel/types/MarkdownToModelOptions';
 import {
     createFormatContainer,
     createListItem,
@@ -23,10 +24,16 @@ describe('createBlockGroupFromMarkdown', () => {
         text: string,
         patternName: string,
         group: ContentModelFormatContainer | undefined,
-        expectedBlockGroup: ContentModelFormatContainer | ContentModelListItem
+        expectedBlockGroup: ContentModelFormatContainer | ContentModelListItem,
+        isRTL?: boolean
     ) {
+        const options: MarkdownToModelOptions = isRTL
+            ? {
+                  direction: 'rtl',
+              }
+            : {};
         // Act
-        const result = createBlockGroupFromMarkdown(text, patternName, group);
+        const result = createBlockGroupFromMarkdown(text, patternName, options, group);
 
         // Assert
         expect(result).toEqual(expectedBlockGroup);
@@ -147,5 +154,33 @@ describe('createBlockGroupFromMarkdown', () => {
         secondBlockquote.blocks.push(paragraph);
         secondBlockquote.blocks.push(secondParagraph);
         runTest('>Second Blockquote', 'blockquote', blockquote, secondBlockquote);
+    });
+
+    it('should return blockquote - RTL', () => {
+        const blockquote = createFormatContainer('blockquote', DEFAULT_BLOCKQUOTE);
+        const paragraph = createParagraph();
+        paragraph.format.direction = 'rtl';
+        const text = createText('First Blockquote');
+        paragraph.segments.push(text);
+
+        blockquote.blocks.push(paragraph);
+        blockquote.format.direction = 'rtl';
+
+        const secondBlockquote = createFormatContainer('blockquote', DEFAULT_BLOCKQUOTE);
+        const secondParagraph = createParagraph();
+        const secondText = createText('Second Blockquote');
+        secondParagraph.segments.push(secondText);
+        secondParagraph.format.direction = 'rtl';
+
+        secondBlockquote.blocks.push(paragraph);
+        secondBlockquote.blocks.push(secondParagraph);
+        secondBlockquote.format.direction = 'rtl';
+        runTest(
+            '>Second Blockquote',
+            'blockquote',
+            blockquote,
+            secondBlockquote,
+            true /* is RTL */
+        );
     });
 });

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createBlockQuoteFromMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createBlockQuoteFromMarkdownTest.ts
@@ -1,6 +1,7 @@
 import { ContentModelFormatContainer } from 'roosterjs-content-model-types';
 import { createBlockQuoteFromMarkdown } from '../../../lib/markdownToModel/creators/createBlockQuoteFromMarkdown';
 import { createFormatContainer, createParagraph, createText } from 'roosterjs-content-model-dom';
+import { MarkdownToModelOptions } from '../../../lib/markdownToModel/types/MarkdownToModelOptions';
 
 const DEFAULT_BLOCKQUOTE = {
     borderLeft: '3px solid rgb(200, 200, 200)',
@@ -16,10 +17,16 @@ describe('createBlockQuoteFromMarkdown', () => {
     function runTest(
         text: string,
         blockquote: ContentModelFormatContainer | undefined,
-        expectedBlockquote: ContentModelFormatContainer
+        expectedBlockquote: ContentModelFormatContainer,
+        isRTL?: boolean
     ) {
+        const options: MarkdownToModelOptions = isRTL
+            ? {
+                  direction: 'rtl',
+              }
+            : {};
         // Act
-        const result = createBlockQuoteFromMarkdown(text, blockquote);
+        const result = createBlockQuoteFromMarkdown(text, options, blockquote);
         expect(result).toEqual(expectedBlockquote);
     }
 
@@ -63,5 +70,24 @@ describe('createBlockQuoteFromMarkdown', () => {
         paragraph.segments.push(text);
         blockquote.blocks.push(paragraph);
         runTest('># text', undefined, blockquote);
+    });
+
+    it('should return blockquote with heading - RTL', () => {
+        const blockquote = createFormatContainer('blockquote', DEFAULT_BLOCKQUOTE);
+        const paragraph = createParagraph();
+        paragraph.format.direction = 'rtl';
+        blockquote.format.direction = 'rtl';
+
+        const text = createText('text');
+        paragraph.decorator = {
+            tagName: 'h1',
+            format: {
+                fontSize: '2em',
+                fontWeight: 'bold',
+            },
+        };
+        paragraph.segments.push(text);
+        blockquote.blocks.push(paragraph);
+        runTest('># text', undefined, blockquote, true /* isRTL */);
     });
 });

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createListFromMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createListFromMarkdownTest.ts
@@ -1,5 +1,6 @@
 import { ContentModelListItem } from 'roosterjs-content-model-types';
 import { createListFromMarkdown } from '../../../lib/markdownToModel/creators/createListFromMarkdown';
+import { MarkdownToModelOptions } from '../../../lib/markdownToModel/types/MarkdownToModelOptions';
 import {
     createListItem,
     createListLevel,
@@ -11,10 +12,16 @@ describe('createListFromMarkdown', () => {
     function runTest(
         text: string,
         patternName: 'OL' | 'UL',
-        expectedBlockGroup: ContentModelListItem
+        expectedBlockGroup: ContentModelListItem,
+        isRTL?: boolean
     ) {
+        const options: MarkdownToModelOptions = isRTL
+            ? {
+                  direction: 'rtl',
+              }
+            : {};
         // Act
-        const result = createListFromMarkdown(text, patternName);
+        const result = createListFromMarkdown(text, patternName, options);
 
         // Assert
         expect(result.blocks).toEqual(expectedBlockGroup.blocks);
@@ -132,5 +139,23 @@ describe('createListFromMarkdown', () => {
         };
         listItem.blocks.push(paragraph);
         runTest('1. # text', 'OL', listItem);
+    });
+
+    it('should return list item for OL - RTL', () => {
+        const listItem = createListItem([createListLevel('OL', { direction: 'rtl' })]);
+        const paragraph = createParagraph();
+        paragraph.format.direction = 'rtl';
+        listItem.format.direction = 'rtl';
+        const text = createText('text');
+        paragraph.segments.push(text);
+        paragraph.decorator = {
+            tagName: 'h1',
+            format: {
+                fontSize: '2em',
+                fontWeight: 'bold',
+            },
+        };
+        listItem.blocks.push(paragraph);
+        runTest('1. # text', 'OL', listItem, true /* isRTL */);
     });
 });

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createParagraphFromMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createParagraphFromMarkdownTest.ts
@@ -1,11 +1,17 @@
 import { ContentModelParagraph } from 'roosterjs-content-model-types';
 import { createImage, createParagraph, createText } from 'roosterjs-content-model-dom';
 import { createParagraphFromMarkdown } from '../../../lib/markdownToModel/creators/createParagraphFromMarkdown';
+import { MarkdownToModelOptions } from '../../../lib/markdownToModel/types/MarkdownToModelOptions';
 
 describe('createParagraphFromMarkdown', () => {
-    function runTest(text: string, expectedContentModel: ContentModelParagraph) {
+    function runTest(text: string, expectedContentModel: ContentModelParagraph, isRTL?: boolean) {
+        const options: MarkdownToModelOptions = isRTL
+            ? {
+                  direction: 'rtl',
+              }
+            : {};
         // Act
-        const result = createParagraphFromMarkdown(text);
+        const result = createParagraphFromMarkdown(text, options);
 
         // Assert
         expect(result).toEqual(expectedContentModel);
@@ -239,5 +245,27 @@ describe('createParagraphFromMarkdown', () => {
             },
         };
         runTest('# [link](https://www.example.com)', paragraph);
+    });
+
+    it('should have heading 1 with link - rtl', () => {
+        const paragraph = createParagraph();
+        paragraph.format.direction = 'rtl';
+        const link = createText('link');
+        link.link = {
+            dataset: {},
+            format: {
+                href: 'https://www.example.com',
+                underline: true,
+            },
+        };
+        paragraph.segments.push(link);
+        paragraph.decorator = {
+            tagName: 'h1',
+            format: {
+                fontSize: '2em',
+                fontWeight: 'bold',
+            },
+        };
+        runTest('# [link](https://www.example.com)', paragraph, true /* isRTL */);
     });
 });

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createTableFromMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createTableFromMarkdownTest.ts
@@ -1,5 +1,6 @@
 import { ContentModelTable } from 'roosterjs-content-model-types';
 import { createTableFromMarkdown } from '../../../lib/markdownToModel/creators/createTableFromMarkdown';
+import { MarkdownToModelOptions } from '../../../lib/markdownToModel/types/MarkdownToModelOptions';
 import {
     applyTableFormat,
     createParagraph,
@@ -10,9 +11,14 @@ import {
 } from 'roosterjs-content-model-dom';
 
 describe('createTableFromMarkdown', () => {
-    function runTest(tableLines: string[], expectedTable: ContentModelTable) {
+    function runTest(tableLines: string[], expectedTable: ContentModelTable, isRTL?: boolean) {
+        const options: MarkdownToModelOptions = isRTL
+            ? {
+                  direction: 'rtl',
+              }
+            : {};
         // Act
-        const result = createTableFromMarkdown(tableLines);
+        const result = createTableFromMarkdown(tableLines, options);
 
         // Assert
         expect(result).toEqual(expectedTable);
@@ -48,6 +54,45 @@ describe('createTableFromMarkdown', () => {
             hasHeaderRow: true,
         });
         runTest(['|text1|', '|----|', '|text2|'], table);
+    });
+
+    it('should return table with two rows and one column - RTL', () => {
+        const table = createTable(0, {
+            borderCollapse: true,
+        });
+        table.format.direction = 'rtl';
+        const row1 = createTableRow();
+        const cell1 = createTableCell();
+        const paragraph1 = createParagraph();
+        const text1 = createText('text1');
+        paragraph1.segments.push(text1);
+        cell1.blocks.push(paragraph1);
+        cell1.format.textAlign = 'start';
+        cell1.isHeader = true;
+        row1.cells.push(cell1);
+        row1.format.direction = 'rtl';
+        paragraph1.format.direction = 'rtl';
+        cell1.format.direction = 'rtl';
+
+        table.rows.push(row1);
+
+        const row2 = createTableRow();
+        const cell2 = createTableCell();
+        const paragraph2 = createParagraph();
+        const text2 = createText('text2');
+        paragraph2.segments.push(text2);
+        cell2.blocks.push(paragraph2);
+        cell2.format.textAlign = 'start';
+        row2.cells.push(cell2);
+        paragraph2.format.direction = 'rtl';
+        cell2.format.direction = 'rtl';
+        row2.format.direction = 'rtl';
+
+        table.rows.push(row2);
+        applyTableFormat(table, {
+            hasHeaderRow: true,
+        });
+        runTest(['|text1|', '|----|', '|text2|'], table, true /* isRTL */);
     });
 
     it('should return table with two rows and two columns', () => {


### PR DESCRIPTION
Enable RTL conversion when converting markdown to content model. 
![ConvertRTL](https://github.com/user-attachments/assets/e1d440f7-1934-4d78-99f2-aee62130e392)
