### PR TITLE
Reconcile IMG src and data-* attribute changes in Content Model cache

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/CachePlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/CachePlugin.ts
@@ -148,6 +148,18 @@ class CachePlugin implements PluginWithState<CachePluginState> {
 
                     break;
 
+                case 'attribute':
+                    if (
+                        !this.state.domIndexer.reconcileImageAttribute(
+                            mutation.element,
+                            mutation.attributeName
+                        )
+                    ) {
+                        this.invalidateCache();
+                    }
+
+                    break;
+
                 case 'unknown':
                     this.invalidateCache();
                     break;

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/MutationType.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/MutationType.ts
@@ -11,6 +11,10 @@ export type MutationType =
      */
     | 'elementId'
     /**
+     * An attribute (such as src or data-*) is changed on an element
+     */
+    | 'attribute'
+    /**
      * Only text is changed
      */
     | 'text'
@@ -41,6 +45,14 @@ export interface ElementIdMutation extends MutationBase<'elementId'> {
 /**
  * @internal
  */
+export interface AttributeMutation extends MutationBase<'attribute'> {
+    element: HTMLElement;
+    attributeName: string;
+}
+
+/**
+ * @internal
+ */
 export interface TextMutation extends MutationBase<'text'> {}
 
 /**
@@ -54,4 +66,9 @@ export interface ChildListMutation extends MutationBase<'childList'> {
 /**
  * @internal
  */
-export type Mutation = UnknownMutation | ElementIdMutation | TextMutation | ChildListMutation;
+export type Mutation =
+    | UnknownMutation
+    | ElementIdMutation
+    | AttributeMutation
+    | TextMutation
+    | ChildListMutation;

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/domIndexerImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/domIndexerImpl.ts
@@ -411,6 +411,38 @@ export class DomIndexerImpl implements DomIndexer {
         }
     }
 
+    reconcileImageAttribute(element: HTMLElement, attributeName: string) {
+        if (isElementOfType(element, 'img')) {
+            const image = getIndexedSegmentItem(element)?.segments[0];
+
+            if (image?.segmentType == 'Image') {
+                if (attributeName == 'src') {
+                    // Use getAttribute('src') instead of retrieving src directly, in case the src
+                    // has port and may be stripped by browser. This matches imageProcessor.
+                    image.src = element.getAttribute('src') ?? '';
+
+                    return true;
+                } else if (attributeName.indexOf('data-') == 0) {
+                    // A data-* attribute may be added, modified or removed. Rebuild the whole
+                    // dataset from DOM to keep it in sync, the same way imageProcessor builds it.
+                    const { dataset } = image;
+
+                    getObjectKeys(dataset).forEach(key => {
+                        delete dataset[key];
+                    });
+
+                    getObjectKeys(element.dataset).forEach(key => {
+                        dataset[key] = element.dataset[key] || '';
+                    });
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     private onBlockEntityDelimiter(
         node: Node | null,
         entity: ContentModelEntity,

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/textMutationObserver.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/textMutationObserver.ts
@@ -79,6 +79,17 @@ class TextMutationObserverImpl implements TextMutationObserver {
                             isNodeOfType(target, 'ELEMENT_NODE')
                         ) {
                             this.onMutation({ type: 'elementId', element: target });
+                        } else if (
+                            mutation.attributeName &&
+                            isNodeOfType(target, 'ELEMENT_NODE') &&
+                            (mutation.attributeName == 'src' ||
+                                mutation.attributeName.indexOf('data-') == 0)
+                        ) {
+                            this.onMutation({
+                                type: 'attribute',
+                                element: target,
+                                attributeName: mutation.attributeName,
+                            });
                         } else {
                             // We cannot handle attributes changes on editor content for now
                             canHandle = false;

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/CachePluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/CachePluginTest.ts
@@ -577,11 +577,13 @@ describe('CachePlugin', () => {
         let mockedObserver: any;
         let reconcileChildListSpy: jasmine.Spy;
         let reconcileElementIdSpy: jasmine.Spy;
+        let reconcileImageAttributeSpy: jasmine.Spy;
         let mockedIndexer: DomIndexer;
 
         beforeEach(() => {
             reconcileChildListSpy = jasmine.createSpy('reconcileChildList');
             reconcileElementIdSpy = jasmine.createSpy('reconcileElementId');
+            reconcileImageAttributeSpy = jasmine.createSpy('reconcileImageAttribute');
             startObservingSpy = jasmine.createSpy('startObserving');
             stopObservingSpy = jasmine.createSpy('stopObserving');
 
@@ -603,6 +605,7 @@ describe('CachePlugin', () => {
                 reconcileSelection: reconcileSelectionSpy,
                 reconcileChildList: reconcileChildListSpy,
                 reconcileElementId: reconcileElementIdSpy,
+                reconcileImageAttribute: reconcileImageAttributeSpy,
             } as any;
         });
 
@@ -784,6 +787,62 @@ describe('CachePlugin', () => {
 
             expect(reconcileElementIdSpy).toHaveBeenCalledTimes(1);
             expect(reconcileElementIdSpy).toHaveBeenCalledWith(mockedElement);
+            expect(state).toEqual({
+                domIndexer: mockedIndexer,
+                textMutationObserver: mockedObserver,
+                cachedModel: undefined,
+                cachedSelection: undefined,
+                paragraphMap: mockedParagraphMap,
+            });
+            expect(resetMapSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('attribute, can reconcile', () => {
+            const state = plugin.getState();
+            state.cachedModel = 'MODEL' as any;
+            state.cachedSelection = 'SELECTION' as any;
+            state.domIndexer = mockedIndexer;
+
+            const mockedElement = 'ELEMENT' as any;
+
+            reconcileImageAttributeSpy.and.returnValue(true);
+
+            onMutation({
+                type: 'attribute',
+                element: mockedElement,
+                attributeName: 'src',
+            });
+
+            expect(reconcileImageAttributeSpy).toHaveBeenCalledTimes(1);
+            expect(reconcileImageAttributeSpy).toHaveBeenCalledWith(mockedElement, 'src');
+            expect(state).toEqual({
+                domIndexer: mockedIndexer,
+                textMutationObserver: mockedObserver,
+                cachedModel: 'MODEL' as any,
+                cachedSelection: 'SELECTION' as any,
+                paragraphMap: mockedParagraphMap,
+            });
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it('attribute, cannot reconcile', () => {
+            const state = plugin.getState();
+            state.cachedModel = 'MODEL' as any;
+            state.cachedSelection = 'SELECTION' as any;
+            state.domIndexer = mockedIndexer;
+
+            const mockedElement = 'ELEMENT' as any;
+
+            reconcileImageAttributeSpy.and.returnValue(false);
+
+            onMutation({
+                type: 'attribute',
+                element: mockedElement,
+                attributeName: 'data-foo',
+            });
+
+            expect(reconcileImageAttributeSpy).toHaveBeenCalledTimes(1);
+            expect(reconcileImageAttributeSpy).toHaveBeenCalledWith(mockedElement, 'data-foo');
             expect(state).toEqual({
                 domIndexer: mockedIndexer,
                 textMutationObserver: mockedObserver,

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
@@ -1695,6 +1695,121 @@ describe('domIndexerImpl.reconcileElementId', () => {
     });
 });
 
+describe('domIndexerImpl.reconcileImageAttribute', () => {
+    function indexImage(img: HTMLImageElement, image: ReturnType<typeof createImage>) {
+        const para = createParagraph();
+        const segIndex: SegmentItem = {
+            paragraph: para,
+            segments: [image],
+        };
+
+        para.segments.push(image);
+        ((img as Node) as IndexedSegmentNode).__roosterjsContentModel = segIndex;
+    }
+
+    it('unindexed image src', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        img.setAttribute('src', 'new.png');
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'src');
+
+        expect(result).toBe(false);
+        expect(image.src).toBe('test');
+    });
+
+    it('indexed image src', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        indexImage(img, image);
+
+        img.setAttribute('src', 'new.png');
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'src');
+
+        expect(result).toBe(true);
+        expect(image.src).toBe('new.png');
+    });
+
+    it('indexed image src removed', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        indexImage(img, image);
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'src');
+
+        expect(result).toBe(true);
+        expect(image.src).toBe('');
+    });
+
+    it('indexed image data-* added', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        indexImage(img, image);
+
+        img.setAttribute('data-foo', 'bar');
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'data-foo');
+
+        expect(result).toBe(true);
+        expect(image.dataset).toEqual({ foo: 'bar' });
+    });
+
+    it('indexed image data-* modified', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        image.dataset.foo = 'old';
+        indexImage(img, image);
+
+        img.setAttribute('data-foo', 'new');
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'data-foo');
+
+        expect(result).toBe(true);
+        expect(image.dataset).toEqual({ foo: 'new' });
+    });
+
+    it('indexed image data-* removed', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        image.dataset.foo = 'bar';
+        indexImage(img, image);
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'data-foo');
+
+        expect(result).toBe(true);
+        expect(image.dataset).toEqual({});
+    });
+
+    it('indexed image, unrelated attribute', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        indexImage(img, image);
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'alt');
+
+        expect(result).toBe(false);
+        expect(image.src).toBe('test');
+    });
+
+    it('non-image element', () => {
+        const div = document.createElement('div');
+
+        div.setAttribute('src', 'new.png');
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(div, 'src');
+
+        expect(result).toBe(false);
+    });
+});
+
 describe('domIndexerImpl.clearIndex', () => {
     it('clear index, no child', () => {
         const domIndexer = new DomIndexerImpl(true);

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/textMutationObserverTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/textMutationObserverTest.ts
@@ -342,6 +342,60 @@ describe('TextMutationObserverImpl', () => {
         expect(onMutation).toHaveBeenCalledWith({ type: 'unknown' });
     });
 
+    it('src change', async () => {
+        const div = document.createElement('div');
+        const img = document.createElement('img');
+
+        div.appendChild(img);
+
+        const onMutation = jasmine.createSpy('onMutation');
+        observer = textMutationObserver.createTextMutationObserver(div, onMutation);
+
+        observer.startObserving();
+
+        img.setAttribute('src', 'test.png');
+
+        observer.flushMutations();
+
+        await new Promise<void>(resolve => {
+            window.setTimeout(resolve, 10);
+        });
+
+        expect(onMutation).toHaveBeenCalledTimes(1);
+        expect(onMutation).toHaveBeenCalledWith({
+            type: 'attribute',
+            element: img,
+            attributeName: 'src',
+        });
+    });
+
+    it('data-* change', async () => {
+        const div = document.createElement('div');
+        const img = document.createElement('img');
+
+        div.appendChild(img);
+
+        const onMutation = jasmine.createSpy('onMutation');
+        observer = textMutationObserver.createTextMutationObserver(div, onMutation);
+
+        observer.startObserving();
+
+        img.setAttribute('data-foo', 'bar');
+
+        observer.flushMutations();
+
+        await new Promise<void>(resolve => {
+            window.setTimeout(resolve, 10);
+        });
+
+        expect(onMutation).toHaveBeenCalledTimes(1);
+        expect(onMutation).toHaveBeenCalledWith({
+            type: 'attribute',
+            element: img,
+            attributeName: 'data-foo',
+        });
+    });
+
     it('Ignore changes under entity', () => {
         const div = document.createElement('div');
         const wrapper = document.createElement('div');

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/brProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/brProcessorTest.ts
@@ -77,6 +77,7 @@ describe('brProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/entityProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/entityProcessorTest.ts
@@ -262,6 +262,7 @@ describe('entityProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/generalProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/generalProcessorTest.ts
@@ -397,6 +397,7 @@ describe('generalProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/imageProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/imageProcessorTest.ts
@@ -326,6 +326,7 @@ describe('imageProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/tableProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/tableProcessorTest.ts
@@ -298,6 +298,7 @@ describe('tableProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/textProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/textProcessorTest.ts
@@ -580,6 +580,7 @@ describe('textProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };
@@ -619,6 +620,7 @@ describe('textProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };
@@ -669,6 +671,7 @@ describe('textProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleParagraphTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleParagraphTest.ts
@@ -691,6 +691,7 @@ describe('handleParagraph', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };
@@ -743,6 +744,7 @@ describe('handleParagraph', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };
@@ -1395,7 +1397,9 @@ describe('Handle paragraph and adjust selections', () => {
             };
             handleParagraph(document, parent, paragraph, context, null);
 
-            expect((context as ModelToDomSegmentContext).noFollowingTextSegmentOrLast).toBeUndefined();
+            expect(
+                (context as ModelToDomSegmentContext).noFollowingTextSegmentOrLast
+            ).toBeUndefined();
         });
     });
 });

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
@@ -613,6 +613,7 @@ describe('handleTable', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-types/lib/context/DomIndexer.ts
+++ b/packages/roosterjs-content-model-types/lib/context/DomIndexer.ts
@@ -80,6 +80,15 @@ export interface DomIndexer {
     reconcileElementId: (element: HTMLElement) => boolean;
 
     /**
+     * When src or a data-* attribute is changed on an indexed IMG element, update the related
+     * ContentModelImage (src property or dataset) so the cached model stays valid.
+     * @param element The element that has an attribute changed
+     * @param attributeName The name of the changed attribute
+     * @returns True if successfully updated, otherwise false
+     */
+    reconcileImageAttribute: (element: HTMLElement, attributeName: string) => boolean;
+
+    /**
      * When child list of editor content is changed, we can use this method to do sync the change from editor into content model.
      * This is mostly used when user start to type in an empty line. In that case browser will remove the existing BR node in the empty line if any,
      * and create a new TEXT node for the typed text. Here we use these information to remove original Br segment and create a new Text segment


### PR DESCRIPTION
@
## Summary

Previously, any attribute change other than `id` on editor content set the cache mutation type to `unknown`, which **invalidated the whole cached Content Model** and forced a full reparse from DOM next time a model was requested.

This PR recognizes two more cases on an **indexed `<img>`** and reconciles them in place instead of invalidating:

- **`src` change** → update `ContentModelImage.src`
- **`data-*` change** → update `ContentModelImage.dataset`

## Changes

- **`MutationType.ts`** — new `attribute` mutation type + `AttributeMutation` interface (`element`, `attributeName`).
- **`textMutationObserver.ts`** — the `attributes` case now recognizes `src` and `data-*` and emits an `attribute` mutation; everything else still falls through to `unknown`.
- **`DomIndexer.ts`** (types) — new `reconcileImageAttribute(element, attributeName)` method.
- **`domIndexerImpl.ts`** — implements it: `src` uses `getAttribute("src")` to match `imageProcessor` (port stripping); `data-*` rebuilds the whole `dataset` from `element.dataset` (covers add/modify/remove, including metadata stored as data attributes). Returns `false` for non-image / unindexed / unrelated attributes.
- **`CachePlugin.ts`** — dispatches the `attribute` mutation, invalidating only when reconcile returns `false`.

## Tests

- New observer tests (`src` / `data-*`), `reconcileImageAttribute` unit tests (indexed/unindexed, src set/removed, data-* add/modify/remove, unrelated attr, non-image), and `CachePlugin` dispatch tests.
- Updated the typed `DomIndexer` mock literals across dom-package tests to satisfy the interface.

All `yarn test:fast`, `yarn eslint`, and `yarn build` pass.

## Note

Adding a required member to the exported `DomIndexer` interface is technically a breaking change for any external implementer — same precedent as when `reconcileChildList` was added. It is effectively an internal interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@