### PR TITLE
Prevent multiple text models when there are multiple parsers.

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/textProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/textProcessor.ts
@@ -19,8 +19,8 @@ export const textProcessor: ElementProcessor<Text> = (
         stackFormat(context, { segment: 'shallowClone' }, () => {
             context.formatParsers.text.forEach(parser => {
                 parser(context.segmentFormat, textNode, context);
-                internalTextProcessor(group, textNode, context);
             });
+            internalTextProcessor(group, textNode, context);
         });
     } else {
         internalTextProcessor(group, textNode, context);

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/textProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/textProcessorTest.ts
@@ -747,6 +747,122 @@ describe('textProcessor', () => {
         expect(parserSpy).toHaveBeenCalledWith({}, text, context);
     });
 
+    it('process with multiple text format parsers (more than 2)', () => {
+        const doc = createContentModelDocument();
+        const text = document.createTextNode('test1');
+        const parser1Spy = jasmine.createSpy('parser1');
+        const parser2Spy = jasmine.createSpy('parser2');
+        const parser3Spy = jasmine.createSpy('parser3');
+
+        context.formatParsers.text = [parser1Spy, parser2Spy, parser3Spy];
+
+        doc.blocks.push({
+            blockType: 'Paragraph',
+            segments: [],
+            format: {},
+        });
+
+        textProcessor(doc, text, context);
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test1',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+        });
+        expect(parser1Spy).toHaveBeenCalledTimes(1);
+        expect(parser1Spy).toHaveBeenCalledWith({}, text, context);
+        expect(parser2Spy).toHaveBeenCalledTimes(1);
+        expect(parser2Spy).toHaveBeenCalledWith({}, text, context);
+        expect(parser3Spy).toHaveBeenCalledTimes(1);
+        expect(parser3Spy).toHaveBeenCalledWith({}, text, context);
+    });
+
+    it('process with empty formatParsers.text array', () => {
+        const doc = createContentModelDocument();
+        const text = document.createTextNode('test1');
+
+        context.formatParsers.text = [];
+
+        doc.blocks.push({
+            blockType: 'Paragraph',
+            segments: [],
+            format: {},
+        });
+
+        textProcessor(doc, text, context);
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test1',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+        });
+    });
+
+    it('process with text format parsers that modify segmentFormat', () => {
+        const doc = createContentModelDocument();
+        const text = document.createTextNode('test1');
+        const parser1Spy = jasmine.createSpy('parser1').and.callFake((format: any) => {
+            format.fontWeight = 'bold';
+        });
+        const parser2Spy = jasmine.createSpy('parser2').and.callFake((format: any) => {
+            format.fontStyle = 'italic';
+        });
+
+        context.formatParsers.text = [parser1Spy, parser2Spy];
+
+        doc.blocks.push({
+            blockType: 'Paragraph',
+            segments: [],
+            format: {},
+        });
+
+        textProcessor(doc, text, context);
+
+        expect(doc).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'test1',
+                            format: {
+                                fontWeight: 'bold',
+                                fontStyle: 'italic',
+                            },
+                        },
+                    ],
+                    format: {},
+                },
+            ],
+        });
+        expect(parser1Spy).toHaveBeenCalledTimes(1);
+        expect(parser2Spy).toHaveBeenCalledTimes(1);
+    });
+
     it('With pending format, match collapsed selection', () => {
         const doc = createContentModelDocument();
         const text = document.createTextNode('test');

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/textProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/textProcessorTest.ts
@@ -827,7 +827,7 @@ describe('textProcessor', () => {
             format.fontWeight = 'bold';
         });
         const parser2Spy = jasmine.createSpy('parser2').and.callFake((format: any) => {
-            format.fontStyle = 'italic';
+            format.fontFamily = 'italic';
         });
 
         context.formatParsers.text = [parser1Spy, parser2Spy];
@@ -851,7 +851,7 @@ describe('textProcessor', () => {
                             text: 'test1',
                             format: {
                                 fontWeight: 'bold',
-                                fontStyle: 'italic',
+                                fontFamily: 'italic',
                             },
                         },
                     ],


### PR DESCRIPTION
If there are more than 2 format parsers, we call internalTextProcessor more than once, which causes that we add more segments into the model.

To fix move the internalTextProcessor function call outside of the for loop