### PR TITLE
Add back the check for handle enter key

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/EditOptions.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditOptions.ts
@@ -55,7 +55,6 @@ export type EditOptions = {
     handleExpandedSelectionOnDelete?: boolean;
 
     /**
-     * @deprecated This is always treated as true now
      * Callback function to determine whether the Rooster should handle the Enter key press.
      * If the function returns true, the Rooster will handle the Enter key press instead of the browser.
      * @param editor - The editor instance.

--- a/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/EditPlugin.ts
@@ -205,7 +205,18 @@ export class EditPlugin implements EditorPlugin {
                         !event.rawEvent.isComposing &&
                         event.rawEvent.keyCode !== DEAD_KEY
                     ) {
-                        keyboardEnter(editor, rawEvent, this.options.formatsToPreserveOnMerge);
+                        const { shouldHandleEnterKey } = this.options;
+                        const handleNormalEnter =
+                            typeof shouldHandleEnterKey === 'function'
+                                ? shouldHandleEnterKey(editor)
+                                : shouldHandleEnterKey !== false;
+
+                        keyboardEnter(
+                            editor,
+                            rawEvent,
+                            handleNormalEnter,
+                            this.options.formatsToPreserveOnMerge
+                        );
                     }
                     break;
 

--- a/packages/roosterjs-content-model-plugins/lib/edit/keyboardEnter.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/keyboardEnter.ts
@@ -8,7 +8,7 @@ import {
     normalizeContentModel,
     runEditSteps,
 } from 'roosterjs-content-model-dom';
-import type { IEditor } from 'roosterjs-content-model-types';
+import type { IEditor, ReadonlyContentModelParagraph } from 'roosterjs-content-model-types';
 
 /**
  * @internal
@@ -16,6 +16,7 @@ import type { IEditor } from 'roosterjs-content-model-types';
 export function keyboardEnter(
     editor: IEditor,
     rawEvent: KeyboardEvent,
+    handleNormalEnter: boolean,
     formatsToPreserveOnMerge: string[] = []
 ) {
     const selection = editor.getDOMSelection();
@@ -35,7 +36,9 @@ export function keyboardEnter(
                     ? []
                     : [handleAutoLink, handleEnterOnList, deleteEmptyQuote];
 
-                steps.push(handleEnterOnParagraph(formatsToPreserveOnMerge));
+                if (handleNormalEnter || handleEnterForEntity(result.insertPoint?.paragraph)) {
+                    steps.push(handleEnterOnParagraph(formatsToPreserveOnMerge));
+                }
 
                 runEditSteps(steps, result);
             }
@@ -59,5 +62,12 @@ export function keyboardEnter(
             getChangeData: () => rawEvent.which,
             apiName: 'handleEnterKey',
         }
+    );
+}
+
+function handleEnterForEntity(paragraph: ReadonlyContentModelParagraph | undefined) {
+    return (
+        paragraph &&
+        (paragraph.isImplicit || paragraph.segments.some(x => x.segmentType == 'Entity'))
     );
 }

--- a/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/EditPluginTest.ts
@@ -240,7 +240,7 @@ describe('EditPlugin', () => {
 
             expect(keyboardDeleteSpy).not.toHaveBeenCalled();
             expect(keyboardInputSpy).not.toHaveBeenCalled();
-            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, undefined);
+            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, true, undefined);
             expect(keyboardTabSpy).not.toHaveBeenCalled();
         });
 
@@ -260,7 +260,7 @@ describe('EditPlugin', () => {
 
             expect(keyboardDeleteSpy).not.toHaveBeenCalled();
             expect(keyboardInputSpy).not.toHaveBeenCalled();
-            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, undefined);
+            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, true, undefined);
             expect(keyboardTabSpy).not.toHaveBeenCalled();
         });
 
@@ -280,7 +280,7 @@ describe('EditPlugin', () => {
 
             expect(keyboardDeleteSpy).not.toHaveBeenCalled();
             expect(keyboardInputSpy).not.toHaveBeenCalled();
-            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, undefined);
+            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, true, undefined);
             expect(keyboardTabSpy).not.toHaveBeenCalled();
         });
 
@@ -300,7 +300,7 @@ describe('EditPlugin', () => {
 
             expect(keyboardDeleteSpy).not.toHaveBeenCalled();
             expect(keyboardInputSpy).not.toHaveBeenCalled();
-            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, undefined);
+            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, true, undefined);
             expect(keyboardTabSpy).not.toHaveBeenCalled();
         });
 
@@ -502,7 +502,7 @@ describe('EditPlugin', () => {
             });
 
             expect(keyboardEnterSpy).toHaveBeenCalledTimes(1);
-            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, [
+            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, true, [
                 'className',
                 'fontFamily',
             ]);
@@ -529,7 +529,7 @@ describe('EditPlugin', () => {
             });
 
             expect(keyboardEnterSpy).toHaveBeenCalledTimes(1);
-            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, undefined);
+            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, true, undefined);
         });
 
         it('should pass empty formatsToPreserveOnMerge array', () => {
@@ -554,7 +554,7 @@ describe('EditPlugin', () => {
             });
 
             expect(keyboardEnterSpy).toHaveBeenCalledTimes(1);
-            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, []);
+            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, true, []);
         });
 
         it('should work with multiple custom format properties', () => {
@@ -579,7 +579,7 @@ describe('EditPlugin', () => {
             });
 
             expect(keyboardEnterSpy).toHaveBeenCalledTimes(1);
-            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, [
+            expect(keyboardEnterSpy).toHaveBeenCalledWith(editor, rawEvent, true, [
                 'className',
                 'customProp',
                 'data-testid',

--- a/packages/roosterjs-content-model-plugins/test/edit/inputSteps/handleEnterOnListTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/inputSteps/handleEnterOnListTest.ts
@@ -1929,7 +1929,7 @@ describe('handleEnterOnList - keyboardEnter', () => {
                     },
                 });
 
-                keyboardEnter(editor, mockedEvent);
+                keyboardEnter(editor, mockedEvent, true);
             },
             input,
             expectedResult,

--- a/packages/roosterjs-content-model-plugins/test/edit/keyboardEnterTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/keyboardEnterTest.ts
@@ -61,7 +61,7 @@ describe('keyboardEnter', () => {
             expect();
         });
 
-        keyboardEnter(editor, rawEvent);
+        keyboardEnter(editor, rawEvent, true);
 
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
         expect(input).toEqual(output);
@@ -1396,7 +1396,7 @@ describe('keyboardEnter', () => {
 
         const runEditStepsSpy = spyOn(runEditSteps, 'runEditSteps');
 
-        keyboardEnter(editor, {} as any, []);
+        keyboardEnter(editor, {} as any, false, []);
 
         expect(runEditStepsSpy).toHaveBeenCalledTimes(2);
         // Check that the second call to runEditSteps includes steps for handling entity
@@ -1434,7 +1434,7 @@ describe('keyboardEnter', () => {
 
         const runEditStepsSpy = spyOn(runEditSteps, 'runEditSteps');
 
-        keyboardEnter(editor, {} as any, []);
+        keyboardEnter(editor, {} as any, false, []);
 
         expect(runEditStepsSpy).toHaveBeenCalledTimes(2);
         expect(
@@ -1479,6 +1479,7 @@ describe('keyboardEnter', () => {
             keyboardEnter(
                 editor,
                 { preventDefault: () => {}, shiftKey: false } as any,
+                true,
                 formatsToPreserve
             );
 
@@ -1514,7 +1515,7 @@ describe('keyboardEnter', () => {
                 callback(model, context);
             });
 
-            keyboardEnter(editor, { preventDefault: () => {}, shiftKey: false } as any, []);
+            keyboardEnter(editor, { preventDefault: () => {}, shiftKey: false } as any, true, []);
 
             expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
         });
@@ -1548,7 +1549,7 @@ describe('keyboardEnter', () => {
                 callback(model, context);
             });
 
-            keyboardEnter(editor, { preventDefault: () => {}, shiftKey: false } as any);
+            keyboardEnter(editor, { preventDefault: () => {}, shiftKey: false } as any, true);
 
             expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
         });


### PR DESCRIPTION
In my previous change I have removed  the check for handleEnterKey callback and always handle enter key using content model.

However, OutlookMobile still have the requirement to let browser handle enter key. So add back the check.