### PR TITLE
Fix #3341: Preserve selection marker when reconciling range across two text nodes

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/domIndexerImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/domIndexerImpl.ts
@@ -325,7 +325,19 @@ export class DomIndexerImpl implements DomIndexer {
                         );
                     } else {
                         const marker1 = this.reconcileNodeSelection(startContainer, startOffset);
-                        const marker2 = this.reconcileNodeSelection(endContainer, endOffset);
+                        // Pass marker1 to the second call so its adjacent-marker cleanup
+                        // does not consume the SelectionMarker we just inserted. Without
+                        // this guard, when marker1 lands directly next to endContainer's
+                        // segment in paragraph.segments (e.g. startOffset == startContainer
+                        // text length), the second splice would absorb marker1 and leave
+                        // setSelection with a dangling reference. See issue #3341.
+                        const marker2 = this.reconcileNodeSelection(
+                            endContainer,
+                            endOffset,
+                            undefined,
+                            undefined,
+                            marker1
+                        );
 
                         if (marker1 && marker2) {
                             if (newSelection.isReverted) {
@@ -421,11 +433,18 @@ export class DomIndexerImpl implements DomIndexer {
         node: Node,
         offset: number,
         defaultFormat?: ContentModelSegmentFormat,
-        selectionMarker?: ContentModelSelectionMarker
+        selectionMarker?: ContentModelSelectionMarker,
+        preserveMarker?: Selectable
     ): Selectable | undefined {
         if (isNodeOfType(node, 'TEXT_NODE')) {
             if (isIndexedSegment(node)) {
-                return this.reconcileTextSelection(node, offset, undefined, selectionMarker);
+                return this.reconcileTextSelection(
+                    node,
+                    offset,
+                    undefined,
+                    selectionMarker,
+                    preserveMarker
+                );
             } else if (isIndexedDelimiter(node)) {
                 return this.reconcileDelimiterSelection(node, defaultFormat);
             } else {
@@ -462,7 +481,8 @@ export class DomIndexerImpl implements DomIndexer {
         textNode: IndexedSegmentNode,
         startOffset?: number,
         endOffset?: number,
-        selectionMarker?: ContentModelSelectionMarker
+        selectionMarker?: ContentModelSelectionMarker,
+        preserveMarker?: Selectable
     ) {
         const { paragraph, segments } = textNode.__roosterjsContentModel;
         const first = segments[0];
@@ -533,14 +553,16 @@ export class DomIndexerImpl implements DomIndexer {
             if (firstIndex >= 0 && lastIndex >= 0) {
                 while (
                     firstIndex > 0 &&
-                    paragraph.segments[firstIndex - 1].segmentType == 'SelectionMarker'
+                    paragraph.segments[firstIndex - 1].segmentType == 'SelectionMarker' &&
+                    paragraph.segments[firstIndex - 1] !== preserveMarker
                 ) {
                     firstIndex--;
                 }
 
                 while (
                     lastIndex < paragraph.segments.length - 1 &&
-                    paragraph.segments[lastIndex + 1].segmentType == 'SelectionMarker'
+                    paragraph.segments[lastIndex + 1].segmentType == 'SelectionMarker' &&
+                    paragraph.segments[lastIndex + 1] !== preserveMarker
                 ) {
                     lastIndex++;
                 }

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
@@ -605,6 +605,74 @@ describe('domIndexerImpl.reconcileSelection', () => {
         expect(model.hasRevertedRangeSelection).toBeFalsy();
     });
 
+    it('Repro #3341: range across two text nodes with startOffset at end of first node', () => {
+        const node1 = document.createTextNode('test1') as any;
+        const node2 = document.createTextNode('test2') as any;
+        const parent = document.createElement('div');
+
+        parent.appendChild(node1);
+        parent.appendChild(node2);
+
+        // Range starts at the END of node1 (offset 5) and ends inside node2 (offset 3).
+        // After the first reconcile call marker1 lands directly before node2's segment;
+        // the second call's adjacent-marker cleanup loop must NOT eat marker1.
+        const newRangeEx: DOMSelection = {
+            type: 'range',
+            range: createRange(node1, 5, node2, 3),
+            isReverted: false,
+        };
+        const paragraph = createParagraph();
+        const oldSegment1 = createText('');
+        const oldSegment2 = createText('');
+
+        paragraph.segments.push(oldSegment1, oldSegment2);
+        domIndexerImpl.onSegment(node1, paragraph, [oldSegment1]);
+        domIndexerImpl.onSegment(node2, paragraph, [oldSegment2]);
+        model.blocks.push(paragraph);
+
+        const result = domIndexerImpl.reconcileSelection(model, newRangeEx);
+
+        const segment1: ContentModelSegment = {
+            segmentType: 'Text',
+            text: 'test1',
+            format: {},
+        };
+        const segment2: ContentModelSegment = {
+            segmentType: 'Text',
+            text: 'tes',
+            format: {},
+            isSelected: true,
+        };
+        const segment3: ContentModelSegment = {
+            segmentType: 'Text',
+            text: 't2',
+            format: {},
+        };
+        const marker1 = createSelectionMarker();
+        const marker2 = createSelectionMarker();
+
+        expect(result).toBeTrue();
+        expect(node1.__roosterjsContentModel).toEqual({
+            paragraph,
+            segments: [segment1],
+        });
+        expect(node2.__roosterjsContentModel).toEqual({
+            paragraph,
+            segments: [segment2, segment3],
+        });
+        expect(paragraph).toEqual({
+            blockType: 'Paragraph',
+            format: {},
+            segments: [segment1, marker1, segment2, marker2, segment3],
+        });
+        expect(setSelectionSpy).toHaveBeenCalledWith(model, marker1, marker2);
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [paragraph],
+        });
+        expect(model.hasRevertedRangeSelection).toBeFalsy();
+    });
+
     it('no old range, normal range on indexed text, expanded on other type of node', () => {
         const node1 = document.createTextNode('test1') as any;
         const node2 = document.createElement('br') as any;


### PR DESCRIPTION
## Summary
- `DomIndexerImpl.reconcileSelection` was losing the `SelectionMarker` inserted by the first `reconcileNodeSelection` call when handling a range that spans two text nodes. The second call's adjacent-marker cleanup loop absorbed `marker1` if it ended up directly next to the second text node's segment (notably when `startOffset == startContainer.nodeValue.length`). `setSelection` then orphaned both markers and the selected segment never received `isSelected`.
- Fix: thread the first call's marker into the second call as `preserveMarker`; the cleanup loops now skip that specific reference while still absorbing other adjacent stale markers.
- Added a regression test (`Repro #3341: range across two text nodes with startOffset at end of first node`) that verifies the full paragraph model after the action.

## Test plan
- [x] `yarn eslint` — clean
- [x] `yarn test:fast` — 5840 passing (includes the new regression test)
- [x] `yarn b` — build succeeds

Fixes #3341

🤖 Generated with [Claude Code](https://claude.com/claude-code)