### PR TITLE
Fix Align Attribute being removed on paste for containers

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop.ts
@@ -7,7 +7,7 @@ import { processWordComments } from './processWordComments';
 import { processWordList } from './processWordLists';
 import { removeNegativeTextIndentParser } from '../parsers/removeNegativeTextIndentParser';
 import { setProcessor } from '../utils/setProcessor';
-import { wordTableParser } from '../parsers/wordTableParser';
+import { wordContainerParser, wordTableParser } from '../parsers/wordTableParser';
 import type { WordMetadata } from './WordMetadata';
 import type { DomToModelOption, ElementProcessor } from 'roosterjs-content-model-types';
 
@@ -28,7 +28,7 @@ export function processPastedContentFromWordDesktop(
     addParser(domToModelOption, 'block', removeNegativeTextIndentParser);
     addParser(domToModelOption, 'listItemElement', removeNegativeTextIndentParser);
     addParser(domToModelOption, 'listLevel', listLevelParser);
-    addParser(domToModelOption, 'container', wordTableParser);
+    addParser(domToModelOption, 'container', wordContainerParser);
     addParser(domToModelOption, 'table', wordTableParser);
 }
 

--- a/packages/roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/WordDesktop/processPastedContentFromWordDesktop.ts
@@ -7,7 +7,8 @@ import { processWordComments } from './processWordComments';
 import { processWordList } from './processWordLists';
 import { removeNegativeTextIndentParser } from '../parsers/removeNegativeTextIndentParser';
 import { setProcessor } from '../utils/setProcessor';
-import { wordContainerParser, wordTableParser } from '../parsers/wordTableParser';
+import { wordContainerParser } from '../parsers/wordContainerParser';
+import { wordTableParser } from '../parsers/wordTableParser';
 import type { WordMetadata } from './WordMetadata';
 import type { DomToModelOption, ElementProcessor } from 'roosterjs-content-model-types';
 

--- a/packages/roosterjs-content-model-plugins/lib/paste/parsers/wordContainerParser.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/parsers/wordContainerParser.ts
@@ -1,0 +1,24 @@
+import type {
+    ContentModelFormatContainerFormat,
+    FormatParser,
+} from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ * Parser for processing container formatting specific to Word Desktop
+ * Removes negative margin-left values which are commonly used in Word lists
+ * @param format The container format to modify
+ * @param element The HTML element being processed
+ * @param context The DOM to model context
+ * @param defaultStyle The default style values
+ */
+export const wordContainerParser: FormatParser<ContentModelFormatContainerFormat> = (
+    format,
+    element,
+    context,
+    defaultStyle
+): void => {
+    if (format.marginLeft?.startsWith('-')) {
+        delete format.marginLeft;
+    }
+};

--- a/packages/roosterjs-content-model-plugins/lib/paste/parsers/wordContainerParser.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/parsers/wordContainerParser.ts
@@ -8,15 +8,9 @@ import type {
  * Parser for processing container formatting specific to Word Desktop
  * Removes negative margin-left values which are commonly used in Word lists
  * @param format The container format to modify
- * @param element The HTML element being processed
- * @param context The DOM to model context
- * @param defaultStyle The default style values
  */
 export const wordContainerParser: FormatParser<ContentModelFormatContainerFormat> = (
-    format,
-    element,
-    context,
-    defaultStyle
+    format
 ): void => {
     if (format.marginLeft?.startsWith('-')) {
         delete format.marginLeft;

--- a/packages/roosterjs-content-model-plugins/lib/paste/parsers/wordTableParser.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/parsers/wordTableParser.ts
@@ -1,4 +1,3 @@
-import { wordContainerParser } from './wordContainerParser';
 import type { ContentModelTableFormat, FormatParser } from 'roosterjs-content-model-types';
 
 /**
@@ -15,5 +14,3 @@ export const wordTableParser: FormatParser<ContentModelTableFormat> = (format, e
         delete format.htmlAlign;
     }
 };
-
-export { wordContainerParser };

--- a/packages/roosterjs-content-model-plugins/lib/paste/parsers/wordTableParser.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/parsers/wordTableParser.ts
@@ -1,3 +1,4 @@
+import { wordContainerParser } from './wordContainerParser';
 import type { ContentModelTableFormat, FormatParser } from 'roosterjs-content-model-types';
 
 /**
@@ -14,3 +15,5 @@ export const wordTableParser: FormatParser<ContentModelTableFormat> = (format, e
         delete format.htmlAlign;
     }
 };
+
+export { wordContainerParser };

--- a/packages/roosterjs-content-model-plugins/test/paste/parsers/wordContainerParserTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/parsers/wordContainerParserTest.ts
@@ -1,0 +1,112 @@
+import {
+    DomToModelContext,
+    ContentModelFormatContainerFormat,
+} from 'roosterjs-content-model-types';
+import { wordContainerParser } from '../../../lib/paste/parsers/wordContainerParser';
+
+describe('wordContainerParser', () => {
+    let format: ContentModelFormatContainerFormat;
+    let element: HTMLElement;
+    let context: DomToModelContext;
+
+    beforeEach(() => {
+        format = {};
+        element = document.createElement('div');
+        context = {} as any;
+    });
+
+    it('should remove negative margin-left with px units', () => {
+        format.marginLeft = '-20px';
+
+        wordContainerParser(format, element, context, {});
+
+        expect(format.marginLeft).toBeUndefined();
+    });
+
+    it('should remove negative margin-left with em units', () => {
+        format.marginLeft = '-1.5em';
+
+        wordContainerParser(format, element, context, {});
+
+        expect(format.marginLeft).toBeUndefined();
+    });
+
+    it('should remove negative margin-left with rem units', () => {
+        format.marginLeft = '-2rem';
+
+        wordContainerParser(format, element, context, {});
+
+        expect(format.marginLeft).toBeUndefined();
+    });
+
+    it('should remove negative margin-left with percentage', () => {
+        format.marginLeft = '-10%';
+
+        wordContainerParser(format, element, context, {});
+
+        expect(format.marginLeft).toBeUndefined();
+    });
+
+    it('should remove negative margin-left with decimal values', () => {
+        format.marginLeft = '-0.25in';
+
+        wordContainerParser(format, element, context, {});
+
+        expect(format.marginLeft).toBeUndefined();
+    });
+
+    it('should preserve positive margin-left', () => {
+        format.marginLeft = '20px';
+
+        wordContainerParser(format, element, context, {});
+
+        expect(format.marginLeft).toBe('20px');
+    });
+
+    it('should preserve zero margin-left', () => {
+        format.marginLeft = '0px';
+
+        wordContainerParser(format, element, context, {});
+
+        expect(format.marginLeft).toBe('0px');
+    });
+
+    it('should handle when margin-left is undefined', () => {
+        format.marginLeft = undefined;
+
+        wordContainerParser(format, element, context, {});
+
+        expect(format.marginLeft).toBeUndefined();
+    });
+
+    it('should handle when margin-left is empty string', () => {
+        format.marginLeft = '';
+
+        wordContainerParser(format, element, context, {});
+
+        expect(format.marginLeft).toBe('');
+    });
+
+    it('should handle format with leading spaces in margin-left', () => {
+        format.marginLeft = '  -15px';
+
+        wordContainerParser(format, element, context, {});
+
+        // Should NOT be removed because it doesn't start with '-' (has spaces)
+        expect(format.marginLeft).toBe('  -15px');
+    });
+
+    it('should only affect margin-left and not touch other properties', () => {
+        format.marginLeft = '-20px';
+        format.marginTop = '-10px';
+        format.paddingLeft = '-5px';
+        format.backgroundColor = 'red';
+
+        wordContainerParser(format, element, context, {});
+
+        expect(format.marginLeft).toBeUndefined();
+        expect(format.marginTop).toBe('-10px');
+        expect(format.paddingLeft).toBe('-5px');
+        expect(format.backgroundColor).toBe('red');
+    });
+});

--- a/packages/roosterjs-content-model-plugins/test/paste/parsers/wordContainerParserTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/parsers/wordContainerParserTest.ts
@@ -1,8 +1,8 @@
+import { wordContainerParser } from '../../../lib/paste/parsers/wordContainerParser';
 import {
     DomToModelContext,
     ContentModelFormatContainerFormat,
 } from 'roosterjs-content-model-types';
-import { wordContainerParser } from '../../../lib/paste/parsers/wordContainerParser';
 
 describe('wordContainerParser', () => {
     let format: ContentModelFormatContainerFormat;

--- a/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
@@ -33,6 +33,11 @@ describe('processPastedContentFromWordDesktopTest', () => {
             fragment,
             createDomToModelContext(undefined, event.domToModelOption)
         );
+
+        if (!expectedModel && !htmlBefore) {
+            navigator.clipboard.writeText(JSON.stringify(model));
+        }
+
         if (expectedModel) {
             if (removeUndefinedValues) {
                 expectEqual(model, expectedModel);
@@ -372,6 +377,24 @@ describe('processPastedContentFromWordDesktopTest', () => {
                         format: {},
                         widths: [],
                         dataset: {},
+                    },
+                ],
+            }
+        );
+    });
+
+    it('Preserve the htmlAlign from Format container', () => {
+        runTest(
+            '<div align="center"><table style="margin-left: -5px;"><tbody><tr><td>Test</td></tr><tbody></table></div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'BlockGroup',
+                        blockGroupType: 'FormatContainer',
+                        tagName: 'div',
+                        blocks: jasmine.any(Array),
+                        format: { htmlAlign: 'center' },
                     },
                 ],
             }

--- a/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWordDesktopTest.ts
@@ -34,10 +34,6 @@ describe('processPastedContentFromWordDesktopTest', () => {
             createDomToModelContext(undefined, event.domToModelOption)
         );
 
-        if (!expectedModel && !htmlBefore) {
-            navigator.clipboard.writeText(JSON.stringify(model));
-        }
-
         if (expectedModel) {
             if (removeUndefinedValues) {
                 expectEqual(model, expectedModel);


### PR DESCRIPTION
In previous PR https://github.com/microsoft/roosterjs/pull/3147 I updated the code from wordTableParser to make sure we remove the align prop from tables, however this caused an issue with containers, as the same function was also used for containers.

To fix add a new function explicitly for containers and don't use the same parser for word tables.

Added unit tests for this scenario.

Before after here:
https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/401167