### PR TITLE
Add Paste As Markdown support and isPastedContentMarkdown API

### DIFF
--- a/demo/scripts/controlsV2/demoButtons/pasteAsMarkdownButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/pasteAsMarkdownButton.ts
@@ -1,0 +1,47 @@
+import {
+    convertMarkdownToContentModel,
+    isPastedContentMarkdown,
+} from 'roosterjs-content-model-markdown';
+import { mergeModel } from 'roosterjs-content-model-dom';
+import { paste } from 'roosterjs-content-model-core';
+import { readClipboardData } from '../../utils/readClipboardData';
+import type { IEditor } from 'roosterjs-content-model-types';
+import type { RibbonButton } from 'roosterjs-react';
+
+/**
+ * @internal
+ * "Paste as Markdown" button on the format ribbon.
+ *
+ * Reads the clipboard, checks whether the content can be interpreted as markdown
+ * (via {@link isMarkdownContent}). If so, converts it with
+ * {@link convertMarkdownToContentModel} and merges the resulting model into the
+ * editor. Otherwise, falls back to the regular paste flow.
+ */
+export const pasteAsMarkdownButton: RibbonButton<'buttonNamePasteAsMarkdown'> = {
+    key: 'buttonNamePasteAsMarkdown',
+    unlocalizedText: 'Paste as Markdown',
+    iconName: 'Paste',
+    onClick: async editor => {
+        const doc = editor.getDocument();
+        const clipboardData = await readClipboardData(doc);
+        if (!clipboardData) {
+            return;
+        }
+
+        if (isPastedContentMarkdown(doc, clipboardData, editor.getDOMCreator())) {
+            insertMarkdown(editor, clipboardData.text);
+        } else {
+            paste(editor, clipboardData);
+        }
+    },
+};
+
+function insertMarkdown(editor: IEditor, text: string) {
+    const newModel = convertMarkdownToContentModel(text);
+    editor.formatContentModel((model, context) => {
+        mergeModel(model, newModel, context, {
+            mergeFormat: 'mergeAll',
+        });
+        return true;
+    });
+}

--- a/demo/scripts/controlsV2/demoButtons/pasteAsMarkdownButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/pasteAsMarkdownButton.ts
@@ -1,10 +1,10 @@
+import { mergeModel } from 'roosterjs-content-model-dom';
+import { paste } from 'roosterjs-content-model-core';
+import { readClipboardData } from '../../utils/readClipboardData';
 import {
     convertMarkdownToContentModel,
     isPastedContentMarkdown,
 } from 'roosterjs-content-model-markdown';
-import { mergeModel } from 'roosterjs-content-model-dom';
-import { paste } from 'roosterjs-content-model-core';
-import { readClipboardData } from '../../utils/readClipboardData';
 import type { IEditor } from 'roosterjs-content-model-types';
 import type { RibbonButton } from 'roosterjs-react';
 
@@ -28,7 +28,7 @@ export const pasteAsMarkdownButton: RibbonButton<'buttonNamePasteAsMarkdown'> = 
             return;
         }
 
-        if (isPastedContentMarkdown(doc, clipboardData, editor.getDOMCreator())) {
+        if (isPastedContentMarkdown(editor, clipboardData)) {
             insertMarkdown(editor, clipboardData.text);
         } else {
             paste(editor, clipboardData);

--- a/demo/scripts/controlsV2/demoButtons/pasteButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/pasteButton.ts
@@ -1,10 +1,6 @@
-import { extractClipboardItems } from 'roosterjs-content-model-dom';
 import { paste } from 'roosterjs-content-model-core';
+import { readClipboardData } from '../../utils/readClipboardData';
 import type { RibbonButton } from 'roosterjs-react';
-
-interface ClipboardWithUnsanitized {
-    read(options?: { unsanitized?: string[] }): Promise<ClipboardItems>;
-}
 
 /**
  * @internal
@@ -15,49 +11,9 @@ export const pasteButton: RibbonButton<'buttonNamePaste'> = {
     unlocalizedText: 'Paste',
     iconName: 'Paste',
     onClick: async editor => {
-        const doc = editor.getDocument();
-        const clipboard = doc.defaultView.navigator.clipboard as ClipboardWithUnsanitized;
-        if (clipboard && clipboard.read) {
-            try {
-                const clipboardItems = await clipboard.read({ unsanitized: ['text/html'] });
-                const dataTransferItems = await Promise.all(
-                    createDataTransferItems(clipboardItems)
-                );
-                const clipboardData = await extractClipboardItems(dataTransferItems);
-                paste(editor, clipboardData);
-            } catch {}
+        const clipboardData = await readClipboardData(editor.getDocument());
+        if (clipboardData) {
+            paste(editor, clipboardData);
         }
     },
-};
-
-const createDataTransfer = (
-    kind: 'string' | 'file',
-    type: string,
-    blob: Blob
-): DataTransferItem => {
-    const file = blob as File;
-    return {
-        kind,
-        type,
-        getAsFile: () => file,
-        getAsString: (callback: (data: string) => void) => {
-            blob.text().then(callback);
-        },
-        webkitGetAsEntry: () => null,
-    };
-};
-
-const createDataTransferItems = (data: ClipboardItems) => {
-    const isTEXT = (type: string) => type.startsWith('text/');
-    const dataTransferItems: Promise<DataTransferItem>[] = [];
-    data.forEach(item => {
-        item.types.forEach(type => {
-            dataTransferItems.push(
-                item
-                    .getType(type)
-                    .then(blob => createDataTransfer(isTEXT(type) ? 'string' : 'file', type, blob))
-            );
-        });
-    });
-    return dataTransferItems;
 };

--- a/demo/scripts/controlsV2/tabs/ribbonButtons.ts
+++ b/demo/scripts/controlsV2/tabs/ribbonButtons.ts
@@ -10,6 +10,7 @@ import { imageBorderWidthButton } from '../demoButtons/imageBorderWidthButton';
 import { imageBoxShadowButton } from '../demoButtons/imageBoxShadowButton';
 import { ImageEditor } from 'roosterjs-content-model-types';
 import { listStartNumberButton } from '../demoButtons/listStartNumberButton';
+import { pasteAsMarkdownButton } from '../demoButtons/pasteAsMarkdownButton';
 import { pasteButton } from '../demoButtons/pasteButton';
 import { setBulletedListStyleButton } from '../demoButtons/setBulletedListStyleButton';
 import { setNumberedListStyleButton } from '../demoButtons/setNumberedListStyleButton';
@@ -137,6 +138,7 @@ const paragraphButtons: RibbonButton<any>[] = [
     spaceBeforeButton,
     spaceAfterButton,
     pasteButton,
+    pasteAsMarkdownButton,
 ];
 
 const allButtons: RibbonButton<any>[] = [
@@ -197,6 +199,7 @@ const allButtons: RibbonButton<any>[] = [
     spaceBeforeButton,
     spaceAfterButton,
     pasteButton,
+    pasteAsMarkdownButton,
 ];
 export function getButtons(
     id: tabNames,

--- a/demo/scripts/utils/readClipboardData.ts
+++ b/demo/scripts/utils/readClipboardData.ts
@@ -1,0 +1,61 @@
+import { extractClipboardItems } from 'roosterjs-content-model-dom';
+import type { ClipboardData } from 'roosterjs-content-model-types';
+
+interface ClipboardWithUnsanitized {
+    read(options?: { unsanitized?: string[] }): Promise<ClipboardItems>;
+}
+
+/**
+ * Read the system clipboard using the async Clipboard API and convert the result
+ * into a {@link ClipboardData} object that the editor's paste pipeline expects.
+ *
+ * Returns `null` when the clipboard API is not available or the read fails (for
+ * example, due to permissions or unsupported types).
+ */
+export async function readClipboardData(doc: Document): Promise<ClipboardData | null> {
+    const clipboard = doc.defaultView?.navigator.clipboard as ClipboardWithUnsanitized | undefined;
+    if (!clipboard || !clipboard.read) {
+        return null;
+    }
+
+    try {
+        const clipboardItems = await clipboard.read();
+        console.log(clipboardItems);
+        const dataTransferItems = await Promise.all(createDataTransferItems(clipboardItems));
+        return await extractClipboardItems(dataTransferItems);
+    } catch {
+        return null;
+    }
+}
+
+const createDataTransfer = (
+    kind: 'string' | 'file',
+    type: string,
+    blob: Blob
+): DataTransferItem => {
+    const file = blob as File;
+    return {
+        kind,
+        type,
+        getAsFile: () => file,
+        getAsString: (callback: (data: string) => void) => {
+            blob.text().then(callback);
+        },
+        webkitGetAsEntry: () => null,
+    };
+};
+
+const createDataTransferItems = (data: ClipboardItems) => {
+    const isTEXT = (type: string) => type.startsWith('text/') || type === 'vscode-editor-data';
+    const dataTransferItems: Promise<DataTransferItem>[] = [];
+    data.forEach(item => {
+        item.types.forEach(type => {
+            dataTransferItems.push(
+                item
+                    .getType(type)
+                    .then(blob => createDataTransfer(isTEXT(type) ? 'string' : 'file', type, blob))
+            );
+        });
+    });
+    return dataTransferItems;
+};

--- a/packages/roosterjs-content-model-dom/lib/domUtils/event/extractClipboardItems.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/event/extractClipboardItems.ts
@@ -9,7 +9,6 @@ const ContentHandlers: {
     ['text/*']: (data, value, type?) => !!type && (data.customValues[type] = value),
     ['text/link-preview']: tryParseLinkPreview,
     ['text/uri-list']: (data, value) => (data.text = value),
-    ['vscode-editor-data']: tryVSCodeDataParser,
 };
 
 /**
@@ -59,8 +58,7 @@ export function extractClipboardItems(
                     resolve();
                 });
             } else {
-                const customType =
-                    getAllowedCustomType(type, allowedCustomPasteType) || getVSCodeTypes(type);
+                const customType = getAllowedCustomType(type, allowedCustomPasteType);
                 const handler =
                     ContentHandlers[type] || (customType ? ContentHandlers['text/*'] : null);
                 return new Promise<void>(resolve =>
@@ -84,19 +82,9 @@ function tryParseLinkPreview(data: ClipboardData, value: string) {
     } catch {}
 }
 
-function tryVSCodeDataParser(data: ClipboardData, _value: string) {
-    try {
-        data.customValues['vscode-editor-data'] = 'true';
-    } catch {}
-}
-
 function getAllowedCustomType(type: string, allowedCustomPasteType?: string[]) {
     const textType = type.indexOf('text/') == 0 ? type.substring('text/'.length) : null;
     const index =
         allowedCustomPasteType && textType ? allowedCustomPasteType.indexOf(textType) : -1;
     return textType && index >= 0 ? textType : undefined;
-}
-
-function getVSCodeTypes(type: string) {
-    return type == 'vscode-editor-data' ? 'vscode-editor-data' : undefined;
 }

--- a/packages/roosterjs-content-model-dom/lib/domUtils/event/extractClipboardItems.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/event/extractClipboardItems.ts
@@ -9,6 +9,7 @@ const ContentHandlers: {
     ['text/*']: (data, value, type?) => !!type && (data.customValues[type] = value),
     ['text/link-preview']: tryParseLinkPreview,
     ['text/uri-list']: (data, value) => (data.text = value),
+    ['vscode-editor-data']: tryVSCodeDataParser,
 };
 
 /**
@@ -58,7 +59,8 @@ export function extractClipboardItems(
                     resolve();
                 });
             } else {
-                const customType = getAllowedCustomType(type, allowedCustomPasteType);
+                const customType =
+                    getAllowedCustomType(type, allowedCustomPasteType) || getVSCodeTypes(type);
                 const handler =
                     ContentHandlers[type] || (customType ? ContentHandlers['text/*'] : null);
                 return new Promise<void>(resolve =>
@@ -82,9 +84,19 @@ function tryParseLinkPreview(data: ClipboardData, value: string) {
     } catch {}
 }
 
+function tryVSCodeDataParser(data: ClipboardData, _value: string) {
+    try {
+        data.customValues['vscode-editor-data'] = 'true';
+    } catch {}
+}
+
 function getAllowedCustomType(type: string, allowedCustomPasteType?: string[]) {
     const textType = type.indexOf('text/') == 0 ? type.substring('text/'.length) : null;
     const index =
         allowedCustomPasteType && textType ? allowedCustomPasteType.indexOf(textType) : -1;
     return textType && index >= 0 ? textType : undefined;
+}
+
+function getVSCodeTypes(type: string) {
+    return type == 'vscode-editor-data' ? 'vscode-editor-data' : undefined;
 }

--- a/packages/roosterjs-content-model-markdown/lib/index.ts
+++ b/packages/roosterjs-content-model-markdown/lib/index.ts
@@ -1,4 +1,5 @@
 export { convertMarkdownToContentModel } from './markdownToModel/convertMarkdownToContentModel';
 export { convertContentModelToMarkdown } from './modelToMarkdown/convertContentModelToMarkdown';
+export { isPastedContentMarkdown } from './publicApi/isPastedContentMarkdown';
 export { MarkdownLineBreaks } from '../lib/constants/markdownLineBreaks';
 export { MarkdownToModelOptions } from './markdownToModel/types/MarkdownToModelOptions';

--- a/packages/roosterjs-content-model-markdown/lib/index.ts
+++ b/packages/roosterjs-content-model-markdown/lib/index.ts
@@ -1,5 +1,6 @@
 export { convertMarkdownToContentModel } from './markdownToModel/convertMarkdownToContentModel';
 export { convertContentModelToMarkdown } from './modelToMarkdown/convertContentModelToMarkdown';
+export { isContentMarkdown } from './publicApi/isContentMarkdown';
 export { isPastedContentMarkdown } from './publicApi/isPastedContentMarkdown';
 export { MarkdownLineBreaks } from '../lib/constants/markdownLineBreaks';
 export { MarkdownToModelOptions } from './markdownToModel/types/MarkdownToModelOptions';

--- a/packages/roosterjs-content-model-markdown/lib/publicApi/isContentMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/publicApi/isContentMarkdown.ts
@@ -1,0 +1,49 @@
+// Block-level markdown patterns. A line that matches any of these is considered markdown.
+const BlockPatterns: RegExp[] = [
+    /^#{1,6}\s.+/, // heading: "# text" .. "###### text"
+    /^\s*>\s.+/, // blockquote: "> text"
+    /^\s*[\*\-\+]\s.+/, // unordered list: "- item", "* item", "+ item"
+    /^\s*\d+\.\s.+/, // ordered list: "1. item"
+    /^---+$/, // horizontal rule: "---"
+    /^\s*\|.*\|\s*$/, // table row: "| a | b |"
+];
+
+// Inline markdown patterns. The text contains markdown if any of these match anywhere.
+const InlinePatterns: RegExp[] = [
+    /!\[[^\[\]]+\]\([^\)\s]+\)/, // image: ![alt](url)
+    /\[[^\[\]]+\]\([^\)\s]+\)/, // link: [text](url)
+    /\*\*[^\s*][^*]*\*\*/, // bold: **text**
+    /(^|[^*])\*[^\s*][^*]*\*([^*]|$)/, // italic: *text* (not part of **)
+    /~~[^\s~][^~]*~~/, // strikethrough: ~~text~~
+];
+
+/**
+ * Detect whether the given plain text contains any markdown markup.
+ * Recognizes block-level patterns (headings, blockquotes, lists, horizontal rules, tables)
+ * and inline patterns (bold, italic, strikethrough, links, images).
+ * @param text The plain text to check.
+ * @returns True if the text contains any markdown markup, false otherwise.
+ */
+export function isContentMarkdown(text: string): boolean {
+    if (!text || !text.trim()) {
+        return false;
+    }
+
+    const lines = text.split(/\r\n|\r|\n/);
+
+    for (const line of lines) {
+        for (const pattern of BlockPatterns) {
+            if (pattern.test(line)) {
+                return true;
+            }
+        }
+    }
+
+    for (const pattern of InlinePatterns) {
+        if (pattern.test(text)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/packages/roosterjs-content-model-markdown/lib/publicApi/isPastedContentMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/publicApi/isPastedContentMarkdown.ts
@@ -1,4 +1,5 @@
-import type { ClipboardData, DOMCreator } from 'roosterjs-content-model-types';
+import { isContentMarkdown } from './isContentMarkdown';
+import type { ClipboardData, DOMCreator, IEditor } from 'roosterjs-content-model-types';
 
 // Tags that are considered "thin wrappers", which only add structure (such as line breaks)
 // around the plain text without applying any real formatting to its content.
@@ -6,31 +7,29 @@ const ThinWrapperTags = new Set<string>(['DIV', 'P', 'BR', 'SPAN']);
 
 /**
  * Detect whether the given clipboard content can be interpreted as markdown.
- * @param doc The document to use for creating the document fragment.
+ * @param editor The editor instance.
  * @param clipboardData The clipboard data to check.
- * @param trustedHTMLHandler The handler to use for parsing HTML.
  * @returns True if the content can be interpreted as markdown, false otherwise.
  */
-export function isPastedContentMarkdown(
-    doc: Document,
-    clipboardData: ClipboardData,
-    trustedHTMLHandler: DOMCreator
-): boolean {
+export function isPastedContentMarkdown(editor: IEditor, clipboardData: ClipboardData): boolean {
     const { text, rawHtml } = clipboardData;
 
-    // There must be some plain text to interpret as markdown
     if (!text || !text.trim()) {
         return false;
     }
 
-    // No HTML content at all (text/plain only), so the plain text is all we have
-    if (!rawHtml) {
-        return true;
+    if (isContentMarkdown(text)) {
+        if (!rawHtml) {
+            return true;
+        }
+
+        const doc = editor.getDocument();
+        const trustedHTMLHandler = editor.getDOMCreator();
+        const fragment = parseHtmlToFragment(rawHtml, doc, trustedHTMLHandler);
+
+        return isThinWrapperOfPlainText(fragment, text);
     }
-
-    const fragment = parseHtmlToFragment(rawHtml, doc, trustedHTMLHandler);
-
-    return isThinWrapperOfPlainText(fragment, text);
+    return false;
 }
 
 function isThinWrapperOfPlainText(fragment: DocumentFragment, text: string): boolean {
@@ -46,13 +45,12 @@ function isThinWrapperOfPlainText(fragment: DocumentFragment, text: string): boo
         for (let j = 0; j < element.attributes.length; j++) {
             const attr = element.attributes[j];
 
-            if (attr.name === 'class' || attr.name !== 'style') {
+            if (attr.name !== 'class' && attr.name !== 'style') {
                 return false;
             }
         }
     }
 
-    // Make sure the HTML and the plain text actually represent the same content
     return removeWhitespace(fragment.textContent || '') === removeWhitespace(text);
 }
 

--- a/packages/roosterjs-content-model-markdown/lib/publicApi/isPastedContentMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/publicApi/isPastedContentMarkdown.ts
@@ -1,0 +1,81 @@
+import type { ClipboardData, DOMCreator } from 'roosterjs-content-model-types';
+
+// Tags that are considered "thin wrappers", which only add structure (such as line breaks)
+// around the plain text without applying any real formatting to its content.
+const ThinWrapperTags = new Set<string>(['DIV', 'P', 'BR', 'SPAN']);
+
+/**
+ * Detect whether the given clipboard content can be interpreted as markdown.
+ * @param doc The document to use for creating the document fragment.
+ * @param clipboardData The clipboard data to check.
+ * @param trustedHTMLHandler The handler to use for parsing HTML.
+ * @returns True if the content can be interpreted as markdown, false otherwise.
+ */
+export function isPastedContentMarkdown(
+    doc: Document,
+    clipboardData: ClipboardData,
+    trustedHTMLHandler: DOMCreator
+): boolean {
+    const { text, rawHtml } = clipboardData;
+
+    // There must be some plain text to interpret as markdown
+    if (!text || !text.trim()) {
+        return false;
+    }
+
+    // No HTML content at all (text/plain only), so the plain text is all we have
+    if (!rawHtml) {
+        return true;
+    }
+
+    const fragment = parseHtmlToFragment(rawHtml, doc, trustedHTMLHandler);
+
+    return isThinWrapperOfPlainText(fragment, text);
+}
+
+function isThinWrapperOfPlainText(fragment: DocumentFragment, text: string): boolean {
+    const elements = fragment.querySelectorAll('*');
+
+    for (let i = 0; i < elements.length; i++) {
+        const element = elements[i];
+
+        if (!ThinWrapperTags.has(element.tagName)) {
+            return false;
+        }
+
+        // Allow elements whose attributes are limited to non-formatting class names
+        // and/or a style attribute (any style is permitted).
+        for (let j = 0; j < element.attributes.length; j++) {
+            const attr = element.attributes[j];
+
+            if (attr.name === 'class' || attr.name !== 'style') {
+                return false;
+            }
+        }
+    }
+
+    // Make sure the HTML and the plain text actually represent the same content
+    return removeWhitespace(fragment.textContent || '') === removeWhitespace(text);
+}
+
+function removeWhitespace(text: string): string {
+    return text.replace(/\s/g, '');
+}
+
+function parseHtmlToFragment(
+    html: string,
+    doc: Document,
+    trustedHTMLHandler: DOMCreator
+): DocumentFragment {
+    const parsedDoc = trustedHTMLHandler.htmlToDOM(html);
+    const fragment = doc.createDocumentFragment();
+    const body = parsedDoc?.body;
+
+    if (body) {
+        while (body.firstChild) {
+            fragment.appendChild(body.firstChild);
+        }
+    }
+
+    return fragment;
+}

--- a/packages/roosterjs-content-model-markdown/lib/publicApi/isPastedContentMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/publicApi/isPastedContentMarkdown.ts
@@ -43,8 +43,6 @@ function isThinWrapperOfPlainText(fragment: DocumentFragment, text: string): boo
             return false;
         }
 
-        // Allow elements whose attributes are limited to non-formatting class names
-        // and/or a style attribute (any style is permitted).
         for (let j = 0; j < element.attributes.length; j++) {
             const attr = element.attributes[j];
 

--- a/packages/roosterjs-content-model-markdown/test/publicApi/isContentMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/publicApi/isContentMarkdownTest.ts
@@ -1,0 +1,107 @@
+import { isContentMarkdown } from '../../lib/publicApi/isContentMarkdown';
+
+describe('isContentMarkdown', () => {
+    function runTest(text: string, expected: boolean) {
+        expect(isContentMarkdown(text)).toBe(expected);
+    }
+
+    it('should return false for empty text', () => {
+        runTest('', false);
+    });
+
+    it('should return false for whitespace-only text', () => {
+        runTest('   \n\t  ', false);
+    });
+
+    it('should return false for plain text with no markup', () => {
+        runTest('Hello world, this is plain text.', false);
+    });
+
+    it('should return false for plain multi-line text', () => {
+        runTest('First line\nSecond line\nThird line', false);
+    });
+
+    it('should detect heading (h1)', () => {
+        runTest('# Heading', true);
+    });
+
+    it('should detect heading (h6)', () => {
+        runTest('###### Heading', true);
+    });
+
+    it('should not treat a hashtag without a space as a heading', () => {
+        runTest('#hashtag', false);
+    });
+
+    it('should not treat 7 hashes as a heading', () => {
+        runTest('####### too many', false);
+    });
+
+    it('should detect blockquote', () => {
+        runTest('> quoted text', true);
+    });
+
+    it('should detect unordered list with dash', () => {
+        runTest('- item 1\n- item 2', true);
+    });
+
+    it('should detect unordered list with asterisk', () => {
+        runTest('* item 1', true);
+    });
+
+    it('should detect unordered list with plus', () => {
+        runTest('+ item 1', true);
+    });
+
+    it('should detect ordered list', () => {
+        runTest('1. first\n2. second', true);
+    });
+
+    it('should detect horizontal rule', () => {
+        runTest('---', true);
+    });
+
+    it('should detect table row', () => {
+        runTest('| col1 | col2 |', true);
+    });
+
+    it('should detect bold text', () => {
+        runTest('this is **bold** text', true);
+    });
+
+    it('should detect italic text', () => {
+        runTest('this is *italic* text', true);
+    });
+
+    it('should not treat double asterisks at line start with no closing as bold', () => {
+        runTest('** not bold', false);
+    });
+
+    it('should detect strikethrough', () => {
+        runTest('this is ~~struck~~ text', true);
+    });
+
+    it('should detect link', () => {
+        runTest('see [docs](https://example.com) for info', true);
+    });
+
+    it('should detect image', () => {
+        runTest('an ![alt](https://example.com/img.png) image', true);
+    });
+
+    it('should detect markdown when it appears on a later line', () => {
+        runTest('plain text first line\n# heading on second line', true);
+    });
+
+    it('should not be confused by lone asterisks', () => {
+        runTest('a * b * c', false);
+    });
+
+    it('should not be confused by lone tilde', () => {
+        runTest('value ~ approx', false);
+    });
+
+    it('should not match a list pattern without trailing content', () => {
+        runTest('-', false);
+    });
+});

--- a/packages/roosterjs-content-model-markdown/test/publicApi/isPastedContentMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/publicApi/isPastedContentMarkdownTest.ts
@@ -1,0 +1,216 @@
+import { ClipboardData, DOMCreator } from 'roosterjs-content-model-types';
+import { isPastedContentMarkdown } from '../../lib/publicApi/isPastedContentMarkdown';
+
+describe('isPastedContentMarkdown', () => {
+    let doc: Document;
+    let trustedHTMLHandler: DOMCreator;
+
+    beforeEach(() => {
+        doc = document.implementation.createHTMLDocument('test');
+        trustedHTMLHandler = {
+            htmlToDOM: (html: string) => new DOMParser().parseFromString(html, 'text/html'),
+        };
+    });
+
+    function runTest(clipboardData: Partial<ClipboardData>, expected: boolean) {
+        const result = isPastedContentMarkdown(
+            doc,
+            clipboardData as ClipboardData,
+            trustedHTMLHandler
+        );
+        expect(result).toBe(expected);
+    }
+
+    it('should return false when text is undefined', () => {
+        runTest({ text: undefined as any, rawHtml: '<p># Hello</p>' }, false);
+    });
+
+    it('should return false when text is empty string', () => {
+        runTest({ text: '', rawHtml: '<p># Hello</p>' }, false);
+    });
+
+    it('should return false when text contains only whitespace', () => {
+        runTest({ text: '   \n\t  ', rawHtml: '<p>foo</p>' }, false);
+    });
+
+    it('should return true when text exists and rawHtml is undefined', () => {
+        runTest({ text: '# Hello', rawHtml: undefined }, true);
+    });
+
+    it('should return true when text exists and rawHtml is empty string', () => {
+        runTest({ text: '# Hello', rawHtml: '' }, true);
+    });
+
+    it('should return true when rawHtml is a thin <p> wrapper of the same plain text', () => {
+        runTest({ text: '# Hello world', rawHtml: '<p># Hello world</p>' }, true);
+    });
+
+    it('should return true when rawHtml is a thin <div> wrapper of the same plain text', () => {
+        runTest({ text: '- item 1', rawHtml: '<div>- item 1</div>' }, true);
+    });
+
+    it('should return true when rawHtml is a <span> wrapper of the same plain text', () => {
+        runTest({ text: '**bold**', rawHtml: '<span>**bold**</span>' }, true);
+    });
+
+    it('should return true when rawHtml uses nested allowed wrapper tags', () => {
+        runTest(
+            {
+                text: 'line1 line2',
+                rawHtml: '<div><p>line1<br/>line2</p></div>',
+            },
+            true
+        );
+    });
+
+    it('should ignore whitespace differences when comparing text content', () => {
+        runTest(
+            {
+                text: '# Hello   world',
+                rawHtml: '<p># Hello world</p>',
+            },
+            true
+        );
+    });
+
+    it('should return true when wrapper element has only a style attribute', () => {
+        runTest(
+            {
+                text: '# Hello',
+                rawHtml: '<p style="color:red"># Hello</p>',
+            },
+            true
+        );
+    });
+
+    it('should return false when wrapper element has a class attribute', () => {
+        runTest(
+            {
+                text: '# Hello',
+                rawHtml: '<p class="md"># Hello</p>',
+            },
+            false
+        );
+    });
+
+    it('should return false when wrapper element has a non-style/non-class attribute', () => {
+        runTest(
+            {
+                text: '# Hello',
+                rawHtml: '<p id="x"># Hello</p>',
+            },
+            false
+        );
+    });
+
+    it('should return false when rawHtml contains a non-thin-wrapper tag (e.g. <strong>)', () => {
+        runTest(
+            {
+                text: 'bold text',
+                rawHtml: '<p><strong>bold text</strong></p>',
+            },
+            false
+        );
+    });
+
+    it('should return false when rawHtml contains a heading tag', () => {
+        runTest(
+            {
+                text: 'Hello',
+                rawHtml: '<h1>Hello</h1>',
+            },
+            false
+        );
+    });
+
+    it('should return false when rawHtml contains a list element', () => {
+        runTest(
+            {
+                text: 'item',
+                rawHtml: '<ul><li>item</li></ul>',
+            },
+            false
+        );
+    });
+
+    it('should return false when rawHtml contains an anchor tag', () => {
+        runTest(
+            {
+                text: 'link',
+                rawHtml: '<p><a href="x">link</a></p>',
+            },
+            false
+        );
+    });
+
+    it('should return false when html text content does not match plain text', () => {
+        runTest(
+            {
+                text: '# Hello',
+                rawHtml: '<p>Goodbye</p>',
+            },
+            false
+        );
+    });
+
+    it('should return false when html text content has extra characters not in plain text', () => {
+        runTest(
+            {
+                text: 'Hello',
+                rawHtml: '<p>Hello world</p>',
+            },
+            false
+        );
+    });
+
+    it('should return true when rawHtml has multiple thin wrappers matching the text', () => {
+        runTest(
+            {
+                text: 'foo bar',
+                rawHtml: '<div><p>foo</p><p>bar</p></div>',
+            },
+            true
+        );
+    });
+
+    it('should return true when <br> is used inside thin wrappers', () => {
+        runTest(
+            {
+                text: 'foo bar',
+                rawHtml: '<p>foo<br/>bar</p>',
+            },
+            true
+        );
+    });
+
+    it('should use the provided trustedHTMLHandler to parse rawHtml', () => {
+        const spyDom = new DOMParser().parseFromString('<p># Hello</p>', 'text/html');
+        const handler: DOMCreator = {
+            htmlToDOM: jasmine.createSpy('htmlToDOM').and.returnValue(spyDom),
+        };
+
+        const result = isPastedContentMarkdown(
+            doc,
+            { text: '# Hello', rawHtml: '<p># Hello</p>' } as ClipboardData,
+            handler
+        );
+
+        expect(handler.htmlToDOM).toHaveBeenCalledWith('<p># Hello</p>');
+        expect(result).toBe(true);
+    });
+
+    it('should return false when trustedHTMLHandler returns a document with no body', () => {
+        const handler: DOMCreator = {
+            htmlToDOM: () => ({} as Document),
+        };
+
+        // Empty fragment textContent ('') will not match the non-empty plain text
+        const result = isPastedContentMarkdown(
+            doc,
+            { text: '# Hello', rawHtml: '<p># Hello</p>' } as ClipboardData,
+            handler
+        );
+
+        expect(result).toBe(false);
+    });
+});

--- a/packages/roosterjs-content-model-markdown/test/publicApi/isPastedContentMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/publicApi/isPastedContentMarkdownTest.ts
@@ -1,23 +1,24 @@
-import { ClipboardData, DOMCreator } from 'roosterjs-content-model-types';
+import { ClipboardData, DOMCreator, IEditor } from 'roosterjs-content-model-types';
 import { isPastedContentMarkdown } from '../../lib/publicApi/isPastedContentMarkdown';
 
 describe('isPastedContentMarkdown', () => {
     let doc: Document;
     let trustedHTMLHandler: DOMCreator;
+    let editor: IEditor;
 
     beforeEach(() => {
         doc = document.implementation.createHTMLDocument('test');
         trustedHTMLHandler = {
             htmlToDOM: (html: string) => new DOMParser().parseFromString(html, 'text/html'),
         };
+        editor = ({
+            getDocument: () => doc,
+            getDOMCreator: () => trustedHTMLHandler,
+        } as unknown) as IEditor;
     });
 
     function runTest(clipboardData: Partial<ClipboardData>, expected: boolean) {
-        const result = isPastedContentMarkdown(
-            doc,
-            clipboardData as ClipboardData,
-            trustedHTMLHandler
-        );
+        const result = isPastedContentMarkdown(editor, clipboardData as ClipboardData);
         expect(result).toBe(expected);
     }
 
@@ -31,6 +32,10 @@ describe('isPastedContentMarkdown', () => {
 
     it('should return false when text contains only whitespace', () => {
         runTest({ text: '   \n\t  ', rawHtml: '<p>foo</p>' }, false);
+    });
+
+    it('should return false when text contains no markdown patterns', () => {
+        runTest({ text: 'just plain text', rawHtml: '<p>just plain text</p>' }, false);
     });
 
     it('should return true when text exists and rawHtml is undefined', () => {
@@ -56,8 +61,8 @@ describe('isPastedContentMarkdown', () => {
     it('should return true when rawHtml uses nested allowed wrapper tags', () => {
         runTest(
             {
-                text: 'line1 line2',
-                rawHtml: '<div><p>line1<br/>line2</p></div>',
+                text: '# line1 line2',
+                rawHtml: '<div><p># line1<br/>line2</p></div>',
             },
             true
         );
@@ -83,13 +88,13 @@ describe('isPastedContentMarkdown', () => {
         );
     });
 
-    it('should return false when wrapper element has a class attribute', () => {
+    it('should return true when wrapper element has only a class attribute', () => {
         runTest(
             {
                 text: '# Hello',
                 rawHtml: '<p class="md"># Hello</p>',
             },
-            false
+            true
         );
     });
 
@@ -106,8 +111,8 @@ describe('isPastedContentMarkdown', () => {
     it('should return false when rawHtml contains a non-thin-wrapper tag (e.g. <strong>)', () => {
         runTest(
             {
-                text: 'bold text',
-                rawHtml: '<p><strong>bold text</strong></p>',
+                text: '**bold text**',
+                rawHtml: '<p><strong>**bold text**</strong></p>',
             },
             false
         );
@@ -116,8 +121,8 @@ describe('isPastedContentMarkdown', () => {
     it('should return false when rawHtml contains a heading tag', () => {
         runTest(
             {
-                text: 'Hello',
-                rawHtml: '<h1>Hello</h1>',
+                text: '# Hello',
+                rawHtml: '<h1># Hello</h1>',
             },
             false
         );
@@ -126,8 +131,8 @@ describe('isPastedContentMarkdown', () => {
     it('should return false when rawHtml contains a list element', () => {
         runTest(
             {
-                text: 'item',
-                rawHtml: '<ul><li>item</li></ul>',
+                text: '- item',
+                rawHtml: '<ul><li>- item</li></ul>',
             },
             false
         );
@@ -136,8 +141,8 @@ describe('isPastedContentMarkdown', () => {
     it('should return false when rawHtml contains an anchor tag', () => {
         runTest(
             {
-                text: 'link',
-                rawHtml: '<p><a href="x">link</a></p>',
+                text: '[link](url)',
+                rawHtml: '<p><a href="x">[link](url)</a></p>',
             },
             false
         );
@@ -156,8 +161,8 @@ describe('isPastedContentMarkdown', () => {
     it('should return false when html text content has extra characters not in plain text', () => {
         runTest(
             {
-                text: 'Hello',
-                rawHtml: '<p>Hello world</p>',
+                text: '# Hello',
+                rawHtml: '<p># Hello world</p>',
             },
             false
         );
@@ -166,8 +171,8 @@ describe('isPastedContentMarkdown', () => {
     it('should return true when rawHtml has multiple thin wrappers matching the text', () => {
         runTest(
             {
-                text: 'foo bar',
-                rawHtml: '<div><p>foo</p><p>bar</p></div>',
+                text: '# foo bar',
+                rawHtml: '<div><p># foo</p><p>bar</p></div>',
             },
             true
         );
@@ -176,24 +181,27 @@ describe('isPastedContentMarkdown', () => {
     it('should return true when <br> is used inside thin wrappers', () => {
         runTest(
             {
-                text: 'foo bar',
-                rawHtml: '<p>foo<br/>bar</p>',
+                text: '# foo bar',
+                rawHtml: '<p># foo<br/>bar</p>',
             },
             true
         );
     });
 
-    it('should use the provided trustedHTMLHandler to parse rawHtml', () => {
+    it('should use the editor-provided trustedHTMLHandler to parse rawHtml', () => {
         const spyDom = new DOMParser().parseFromString('<p># Hello</p>', 'text/html');
         const handler: DOMCreator = {
             htmlToDOM: jasmine.createSpy('htmlToDOM').and.returnValue(spyDom),
         };
+        const editorWithSpy = ({
+            getDocument: () => doc,
+            getDOMCreator: () => handler,
+        } as unknown) as IEditor;
 
-        const result = isPastedContentMarkdown(
-            doc,
-            { text: '# Hello', rawHtml: '<p># Hello</p>' } as ClipboardData,
-            handler
-        );
+        const result = isPastedContentMarkdown(editorWithSpy, {
+            text: '# Hello',
+            rawHtml: '<p># Hello</p>',
+        } as ClipboardData);
 
         expect(handler.htmlToDOM).toHaveBeenCalledWith('<p># Hello</p>');
         expect(result).toBe(true);
@@ -203,13 +211,16 @@ describe('isPastedContentMarkdown', () => {
         const handler: DOMCreator = {
             htmlToDOM: () => ({} as Document),
         };
+        const editorWithEmpty = ({
+            getDocument: () => doc,
+            getDOMCreator: () => handler,
+        } as unknown) as IEditor;
 
         // Empty fragment textContent ('') will not match the non-empty plain text
-        const result = isPastedContentMarkdown(
-            doc,
-            { text: '# Hello', rawHtml: '<p># Hello</p>' } as ClipboardData,
-            handler
-        );
+        const result = isPastedContentMarkdown(editorWithEmpty, {
+            text: '# Hello',
+            rawHtml: '<p># Hello</p>',
+        } as ClipboardData);
 
         expect(result).toBe(false);
     });


### PR DESCRIPTION
Adds two new public APIs to roosterjs-content-model-markdown and a "Paste as Markdown" demo button that uses them to decide whether to convert clipboard content with convertMarkdownToContentModel or fall back to the regular paste flow.

**New public APIs** `(roosterjs-content-model-markdown)`:

* `isContentMarkdown(text: string): boolean `— Heuristic check on plain text. Returns `true` if the text contains markdown markup, recognizing both block-level patterns (headings `#`, blockquotes `>`, ordered/unordered lists, horizontal rules `---`, table rows `| a | b |`) and inline patterns (bold `**text**`, italic `*text*`, strikethrough `~~text~~`, links `text`, images `!alt`).

* `isPastedContentMarkdown(editor: IEditor, clipboardData: ClipboardData): boolean `— Decides whether clipboard content should be treated as markdown. Returns `true` when the plain text contains markdown markup and the accompanying HTML (if any) is just a thin wrapper of the same plain text — i.e. only `<div>, <p>, <br>, <span> `elements with no attributes other than `class / style`, and the textual content matches. This avoids treating rich content (tables, images, lists, formatted text) as markdown, which would lose information when converted.

<img width="948" height="802" alt="RoosterPasteAsMarkdown" src="https://github.com/user-attachments/assets/8465ebe3-30cc-4219-884e-ac455347f836" />
