### PR TITLE
Support passing event to getContextMenuItems when plugin is a MixedPlugin

### DIFF
--- a/packages/roosterjs-editor-adapter/lib/corePlugins/BridgePlugin.ts
+++ b/packages/roosterjs-editor-adapter/lib/corePlugins/BridgePlugin.ts
@@ -153,17 +153,28 @@ export class BridgePlugin implements ContextMenuProvider<any> {
      * @param target Target node that triggered a ContextMenu event
      * @returns An array of context menu items, or null means no items needed
      */
-    getContextMenuItems(target: Node): any[] {
+    getContextMenuItems(target: Node, event?: Event): any[] {
         const allItems: any[] = [];
 
         this.contextMenuProviders.forEach(provider => {
-            const items = provider.getContextMenuItems(target) ?? [];
-            if (items?.length > 0) {
-                if (allItems.length > 0) {
-                    allItems.push(null);
-                }
+            if (isV9ContextMenuProvider(provider)) {
+                const items = provider.getContextMenuItems(target, event) ?? [];
+                if (items?.length > 0) {
+                    if (allItems.length > 0) {
+                        allItems.push(null);
+                    }
 
-                allItems.push(...items);
+                    allItems.push(...items);
+                }
+            } else {
+                const items = provider.getContextMenuItems(target) ?? [];
+                if (items?.length > 0) {
+                    if (allItems.length > 0) {
+                        allItems.push(null);
+                    }
+
+                    allItems.push(...items);
+                }
             }
         });
 
@@ -218,6 +229,10 @@ export class BridgePlugin implements ContextMenuProvider<any> {
             plugin.onPluginEventV9?.(newEvent);
         }
     }
+}
+
+function isV9ContextMenuProvider(provider: any): provider is ContextMenuProvider<any> {
+    return (provider?.getContextMenuItems?.length || 0) == 2;
 }
 
 /**

--- a/packages/roosterjs-editor-adapter/lib/corePlugins/BridgePlugin.ts
+++ b/packages/roosterjs-editor-adapter/lib/corePlugins/BridgePlugin.ts
@@ -157,7 +157,7 @@ export class BridgePlugin implements ContextMenuProvider<any> {
         const allItems: any[] = [];
 
         this.contextMenuProviders.forEach(provider => {
-            if (isV9ContextMenuProvider(provider)) {
+            if (isMixedPluginProvider(provider)) {
                 const items = provider.getContextMenuItems(target, event) ?? [];
                 if (items?.length > 0) {
                     if (allItems.length > 0) {
@@ -236,9 +236,8 @@ export class BridgePlugin implements ContextMenuProvider<any> {
  * @param provider The provider to check
  * @returns True if the provider is a V9 context menu provider, false otherwise
  */
-function isV9ContextMenuProvider(provider: any): provider is ContextMenuProvider<any> {
-    // v9 getContextMenuItems has 2 parameters signature, use this check to confirm that the provider is v9
-    return (provider?.getContextMenuItems?.length || 0) == 2 && isMixedPlugin(provider);
+function isMixedPluginProvider(provider: any): provider is ContextMenuProvider<any> {
+    return isMixedPlugin(provider);
 }
 
 /**

--- a/packages/roosterjs-editor-adapter/lib/corePlugins/BridgePlugin.ts
+++ b/packages/roosterjs-editor-adapter/lib/corePlugins/BridgePlugin.ts
@@ -232,7 +232,7 @@ export class BridgePlugin implements ContextMenuProvider<any> {
 }
 
 function isV9ContextMenuProvider(provider: any): provider is ContextMenuProvider<any> {
-    return (provider?.getContextMenuItems?.length || 0) == 2;
+    return (provider?.getContextMenuItems?.length || 0) == 2 && isMixedPlugin(provider);
 }
 
 /**

--- a/packages/roosterjs-editor-adapter/lib/corePlugins/BridgePlugin.ts
+++ b/packages/roosterjs-editor-adapter/lib/corePlugins/BridgePlugin.ts
@@ -231,7 +231,13 @@ export class BridgePlugin implements ContextMenuProvider<any> {
     }
 }
 
+/**
+ * Check if a provider is a V9 context menu provider
+ * @param provider The provider to check
+ * @returns True if the provider is a V9 context menu provider, false otherwise
+ */
 function isV9ContextMenuProvider(provider: any): provider is ContextMenuProvider<any> {
+    // v9 getContextMenuItems has 2 parameters signature, use this check to confirm that the provider is v9
     return (provider?.getContextMenuItems?.length || 0) == 2 && isMixedPlugin(provider);
 }
 

--- a/packages/roosterjs-editor-adapter/test/corePlugins/BridgePluginTest.ts
+++ b/packages/roosterjs-editor-adapter/test/corePlugins/BridgePluginTest.ts
@@ -608,10 +608,7 @@ describe('BridgePlugin', () => {
             },
         } as any;
         const mockedDarkColorHandler = 'COLOR' as any;
-        const createDarkColorHandlerSpy = spyOn(
-            DarkColorHandler,
-            'createDarkColorHandler'
-        ).and.returnValue(mockedDarkColorHandler);
+        spyOn(DarkColorHandler, 'createDarkColorHandler').and.returnValue(mockedDarkColorHandler);
 
         plugin.initialize(mockedInnerEditor);
 
@@ -714,10 +711,7 @@ describe('BridgePlugin', () => {
             },
         } as any;
         const mockedDarkColorHandler = 'COLOR' as any;
-        const createDarkColorHandlerSpy = spyOn(
-            DarkColorHandler,
-            'createDarkColorHandler'
-        ).and.returnValue(mockedDarkColorHandler);
+        spyOn(DarkColorHandler, 'createDarkColorHandler').and.returnValue(mockedDarkColorHandler);
 
         plugin.initialize(mockedInnerEditor);
 
@@ -815,10 +809,7 @@ describe('BridgePlugin', () => {
             },
         } as any;
 
-        const createDarkColorHandlerSpy = spyOn(
-            DarkColorHandler,
-            'createDarkColorHandler'
-        ).and.returnValue('COLOR' as any);
+        spyOn(DarkColorHandler, 'createDarkColorHandler').and.returnValue('COLOR' as any);
 
         plugin.initialize(mockedInnerEditor);
 

--- a/packages/roosterjs-editor-adapter/test/corePlugins/BridgePluginTest.ts
+++ b/packages/roosterjs-editor-adapter/test/corePlugins/BridgePluginTest.ts
@@ -568,6 +568,7 @@ describe('BridgePlugin', () => {
             dispose: disposeSpy,
             getContextMenuItems: getContextMenuItemsSpyV9,
             getName: () => '',
+            initializeV9: jasmine.createSpy('initializeV9'),
         } as any;
 
         const mockedPluginRegular = {
@@ -672,6 +673,7 @@ describe('BridgePlugin', () => {
             dispose: disposeSpy,
             getContextMenuItems: getContextMenuItemsSpyV9Null,
             getName: () => '',
+            initializeV9: jasmine.createSpy('initializeV9'),
         } as any;
 
         const mockedPluginV9Items = {
@@ -679,6 +681,7 @@ describe('BridgePlugin', () => {
             dispose: disposeSpy,
             getContextMenuItems: getContextMenuItemsSpyV9Items,
             getName: () => '',
+            initializeV9: jasmine.createSpy('initializeV9'),
         } as any;
 
         const mockedEditor = {
@@ -772,6 +775,7 @@ describe('BridgePlugin', () => {
             dispose: disposeSpy,
             getContextMenuItems: getContextMenuItemsV9,
             getName: () => 'V9Plugin',
+            initializeV9: jasmine.createSpy('initializeV9'),
         } as any;
 
         const mockedPluginZero = {


### PR DESCRIPTION
In previous change I added support to pass in event to getContextMenuItems, now I am also adding the support to the BridgePlugin when the plugin is a MixedPlugin and getContextMenuItems needs 2 parameters.