### PR TITLE
Add per-PR preview deployment workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -39,3 +39,4 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   BRANCH: gh-pages
                   FOLDER: dist/deploy
+                  CLEAN_EXCLUDE: '["pr-preview/**"]'

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,46 @@
+name: Deploy PR Preview
+on:
+    pull_request:
+        types:
+            - opened
+            - reopened
+            - synchronize
+            - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+    deploy-preview:
+        # Skip PRs from forks: GITHUB_TOKEN is read-only for fork PRs,
+        # so it cannot push to gh-pages. Fork support requires a separate
+        # workflow_run-based design.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Set Node Version
+              if: github.event.action != 'closed'
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 'v18.16.0'
+
+            - name: Install dependencies
+              if: github.event.action != 'closed'
+              run: yarn
+
+            - name: Build
+              if: github.event.action != 'closed'
+              run: yarn build
+
+            - name: Deploy preview
+              uses: rossjrw/pr-preview-action@v1
+              with:
+                  source-dir: ./dist/deploy
+                  preview-branch: gh-pages
+                  umbrella-dir: pr-preview
+                  action: auto

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -38,7 +38,9 @@ jobs:
               run: yarn build
 
             - name: Deploy preview
-              uses: rossjrw/pr-preview-action@v1
+              # Pinned to commit SHA (v1.8.1) for supply-chain safety, since
+              # this third-party action runs with write access to gh-pages and PRs.
+              uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
               with:
                   source-dir: ./dist/deploy
                   preview-branch: gh-pages


### PR DESCRIPTION
## Summary

- New workflow `pr-preview.yml` deploys each PR's demo site to `gh-pages/pr-preview/pr-<n>/` using `rossjrw/pr-preview-action`. The action comments the preview URL on the PR, redeploys on push, and removes the directory when the PR is closed or merged.
- Updates `build-and-deploy.yml` with `CLEAN_EXCLUDE: '["pr-preview/**"]'` so master deploys no longer wipe per-PR preview directories from the `gh-pages` branch.
- Skips fork PRs (the `if:` guard) because `GITHUB_TOKEN` is read-only in that context and cannot push to `gh-pages`. Fork support can be added later via a `workflow_run`-based design.

## Test plan

- [ ] This PR itself triggers the new workflow — preview URL is posted as a comment by the action.
- [ ] Visit the posted URL and confirm the demo loads.
- [ ] Push an additional commit to this branch and confirm the preview redeploys.
- [ ] After merge, open a follow-up PR and confirm a master deploy (triggered by this merge) did not wipe the new PR's preview directory.
- [ ] Close a test PR and confirm `pr-preview/pr-<n>/` is removed from `gh-pages` and the comment is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)