### PR TITLE
Remove redundant leading/trailing selection markers within a paragraph

### DIFF
--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
@@ -595,7 +595,7 @@ describe('domIndexerImpl.reconcileSelection', () => {
         expect(paragraph).toEqual({
             blockType: 'Paragraph',
             format: {},
-            segments: [segment1, marker1, segment2, segment3, marker2, segment4],
+            segments: [segment1, segment2, segment3, segment4],
         });
         expect(setSelectionSpy).toHaveBeenCalledWith(model, marker1, marker2);
         expect(model).toEqual({
@@ -615,7 +615,10 @@ describe('domIndexerImpl.reconcileSelection', () => {
 
         // Range starts at the END of node1 (offset 5) and ends inside node2 (offset 3).
         // After the first reconcile call marker1 lands directly before node2's segment;
-        // the second call's adjacent-marker cleanup loop must NOT eat marker1.
+        // the second call's adjacent-marker cleanup loop must NOT eat marker1, so that
+        // setSelection still receives both live markers. setSelection then drops both
+        // boundary markers (redundant: "tes" is selected between them in the same paragraph),
+        // which is why the final paragraph segments contain no SelectionMarker.
         const newRangeEx: DOMSelection = {
             type: 'range',
             range: createRange(node1, 5, node2, 3),
@@ -663,7 +666,7 @@ describe('domIndexerImpl.reconcileSelection', () => {
         expect(paragraph).toEqual({
             blockType: 'Paragraph',
             format: {},
-            segments: [segment1, marker1, segment2, marker2, segment3],
+            segments: [segment1, segment2, segment3],
         });
         expect(setSelectionSpy).toHaveBeenCalledWith(model, marker1, marker2);
         expect(model).toEqual({
@@ -724,7 +727,7 @@ describe('domIndexerImpl.reconcileSelection', () => {
         expect(paragraph).toEqual({
             blockType: 'Paragraph',
             format: {},
-            segments: [segment1, marker1, segment2, oldSegment2, marker2],
+            segments: [segment1, segment2, oldSegment2],
         });
         expect(setSelectionSpy).toHaveBeenCalledWith(model, marker1, marker2);
         expect(model).toEqual({

--- a/packages/roosterjs-content-model-dom/lib/modelApi/selection/setSelection.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/selection/setSelection.ts
@@ -93,7 +93,11 @@ function setSelectionToBlock(
             });
 
         case 'Paragraph':
-            const segmentsToDelete: number[] = [];
+            const state: ParagraphSelectionState = {
+                segmentsToDelete: [],
+                boundaryMarkers: [],
+                hasSelectedNonMarker: false,
+            };
 
             block.segments.forEach((segment, i) => {
                 isInSelection = handleSelection(
@@ -106,7 +110,7 @@ function setSelectionToBlock(
                             block,
                             segment,
                             isInSelection,
-                            segmentsToDelete,
+                            state,
                             start,
                             end,
                             i
@@ -115,12 +119,25 @@ function setSelectionToBlock(
                 );
             });
 
-            if (segmentsToDelete.length > 0) {
+            if (state.hasSelectedNonMarker) {
+                // This paragraph contains a real (non-marker) selected segment, so any leading/trailing
+                // selection marker of the range is redundant within this paragraph and can be removed.
+                // We only do this within the same paragraph: a boundary marker at a paragraph edge must be
+                // kept to distinguish "selection starts at the beginning of this line" from "selection
+                // starts at the end of the previous line".
+                state.segmentsToDelete.push(...state.boundaryMarkers);
+            }
+
+            if (state.segmentsToDelete.length > 0) {
                 const mutablePara = mutateBlock(block);
 
                 let index: number | undefined;
 
-                while ((index = segmentsToDelete.pop()) !== undefined) {
+                // Sort ascending so the pop()-based splice below always removes the highest index first,
+                // keeping the remaining indices valid (boundary markers may sit before queued deletions).
+                state.segmentsToDelete.sort((a, b) => a - b);
+
+                while ((index = state.segmentsToDelete.pop()) !== undefined) {
                     if (index >= 0) {
                         mutablePara.segments.splice(index, 1);
                     }
@@ -191,22 +208,43 @@ function findCell(
     return { row, col };
 }
 
+interface ParagraphSelectionState {
+    // Indexes of segments to delete after the paragraph is fully processed
+    segmentsToDelete: number[];
+
+    // Indexes of leading/trailing selection markers of the range that are kept for now, but will be
+    // removed if this paragraph also contains a real (non-marker) selected segment
+    boundaryMarkers: number[];
+
+    // Whether this paragraph contains at least one selected segment that is not a selection marker
+    hasSelectedNonMarker: boolean;
+}
+
 function setSelectionToSegment(
     paragraph: ReadonlyContentModelParagraph,
     segment: ReadonlyContentModelSegment,
     isInSelection: boolean,
-    segmentsToDelete: number[],
+    state: ParagraphSelectionState,
     start: ReadonlySelectable | null,
     end: ReadonlySelectable | null,
     i: number
 ) {
+    if (segment.segmentType != 'SelectionMarker' && isInSelection) {
+        state.hasSelectedNonMarker = true;
+    }
+
     switch (segment.segmentType) {
         case 'SelectionMarker':
             if (!isInSelection || (segment != start && segment != end)) {
                 // Delete the selection marker when
                 // 1. It is not in selection any more. Or
                 // 2. It is in middle of selection, so no need to have it
-                segmentsToDelete.push(i);
+                state.segmentsToDelete.push(i);
+            } else {
+                // It is a leading/trailing selection marker of a range selection. Keep it for now, but
+                // remember it so it can be removed later if this same paragraph also contains a real
+                // (non-marker) selected segment, in which case the marker is redundant.
+                state.boundaryMarkers.push(i);
             }
             return isInSelection;
 

--- a/packages/roosterjs-content-model-dom/test/modelApi/selection/setSelectionTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/selection/setSelectionTest.ts
@@ -1004,4 +1004,173 @@ describe('setSelection', () => {
             blocks: [],
         });
     });
+
+    it('Remove leading and trailing markers when paragraph has a real selected segment in between', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker1 = createSelectionMarker();
+        const text = createText('test');
+        const marker2 = createSelectionMarker();
+
+        para.segments.push(marker1, text, marker2);
+        model.blocks.push(para);
+
+        setSelection(model, marker1, marker2);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test',
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Keep leading marker at end of paragraph when selected content is in the next paragraph', () => {
+        const model = createContentModelDocument();
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const text1 = createText('test1');
+        const marker = createSelectionMarker();
+        const text2 = createText('test2');
+
+        para1.segments.push(text1, marker);
+        para2.segments.push(text2);
+        model.blocks.push(para1, para2);
+
+        setSelection(model, marker, text2);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test1',
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test2',
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Keep trailing marker at start of paragraph when selected content is in the previous paragraph', () => {
+        const model = createContentModelDocument();
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const text1 = createText('test1');
+        const marker = createSelectionMarker();
+        const text2 = createText('test2');
+
+        para1.segments.push(text1);
+        para2.segments.push(marker, text2);
+        model.blocks.push(para1, para2);
+
+        setSelection(model, text1, marker);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test1',
+                            isSelected: true,
+                        },
+                    ],
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test2',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Keep collapsed selection marker when there is no other selected segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const text1 = createText('test1');
+        const marker = createSelectionMarker();
+        const text2 = createText('test2');
+
+        para.segments.push(text1, marker, text2);
+        model.blocks.push(para);
+
+        setSelection(model, marker);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test1',
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test2',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
## Summary

When `setSelection` applies a range selection, a leading or trailing `SelectionMarker` that sits next to a real (non-marker) selected segment **in the same paragraph** carries no selection information — the range is already fully defined by the selected content. This change removes those redundant boundary markers.

The cleanup is deliberately scoped to **within a single paragraph**. A marker at a paragraph edge must be preserved, because it is the only way to distinguish *"selection starts at the beginning of this line"* from *"selection starts at the end of the previous line"*. Collapsed-cursor markers (no other selected segment) are likewise preserved.

## Implementation

- `setSelection.ts`: a per-paragraph `ParagraphSelectionState` tracks whether any non-marker segment was selected (`hasSelectedNonMarker`) and which boundary markers were tentatively kept (`boundaryMarkers`). After the segment loop, the boundary markers are dropped if the paragraph contained real selected content. The delete list is sorted ascending before the pop/splice so the appended (lower-index) boundary markers don't corrupt indices.

## Tests

- Added 4 `setSelection` cases: both markers removed with content between; leading marker kept across a paragraph boundary; trailing marker kept across a paragraph boundary; collapsed marker preserved.
- Updated 3 `domIndexerImpl.reconcileSelection` snapshots (including Repro #3341). The #3341 `preserveMarker` guard is untouched and still hands `setSelection` two live markers, so the selected segment keeps `isSelected`; `setSelection` now additionally drops the redundant boundary markers.

## Validation

- `yarn test:fast` — 5901 passing, 0 failures
- `yarn eslint` — clean
- `yarn b` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
