### PR TITLE
Keep Margins in the List items, and set the padding of list elements for better paste interop with Wac Components

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents.ts
+++ b/packages/roosterjs-content-model-plugins/lib/paste/WacComponents/processPastedContentWacComponents.ts
@@ -25,6 +25,7 @@ const LIST_ELEMENT_TAGS = ['UL', 'OL', 'LI'];
 const LIST_ELEMENT_SELECTOR = LIST_ELEMENT_TAGS.join(',');
 const END_OF_PARAGRAPH = 'EOP';
 const SELECTED_CLASS = 'Selected';
+const BASE_PADDING_WAC_LISTS = '1em';
 
 interface WacContext extends DomToModelListFormat {
     /**
@@ -159,9 +160,6 @@ const wacListItemParser: FormatParser<ContentModelListItemLevelFormat> = (
     if (element.style.display === 'block') {
         format.displayForDummyItem = undefined;
     }
-
-    format.marginLeft = undefined;
-    format.marginRight = undefined;
 };
 
 /**
@@ -171,7 +169,7 @@ const wacListLevelParser: FormatParser<ContentModelListItemLevelFormat> = (
     format: ContentModelListItemLevelFormat
 ): void => {
     format.marginLeft = undefined;
-    format.paddingLeft = undefined;
+    format.paddingLeft = BASE_PADDING_WAC_LISTS;
 };
 
 /**

--- a/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWacTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWacTest.ts
@@ -6344,31 +6344,6 @@ describe('wordOnlineHandler', () => {
     });
 
     describe('wacLiElementProcessor - paddingInlineStart override', () => {
-        it('zeroes out padding-inline-start on the parent ul element when processing a list item', () => {
-            const ul = document.createElement('ul');
-            ul.className = 'BulletListStyle1';
-            ul.style.paddingInlineStart = '40px';
-            const li = document.createElement('li');
-            li.className = 'OutlineElement';
-            li.setAttribute('data-aria-level', '1');
-            li.textContent = 'TEST';
-            ul.appendChild(li);
-
-            const wrapper = document.createElement('div');
-            wrapper.className = 'ListContainerWrapper';
-            wrapper.appendChild(ul);
-
-            fragment = document.createDocumentFragment();
-            fragment.appendChild(wrapper);
-
-            const event = createBeforePasteEventMock(fragment);
-            processPastedContentWacComponents(event);
-
-            domToContentModel(fragment, createDomToModelContext(undefined, event.domToModelOption));
-
-            expect(ul.style.paddingInlineStart).toBe('0px');
-        });
-
         it('sets paddingLeft to 0px in the copied list level format for subsequent list items', () => {
             runTest(
                 '<div class="ListContainerWrapper"><ul class="BulletListStyle1"><li class="OutlineElement" data-aria-level="1">A</li><li class="OutlineElement" data-aria-level="1">B</li></ul></div>',

--- a/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWacTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/paste/word/processPastedContentFromWacTest.ts
@@ -128,7 +128,7 @@ describe('processPastedContentFromWacTest', () => {
     it('Single DIV with child LI', () => {
         runTest(
             '<div class="ListContainerWrapper"><ul><li>1</li><li>2</li></ul></div>',
-            '<ul><li>1</li><li>2</li></ul>',
+            '<ul style="padding-left: 1em;"><li>1</li><li>2</li></ul>',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -143,7 +143,7 @@ describe('processPastedContentFromWacTest', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -162,7 +162,7 @@ describe('processPastedContentFromWacTest', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -179,7 +179,7 @@ describe('processPastedContentFromWacTest', () => {
     it('Single DIV with deeper child LI', () => {
         runTest(
             '<div><div class="ListContainerWrapper"><ul><li>1</li></ul><ul><li>2</li></ul></div></div>',
-            '<ul><li>1</li><li>2</li></ul>',
+            '<ul style="padding-left: 1em;"><li>1</li><li>2</li></ul>',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -194,7 +194,7 @@ describe('processPastedContentFromWacTest', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -213,7 +213,7 @@ describe('processPastedContentFromWacTest', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -230,7 +230,7 @@ describe('processPastedContentFromWacTest', () => {
     it('Single DIV with text and LI', () => {
         runTest(
             '<div class="ListContainerWrapper">test<ul><li>1</li></ul></div>',
-            'test<ul><li>1</li></ul>',
+            'test<ul style="padding-left: 1em;"><li>1</li></ul>',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -251,7 +251,7 @@ describe('processPastedContentFromWacTest', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -268,7 +268,7 @@ describe('processPastedContentFromWacTest', () => {
     it('Single LI', () => {
         runTest(
             '<ul><li>1</li></ul>',
-            '<ul><li>1</li></ul>',
+            '<ul style="padding-left: 1em;"><li>1</li></ul>',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -283,7 +283,7 @@ describe('processPastedContentFromWacTest', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -300,7 +300,7 @@ describe('processPastedContentFromWacTest', () => {
     it('Single LI and text', () => {
         runTest(
             '<ul><li>1</li></ul>test',
-            '<ul><li>1</li></ul>test',
+            '<ul style="padding-left: 1em;"><li>1</li></ul>test',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -315,7 +315,7 @@ describe('processPastedContentFromWacTest', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -338,7 +338,7 @@ describe('processPastedContentFromWacTest', () => {
     it('Multiple LI', () => {
         runTest(
             '<ul><li>1</li><li>2</li></ul>',
-            '<ul><li>1</li><li>2</li></ul>',
+            '<ul style="padding-left: 1em;"><li>1</li><li>2</li></ul>',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -353,7 +353,7 @@ describe('processPastedContentFromWacTest', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -372,7 +372,7 @@ describe('processPastedContentFromWacTest', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -455,7 +455,7 @@ describe('wordOnlineHandler', () => {
             it('has all list items on the same level', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW225173058"><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">A</li></ul></div><div class="ListContainerWrapper BCX0 SCXW225173058"><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">B</li></ul></div><div class="ListContainerWrapper BCX0 SCXW225173058"><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="2">C</li></ul></div>',
-                    '<ul><li>A</li><li>B</li><ul><li>C</li></ul></ul>',
+                    '<ul style="padding-left: 1em;"><li>A</li><li>B</li><ul style="padding-left: 1em;"><li>C</li></ul></ul>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -470,7 +470,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -489,7 +491,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -509,8 +513,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -532,7 +536,7 @@ describe('wordOnlineHandler', () => {
             it('List items on different level but only going on direction in terms of depth', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW200751125"><ul class="BulletListStyle1 BCX0 SCXW200751125"><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW200751125">A</li></ul></div><div class="ListContainerWrapper BCX0 SCXW200751125"><ul class="BulletListStyle2 BCX0 SCXW200751125" role="list"><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW200751125">B</li></ul></div><div class="ListContainerWrapper BCX0 SCXW200751125" style="margin: 0px;"><ul class="BulletListStyle2 BCX0 SCXW200751125" role="list"><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW200751125">C</li></ul></div>',
-                    '<ul><li>A</li><ul><li>B</li><ul><li>C</li></ul></ul></ul>',
+                    '<ul style="padding-left: 1em;"><li>A</li><ul style="padding-left: 1em;"><li>B</li><ul style="padding-left: 1em;"><li>C</li></ul></ul></ul>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -547,7 +551,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -567,8 +573,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -589,9 +595,9 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -616,7 +622,7 @@ describe('wordOnlineHandler', () => {
             it('List items on different level but have different branch in each level', () => {
                 runTest(
                     '<div class="ListContainerWrapper SCXW81557186 BCX0"><ul class="BulletListStyle1"><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW81557186">A</li></ul></div><div class="ListContainerWrapper SCXW81557186 BCX0"><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW81557186">B</li></ul></div><div class="ListContainerWrapper SCXW81557186 BCX0"><ul><li role="listitem" data-aria-level="3" class="OutlineElement Ltr SCXW81557186 BCX0" style="margin: 0px 0px 0px 120px;">C</li></ul></div><div class="ListContainerWrapper SCXW81557186 BCX0"><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr SCXW81557186 BCX0">D</li></ul></div><div class="ListContainerWrapper SCXW81557186 BCX0"><ul><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW81557186" style="margin: 0px 0px 0px 120px;">E</li></ul></div>',
-                    '<ul><li>A</li><ul><li>B</li><ul style="margin-top: 0px; margin-bottom: 0px;"><li style="margin-top: 0px; margin-bottom: 0px;">C</li></ul><li>D</li><ul style="margin-top: 0px; margin-bottom: 0px;"><li style="margin-top: 0px; margin-bottom: 0px;">E</li></ul></ul></ul>',
+                    '<ul style="padding-left: 1em;"><li>A</li><ul style="padding-left: 1em;"><li>B</li><ul style="margin-top: 0px; margin-right: 0px; margin-bottom: 0px; padding-left: 1em;"><li style="margin: 0px 0px 0px 120px;">C</li></ul><li>D</li><ul style="margin-top: 0px; margin-right: 0px; margin-bottom: 0px; padding-left: 1em;"><li style="margin: 0px 0px 0px 120px;">E</li></ul></ul></ul>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -631,7 +637,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -651,8 +659,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -673,11 +681,16 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                     {
                                         listType: 'UL',
-                                        format: { marginTop: '0px', marginBottom: '0px' },
+                                        format: {
+                                            marginTop: '0px',
+                                            marginRight: '0px',
+                                            marginBottom: '0px',
+                                            paddingLeft: '1em',
+                                        },
                                         dataset: {},
                                     },
                                 ],
@@ -686,7 +699,12 @@ describe('wordOnlineHandler', () => {
                                     isSelected: false,
                                     format: {},
                                 },
-                                format: { marginTop: '0px', marginBottom: '0px' },
+                                format: {
+                                    marginTop: '0px',
+                                    marginRight: '0px',
+                                    marginBottom: '0px',
+                                    marginLeft: '120px',
+                                },
                             },
                             {
                                 blockType: 'BlockGroup',
@@ -700,8 +718,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -722,11 +740,16 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                     {
                                         listType: 'UL',
-                                        format: { marginTop: '0px', marginBottom: '0px' },
+                                        format: {
+                                            marginTop: '0px',
+                                            marginRight: '0px',
+                                            marginBottom: '0px',
+                                            paddingLeft: '1em',
+                                        },
                                         dataset: {},
                                     },
                                 ],
@@ -735,7 +758,12 @@ describe('wordOnlineHandler', () => {
                                     isSelected: false,
                                     format: {},
                                 },
-                                format: { marginTop: '0px', marginBottom: '0px' },
+                                format: {
+                                    marginTop: '0px',
+                                    marginRight: '0px',
+                                    marginBottom: '0px',
+                                    marginLeft: '120px',
+                                },
                             },
                         ],
                     },
@@ -754,7 +782,7 @@ describe('wordOnlineHandler', () => {
             it('List items on different level with different branch with a combination of order and unordered list items', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW221836524"><ul class="BulletListStyle1"><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW221836524"> A </li></ul></div><div class="ListContainerWrapper BCX0 SCXW221836524"><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW221836524"> B </li></ul></div><div class="ListContainerWrapper BCX0 SCXW221836524"><ol><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW221836524" style="margin: 0px 0px 0px 120px;"> C1 </li></ol></div><div class="ListContainerWrapper BCX0 SCXW221836524"><ol start="2"><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW221836524" style="margin: 0px 0px 0px 120px;"> C2 </li></ol></div><div class="ListContainerWrapper BCX0 SCXW221836524"><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW221836524"> D </li></ul></div>',
-                    '<ul><li>A</li><ul><li>B</li><ol start="1" style="margin-top: 0px; margin-bottom: 0px;"><li style="margin-top: 0px; margin-bottom: 0px;">C1</li><li style="margin-top: 0px; margin-bottom: 0px;">C2</li></ol><li>D</li></ul></ul>',
+                    '<ul style="padding-left: 1em;"><li>A</li><ul style="padding-left: 1em;"><li>B</li><ol start="1" style="margin-top: 0px; margin-right: 0px; margin-bottom: 0px; padding-left: 1em;"><li style="margin: 0px 0px 0px 120px;">C1</li><li style="margin: 0px 0px 0px 120px;">C2</li></ol><li>D</li></ul></ul>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -769,7 +797,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -789,8 +819,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -811,11 +841,16 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                     {
                                         listType: 'OL',
-                                        format: { marginTop: '0px', marginBottom: '0px' },
+                                        format: {
+                                            marginTop: '0px',
+                                            marginRight: '0px',
+                                            marginBottom: '0px',
+                                            paddingLeft: '1em',
+                                        },
                                         dataset: {},
                                     },
                                 ],
@@ -824,7 +859,12 @@ describe('wordOnlineHandler', () => {
                                     isSelected: false,
                                     format: {},
                                 },
-                                format: { marginTop: '0px', marginBottom: '0px' },
+                                format: {
+                                    marginTop: '0px',
+                                    marginRight: '0px',
+                                    marginBottom: '0px',
+                                    marginLeft: '120px',
+                                },
                             },
                             {
                                 blockType: 'BlockGroup',
@@ -838,11 +878,16 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                     {
                                         listType: 'OL',
-                                        format: { marginTop: '0px', marginBottom: '0px' },
+                                        format: {
+                                            marginTop: '0px',
+                                            marginRight: '0px',
+                                            marginBottom: '0px',
+                                            paddingLeft: '1em',
+                                        },
                                         dataset: {},
                                     },
                                 ],
@@ -851,7 +896,12 @@ describe('wordOnlineHandler', () => {
                                     isSelected: false,
                                     format: {},
                                 },
-                                format: { marginTop: '0px', marginBottom: '0px' },
+                                format: {
+                                    marginTop: '0px',
+                                    marginRight: '0px',
+                                    marginBottom: '0px',
+                                    marginLeft: '120px',
+                                },
                             },
                             {
                                 blockType: 'BlockGroup',
@@ -865,8 +915,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -894,7 +944,7 @@ describe('wordOnlineHandler', () => {
             it('only has text and list', () => {
                 runTest(
                     '<div class="BCX0 SCXW32709461"><div class="OutlineElement Ltr BCX0 SCXW32709461"><p><span><span>asdfasdf</span></span><span></span></p></div><div class="ListContainerWrapper BCX0 SCXW32709461"><ul class="BulletListStyle1"><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW32709461"> A </li></ul></div><div class="ListContainerWrapper BCX0 SCXW32709461"><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW32709461"> B </li></ul></div><div class="ListContainerWrapper BCX0 SCXW32709461"><ol><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW32709461" style="margin: 0px 0px 0px 120px;"> C1 </li></ol></div><div class="ListContainerWrapper BCX0 SCXW32709461"><ol start="2"><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW32709461" style="margin: 0px 0px 0px 120px;"> C2 </li></ol></div><div class="ListContainerWrapper BCX0 SCXW32709461"><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW32709461"> D </li></ul></div></div><div class="OutlineElement Ltr BCX0 SCXW32709461"><p><span><span>asdfasdf</span></span><span></span></p></div>',
-                    '<p>asdfasdf</p><ul><li>A</li><ul><li>B</li><ol start="1" style="margin-top: 0px; margin-bottom: 0px;"><li style="margin-top: 0px; margin-bottom: 0px;">C1</li><li style="margin-top: 0px; margin-bottom: 0px;">C2</li></ol><li>D</li></ul></ul><p>asdfasdf</p>',
+                    '<p>asdfasdf</p><ul style="padding-left: 1em;"><li>A</li><ul style="padding-left: 1em;"><li>B</li><ol start="1" style="margin-top: 0px; margin-right: 0px; margin-bottom: 0px; padding-left: 1em;"><li style="margin: 0px 0px 0px 120px;">C1</li><li style="margin: 0px 0px 0px 120px;">C2</li></ol><li>D</li></ul></ul><p>asdfasdf</p>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -915,7 +965,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -935,8 +987,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -957,11 +1009,16 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                     {
                                         listType: 'OL',
-                                        format: { marginTop: '0px', marginBottom: '0px' },
+                                        format: {
+                                            marginTop: '0px',
+                                            marginRight: '0px',
+                                            marginBottom: '0px',
+                                            paddingLeft: '1em',
+                                        },
                                         dataset: {},
                                     },
                                 ],
@@ -970,7 +1027,12 @@ describe('wordOnlineHandler', () => {
                                     isSelected: false,
                                     format: {},
                                 },
-                                format: { marginTop: '0px', marginBottom: '0px' },
+                                format: {
+                                    marginTop: '0px',
+                                    marginRight: '0px',
+                                    marginBottom: '0px',
+                                    marginLeft: '120px',
+                                },
                             },
                             {
                                 blockType: 'BlockGroup',
@@ -984,11 +1046,16 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                     {
                                         listType: 'OL',
-                                        format: { marginTop: '0px', marginBottom: '0px' },
+                                        format: {
+                                            marginTop: '0px',
+                                            marginRight: '0px',
+                                            marginBottom: '0px',
+                                            paddingLeft: '1em',
+                                        },
                                         dataset: {},
                                     },
                                 ],
@@ -997,7 +1064,12 @@ describe('wordOnlineHandler', () => {
                                     isSelected: false,
                                     format: {},
                                 },
-                                format: { marginTop: '0px', marginBottom: '0px' },
+                                format: {
+                                    marginTop: '0px',
+                                    marginRight: '0px',
+                                    marginBottom: '0px',
+                                    marginLeft: '120px',
+                                },
                             },
                             {
                                 blockType: 'BlockGroup',
@@ -1011,8 +1083,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -1052,7 +1124,7 @@ describe('wordOnlineHandler', () => {
             it('fragments contains text, list and table that consist of list 2', () => {
                 runTest(
                     '<div class="BCX0 SCXW32709461"><div class="OutlineElement Ltr BCX0 SCXW32709461"><p><span><span>asdfasdf</span></span><span></span></p></div><div class="ListContainerWrapper BCX0 SCXW32709461"><ul class="BulletListStyle1"><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW32709461"> A </li></ul></div><div class="ListContainerWrapper BCX0 SCXW32709461"><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW32709461"> B </li></ul></div><div class="ListContainerWrapper BCX0 SCXW32709461"><ol><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW32709461" style="margin: 0px 0px 0px 120px;"> C1 </li></ol></div><div class="ListContainerWrapper BCX0 SCXW32709461"><ol><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW32709461" style="margin: 0px 0px 0px 120px;"> C2 </li></ol></div><div class="ListContainerWrapper BCX0 SCXW32709461"><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW32709461"> D </li></ul></div></div><div class="OutlineElement Ltr BCX0 SCXW32709461"><p><span><span>asdfasdf</span></span><span></span></p></div><div class="OutlineElement Ltr BCX0 SCXW244795937"><div class="TableContainer SCXW244795937 BCX0"><table><tbody><tr><td><div><div class="OutlineElement Ltr BCX0 SCXW32709461"><p><span><span>asdfasdf</span></span><span></span></p></div></div></td></tr><tr><td><div><div class="ListContainerWrapper SCXW244795937 BCX0"><ul><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW244795937"> A </li><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW244795937"> B </li><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW244795937"> C </li><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW244795937"> D </li></ul></div></div></td></tr></tbody></table></div></div><div class="OutlineElement Ltr BCX0 SCXW244795937"><p><span><span></span></span><span></span></p></div>',
-                    '<p>asdfasdf</p><ul><li>A</li><ul><li>B</li><ol start="1" style="margin-top: 0px; margin-bottom: 0px;"><li style="margin-top: 0px; margin-bottom: 0px;">C1</li></ol><ol start="1" style="margin-top: 0px; margin-bottom: 0px;"><li style="margin-top: 0px; margin-bottom: 0px;">C2</li></ol><li>D</li></ul></ul><p>asdfasdf</p><table><tbody><tr><td><p>asdfasdf</p></td></tr><tr><td><ul><li>A</li><li>B</li><li>C</li><li>D</li></ul></td></tr></tbody></table>',
+                    '<p>asdfasdf</p><ul style="padding-left: 1em;"><li>A</li><ul style="padding-left: 1em;"><li>B</li><ol start="1" style="margin-top: 0px; margin-right: 0px; margin-bottom: 0px; padding-left: 1em;"><li style="margin: 0px 0px 0px 120px;">C1</li></ol><ol start="1" style="margin-top: 0px; margin-right: 0px; margin-bottom: 0px; padding-left: 1em;"><li style="margin: 0px 0px 0px 120px;">C2</li></ol><li>D</li></ul></ul><p>asdfasdf</p><table><tbody><tr><td><p>asdfasdf</p></td></tr><tr><td><ul style="padding-left: 1em;"><li>A</li><li>B</li><li>C</li><li>D</li></ul></td></tr></tbody></table>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -1073,7 +1145,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -1093,8 +1167,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -1115,11 +1189,16 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                     {
                                         listType: 'OL',
-                                        format: { marginTop: '0px', marginBottom: '0px' },
+                                        format: {
+                                            marginTop: '0px',
+                                            marginRight: '0px',
+                                            marginBottom: '0px',
+                                            paddingLeft: '1em',
+                                        },
                                         dataset: {},
                                     },
                                 ],
@@ -1128,7 +1207,12 @@ describe('wordOnlineHandler', () => {
                                     isSelected: false,
                                     format: {},
                                 },
-                                format: { marginTop: '0px', marginBottom: '0px' },
+                                format: {
+                                    marginTop: '0px',
+                                    marginRight: '0px',
+                                    marginBottom: '0px',
+                                    marginLeft: '120px',
+                                },
                             },
                             {
                                 blockType: 'BlockGroup',
@@ -1142,14 +1226,16 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                     {
                                         listType: 'OL',
                                         format: {
                                             marginTop: '0px',
+                                            marginRight: '0px',
                                             marginBottom: '0px',
                                             startNumberOverride: 1,
+                                            paddingLeft: '1em',
                                         },
                                         dataset: {},
                                     },
@@ -1159,7 +1245,12 @@ describe('wordOnlineHandler', () => {
                                     isSelected: false,
                                     format: {},
                                 },
-                                format: { marginTop: '0px', marginBottom: '0px' },
+                                format: {
+                                    marginTop: '0px',
+                                    marginRight: '0px',
+                                    marginBottom: '0px',
+                                    marginLeft: '120px',
+                                },
                             },
                             {
                                 blockType: 'BlockGroup',
@@ -1173,8 +1264,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -1250,7 +1341,7 @@ describe('wordOnlineHandler', () => {
                                                         levels: [
                                                             {
                                                                 listType: 'UL',
-                                                                format: {},
+                                                                format: { paddingLeft: '1em' },
                                                                 dataset: {},
                                                             },
                                                         ],
@@ -1281,7 +1372,7 @@ describe('wordOnlineHandler', () => {
                                                         levels: [
                                                             {
                                                                 listType: 'UL',
-                                                                format: {},
+                                                                format: { paddingLeft: '1em' },
                                                                 dataset: {},
                                                             },
                                                         ],
@@ -1312,7 +1403,7 @@ describe('wordOnlineHandler', () => {
                                                         levels: [
                                                             {
                                                                 listType: 'UL',
-                                                                format: {},
+                                                                format: { paddingLeft: '1em' },
                                                                 dataset: {},
                                                             },
                                                         ],
@@ -1343,7 +1434,7 @@ describe('wordOnlineHandler', () => {
                                                         levels: [
                                                             {
                                                                 listType: 'UL',
-                                                                format: {},
+                                                                format: { paddingLeft: '1em' },
                                                                 dataset: {},
                                                             },
                                                         ],
@@ -1382,7 +1473,7 @@ describe('wordOnlineHandler', () => {
             it('fragments contains text, list and table that consist of list', () => {
                 runTest(
                     '<div class="OutlineElement"><div class="TableContainer"><table><tbody><tr><td><div><div class="OutlineElement"><p>asdfasdf</p></div></div></td><td><div><div class="OutlineElement"><p>asdfasdf222</p></div></div></td></tr><tr><td><div><div class="ListContainerWrapper"><ul><li role="listitem" data-aria-level="1" class="OutlineElement">A</li></ul></div></div></td><td><div><div class="ListContainerWrapper"><ul><li role="listitem" data-aria-level="1" class="OutlineElement">A</li></ul></div></div></td></tr></tbody></table></div></div>',
-                    '<table><tbody><tr><td><p>asdfasdf</p></td><td><p>asdfasdf222</p></td></tr><tr><td><ul><li>A</li></ul></td><td><ul><li>A</li></ul></td></tr></tbody></table>',
+                    '<table><tbody><tr><td><p>asdfasdf</p></td><td><p>asdfasdf222</p></td></tr><tr><td><ul style="padding-left: 1em;"><li>A</li></ul></td><td><ul style="padding-left: 1em;"><li>A</li></ul></td></tr></tbody></table>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -1472,7 +1563,7 @@ describe('wordOnlineHandler', () => {
                                                         levels: [
                                                             {
                                                                 listType: 'UL',
-                                                                format: {},
+                                                                format: { paddingLeft: '1em' },
                                                                 dataset: {},
                                                             },
                                                         ],
@@ -1513,7 +1604,7 @@ describe('wordOnlineHandler', () => {
                                                         levels: [
                                                             {
                                                                 listType: 'UL',
-                                                                format: {},
+                                                                format: { paddingLeft: '1em' },
                                                                 dataset: {},
                                                             },
                                                         ],
@@ -1548,7 +1639,7 @@ describe('wordOnlineHandler', () => {
         it('does not have list container', () => {
             runTest(
                 '<ul class="BulletListStyle1"><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW81557186">A</li></ul><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW81557186">B</li></ul><ul><li role="listitem" data-aria-level="3" class="OutlineElement Ltr SCXW81557186 BCX0" style="margin: 0px 0px 0px 120px;">C</li></ul><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr SCXW81557186 BCX0">D</li></ul><ul><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW81557186" style="margin: 0px 0px 0px 120px;">E</li></ul>',
-                '<ul><li>A</li><ul><li>B</li><ul style="margin-top: 0px; margin-bottom: 0px;"><li style="margin-top: 0px; margin-bottom: 0px;">C</li></ul><li>D</li><ul style="margin-top: 0px; margin-bottom: 0px;"><li style="margin-top: 0px; margin-bottom: 0px;">E</li></ul></ul></ul>',
+                '<ul style="padding-left: 1em;"><li>A</li><ul style="padding-left: 1em;"><li>B</li><ul style="margin-top: 0px; margin-right: 0px; margin-bottom: 0px; padding-left: 1em;"><li style="margin: 0px 0px 0px 120px;">C</li></ul><li>D</li><ul style="margin-top: 0px; margin-right: 0px; margin-bottom: 0px; padding-left: 1em;"><li style="margin: 0px 0px 0px 120px;">E</li></ul></ul></ul>',
                 {
                     blockGroupType: 'Document',
                     blocks: [
@@ -1563,7 +1654,9 @@ describe('wordOnlineHandler', () => {
                                     isImplicit: true,
                                 },
                             ],
-                            levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                            levels: [
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                            ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
                                 isSelected: false,
@@ -1583,8 +1676,8 @@ describe('wordOnlineHandler', () => {
                                 },
                             ],
                             levels: [
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'UL', format: {}, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                             ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
@@ -1605,11 +1698,16 @@ describe('wordOnlineHandler', () => {
                                 },
                             ],
                             levels: [
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'UL', format: {}, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 {
                                     listType: 'UL',
-                                    format: { marginTop: '0px', marginBottom: '0px' },
+                                    format: {
+                                        marginTop: '0px',
+                                        marginRight: '0px',
+                                        marginBottom: '0px',
+                                        paddingLeft: '1em',
+                                    },
                                     dataset: {},
                                 },
                             ],
@@ -1618,7 +1716,12 @@ describe('wordOnlineHandler', () => {
                                 isSelected: false,
                                 format: {},
                             },
-                            format: { marginTop: '0px', marginBottom: '0px' },
+                            format: {
+                                marginTop: '0px',
+                                marginRight: '0px',
+                                marginBottom: '0px',
+                                marginLeft: '120px',
+                            },
                         },
                         {
                             blockType: 'BlockGroup',
@@ -1632,8 +1735,8 @@ describe('wordOnlineHandler', () => {
                                 },
                             ],
                             levels: [
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'UL', format: {}, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                             ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
@@ -1654,11 +1757,16 @@ describe('wordOnlineHandler', () => {
                                 },
                             ],
                             levels: [
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'UL', format: {}, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 {
                                     listType: 'UL',
-                                    format: { marginTop: '0px', marginBottom: '0px' },
+                                    format: {
+                                        marginTop: '0px',
+                                        marginRight: '0px',
+                                        marginBottom: '0px',
+                                        paddingLeft: '1em',
+                                    },
                                     dataset: {},
                                 },
                             ],
@@ -1667,7 +1775,12 @@ describe('wordOnlineHandler', () => {
                                 isSelected: false,
                                 format: {},
                             },
-                            format: { marginTop: '0px', marginBottom: '0px' },
+                            format: {
+                                marginTop: '0px',
+                                marginRight: '0px',
+                                marginBottom: '0px',
+                                marginLeft: '120px',
+                            },
                         },
                     ],
                 },
@@ -1678,7 +1791,7 @@ describe('wordOnlineHandler', () => {
         it('does not have BulletListStyle or NumberListStyle but has ListContainerWrapper', () => {
             runTest(
                 '<div class="ListContainerWrapper BCX0 SCXW200751125"><ul><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW200751125">A</li></ul></div><div class="ListContainerWrapper BCX0 SCXW200751125"><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW200751125">B</li></ul></div><div class="ListContainerWrapper BCX0 SCXW200751125" style="margin: 0px;"><ul><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW200751125">C</li></ul></div>',
-                '<ul><li>A</li><ul><li>B</li><ul><li>C</li></ul></ul></ul>',
+                '<ul style="padding-left: 1em;"><li>A</li><ul style="padding-left: 1em;"><li>B</li><ul style="padding-left: 1em;"><li>C</li></ul></ul></ul>',
                 {
                     blockGroupType: 'Document',
                     blocks: [
@@ -1693,7 +1806,9 @@ describe('wordOnlineHandler', () => {
                                     isImplicit: true,
                                 },
                             ],
-                            levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                            levels: [
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                            ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
                                 isSelected: false,
@@ -1713,8 +1828,8 @@ describe('wordOnlineHandler', () => {
                                 },
                             ],
                             levels: [
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'UL', format: {}, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                             ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
@@ -1735,9 +1850,9 @@ describe('wordOnlineHandler', () => {
                                 },
                             ],
                             levels: [
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'UL', format: {}, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                             ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
@@ -1755,7 +1870,7 @@ describe('wordOnlineHandler', () => {
         it('does not have BulletListStyle or NumberListStyle but has no ListContainerWrapper', () => {
             runTest(
                 '<div class="BCX0 SCXW200751125"><ul><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW200751125">A</li></ul></div><div class="BCX0 SCXW200751125"><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW200751125">B</li></ul></div><div class="BCX0 SCXW200751125" style="margin: 0px;"><ul><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW200751125">C</li></ul></div>',
-                '<ul><li>A</li><ul><li>B</li><ul><li>C</li></ul></ul></ul>',
+                '<ul style="padding-left: 1em;"><li>A</li><ul style="padding-left: 1em;"><li>B</li><ul style="padding-left: 1em;"><li>C</li></ul></ul></ul>',
                 {
                     blockGroupType: 'Document',
                     blocks: [
@@ -1770,7 +1885,9 @@ describe('wordOnlineHandler', () => {
                                     isImplicit: true,
                                 },
                             ],
-                            levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                            levels: [
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                            ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
                                 isSelected: false,
@@ -1790,8 +1907,8 @@ describe('wordOnlineHandler', () => {
                                 },
                             ],
                             levels: [
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'UL', format: {}, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                             ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
@@ -1812,9 +1929,9 @@ describe('wordOnlineHandler', () => {
                                 },
                             ],
                             levels: [
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'UL', format: {}, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                             ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
@@ -1842,7 +1959,7 @@ describe('wordOnlineHandler', () => {
             it('should process html properly, if ListContainerWrapper contains two UL', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW225173058"><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">A</li></ul><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">B</li></ul></div><div class="ListContainerWrapper BCX0 SCXW225173058"><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">C</li></ul></div>',
-                    '<ul><li>A</li><li>B</li><li>C</li></ul>',
+                    '<ul style="padding-left: 1em;"><li>A</li><li>B</li><li>C</li></ul>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -1857,7 +1974,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -1876,7 +1995,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -1895,7 +2016,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2001,7 +2124,7 @@ describe('wordOnlineHandler', () => {
             it('should process html properly, if ListContainerWrapper contains list that is already well formatted', () => {
                 runTest(
                     '<div class="ListContainerWrapper SCXW81557186 BCX0"><ul class="BulletListStyle1"><li role="listitem" data-aria-level="1" class="OutlineElement Ltr BCX0 SCXW81557186">A</li><ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr BCX0 SCXW81557186">B</li><ul><li role="listitem" data-aria-level="3" class="OutlineElement Ltr SCXW81557186 BCX0">C</li></ul><li role="listitem" data-aria-level="2" class="OutlineElement Ltr SCXW81557186 BCX0">D</li><ul><li role="listitem" data-aria-level="3" class="OutlineElement Ltr BCX0 SCXW81557186">E</li></ul></ul></ul></div>',
-                    '<ul><li>A</li><ul><li>B</li><ul><li>C</li></ul><li>D</li><ul><li>E</li></ul></ul></ul>',
+                    '<ul style="padding-left: 1em;"><li>A</li><ul style="padding-left: 1em;"><li>B</li><ul style="padding-left: 1em;"><li>C</li></ul><li>D</li><ul style="padding-left: 1em;"><li>E</li></ul></ul></ul>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -2016,7 +2139,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2036,8 +2161,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -2058,9 +2183,9 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -2081,8 +2206,8 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -2103,9 +2228,9 @@ describe('wordOnlineHandler', () => {
                                     },
                                 ],
                                 levels: [
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
-                                    { listType: 'UL', format: {}, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
                                 ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
@@ -2134,7 +2259,7 @@ describe('wordOnlineHandler', () => {
             it('should process html properly, if there are multiple list item in ol (word online has one list item in each ol for ordered list)', () => {
                 runTest(
                     '<html><body><div class="ListContainerWrapper BCX0 SCXW225173058"><ol class="NumberListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">A</li><li class="OutlineElement" role="listitem" data-aria-level="1">B</li></ol></div><div class="ListContainerWrapper BCX0 SCXW225173058"><ol class="NumberListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">C</li></ol></div></body></html>',
-                    '<ol start="1"><li>A</li><li>B</li></ol><ol start="1"><li>C</li></ol>',
+                    '<ol start="1" style="padding-left: 1em;"><li>A</li><li>B</li></ol><ol start="1" style="padding-left: 1em;"><li>C</li></ol>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -2149,7 +2274,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2168,7 +2295,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2190,7 +2319,7 @@ describe('wordOnlineHandler', () => {
                                 levels: [
                                     {
                                         listType: 'OL',
-                                        format: { startNumberOverride: 1 },
+                                        format: { startNumberOverride: 1, paddingLeft: '1em' },
                                         dataset: {},
                                     },
                                 ],
@@ -2290,7 +2419,7 @@ describe('wordOnlineHandler', () => {
             it('should process html properly, if ListContainerWrapper contains well formated UL and non formated ol', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW225173058"><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">A</li></ul></div><div class="ListContainerWrapper BCX0 SCXW225173058"><ol class="NumberListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">B</li></ol></div>',
-                    '<ul><li>A</li></ul><ol start="1"><li>B</li></ol>',
+                    '<ul style="padding-left: 1em;"><li>A</li></ul><ol start="1" style="padding-left: 1em;"><li>B</li></ol>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -2305,7 +2434,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2324,7 +2455,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2353,7 +2486,7 @@ describe('wordOnlineHandler', () => {
             it('should process html properly, if ListContainerWrapper contains two OL', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW225173058"><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">A</li></ul></div><div class="ListContainerWrapper BCX0 SCXW225173058"><ol class="NumberListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">B</li></ol><ol start="2"><li class="OutlineElement" role="listitem" data-aria-level="1">C</li></ol></div>',
-                    '<ul><li>A</li></ul><ol start="1"><li>B</li><li>C</li></ol>',
+                    '<ul style="padding-left: 1em;"><li>A</li></ul><ol start="1" style="padding-left: 1em;"><li>B</li><li>C</li></ol>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -2368,7 +2501,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2387,7 +2522,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2406,7 +2543,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2433,7 +2572,7 @@ describe('wordOnlineHandler', () => {
             it('should process html properly, if ListContainerWrapper contains two OL and one UL', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW225173058"><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">A</li></ul><ol class="NumberListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">B</li></ol><ol class="NumberListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">C</li></ol></div>',
-                    '<ul><li>A</li></ul><ol start="1"><li>B</li></ol><ol start="1"><li>C</li></ol>',
+                    '<ul style="padding-left: 1em;"><li>A</li></ul><ol start="1" style="padding-left: 1em;"><li>B</li></ol><ol start="1" style="padding-left: 1em;"><li>C</li></ol>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -2448,7 +2587,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2467,7 +2608,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2489,7 +2632,7 @@ describe('wordOnlineHandler', () => {
                                 levels: [
                                     {
                                         listType: 'OL',
-                                        format: { startNumberOverride: 1 },
+                                        format: { startNumberOverride: 1, paddingLeft: '1em' },
                                         dataset: {},
                                     },
                                 ],
@@ -2517,7 +2660,7 @@ describe('wordOnlineHandler', () => {
             it('should process html properly, if there are list not in the ListContainerWrapper', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW225173058"><ol class="NumberListStyle1"><li class=OutlineElement role="listitem" data-aria-level="1">C</li></ol></div><ul class="NumberListStyle1"><li class=OutlineElement role="listitem" data-aria-level="1">A</li></ul>',
-                    '<ol start="1"><li>C</li></ol><ul><li>A</li></ul>',
+                    '<ol start="1" style="padding-left: 1em;"><li>C</li></ol><ul style="padding-left: 1em;"><li>A</li></ul>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -2532,7 +2675,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2551,7 +2696,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2580,7 +2727,7 @@ describe('wordOnlineHandler', () => {
             it('should process html properly, if ListContainerWrapper contains two UL', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW225173058"><ol class="NumberListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">C</li></ol></div><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">A</li></ul><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">A</li></ul><ul class="BulletListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">A</li></ul>',
-                    '<ol start="1"><li>C</li></ol><ul><li>A</li><li>A</li><li>A</li></ul>',
+                    '<ol start="1" style="padding-left: 1em;"><li>C</li></ol><ul style="padding-left: 1em;"><li>A</li><li>A</li><li>A</li></ul>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -2595,7 +2742,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2614,7 +2763,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2633,7 +2784,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2652,7 +2805,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2674,7 +2829,7 @@ describe('wordOnlineHandler', () => {
             it('should retain all text, if ListContainerWrapper contains Elements before li and ul', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW225173058"><p>paragraph</p><ol class="NumberListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">C</li></ol></div>',
-                    '<p>paragraph</p><ol start="1"><li>C</li></ol>',
+                    '<p>paragraph</p><ol start="1" style="padding-left: 1em;"><li>C</li></ol>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -2695,7 +2850,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2717,7 +2874,7 @@ describe('wordOnlineHandler', () => {
             it('should retain all text, if ListContainerWrapper contains Elements after li and ul', () => {
                 runTest(
                     '<div class="ListContainerWrapper BCX0 SCXW225173058"><ol class="NumberListStyle1"><li class="OutlineElement" role="listitem" data-aria-level="1">C</li></ol><p>paragraph</p></div>',
-                    '<ol start="1"><li>C</li></ol><p>paragraph</p>',
+                    '<ol start="1" style="padding-left: 1em;"><li>C</li></ol><p>paragraph</p>',
                     {
                         blockGroupType: 'Document',
                         blocks: [
@@ -2732,7 +2889,9 @@ describe('wordOnlineHandler', () => {
                                         isImplicit: true,
                                     },
                                 ],
-                                levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                                levels: [
+                                    { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
+                                ],
                                 formatHolder: {
                                     segmentType: 'SelectionMarker',
                                     isSelected: false,
@@ -2806,7 +2965,7 @@ describe('wordOnlineHandler', () => {
     it('List directly under fragment', () => {
         runTest(
             '<div class="ListContainerWrapper"><ul class="BulletListStyle1"><li data-listid="6" class="OutlineElement"><p class="Paragraph" paraid="1126911352"><span data-contrast="auto" class="TextRun"><span class="NormalTextRun">A</span></span></p></li></ul></div><div class="OutlineElement"><p class="Paragraph" paraid="1628213048"><span data-contrast="none" class="TextRun"><span class="NormalTextRun">B</span></span></p></div>',
-            '<ul><li><p role="presentation">A</p></li></ul><p>B</p>',
+            '<ul style="padding-left: 1em;"><li><p role="presentation">A</p></li></ul><p>B</p>',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -2821,7 +2980,7 @@ describe('wordOnlineHandler', () => {
                                 decorator: { tagName: 'p', format: {} },
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -2850,7 +3009,7 @@ describe('wordOnlineHandler', () => {
         it('should remove the display and margin styles from the element', () => {
             runTest(
                 '<ul class="BulletListStyle3 BCX0 SCXO236767657" role="list"><li class="OutlineElement"><p>A</p></li><li class="OutlineElement"><p>B</p></li><li class="OutlineElement"><p>C</p><ol class="NumberListStyle3 BCX0 SCXO236767657" role="list"><li data-aria-level="2" class="OutlineElement"><p>D</p></li></ol></li></ul>',
-                '<ul><li><p role="presentation">A</p></li><li><p role="presentation">B</p></li><li><p role="presentation">C</p></li><ol start="1"><li><p role="presentation">D</p></li></ol></ul>',
+                '<ul style="padding-left: 1em;"><li><p role="presentation">A</p></li><li><p role="presentation">B</p></li><li><p role="presentation">C</p></li><ol start="1" style="padding-left: 1em;"><li><p role="presentation">D</p></li></ol></ul>',
                 {
                     blockGroupType: 'Document',
                     blocks: [
@@ -2865,7 +3024,9 @@ describe('wordOnlineHandler', () => {
                                     decorator: { tagName: 'p', format: {} },
                                 },
                             ],
-                            levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                            levels: [
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                            ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
                                 isSelected: false,
@@ -2884,7 +3045,9 @@ describe('wordOnlineHandler', () => {
                                     decorator: { tagName: 'p', format: {} },
                                 },
                             ],
-                            levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                            levels: [
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                            ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
                                 isSelected: false,
@@ -2903,7 +3066,9 @@ describe('wordOnlineHandler', () => {
                                     decorator: { tagName: 'p', format: {} },
                                 },
                             ],
-                            levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                            levels: [
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                            ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
                                 isSelected: false,
@@ -2923,8 +3088,8 @@ describe('wordOnlineHandler', () => {
                                 },
                             ],
                             levels: [
-                                { listType: 'UL', format: {}, dataset: {} },
-                                { listType: 'OL', format: {}, dataset: {} },
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                                { listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} },
                             ],
                             formatHolder: {
                                 segmentType: 'SelectionMarker',
@@ -3030,7 +3195,7 @@ describe('wordOnlineHandler', () => {
     it('Text between lists', () => {
         runTest(
             '<div class="ListContainerWrapper"><ul><li>List1</li></ul></div><div><p>Text</p></div><div class="ListContainerWrapper"><ul><li>List2</li></ul></div>',
-            '<ul><li>List1</li></ul><p>Text</p><ul><li>List2</li></ul>',
+            '<ul style="padding-left: 1em;"><li>List1</li></ul><p>Text</p><ul style="padding-left: 1em;"><li>List2</li></ul>',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -3045,7 +3210,7 @@ describe('wordOnlineHandler', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -3070,7 +3235,7 @@ describe('wordOnlineHandler', () => {
                                 isImplicit: true,
                             },
                         ],
-                        levels: [{ listType: 'UL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -3097,7 +3262,7 @@ describe('wordOnlineHandler', () => {
     it('Remove temp marker from Word Online', () => {
         runTest(
             '<div class="OutlineElement Ltr BCX8 SCXW152957598"><p class="Paragraph SCXW152957598 BCX8" paraid="1448465497" paraeid="{96fbc754-61d4-42f8-b9cb-d86b35e3a21c}{224}"><span data-contrast="auto" xml:lang="EN-US" lang="EN-US" class="TextRun SCXW152957598 BCX8">it went:&nbsp;</span><span class="EOP SCXW152957598 BCX8" data-ccp-props="{&quot;201341983&quot;:0,&quot;335559739&quot;:160,&quot;335559740&quot;:259}">&nbsp;</span></p></div><div class="ListContainerWrapper SCXW152957598 BCX8"><ol class="NumberListStyle1 SCXW152957598 BCX8" role="list" start="1"><li data-leveltext="%1." data-font="Arial" data-listid="10" data-list-defn-props="{&quot;335552541&quot;:0,&quot;335559684&quot;:-1,&quot;335559685&quot;:720,&quot;335559991&quot;:360,&quot;469769242&quot;:[65533,0],&quot;469777803&quot;:&quot;left&quot;,&quot;469777804&quot;:&quot;%1.&quot;,&quot;469777815&quot;:&quot;hybridMultilevel&quot;}" aria-setsize="-1" data-aria-posinset="1" data-aria-level="1" role="listitem" class="OutlineElement Ltr BCX8 SCXW152957598"><p class="Paragraph SCXW152957598 BCX8" paraid="1079168982" paraeid="{96fbc754-61d4-42f8-b9cb-d86b35e3a21c}{230}"><span data-contrast="auto" xml:lang="EN-US" lang="EN-US" class="TextRun SCXW152957598 BCX8"><span class="NormalTextRun SCXW152957598 BCX8">Test</span></span></p><span class="ListMarkerWrappingSpan BCX8 SCXW152957598"><span class="ListMarker BCX8 SCXW152957598"></span></span></li></ol></div><div class="ListContainerWrapper SCXW152957598 BCX8"><ol class="NumberListStyle1 SCXW152957598 BCX8" role="list" start="2"><li data-leveltext="%1." data-font="Arial" data-listid="10" data-list-defn-props="{&quot;335552541&quot;:0,&quot;335559684&quot;:-1,&quot;335559685&quot;:720,&quot;335559991&quot;:360,&quot;469769242&quot;:[65533,0],&quot;469777803&quot;:&quot;left&quot;,&quot;469777804&quot;:&quot;%1.&quot;,&quot;469777815&quot;:&quot;hybridMultilevel&quot;}" aria-setsize="-1" data-aria-posinset="2" data-aria-level="1" role="listitem" class="OutlineElement Ltr BCX8 SCXW152957598"><p class="Paragraph SCXW152957598 BCX8" paraid="500697608" paraeid="{96fbc754-61d4-42f8-b9cb-d86b35e3a21c}{239}"><span data-contrast="auto" xml:lang="EN-US" lang="EN-US" class="TextRun SCXW152957598 BCX8">Test.</span><span class="EOP SCXW152957598 BCX8" data-ccp-props="{&quot;201341983&quot;:0,&quot;335559739&quot;:160,&quot;335559740&quot;:259}">&nbsp;</span></p><span class="ListMarkerWrappingSpan BCX8 SCXW152957598"></span></li><li data-leveltext="%1." data-font="Arial" data-listid="10" data-list-defn-props="{&quot;335552541&quot;:0,&quot;335559684&quot;:-1,&quot;335559685&quot;:720,&quot;335559991&quot;:360,&quot;469769242&quot;:[65533,0],&quot;469777803&quot;:&quot;left&quot;,&quot;469777804&quot;:&quot;%1.&quot;,&quot;469777815&quot;:&quot;hybridMultilevel&quot;}" aria-setsize="-1" data-aria-posinset="2" data-aria-level="1" role="listitem" class="OutlineElement Ltr BCX8 SCXW152957598"><div><span class="EOP SCXW152957598 BCX8" data-ccp-props="{&quot;201341983&quot;:0,&quot;335559739&quot;:160,&quot;335559740&quot;:259}"><br></span></div></li></ol></div>',
-            '<p>it went: &nbsp;</p><ol start="1"><li><p role="presentation">Test</p></li><li><p role="presentation">Test.&nbsp;</p></li><li><div role="presentation"><br></div></li></ol>',
+            '<p>it went: &nbsp;</p><ol start="1" style="padding-left: 1em;"><li><p role="presentation">Test</p></li><li><p role="presentation">Test.&nbsp;</p></li><li><div role="presentation"><br></div></li></ol>',
             {
                 blockGroupType: 'Document',
                 blocks: [
@@ -3121,7 +3286,7 @@ describe('wordOnlineHandler', () => {
                                 decorator: { tagName: 'p', format: {} },
                             },
                         ],
-                        levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -3143,7 +3308,7 @@ describe('wordOnlineHandler', () => {
                                 decorator: { tagName: 'p', format: {} },
                             },
                         ],
-                        levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -3161,7 +3326,7 @@ describe('wordOnlineHandler', () => {
                                 format: {},
                             },
                         ],
-                        levels: [{ listType: 'OL', format: {}, dataset: {} }],
+                        levels: [{ listType: 'OL', format: { paddingLeft: '1em' }, dataset: {} }],
                         formatHolder: {
                             segmentType: 'SelectionMarker',
                             isSelected: false,
@@ -6176,5 +6341,87 @@ describe('wordOnlineHandler', () => {
             },
             true
         );
+    });
+
+    describe('wacLiElementProcessor - paddingInlineStart override', () => {
+        it('zeroes out padding-inline-start on the parent ul element when processing a list item', () => {
+            const ul = document.createElement('ul');
+            ul.className = 'BulletListStyle1';
+            ul.style.paddingInlineStart = '40px';
+            const li = document.createElement('li');
+            li.className = 'OutlineElement';
+            li.setAttribute('data-aria-level', '1');
+            li.textContent = 'TEST';
+            ul.appendChild(li);
+
+            const wrapper = document.createElement('div');
+            wrapper.className = 'ListContainerWrapper';
+            wrapper.appendChild(ul);
+
+            fragment = document.createDocumentFragment();
+            fragment.appendChild(wrapper);
+
+            const event = createBeforePasteEventMock(fragment);
+            processPastedContentWacComponents(event);
+
+            domToContentModel(fragment, createDomToModelContext(undefined, event.domToModelOption));
+
+            expect(ul.style.paddingInlineStart).toBe('0px');
+        });
+
+        it('sets paddingLeft to 0px in the copied list level format for subsequent list items', () => {
+            runTest(
+                '<div class="ListContainerWrapper"><ul class="BulletListStyle1"><li class="OutlineElement" data-aria-level="1">A</li><li class="OutlineElement" data-aria-level="1">B</li></ul></div>',
+                undefined,
+                {
+                    blockGroupType: 'Document',
+                    blocks: [
+                        {
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [{ segmentType: 'Text', text: 'A', format: {} }],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
+                            levels: [
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                            ],
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
+                            format: {},
+                        },
+                        {
+                            blockType: 'BlockGroup',
+                            blockGroupType: 'ListItem',
+                            blocks: [
+                                {
+                                    blockType: 'Paragraph',
+                                    segments: [{ segmentType: 'Text', text: 'B', format: {} }],
+                                    format: {},
+                                    isImplicit: true,
+                                },
+                            ],
+                            levels: [
+                                { listType: 'UL', format: { paddingLeft: '1em' }, dataset: {} },
+                            ],
+                            formatHolder: {
+                                segmentType: 'SelectionMarker',
+                                isSelected: false,
+                                format: {},
+                            },
+                            format: {},
+                        },
+                    ],
+                },
+                true
+            );
+        });
     });
 });


### PR DESCRIPTION
Keep Margins in the List items, and set the padding of list elements for better paste interop with Wac Components

ADO https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/408585/ The Word Online doc is available in the description.

Before
<img width="681" height="832" alt="image" src="https://github.com/user-attachments/assets/b332c855-caa3-490e-961b-22cea0d774a1" />

After
<img width="668" height="797" alt="image" src="https://github.com/user-attachments/assets/2c74dddd-39fa-43f1-9679-931fe8c4823c" />
