### PR TITLE
Preserve trailing space in last paragraph segment by converting to nbsp (#3235)

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
@@ -56,7 +56,7 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
                 if (parent) {
                     const firstSegment = paragraph.segments[0];
 
-                    const segmentContext = context as ModelToDomSegmentContext;
+                    const segmentContext: ModelToDomSegmentContext = context;
 
                     if (firstSegment?.segmentType == 'SelectionMarker') {
                         // Make sure there is a segment created before selection marker.
@@ -75,9 +75,21 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
                         );
                     }
 
+                    // Find the last logical inline segment to be treated as the "last" one.
+                    // Skip SelectionMarker since it is not rendered as visible content.
+                    let lastSegmentIndex = -1;
+
+                    for (let i = paragraph.segments.length - 1; i >= 0; i--) {
+                        const seg = paragraph.segments[i];
+
+                        if (seg.segmentType != 'SelectionMarker') {
+                            lastSegmentIndex = i;
+                            break;
+                        }
+                    }
+
                     paragraph.segments.forEach((segment, index) => {
-                        segmentContext.isLastSegment =
-                            index === paragraph.segments.length - 1;
+                        segmentContext.isLastSegment = index === lastSegmentIndex;
 
                         const newSegments: Node[] = [];
                         context.modelHandlers.segment(

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
@@ -7,6 +7,7 @@ import { unwrap } from '../../domUtils/unwrap';
 import type {
     ContentModelBlockHandler,
     ContentModelParagraph,
+    ContentModelSegment,
     ModelToDomContext,
     ModelToDomSegmentContext,
 } from 'roosterjs-content-model-types';
@@ -75,21 +76,12 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
                         );
                     }
 
-                    // Find the last logical inline segment to be treated as the "last" one.
-                    // Skip SelectionMarker since it is not rendered as visible content.
-                    let lastSegmentIndex = -1;
+                    for (let i = 0; i < paragraph.segments.length; i++) {
+                        const segment = paragraph.segments[i];
 
-                    for (let i = paragraph.segments.length - 1; i >= 0; i--) {
-                        const seg = paragraph.segments[i];
-
-                        if (seg.segmentType != 'SelectionMarker') {
-                            lastSegmentIndex = i;
-                            break;
-                        }
-                    }
-
-                    paragraph.segments.forEach((segment, index) => {
-                        segmentContext.isLastSegment = index === lastSegmentIndex;
+                        segmentContext.noFollowingTextSegmentOrLast =
+                            i === paragraph.segments.length - 1 ||
+                            !hasTextSegmentAfter(paragraph.segments, i);
 
                         const newSegments: Node[] = [];
                         context.modelHandlers.segment(
@@ -100,12 +92,12 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
                             newSegments
                         );
 
-                        newSegments.forEach(node => {
+                        for (const node of newSegments) {
                             context.domIndexer?.onSegment(node, paragraph, [segment]);
-                        });
-                    });
+                        }
+                    }
 
-                    delete segmentContext.isLastSegment;
+                    delete segmentContext.noFollowingTextSegmentOrLast;
                 }
             };
 
@@ -156,3 +148,18 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
 
     return refNode;
 };
+
+function hasTextSegmentAfter(segments: ReadonlyArray<ContentModelSegment>, index: number): boolean {
+    for (let i = index + 1; i < segments.length; i++) {
+        const type = segments[i].segmentType;
+        if (type === 'SelectionMarker') {
+            continue;
+        }
+        if (type === 'Text') {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    return false;
+}

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleParagraph.ts
@@ -8,6 +8,7 @@ import type {
     ContentModelBlockHandler,
     ContentModelParagraph,
     ModelToDomContext,
+    ModelToDomSegmentContext,
 } from 'roosterjs-content-model-types';
 
 const DefaultParagraphTag = 'div';
@@ -55,6 +56,8 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
                 if (parent) {
                     const firstSegment = paragraph.segments[0];
 
+                    const segmentContext = context as ModelToDomSegmentContext;
+
                     if (firstSegment?.segmentType == 'SelectionMarker') {
                         // Make sure there is a segment created before selection marker.
                         // If selection marker is the first selected segment in a paragraph, create a dummy text node,
@@ -67,19 +70,30 @@ export const handleParagraph: ContentModelBlockHandler<ContentModelParagraph> = 
                                 segmentType: 'Text',
                                 text: '',
                             },
-                            context,
+                            segmentContext,
                             []
                         );
                     }
 
-                    paragraph.segments.forEach(segment => {
+                    paragraph.segments.forEach((segment, index) => {
+                        segmentContext.isLastSegment =
+                            index === paragraph.segments.length - 1;
+
                         const newSegments: Node[] = [];
-                        context.modelHandlers.segment(doc, parent, segment, context, newSegments);
+                        context.modelHandlers.segment(
+                            doc,
+                            parent,
+                            segment,
+                            segmentContext,
+                            newSegments
+                        );
 
                         newSegments.forEach(node => {
                             context.domIndexer?.onSegment(node, paragraph, [segment]);
                         });
                     });
+
+                    delete segmentContext.isLastSegment;
                 }
             };
 

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleText.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleText.ts
@@ -1,6 +1,8 @@
 import { handleSegmentCommon } from '../utils/handleSegmentCommon';
 import type { ContentModelSegmentHandler, ContentModelText } from 'roosterjs-content-model-types';
 
+const nonBreakingSpace = '\u00A0';
+
 /**
  * @internal
  */
@@ -11,7 +13,11 @@ export const handleText: ContentModelSegmentHandler<ContentModelText> = (
     context,
     segmentNodes
 ) => {
-    const txt = doc.createTextNode(segment.text);
+    const textContent =
+        context.isLastSegment && segment.text.endsWith(' ')
+            ? segment.text.slice(0, -1) + nonBreakingSpace
+            : segment.text;
+    const txt = doc.createTextNode(textContent);
     const element = doc.createElement('span');
 
     parent.appendChild(element);

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleText.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleText.ts
@@ -14,7 +14,7 @@ export const handleText: ContentModelSegmentHandler<ContentModelText> = (
     segmentNodes
 ) => {
     const textContent =
-        context.isLastSegment && segment.text.endsWith(' ')
+        context.noFollowingTextSegmentOrLast && segment.text.endsWith(' ')
             ? segment.text.slice(0, -1) + nonBreakingSpace
             : segment.text;
     const txt = doc.createTextNode(textContent);

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTextTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTextTest.ts
@@ -9,7 +9,7 @@ describe('handleText', () => {
 
     beforeEach(() => {
         parent = document.createElement('div');
-        context = { ...createModelToDomContext(), isLastSegment: false };
+        context = { ...createModelToDomContext() };
     });
 
     it('Text segment', () => {
@@ -165,7 +165,7 @@ describe('handleText', () => {
             format: {},
         };
 
-        context.isLastSegment = true;
+        context.noFollowingTextSegmentOrLast = true;
 
         handleText(document, parent, text, context, []);
 
@@ -179,7 +179,7 @@ describe('handleText', () => {
             format: {},
         };
 
-        context.isLastSegment = true;
+        context.noFollowingTextSegmentOrLast = true;
 
         handleText(document, parent, text, context, []);
 
@@ -193,7 +193,19 @@ describe('handleText', () => {
             format: {},
         };
 
-        context.isLastSegment = false;
+        context.noFollowingTextSegmentOrLast = false;
+
+        handleText(document, parent, text, context, []);
+
+        expect(parent.innerHTML).toBe('<span>hello </span>');
+    });
+
+    it('Text ending with space without noFollowingTextSegmentOrLast set keeps space', () => {
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'hello ',
+            format: {},
+        };
 
         handleText(document, parent, text, context, []);
 

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTextTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTextTest.ts
@@ -1,15 +1,15 @@
 import * as stackFormat from '../../../lib/modelToDom/utils/stackFormat';
-import { ContentModelText, ModelToDomContext } from 'roosterjs-content-model-types';
+import { ContentModelText, ModelToDomSegmentContext } from 'roosterjs-content-model-types';
 import { createModelToDomContext } from '../../../lib/modelToDom/context/createModelToDomContext';
 import { handleText } from '../../../lib/modelToDom/handlers/handleText';
 
 describe('handleText', () => {
     let parent: HTMLElement;
-    let context: ModelToDomContext;
+    let context: ModelToDomSegmentContext;
 
     beforeEach(() => {
         parent = document.createElement('div');
-        context = createModelToDomContext();
+        context = { ...createModelToDomContext(), isLastSegment: false };
     });
 
     it('Text segment', () => {
@@ -156,5 +156,47 @@ describe('handleText', () => {
         expect(segmentNodes[0]).toBe(parent.firstChild!.firstChild!);
         expect(applierSpy).toHaveBeenCalledTimes(1);
         expect(applierSpy).toHaveBeenCalledWith(text.format, segmentNodes[0], context);
+    });
+
+    it('Last segment ending with space is converted to nbsp', () => {
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'hello ',
+            format: {},
+        };
+
+        context.isLastSegment = true;
+
+        handleText(document, parent, text, context, []);
+
+        expect(parent.innerHTML).toBe('<span>hello&nbsp;</span>');
+    });
+
+    it('Last segment not ending with space is unchanged', () => {
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'hello',
+            format: {},
+        };
+
+        context.isLastSegment = true;
+
+        handleText(document, parent, text, context, []);
+
+        expect(parent.innerHTML).toBe('<span>hello</span>');
+    });
+
+    it('Non-last segment ending with space is unchanged', () => {
+        const text: ContentModelText = {
+            segmentType: 'Text',
+            text: 'hello ',
+            format: {},
+        };
+
+        context.isLastSegment = false;
+
+        handleText(document, parent, text, context, []);
+
+        expect(parent.innerHTML).toBe('<span>hello </span>');
     });
 });

--- a/packages/roosterjs-content-model-types/lib/context/ContentModelHandler.ts
+++ b/packages/roosterjs-content-model-types/lib/context/ContentModelHandler.ts
@@ -2,7 +2,7 @@ import type { ContentModelBlock } from '../contentModel/block/ContentModelBlock'
 import type { ContentModelBlockGroup } from '../contentModel/blockGroup/ContentModelBlockGroup';
 import type { ContentModelDecorator } from '../contentModel/decorator/ContentModelDecorator';
 import type { ContentModelSegment } from '../contentModel/segment/ContentModelSegment';
-import type { ModelToDomContext } from './ModelToDomContext';
+import type { ModelToDomContext, ModelToDomSegmentContext } from './ModelToDomContext';
 
 /**
  * Type of Content Model to DOM handler
@@ -46,6 +46,6 @@ export type ContentModelSegmentHandler<T extends ContentModelSegment> = (
     doc: Document,
     parent: Node,
     model: T,
-    context: ModelToDomContext,
+    context: ModelToDomSegmentContext,
     segmentNodes: Node[]
 ) => void;

--- a/packages/roosterjs-content-model-types/lib/context/ModelToDomContext.ts
+++ b/packages/roosterjs-content-model-types/lib/context/ModelToDomContext.ts
@@ -19,7 +19,9 @@ export interface ModelToDomContext
  */
 export interface ModelToDomSegmentContext extends ModelToDomContext {
     /**
-     * Whether the current segment being processed is the last segment in its paragraph
+     * Whether the current segment is the last segment in the paragraph,
+     * or there are no more Text segments after it (excluding SelectionMarkers).
+     * When true, trailing spaces should be converted to &amp;nbsp;.
      */
-    isLastSegment?: boolean;
+    noFollowingTextSegmentOrLast?: boolean;
 }

--- a/packages/roosterjs-content-model-types/lib/context/ModelToDomContext.ts
+++ b/packages/roosterjs-content-model-types/lib/context/ModelToDomContext.ts
@@ -13,3 +13,13 @@ export interface ModelToDomContext
         ModelToDomFormatContext,
         ModelToDomSettings,
         RewriteFromModelContext {}
+
+/**
+ * Extended context used by segment and text handlers to carry per-paragraph segment state
+ */
+export interface ModelToDomSegmentContext extends ModelToDomContext {
+    /**
+     * Whether the current segment being processed is the last segment in its paragraph
+     */
+    isLastSegment?: boolean;
+}

--- a/packages/roosterjs-content-model-types/lib/index.ts
+++ b/packages/roosterjs-content-model-types/lib/index.ts
@@ -294,7 +294,7 @@ export {
     DomToModelDecoratorContext,
     DomToModelListFormat,
 } from './context/DomToModelFormatContext';
-export { ModelToDomContext } from './context/ModelToDomContext';
+export { ModelToDomContext, ModelToDomSegmentContext } from './context/ModelToDomContext';
 export {
     ModelToDomBlockAndSegmentNode,
     ModelToDomRegularSelection,


### PR DESCRIPTION
When the last text segment in a paragraph ends with a regular space, browsers collapse it during rendering. This change detects that case in handleText and replaces the trailing space with a non-breaking space (\u00A0) so it is preserved in the output.

To support this, a new ModelToDomSegmentContext interface is introduced that extends ModelToDomContext with an isLastSegment flag. handleParagraph sets this flag for each segment before dispatching, and ContentModelSegmentHandler is updated to use ModelToDomSegmentContext as its context type, eliminating the need for type casts in the handlers.

import this model:
```
{
    "blockGroupType": "Document",
    "blocks": [
        {
            "blockType": "Paragraph",
            "segments": [
                {
                    "segmentType": "Text",
                    "text": "Could you please provide more information ",
                    "format": {
                        "fontFamily": "Corbel, Skia, sans-serif",
                        "fontSize": "12pt",
                        "textColor": "rgb(94, 50, 124)"
                    }
                }
            ],
            "format": {
                "isProofing": true
            },
            "segmentFormat": {
                "fontFamily": "Corbel, Skia, sans-serif",
                "fontSize": "12pt",
                "textColor": "rgb(94, 50, 124)"
            }
        },
        {
            "blockType": "Paragraph",
            "segments": [
                {
                    "segmentType": "SelectionMarker",
                    "isSelected": true,
                    "format": {
                        "fontFamily": "Corbel, Skia, sans-serif",
                        "fontSize": "12pt",
                        "textColor": "rgb(94, 50, 124)"
                    }
                }
            ],
            "format": {
                "isProofing": true
            },
            "segmentFormat": {
                "fontFamily": "Corbel, Skia, sans-serif",
                "fontSize": "12pt",
                "textColor": "rgb(94, 50, 124)"
            }
        }
    ],
    "format": {
        "fontFamily": "'Corbel', 'Skia', sans-serif",
        "fontSize": "12pt",
        "textColor": "#5e327c"
    }
}
```


Before
<img width="346" height="126" alt="image" src="https://github.com/user-attachments/assets/42ec2606-0997-45e8-93e2-ef61cc3a5f74" /> 

After
<img width="345" height="150" alt="image" src="https://github.com/user-attachments/assets/2a7eb550-5327-4b2b-9f99-3913b3d725e1" /> 
