### PR TITLE
Export formatContainerProcessor from public API #3236

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/formatContainerProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/formatContainerProcessor.ts
@@ -25,7 +25,25 @@ export const ContextStyles: (keyof (MarginFormat & PaddingFormat))[] = [
 ];
 
 /**
- * @internal
+ * Content Model Element Processor for format container
+ *
+ * This processor converts DOM elements into FormatContainer blocks in the content model.
+ * It can be used in processorOverride to force certain elements (like blockquote with zero margins)
+ * to always be processed as format containers, even when they don't meet the default criteria.
+ *
+ * @example
+ * ```typescript
+ * // Force blockquote elements to always use formatContainerProcessor
+ * const domToModelOption: DomToModelOption = {
+ *   processorOverride: {
+ *     blockquote: formatContainerProcessor
+ *   }
+ * };
+ * ```
+ *
+ * @param group The parent block group
+ * @param element Parent DOM node to process
+ * @param context DOM to Content Model context
  */
 export const formatContainerProcessor: ElementProcessor<HTMLElement> = (
     group,

--- a/packages/roosterjs-content-model-dom/lib/index.ts
+++ b/packages/roosterjs-content-model-dom/lib/index.ts
@@ -9,6 +9,7 @@ export {
 } from './domToModel/processors/childProcessor';
 export { entityProcessor } from './domToModel/processors/entityProcessor';
 export { tableProcessor } from './domToModel/processors/tableProcessor';
+export { formatContainerProcessor } from './domToModel/processors/formatContainerProcessor';
 export { getRegularSelectionOffsets } from './domToModel/utils/getRegularSelectionOffsets';
 export { parseFormat } from './domToModel/utils/parseFormat';
 export { areSameFormats } from './domToModel/utils/areSameFormats';


### PR DESCRIPTION
## Description
Export `formatContainerProcessor` from public API to allow users to use it in `processorOverride`.

## Use Case
We're building an email client and need to customize how `<blockquote>` elements are processed during DOM-to-Model conversion. Email citations use blockquotes with zero margins (`margin-top: 0; margin-bottom: 0`), and we want these blockquotes to always preserve their FormatContainer semantics, but the default `knownElementProcessor` only triggers `formatContainerProcessor` when certain style values are > 0.

## Changes
- Export `formatContainerProcessor` from `roosterjs-content-model-dom/lib/index.ts`
- Update documentation comments with usage examples

## Example Usage
```typescript
import { formatContainerProcessor } from 'roosterjs-content-model-dom';

const domToModelOption: DomToModelOption = {
  processorOverride: {
    blockquote: formatContainerProcessor
  }
};
```

## Rationale
- Other processors (`childProcessor`, `entityProcessor`, `tableProcessor`) are already publicly exported
- `processorOverride` is a public API, but users lack access to reusable processor implementations
- Exporting `formatContainerProcessor` enables legitimate customization without relying on internal paths

## Note
The diff appears large due to Prettier auto-formatting (CRLF line endings per project configuration). The actual changes are minimal:
- Added one export line in `index.ts`
- Updated documentation comments

You can view the actual changes by enabling "Hide whitespace changes" in GitHub.

Fixes #3236
