### PR TITLE
Fix #3100: Hoist whitespace outside markdown emphasis markers

### DIFF
--- a/packages/roosterjs-content-model-markdown/lib/modelToMarkdown/creators/createMarkdownParagraph.ts
+++ b/packages/roosterjs-content-model-markdown/lib/modelToMarkdown/creators/createMarkdownParagraph.ts
@@ -57,8 +57,8 @@ function textProcessor(text: ContentModelText): string {
     // Move leading/trailing whitespace outside the markers so the emitted
     // markdown is valid (CommonMark requires emphasis markers to hug
     // non-whitespace), e.g. "world " with <b> => " " + "**world**".
-    const match = /^(\s*)([\s\S]*?)(\s*)$/.exec(text.text) ?? [];
-    const [, leading, core, trailing] = match;
+    const match = /^(\s*)([\s\S]*?)(\s*)$/.exec(text.text);
+    const [, leading, core, trailing] = match ? match : ['', '', text.text, ''];
 
     if (!core) {
         return text.text;

--- a/packages/roosterjs-content-model-markdown/lib/modelToMarkdown/creators/createMarkdownParagraph.ts
+++ b/packages/roosterjs-content-model-markdown/lib/modelToMarkdown/creators/createMarkdownParagraph.ts
@@ -47,18 +47,33 @@ export function createMarkdownParagraph(
 }
 
 function textProcessor(text: ContentModelText): string {
-    let markdownString = text.text;
-    if (text.link) {
-        markdownString = `[${text.text}](${text.link.format.href})`;
+    const { fontWeight, italic, strikethrough } = text.format;
+    const hasInlineFormat = fontWeight == 'bold' || italic || strikethrough;
+
+    if (!hasInlineFormat) {
+        return text.link ? `[${text.text}](${text.link.format.href})` : text.text;
     }
-    if (text.format.fontWeight == 'bold') {
-        markdownString = `**${markdownString}**`;
+
+    // Move leading/trailing whitespace outside the markers so the emitted
+    // markdown is valid (CommonMark requires emphasis markers to hug
+    // non-whitespace), e.g. "world " with <b> => " " + "**world**".
+    const match = /^(\s*)([\s\S]*?)(\s*)$/.exec(text.text) ?? [];
+    const [, leading, core, trailing] = match;
+
+    if (!core) {
+        return text.text;
     }
-    if (text.format.strikethrough) {
-        markdownString = `~~${markdownString}~~`;
+
+    let inner = text.link ? `[${core}](${text.link.format.href})` : core;
+    if (fontWeight == 'bold') {
+        inner = `**${inner}**`;
     }
-    if (text.format.italic) {
-        markdownString = `*${markdownString}*`;
+    if (strikethrough) {
+        inner = `~~${inner}~~`;
     }
-    return markdownString;
+    if (italic) {
+        inner = `*${inner}*`;
+    }
+
+    return `${leading}${inner}${trailing}`;
 }

--- a/packages/roosterjs-content-model-markdown/test/modelToMarkdown/convertContentModelToMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/modelToMarkdown/convertContentModelToMarkdownTest.ts
@@ -115,6 +115,66 @@ describe('convertContentModelToMarkdown', () => {
         expect(md).toEqual(markdown);
     });
 
+    it('should move trailing whitespace outside bold markers (issue 3100)', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        paragraph.segments.push(createText('hello '));
+        paragraph.segments.push(createText('world ', { fontWeight: 'bold' }));
+        paragraph.segments.push(createText('how are you?'));
+        model.blocks.push(paragraph);
+
+        const md = convertContentModelToMarkdown(model).trim();
+        expect(md).toEqual('hello **world** how are you?');
+    });
+
+    it('should move leading whitespace outside italic markers (issue 3100)', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        paragraph.segments.push(createText('hello'));
+        paragraph.segments.push(createText(' world', { italic: true }));
+        paragraph.segments.push(createText(' how are you?'));
+        model.blocks.push(paragraph);
+
+        const md = convertContentModelToMarkdown(model).trim();
+        expect(md).toEqual('hello *world* how are you?');
+    });
+
+    it('should move surrounding whitespace outside strikethrough markers', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        paragraph.segments.push(createText('a'));
+        paragraph.segments.push(createText(' b ', { strikethrough: true }));
+        paragraph.segments.push(createText('c'));
+        model.blocks.push(paragraph);
+
+        const md = convertContentModelToMarkdown(model).trim();
+        expect(md).toEqual('a ~~b~~ c');
+    });
+
+    it('should move whitespace outside combined bold + italic markers', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        paragraph.segments.push(createText('x'));
+        paragraph.segments.push(createText(' y ', { fontWeight: 'bold', italic: true }));
+        paragraph.segments.push(createText('z'));
+        model.blocks.push(paragraph);
+
+        const md = convertContentModelToMarkdown(model).trim();
+        expect(md).toEqual('x ***y*** z');
+    });
+
+    it('should not wrap whitespace-only segments with markers', () => {
+        const model = createContentModelDocument();
+        const paragraph = createParagraph();
+        paragraph.segments.push(createText('a'));
+        paragraph.segments.push(createText(' ', { fontWeight: 'bold' }));
+        paragraph.segments.push(createText('b'));
+        model.blocks.push(paragraph);
+
+        const md = convertContentModelToMarkdown(model).trim();
+        expect(md).toEqual('a b');
+    });
+
     it('should set a default alt to images', () => {
         const markdown = '![image](https://www.example.com/image)';
         const model = createModelFromHtml("<img src='https://www.example.com/image'>");

--- a/packages/roosterjs-content-model-markdown/test/modelToMarkdown/creators/createMarkdownBlockgroupTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/modelToMarkdown/creators/createMarkdownBlockgroupTest.ts
@@ -204,7 +204,7 @@ describe('createMarkdownBlockGroup', () => {
         paragraph.segments.push(text);
         paragraph.segments.push(linkText);
         blockGroup.blocks.push(paragraph);
-        runTest(blockGroup, `> *text *[link](https://example.com)\n\n`, {
+        runTest(blockGroup, `> *text* [link](https://example.com)\n\n`, {
             listItemCount: 0,
             subListItemCount: 0,
         });


### PR DESCRIPTION
## Summary
- Fixes #3100. The markdown emitter wrapped segment text with `**`/`*`/`~~` verbatim, so a text segment with surrounding whitespace produced invalid CommonMark (e.g. `**world **how` instead of `**world** how`).
- `textProcessor` in `createMarkdownParagraph.ts` now hoists leading/trailing whitespace outside the emphasis markers and skips wrapping for whitespace-only segments.
- One existing test in `createMarkdownBlockgroupTest` was asserting the buggy `> *text *[link](...)` output — updated to the correct `> *text* [link](...)`.

## Test plan
- [x] `yarn test:fast --testPathPattern=roosterjs-content-model-markdown` — 199/199 pass
- [x] `yarn eslint` — clean
- [x] Five new unit tests cover: trailing whitespace inside bold, leading whitespace inside italic, surrounding whitespace inside strikethrough, combined bold+italic, and whitespace-only segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)