### PR TITLE
Fix ordinal superscript for numbers ending in 0 (20th, 30th, etc.)

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
+++ b/packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts
@@ -40,7 +40,7 @@ const ORDINAL_LENGTH = 2;
             if (
                 numberSegment &&
                 numberSegment.segmentType == 'Text' &&
-                (numericValue = getNumericValue(numberSegment.text, true /* checkFullText */)) &&
+                ((numericValue = getNumericValue(numberSegment.text, true /* checkFullText */)) !== null) &&
                 getOrdinal(numericValue) === value
             ) {
                 shouldAddSuperScript = true;
@@ -48,7 +48,7 @@ const ORDINAL_LENGTH = 2;
         } else {
             const ordinal = value.substring(value.length - ORDINAL_LENGTH); // This value  is equal st, nd, rd, th
             const numericValue = getNumericValue(value); //This is the numeric part. Ex: 10th, numeric value =
-            if (numericValue && getOrdinal(numericValue) === ordinal) {
+            if (numericValue !== null && getOrdinal(numericValue) === ordinal) {
                 shouldAddSuperScript = true;
             }
         }

--- a/packages/roosterjs-content-model-plugins/test/autoFormat/numbers/transformOrdinalsTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/autoFormat/numbers/transformOrdinalsTest.ts
@@ -142,6 +142,48 @@ describe('transformOrdinals', () => {
         runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
     });
 
+    it('with 20th', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '20th',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('with 30th', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '30th',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
+    it('with 40th', () => {
+        const segment: ContentModelText = {
+            segmentType: 'Text',
+            text: '40th',
+            format: {},
+        };
+        const paragraph: ContentModelParagraph = {
+            blockType: 'Paragraph',
+            segments: [segment],
+            format: {},
+        };
+        runTest(segment, paragraph, { canUndoByBackspace: true } as any, true);
+    });
+
     it('with 11th', () => {
         const segment: ContentModelText = {
             segmentType: 'Text',


### PR DESCRIPTION
## Fix: Ordinal superscript not applied to numbers ending in 0 (20th, 30th, 40th, etc.)

### Problem
When typing ordinal numbers ending in 0 (20th, 30th, 40th, 50th, etc.) in the editor, the superscript formatting is not applied to the suffix ("th"). Other ordinals like 1st-19th, 21st-29th, 31st-39th work correctly.

Additionally, the same issue occurs when the number and suffix are in separate segments, such as when a number is hyperlinked followed by an unlinked ordinal suffix (e.g., 20th).

### Root Cause
In `transformOrdinals.ts`, the code uses falsy checks (`&&`) to validate numeric values:
- Line 43: `(numericValue = getNumericValue(...)) &&`
- Line 51: `if (numericValue && getOrdinal(numericValue) === ordinal)`

For numbers ≥20, `getNumericValue()` extracts the last digit to determine the ordinal suffix. When that digit is `0`, the function correctly returns `0`, but the falsy check treats `0` as false, causing the superscript logic to be skipped even though `0` is a valid numeric result.

### Solution
Changed both falsy checks to explicit null checks:
- Line 43: `(numericValue = getNumericValue(...)) !== null &&`
- Line 51: `if (numericValue !== null && getOrdinal(numericValue) === ordinal)`

This allows `0` to be treated as a valid numeric value while still rejecting actual null/undefined values.

### Testing
- ✅ Manually tested in demo site: 20th, 30th, 40th, 50th, 60th all now apply superscript correctly
- ✅ Manually tested: 21st, 22nd, 23rd, 24th still work correctly (regression check)
- ✅ Manually tested: Space-separated case "20 th" now works
- ✅ Logic verification: Created test script confirming numeric extraction and ordinal matching work correctly for all cases

### Changes
- Modified 2 lines in `packages/roosterjs-content-model-plugins/lib/autoFormat/numbers/transformOrdinals.ts`
- No breaking changes
- Backward compatible with all existing functionality