### PR TITLE
Filter temporary EOP elements in Word Online paste and add test pattern support

### DIFF
--- a/karma.fast.conf.js
+++ b/karma.fast.conf.js
@@ -1,5 +1,7 @@
 const argv = require('minimist')(process.argv.slice(2));
 const components = argv.components !== true && argv.components;
+const testPathPattern = argv.testPathPattern !== true && argv.testPathPattern;
+const testNamePattern = argv.testNamePattern !== true && argv.testNamePattern;
 const runCoverage = typeof argv.coverage !== 'undefined';
 const runFirefox = typeof argv.firefox !== 'undefined';
 const runChrome = typeof argv.chrome !== 'undefined';
@@ -69,8 +71,13 @@ module.exports = function (config) {
         plugins,
         client: {
             components: components,
+            testPathPattern: testPathPattern,
+            testNamePattern: testNamePattern,
             clearContext: false,
             captureConsole: true,
+            jasmine: {
+                grep: testNamePattern || null,
+            },
         },
         browsers: launcher,
         files: ['tools/karma.test.all.js'],

--- a/packages/roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents.ts
@@ -81,7 +81,7 @@ const wacElementProcessor: ElementProcessor<HTMLElement> = (
 
     if (
         TEMP_ELEMENTS_CLASSES.some(className => element.classList.contains(className)) ||
-        // This is needed to remove some temporary End of paragraph elements that WAC sometimes preserve
+        // This is needed to remove some temporary End of paragraph elements that WAC sometimes preserves
         (element.classList.contains(SELECTED_CLASS) && element.classList.contains(END_OF_PARAGRAPH))
     ) {
         return;

--- a/packages/roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents.ts
@@ -23,6 +23,8 @@ import type {
 
 const LIST_ELEMENT_TAGS = ['UL', 'OL', 'LI'];
 const LIST_ELEMENT_SELECTOR = LIST_ELEMENT_TAGS.join(',');
+const END_OF_PARAGRAPH = 'EOP';
+const SELECTED_CLASS = 'Selected';
 
 interface WacContext extends DomToModelListFormat {
     /**
@@ -77,7 +79,11 @@ const wacElementProcessor: ElementProcessor<HTMLElement> = (
         return;
     }
 
-    if (TEMP_ELEMENTS_CLASSES.some(className => element.classList.contains(className))) {
+    if (
+        TEMP_ELEMENTS_CLASSES.some(className => element.classList.contains(className)) ||
+        // This is needed to remove some temporary End of paragraph elements that WAC sometimes preserve
+        (element.classList.contains(SELECTED_CLASS) && element.classList.contains(END_OF_PARAGRAPH))
+    ) {
         return;
     } else if (shouldClearListContext(elementTag, element, context)) {
         const { listFormat } = context;

--- a/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWacTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWacTest.ts
@@ -6112,4 +6112,69 @@ describe('wordOnlineHandler', () => {
             true
         );
     });
+
+    it('Should skip elements with both Selected and EOP classes', () => {
+        runTest(
+            '<div>Hello<span class="Selected EOP"></span>World</div>',
+            '<div>HelloWorld</div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            { segmentType: 'Text', text: 'Hello', format: {} },
+                            { segmentType: 'Text', text: 'World', format: {} },
+                        ],
+                        format: {},
+                    },
+                ],
+            },
+            true
+        );
+    });
+
+    it('Should not skip elements with only Selected class', () => {
+        runTest(
+            '<div>Hello<span class="Selected">!</span>World</div>',
+            '<div>Hello!World</div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            { segmentType: 'Text', text: 'Hello', format: {} },
+                            { segmentType: 'Text', text: '!', format: {} },
+                            { segmentType: 'Text', text: 'World', format: {} },
+                        ],
+                        format: {},
+                    },
+                ],
+            },
+            true
+        );
+    });
+
+    it('Should not skip elements with only EOP class', () => {
+        runTest(
+            '<div>Hello<span class="EOP">!</span>World</div>',
+            '<div>Hello!World</div>',
+            {
+                blockGroupType: 'Document',
+                blocks: [
+                    {
+                        blockType: 'Paragraph',
+                        segments: [
+                            { segmentType: 'Text', text: 'Hello', format: {} },
+                            { segmentType: 'Text', text: '!', format: {} },
+                            { segmentType: 'Text', text: 'World', format: {} },
+                        ],
+                        format: {},
+                    },
+                ],
+            },
+            true
+        );
+    });
 });

--- a/tools/karma.test.js
+++ b/tools/karma.test.js
@@ -1,14 +1,24 @@
 module.exports = function (contexts) {
-    if (!!__karma__.config.components) {
-        const filenameWithoutTest = __karma__.config.components.replace('Test', '');
-        const filterRegExpByFilename = new RegExp(filenameWithoutTest);
+    const components = __karma__.config.components;
+    const testPathPattern = __karma__.config.testPathPattern;
+
+    if (!!components || !!testPathPattern) {
+        const pattern = testPathPattern || components.replace('Test', '');
+        const filterRegExpByFilename = new RegExp(pattern);
         const specificFiles = [];
 
         contexts.forEach(context => {
             specificFiles.push(...context.keys().filter(path => filterRegExpByFilename.test(path)));
         });
 
-        return specificFiles.map(context);
+        console.log(
+            '\n\nRunning test cases from ' +
+                specificFiles.length +
+                ' files matching pattern: ' +
+                pattern
+        );
+
+        return specificFiles.map(file => contexts[0](file));
     } else {
         const specificFiles = [];
 


### PR DESCRIPTION
Filter temporary EOP elements in Word Online paste and add test pattern support

- Skip elements with both 'Selected' and 'EOP' classes during WAC paste processing to remove temporary End of Paragraph markers
- Add unit tests for EOP element filtering behavior (3 test cases)
- Enhance test runner with --testPathPattern and --testNamePattern flags for faster targeted test execution

Before
<img width="1440" height="370" alt="image" src="https://github.com/user-attachments/assets/4e3eb803-4f61-4264-99ba-7eed8e0dc00c" />


After
<img width="1290" height="505" alt="image" src="https://github.com/user-attachments/assets/6927c25f-7273-47c8-b22f-df218714b704" />
