### PR TITLE
Version bump main: 9.53.0 → 9.54.0

### DIFF
--- a/demo/scripts/controlsV2/demoButtons/pasteAsMarkdownButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/pasteAsMarkdownButton.ts
@@ -1,0 +1,47 @@
+import { mergeModel } from 'roosterjs-content-model-dom';
+import { paste } from 'roosterjs-content-model-core';
+import { readClipboardData } from '../../utils/readClipboardData';
+import {
+    convertMarkdownToContentModel,
+    isPastedContentMarkdown,
+} from 'roosterjs-content-model-markdown';
+import type { IEditor } from 'roosterjs-content-model-types';
+import type { RibbonButton } from 'roosterjs-react';
+
+/**
+ * @internal
+ * "Paste as Markdown" button on the format ribbon.
+ *
+ * Reads the clipboard, checks whether the content can be interpreted as markdown
+ * (via {@link isMarkdownContent}). If so, converts it with
+ * {@link convertMarkdownToContentModel} and merges the resulting model into the
+ * editor. Otherwise, falls back to the regular paste flow.
+ */
+export const pasteAsMarkdownButton: RibbonButton<'buttonNamePasteAsMarkdown'> = {
+    key: 'buttonNamePasteAsMarkdown',
+    unlocalizedText: 'Paste as Markdown',
+    iconName: 'Paste',
+    onClick: async editor => {
+        const doc = editor.getDocument();
+        const clipboardData = await readClipboardData(doc);
+        if (!clipboardData) {
+            return;
+        }
+
+        if (isPastedContentMarkdown(editor, clipboardData)) {
+            insertMarkdown(editor, clipboardData.text);
+        } else {
+            paste(editor, clipboardData);
+        }
+    },
+};
+
+function insertMarkdown(editor: IEditor, text: string) {
+    const newModel = convertMarkdownToContentModel(text);
+    editor.formatContentModel((model, context) => {
+        mergeModel(model, newModel, context, {
+            mergeFormat: 'mergeAll',
+        });
+        return true;
+    });
+}

--- a/demo/scripts/controlsV2/demoButtons/pasteAsMarkdownButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/pasteAsMarkdownButton.ts
@@ -1,11 +1,6 @@
-import { mergeModel } from 'roosterjs-content-model-dom';
 import { paste } from 'roosterjs-content-model-core';
 import { readClipboardData } from '../../utils/readClipboardData';
-import {
-    convertMarkdownToContentModel,
-    isPastedContentMarkdown,
-} from 'roosterjs-content-model-markdown';
-import type { IEditor } from 'roosterjs-content-model-types';
+
 import type { RibbonButton } from 'roosterjs-react';
 
 /**
@@ -28,20 +23,6 @@ export const pasteAsMarkdownButton: RibbonButton<'buttonNamePasteAsMarkdown'> = 
             return;
         }
 
-        if (isPastedContentMarkdown(editor, clipboardData)) {
-            insertMarkdown(editor, clipboardData.text);
-        } else {
-            paste(editor, clipboardData);
-        }
+        paste(editor, clipboardData, 'asMarkdown');
     },
 };
-
-function insertMarkdown(editor: IEditor, text: string) {
-    const newModel = convertMarkdownToContentModel(text);
-    editor.formatContentModel((model, context) => {
-        mergeModel(model, newModel, context, {
-            mergeFormat: 'mergeAll',
-        });
-        return true;
-    });
-}

--- a/demo/scripts/controlsV2/demoButtons/pasteButton.ts
+++ b/demo/scripts/controlsV2/demoButtons/pasteButton.ts
@@ -1,10 +1,6 @@
-import { extractClipboardItems } from 'roosterjs-content-model-dom';
 import { paste } from 'roosterjs-content-model-core';
+import { readClipboardData } from '../../utils/readClipboardData';
 import type { RibbonButton } from 'roosterjs-react';
-
-interface ClipboardWithUnsanitized {
-    read(options?: { unsanitized?: string[] }): Promise<ClipboardItems>;
-}
 
 /**
  * @internal
@@ -15,49 +11,9 @@ export const pasteButton: RibbonButton<'buttonNamePaste'> = {
     unlocalizedText: 'Paste',
     iconName: 'Paste',
     onClick: async editor => {
-        const doc = editor.getDocument();
-        const clipboard = doc.defaultView.navigator.clipboard as ClipboardWithUnsanitized;
-        if (clipboard && clipboard.read) {
-            try {
-                const clipboardItems = await clipboard.read({ unsanitized: ['text/html'] });
-                const dataTransferItems = await Promise.all(
-                    createDataTransferItems(clipboardItems)
-                );
-                const clipboardData = await extractClipboardItems(dataTransferItems);
-                paste(editor, clipboardData);
-            } catch {}
+        const clipboardData = await readClipboardData(editor.getDocument());
+        if (clipboardData) {
+            paste(editor, clipboardData);
         }
     },
-};
-
-const createDataTransfer = (
-    kind: 'string' | 'file',
-    type: string,
-    blob: Blob
-): DataTransferItem => {
-    const file = blob as File;
-    return {
-        kind,
-        type,
-        getAsFile: () => file,
-        getAsString: (callback: (data: string) => void) => {
-            blob.text().then(callback);
-        },
-        webkitGetAsEntry: () => null,
-    };
-};
-
-const createDataTransferItems = (data: ClipboardItems) => {
-    const isTEXT = (type: string) => type.startsWith('text/');
-    const dataTransferItems: Promise<DataTransferItem>[] = [];
-    data.forEach(item => {
-        item.types.forEach(type => {
-            dataTransferItems.push(
-                item
-                    .getType(type)
-                    .then(blob => createDataTransfer(isTEXT(type) ? 'string' : 'file', type, blob))
-            );
-        });
-    });
-    return dataTransferItems;
 };

--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -19,6 +19,7 @@ import { getPresetModelById } from '../sidePane/presets/allPresets/allPresets';
 import { getTabs, tabNames } from '../tabs/getTabs';
 import { getTheme } from '../theme/themes';
 import { MarkdownPanePlugin } from '../sidePane/MarkdownPane/MarkdownPanePlugin';
+import { MarkdownPastePlugin } from 'roosterjs-content-model-markdown';
 import { OptionState, UrlPlaceholder } from '../sidePane/editorOptions/OptionState';
 import { popoutButton } from '../demoButtons/popoutButton';
 import { PresetPlugin } from '../sidePane/presets/PresetPlugin';
@@ -568,6 +569,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             imageMenu,
             watermarkText,
             markdownOptions,
+            markdownPasteOptions,
             autoFormatOptions,
             linkTitle,
             customReplacements,
@@ -583,6 +585,7 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             pluginList.tableEdit && new TableEditPlugin(),
             pluginList.watermark && new WatermarkPlugin(watermarkText),
             pluginList.markdown && new MarkdownPlugin(markdownOptions),
+            pluginList.markdownPaste && new MarkdownPastePlugin(markdownPasteOptions),
             imageEditPlugin,
             pluginList.emoji && createEmojiPlugin(),
             pluginList.pasteOption && createPasteOptionPlugin(),

--- a/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/EditorOptionsPlugin.ts
@@ -18,6 +18,7 @@ const initialState: OptionState = {
         pasteOption: true,
         sampleEntity: true,
         markdown: true,
+        markdownPaste: true,
         imageEditPlugin: true,
         hyperlink: true,
         customReplace: true,
@@ -58,6 +59,9 @@ const initialState: OptionState = {
         italic: true,
         strikethrough: true,
         codeFormat: {},
+    },
+    markdownPasteOptions: {
+        autoConversion: false,
     },
     editPluginOptions: {
         handleTabKey: {

--- a/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/OptionState.ts
@@ -5,6 +5,7 @@ import {
     HandleTabOptions,
     MarkdownOptions,
 } from 'roosterjs-content-model-plugins';
+import type { MarkdownPasteOptions } from 'roosterjs-content-model-markdown';
 import type { SidePaneElementProps } from '../SidePaneElement';
 import type { ContentModelSegmentFormat, ExperimentalFeature } from 'roosterjs-content-model-types';
 
@@ -20,6 +21,7 @@ export interface BuildInPluginList {
     pasteOption: boolean;
     sampleEntity: boolean;
     markdown: boolean;
+    markdownPaste: boolean;
     hyperlink: boolean;
     imageEditPlugin: boolean;
     customReplace: boolean;
@@ -40,6 +42,7 @@ export interface OptionState {
     watermarkText: string;
     autoFormatOptions: AutoFormatOptions;
     markdownOptions: MarkdownOptions;
+    markdownPasteOptions: MarkdownPasteOptions;
     customReplacements: CustomReplace[];
     editPluginOptions: EditOptions & { handleTabKey: HandleTabOptions };
     disableSideResize: boolean;

--- a/demo/scripts/controlsV2/sidePane/editorOptions/OptionsPane.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/OptionsPane.tsx
@@ -126,6 +126,7 @@ export class OptionsPane extends React.Component<OptionPaneProps, OptionState> {
             imageMenu: this.state.imageMenu,
             autoFormatOptions: { ...this.state.autoFormatOptions },
             markdownOptions: { ...this.state.markdownOptions },
+            markdownPasteOptions: { ...this.state.markdownPasteOptions },
             customReplacements: this.state.customReplacements,
             experimentalFeatures: this.state.experimentalFeatures,
             editPluginOptions: { ...this.state.editPluginOptions },

--- a/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/Plugins.tsx
@@ -118,6 +118,7 @@ export class Plugins extends PluginsBase<keyof BuildInPluginList> {
     private markdownItalic = React.createRef<HTMLInputElement>();
     private markdownStrikethrough = React.createRef<HTMLInputElement>();
     private markdownCode = React.createRef<HTMLInputElement>();
+    private markdownPasteAutoConversion = React.createRef<HTMLInputElement>();
     private linkTitle = React.createRef<HTMLInputElement>();
     private disableSideResize = React.createRef<HTMLInputElement>();
 
@@ -322,6 +323,19 @@ export class Plugins extends PluginsBase<keyof BuildInPluginList> {
                                     value
                                         ? (state.markdownOptions.codeFormat = {})
                                         : (state.markdownOptions.codeFormat = undefined)
+                            )}
+                        </>
+                    )}
+                    {this.renderPluginItem(
+                        'markdownPaste',
+                        'MarkdownPaste',
+                        <>
+                            {this.renderCheckBox(
+                                'Auto convert pasted markdown',
+                                this.markdownPasteAutoConversion,
+                                this.props.state.markdownPasteOptions.autoConversion,
+                                (state, value) =>
+                                    (state.markdownPasteOptions.autoConversion = value)
                             )}
                         </>
                     )}

--- a/demo/scripts/controlsV2/sidePane/editorOptions/codes/MarkdownPasteCode.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/codes/MarkdownPasteCode.ts
@@ -1,0 +1,14 @@
+import { CodeElement } from './CodeElement';
+import type { MarkdownPasteOptions } from 'roosterjs-content-model-markdown';
+
+export class MarkdownPasteCode extends CodeElement {
+    constructor(private markdownPasteOptions: MarkdownPasteOptions) {
+        super();
+    }
+
+    getCode() {
+        return `new roosterjs.MarkdownPastePlugin({
+            autoConversion: ${this.markdownPasteOptions.autoConversion},
+        })`;
+    }
+}

--- a/demo/scripts/controlsV2/sidePane/editorOptions/codes/PluginsCode.ts
+++ b/demo/scripts/controlsV2/sidePane/editorOptions/codes/PluginsCode.ts
@@ -1,6 +1,7 @@
 import { AutoFormatCode } from './AutoFormatCode';
 import { CodeElement } from './CodeElement';
 import { MarkdownCode } from './MarkdownCode';
+import { MarkdownPasteCode } from './MarkdownPasteCode';
 import { OptionState } from '../OptionState';
 import { WatermarkCode } from './WatermarkCode';
 
@@ -45,6 +46,7 @@ export class PluginsCode extends PluginsCodeBase {
             pluginList.shortcut && new ShortcutPluginCode(),
             pluginList.watermark && new WatermarkCode(state.watermarkText),
             pluginList.markdown && new MarkdownCode(state.markdownOptions),
+            pluginList.markdownPaste && new MarkdownPasteCode(state.markdownPasteOptions),
             pluginList.imageEditPlugin && new ImageEditPluginCode(),
             pluginList.dragAndDrop && new DragAndDropPluginCode(),
         ]);

--- a/demo/scripts/controlsV2/tabs/ribbonButtons.ts
+++ b/demo/scripts/controlsV2/tabs/ribbonButtons.ts
@@ -10,6 +10,7 @@ import { imageBorderWidthButton } from '../demoButtons/imageBorderWidthButton';
 import { imageBoxShadowButton } from '../demoButtons/imageBoxShadowButton';
 import { ImageEditor } from 'roosterjs-content-model-types';
 import { listStartNumberButton } from '../demoButtons/listStartNumberButton';
+import { pasteAsMarkdownButton } from '../demoButtons/pasteAsMarkdownButton';
 import { pasteButton } from '../demoButtons/pasteButton';
 import { setBulletedListStyleButton } from '../demoButtons/setBulletedListStyleButton';
 import { setNumberedListStyleButton } from '../demoButtons/setNumberedListStyleButton';
@@ -137,6 +138,7 @@ const paragraphButtons: RibbonButton<any>[] = [
     spaceBeforeButton,
     spaceAfterButton,
     pasteButton,
+    pasteAsMarkdownButton,
 ];
 
 const allButtons: RibbonButton<any>[] = [
@@ -197,6 +199,7 @@ const allButtons: RibbonButton<any>[] = [
     spaceBeforeButton,
     spaceAfterButton,
     pasteButton,
+    pasteAsMarkdownButton,
 ];
 export function getButtons(
     id: tabNames,

--- a/demo/scripts/utils/readClipboardData.ts
+++ b/demo/scripts/utils/readClipboardData.ts
@@ -1,0 +1,61 @@
+import { extractClipboardItems } from 'roosterjs-content-model-dom';
+import type { ClipboardData } from 'roosterjs-content-model-types';
+
+interface ClipboardWithUnsanitized {
+    read(options?: { unsanitized?: string[] }): Promise<ClipboardItems>;
+}
+
+/**
+ * Read the system clipboard using the async Clipboard API and convert the result
+ * into a {@link ClipboardData} object that the editor's paste pipeline expects.
+ *
+ * Returns `null` when the clipboard API is not available or the read fails (for
+ * example, due to permissions or unsupported types).
+ */
+export async function readClipboardData(doc: Document): Promise<ClipboardData | null> {
+    const clipboard = doc.defaultView?.navigator.clipboard as ClipboardWithUnsanitized | undefined;
+    if (!clipboard || !clipboard.read) {
+        return null;
+    }
+
+    try {
+        const clipboardItems = await clipboard.read();
+        console.log(clipboardItems);
+        const dataTransferItems = await Promise.all(createDataTransferItems(clipboardItems));
+        return await extractClipboardItems(dataTransferItems);
+    } catch {
+        return null;
+    }
+}
+
+const createDataTransfer = (
+    kind: 'string' | 'file',
+    type: string,
+    blob: Blob
+): DataTransferItem => {
+    const file = blob as File;
+    return {
+        kind,
+        type,
+        getAsFile: () => file,
+        getAsString: (callback: (data: string) => void) => {
+            blob.text().then(callback);
+        },
+        webkitGetAsEntry: () => null,
+    };
+};
+
+const createDataTransferItems = (data: ClipboardItems) => {
+    const isTEXT = (type: string) => type.startsWith('text/') || type === 'vscode-editor-data';
+    const dataTransferItems: Promise<DataTransferItem>[] = [];
+    data.forEach(item => {
+        item.types.forEach(type => {
+            dataTransferItems.push(
+                item
+                    .getType(type)
+                    .then(blob => createDataTransfer(isTEXT(type) ? 'string' : 'file', type, blob))
+            );
+        });
+    });
+    return dataTransferItems;
+};

--- a/demo/scripts/utils/readClipboardData.ts
+++ b/demo/scripts/utils/readClipboardData.ts
@@ -20,7 +20,6 @@ export async function readClipboardData(doc: Document): Promise<ClipboardData | 
 
     try {
         const clipboardItems = await clipboard.read();
-        console.log(clipboardItems);
         const dataTransferItems = await Promise.all(createDataTransferItems(clipboardItems));
         return await extractClipboardItems(dataTransferItems);
     } catch {

--- a/packages/roosterjs-content-model-api/lib/publicApi/utils/formatInsertPointWithContentModel.ts
+++ b/packages/roosterjs-content-model-api/lib/publicApi/utils/formatInsertPointWithContentModel.ts
@@ -60,6 +60,15 @@ export function formatInsertPointWithContentModel(
                 textWithSelection: getShadowTextProcessor(bundle),
             },
             tryGetFromCache: false,
+            // When an element carries "container level" styles such as margin or padding, we first
+            // wrap it in a FormatContainer. After all its child nodes are processed, we decide whether
+            // to keep the FormatContainer or fall back to a plain paragraph when it only wraps a single
+            // paragraph. However, formatInsertPointWithContentModel persists the Content Model group path
+            // during processing so the later formatting callback can still use it (see the
+            // DomToModelContextWithPath interface below). If the FormatContainer falls back to a paragraph,
+            // it is removed from the model and the persisted path becomes invalid. To keep the path valid,
+            // we skip the fallback check here and always keep the FormatContainer when one is needed.
+            skipFormatContainerFallbackCheck: true,
         }
     );
 }

--- a/packages/roosterjs-content-model-api/test/publicApi/utils/formatInsertPointWithContentModelTest.ts
+++ b/packages/roosterjs-content-model-api/test/publicApi/utils/formatInsertPointWithContentModelTest.ts
@@ -47,6 +47,7 @@ describe('formatInsertPointWithContentModel', () => {
                     textWithSelection: jasmine.anything() as any,
                 },
                 tryGetFromCache: false,
+                skipFormatContainerFallbackCheck: true,
             }
         );
 
@@ -112,6 +113,7 @@ describe('formatInsertPointWithContentModel', () => {
                     textWithSelection: jasmine.anything() as any,
                 },
                 tryGetFromCache: false,
+                skipFormatContainerFallbackCheck: true,
             }
         );
 

--- a/packages/roosterjs-content-model-core/lib/coreApi/createContentModel/createContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/createContentModel/createContentModel.ts
@@ -45,6 +45,10 @@ export const createContentModel: CreateContentModel = (core, option, selectionOv
         ? createDomToModelContext(editorContext, settings.builtIn, settings.customized, option)
         : createDomToModelContextWithConfig(settings.calculated, editorContext);
 
+    if (option?.skipFormatContainerFallbackCheck) {
+        domToModelContext.skipFormatContainerFallbackCheck = true;
+    }
+
     if (selection) {
         domToModelContext.selection = selection;
     }

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/CachePlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/CachePlugin.ts
@@ -148,6 +148,18 @@ class CachePlugin implements PluginWithState<CachePluginState> {
 
                     break;
 
+                case 'attribute':
+                    if (
+                        !this.state.domIndexer.reconcileImageAttribute(
+                            mutation.element,
+                            mutation.attributeName
+                        )
+                    ) {
+                        this.invalidateCache();
+                    }
+
+                    break;
+
                 case 'unknown':
                     this.invalidateCache();
                     break;

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/MutationType.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/MutationType.ts
@@ -11,6 +11,10 @@ export type MutationType =
      */
     | 'elementId'
     /**
+     * An attribute (such as src or data-*) is changed on an element
+     */
+    | 'attribute'
+    /**
      * Only text is changed
      */
     | 'text'
@@ -41,6 +45,14 @@ export interface ElementIdMutation extends MutationBase<'elementId'> {
 /**
  * @internal
  */
+export interface AttributeMutation extends MutationBase<'attribute'> {
+    element: HTMLElement;
+    attributeName: string;
+}
+
+/**
+ * @internal
+ */
 export interface TextMutation extends MutationBase<'text'> {}
 
 /**
@@ -54,4 +66,9 @@ export interface ChildListMutation extends MutationBase<'childList'> {
 /**
  * @internal
  */
-export type Mutation = UnknownMutation | ElementIdMutation | TextMutation | ChildListMutation;
+export type Mutation =
+    | UnknownMutation
+    | ElementIdMutation
+    | AttributeMutation
+    | TextMutation
+    | ChildListMutation;

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/domIndexerImpl.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/domIndexerImpl.ts
@@ -411,6 +411,38 @@ export class DomIndexerImpl implements DomIndexer {
         }
     }
 
+    reconcileImageAttribute(element: HTMLElement, attributeName: string) {
+        if (isElementOfType(element, 'img')) {
+            const image = getIndexedSegmentItem(element)?.segments[0];
+
+            if (image?.segmentType == 'Image') {
+                if (attributeName == 'src') {
+                    // Use getAttribute('src') instead of retrieving src directly, in case the src
+                    // has port and may be stripped by browser. This matches imageProcessor.
+                    image.src = element.getAttribute('src') ?? '';
+
+                    return true;
+                } else if (attributeName.indexOf('data-') == 0) {
+                    // A data-* attribute may be added, modified or removed. Rebuild the whole
+                    // dataset from DOM to keep it in sync, the same way imageProcessor builds it.
+                    const { dataset } = image;
+
+                    getObjectKeys(dataset).forEach(key => {
+                        delete dataset[key];
+                    });
+
+                    getObjectKeys(element.dataset).forEach(key => {
+                        dataset[key] = element.dataset[key] || '';
+                    });
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     private onBlockEntityDelimiter(
         node: Node | null,
         entity: ContentModelEntity,

--- a/packages/roosterjs-content-model-core/lib/corePlugin/cache/textMutationObserver.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/cache/textMutationObserver.ts
@@ -79,6 +79,17 @@ class TextMutationObserverImpl implements TextMutationObserver {
                             isNodeOfType(target, 'ELEMENT_NODE')
                         ) {
                             this.onMutation({ type: 'elementId', element: target });
+                        } else if (
+                            mutation.attributeName &&
+                            isNodeOfType(target, 'ELEMENT_NODE') &&
+                            (mutation.attributeName == 'src' ||
+                                mutation.attributeName.indexOf('data-') == 0)
+                        ) {
+                            this.onMutation({
+                                type: 'attribute',
+                                element: target,
+                                attributeName: mutation.attributeName,
+                            });
                         } else {
                             // We cannot handle attributes changes on editor content for now
                             canHandle = false;

--- a/packages/roosterjs-content-model-core/test/coreApi/createContentModel/createContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/createContentModel/createContentModelTest.ts
@@ -107,6 +107,30 @@ describe('createContentModel', () => {
         expect(domToContentModelSpy).toHaveBeenCalledWith(mockedDiv, currentContext);
         expect(model).toBe(mockedModel);
     });
+
+    it('Pass skipFormatContainerFallbackCheck option to context', () => {
+        const currentContext = { ...originalContext } as DomToModelContext;
+
+        spyOn(createDomToModelContext, 'createDomToModelContext').and.returnValue(currentContext);
+
+        createContentModel(core, {
+            tryGetFromCache: false,
+            skipFormatContainerFallbackCheck: true,
+        });
+
+        expect(domToContentModelSpy).toHaveBeenCalledWith(mockedDiv, currentContext);
+        expect(currentContext.skipFormatContainerFallbackCheck).toBe(true);
+    });
+
+    it('Do not set skipFormatContainerFallbackCheck when option not passed', () => {
+        const currentContext = { ...originalContext } as DomToModelContext;
+
+        spyOn(createDomToModelContext, 'createDomToModelContext').and.returnValue(currentContext);
+
+        createContentModel(core, { tryGetFromCache: false });
+
+        expect(currentContext.skipFormatContainerFallbackCheck).toBeUndefined();
+    });
 });
 
 describe('createContentModel with selection', () => {

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/CachePluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/CachePluginTest.ts
@@ -577,11 +577,13 @@ describe('CachePlugin', () => {
         let mockedObserver: any;
         let reconcileChildListSpy: jasmine.Spy;
         let reconcileElementIdSpy: jasmine.Spy;
+        let reconcileImageAttributeSpy: jasmine.Spy;
         let mockedIndexer: DomIndexer;
 
         beforeEach(() => {
             reconcileChildListSpy = jasmine.createSpy('reconcileChildList');
             reconcileElementIdSpy = jasmine.createSpy('reconcileElementId');
+            reconcileImageAttributeSpy = jasmine.createSpy('reconcileImageAttribute');
             startObservingSpy = jasmine.createSpy('startObserving');
             stopObservingSpy = jasmine.createSpy('stopObserving');
 
@@ -603,6 +605,7 @@ describe('CachePlugin', () => {
                 reconcileSelection: reconcileSelectionSpy,
                 reconcileChildList: reconcileChildListSpy,
                 reconcileElementId: reconcileElementIdSpy,
+                reconcileImageAttribute: reconcileImageAttributeSpy,
             } as any;
         });
 
@@ -784,6 +787,62 @@ describe('CachePlugin', () => {
 
             expect(reconcileElementIdSpy).toHaveBeenCalledTimes(1);
             expect(reconcileElementIdSpy).toHaveBeenCalledWith(mockedElement);
+            expect(state).toEqual({
+                domIndexer: mockedIndexer,
+                textMutationObserver: mockedObserver,
+                cachedModel: undefined,
+                cachedSelection: undefined,
+                paragraphMap: mockedParagraphMap,
+            });
+            expect(resetMapSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('attribute, can reconcile', () => {
+            const state = plugin.getState();
+            state.cachedModel = 'MODEL' as any;
+            state.cachedSelection = 'SELECTION' as any;
+            state.domIndexer = mockedIndexer;
+
+            const mockedElement = 'ELEMENT' as any;
+
+            reconcileImageAttributeSpy.and.returnValue(true);
+
+            onMutation({
+                type: 'attribute',
+                element: mockedElement,
+                attributeName: 'src',
+            });
+
+            expect(reconcileImageAttributeSpy).toHaveBeenCalledTimes(1);
+            expect(reconcileImageAttributeSpy).toHaveBeenCalledWith(mockedElement, 'src');
+            expect(state).toEqual({
+                domIndexer: mockedIndexer,
+                textMutationObserver: mockedObserver,
+                cachedModel: 'MODEL' as any,
+                cachedSelection: 'SELECTION' as any,
+                paragraphMap: mockedParagraphMap,
+            });
+            expect(resetMapSpy).toHaveBeenCalledTimes(0);
+        });
+
+        it('attribute, cannot reconcile', () => {
+            const state = plugin.getState();
+            state.cachedModel = 'MODEL' as any;
+            state.cachedSelection = 'SELECTION' as any;
+            state.domIndexer = mockedIndexer;
+
+            const mockedElement = 'ELEMENT' as any;
+
+            reconcileImageAttributeSpy.and.returnValue(false);
+
+            onMutation({
+                type: 'attribute',
+                element: mockedElement,
+                attributeName: 'data-foo',
+            });
+
+            expect(reconcileImageAttributeSpy).toHaveBeenCalledTimes(1);
+            expect(reconcileImageAttributeSpy).toHaveBeenCalledWith(mockedElement, 'data-foo');
             expect(state).toEqual({
                 domIndexer: mockedIndexer,
                 textMutationObserver: mockedObserver,

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
@@ -1698,6 +1698,121 @@ describe('domIndexerImpl.reconcileElementId', () => {
     });
 });
 
+describe('domIndexerImpl.reconcileImageAttribute', () => {
+    function indexImage(img: HTMLImageElement, image: ReturnType<typeof createImage>) {
+        const para = createParagraph();
+        const segIndex: SegmentItem = {
+            paragraph: para,
+            segments: [image],
+        };
+
+        para.segments.push(image);
+        ((img as Node) as IndexedSegmentNode).__roosterjsContentModel = segIndex;
+    }
+
+    it('unindexed image src', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        img.setAttribute('src', 'new.png');
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'src');
+
+        expect(result).toBe(false);
+        expect(image.src).toBe('test');
+    });
+
+    it('indexed image src', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        indexImage(img, image);
+
+        img.setAttribute('src', 'new.png');
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'src');
+
+        expect(result).toBe(true);
+        expect(image.src).toBe('new.png');
+    });
+
+    it('indexed image src removed', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        indexImage(img, image);
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'src');
+
+        expect(result).toBe(true);
+        expect(image.src).toBe('');
+    });
+
+    it('indexed image data-* added', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        indexImage(img, image);
+
+        img.setAttribute('data-foo', 'bar');
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'data-foo');
+
+        expect(result).toBe(true);
+        expect(image.dataset).toEqual({ foo: 'bar' });
+    });
+
+    it('indexed image data-* modified', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        image.dataset.foo = 'old';
+        indexImage(img, image);
+
+        img.setAttribute('data-foo', 'new');
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'data-foo');
+
+        expect(result).toBe(true);
+        expect(image.dataset).toEqual({ foo: 'new' });
+    });
+
+    it('indexed image data-* removed', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        image.dataset.foo = 'bar';
+        indexImage(img, image);
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'data-foo');
+
+        expect(result).toBe(true);
+        expect(image.dataset).toEqual({});
+    });
+
+    it('indexed image, unrelated attribute', () => {
+        const img = document.createElement('img');
+        const image = createImage('test');
+
+        indexImage(img, image);
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(img, 'alt');
+
+        expect(result).toBe(false);
+        expect(image.src).toBe('test');
+    });
+
+    it('non-image element', () => {
+        const div = document.createElement('div');
+
+        div.setAttribute('src', 'new.png');
+
+        const result = new DomIndexerImpl().reconcileImageAttribute(div, 'src');
+
+        expect(result).toBe(false);
+    });
+});
+
 describe('domIndexerImpl.clearIndex', () => {
     it('clear index, no child', () => {
         const domIndexer = new DomIndexerImpl(true);

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/domIndexerImplTest.ts
@@ -595,7 +595,7 @@ describe('domIndexerImpl.reconcileSelection', () => {
         expect(paragraph).toEqual({
             blockType: 'Paragraph',
             format: {},
-            segments: [segment1, marker1, segment2, segment3, marker2, segment4],
+            segments: [segment1, segment2, segment3, segment4],
         });
         expect(setSelectionSpy).toHaveBeenCalledWith(model, marker1, marker2);
         expect(model).toEqual({
@@ -615,7 +615,10 @@ describe('domIndexerImpl.reconcileSelection', () => {
 
         // Range starts at the END of node1 (offset 5) and ends inside node2 (offset 3).
         // After the first reconcile call marker1 lands directly before node2's segment;
-        // the second call's adjacent-marker cleanup loop must NOT eat marker1.
+        // the second call's adjacent-marker cleanup loop must NOT eat marker1, so that
+        // setSelection still receives both live markers. setSelection then drops both
+        // boundary markers (redundant: "tes" is selected between them in the same paragraph),
+        // which is why the final paragraph segments contain no SelectionMarker.
         const newRangeEx: DOMSelection = {
             type: 'range',
             range: createRange(node1, 5, node2, 3),
@@ -663,7 +666,7 @@ describe('domIndexerImpl.reconcileSelection', () => {
         expect(paragraph).toEqual({
             blockType: 'Paragraph',
             format: {},
-            segments: [segment1, marker1, segment2, marker2, segment3],
+            segments: [segment1, segment2, segment3],
         });
         expect(setSelectionSpy).toHaveBeenCalledWith(model, marker1, marker2);
         expect(model).toEqual({
@@ -724,7 +727,7 @@ describe('domIndexerImpl.reconcileSelection', () => {
         expect(paragraph).toEqual({
             blockType: 'Paragraph',
             format: {},
-            segments: [segment1, marker1, segment2, oldSegment2, marker2],
+            segments: [segment1, segment2, oldSegment2],
         });
         expect(setSelectionSpy).toHaveBeenCalledWith(model, marker1, marker2);
         expect(model).toEqual({

--- a/packages/roosterjs-content-model-core/test/corePlugin/cache/textMutationObserverTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/cache/textMutationObserverTest.ts
@@ -342,6 +342,60 @@ describe('TextMutationObserverImpl', () => {
         expect(onMutation).toHaveBeenCalledWith({ type: 'unknown' });
     });
 
+    it('src change', async () => {
+        const div = document.createElement('div');
+        const img = document.createElement('img');
+
+        div.appendChild(img);
+
+        const onMutation = jasmine.createSpy('onMutation');
+        observer = textMutationObserver.createTextMutationObserver(div, onMutation);
+
+        observer.startObserving();
+
+        img.setAttribute('src', 'test.png');
+
+        observer.flushMutations();
+
+        await new Promise<void>(resolve => {
+            window.setTimeout(resolve, 10);
+        });
+
+        expect(onMutation).toHaveBeenCalledTimes(1);
+        expect(onMutation).toHaveBeenCalledWith({
+            type: 'attribute',
+            element: img,
+            attributeName: 'src',
+        });
+    });
+
+    it('data-* change', async () => {
+        const div = document.createElement('div');
+        const img = document.createElement('img');
+
+        div.appendChild(img);
+
+        const onMutation = jasmine.createSpy('onMutation');
+        observer = textMutationObserver.createTextMutationObserver(div, onMutation);
+
+        observer.startObserving();
+
+        img.setAttribute('data-foo', 'bar');
+
+        observer.flushMutations();
+
+        await new Promise<void>(resolve => {
+            window.setTimeout(resolve, 10);
+        });
+
+        expect(onMutation).toHaveBeenCalledTimes(1);
+        expect(onMutation).toHaveBeenCalledWith({
+            type: 'attribute',
+            element: img,
+            attributeName: 'data-foo',
+        });
+    });
+
     it('Ignore changes under entity', () => {
         const div = document.createElement('div');
         const wrapper = document.createElement('div');

--- a/packages/roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/context/createDomToModelContext.ts
@@ -39,7 +39,7 @@ export function createDomToModelContext(
 export function createDomToModelContextWithConfig(
     config: DomToModelSettings,
     editorContext?: EditorContext
-) {
+): DomToModelContext {
     return Object.assign(
         {},
         editorContext,

--- a/packages/roosterjs-content-model-dom/lib/domToModel/processors/formatContainerProcessor.ts
+++ b/packages/roosterjs-content-model-dom/lib/domToModel/processors/formatContainerProcessor.ts
@@ -86,7 +86,11 @@ const formatContainerProcessorInternal = (
             formatContainer.zeroFontSize = true;
         }
 
-        if (shouldFallbackToParagraph(formatContainer) && !forceFormatContainer) {
+        if (
+            !context.skipFormatContainerFallbackCheck &&
+            shouldFallbackToParagraph(formatContainer) &&
+            !forceFormatContainer
+        ) {
             // For DIV container that only has one paragraph child, container style can be merged into paragraph
             // and no need to have this container
             const paragraph = formatContainer.blocks[0] as ContentModelParagraph;

--- a/packages/roosterjs-content-model-dom/lib/modelApi/selection/setSelection.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/selection/setSelection.ts
@@ -93,7 +93,11 @@ function setSelectionToBlock(
             });
 
         case 'Paragraph':
-            const segmentsToDelete: number[] = [];
+            const state: ParagraphSelectionState = {
+                segmentsToDelete: [],
+                boundaryMarkers: [],
+                hasSelectedNonMarker: false,
+            };
 
             block.segments.forEach((segment, i) => {
                 isInSelection = handleSelection(
@@ -106,7 +110,7 @@ function setSelectionToBlock(
                             block,
                             segment,
                             isInSelection,
-                            segmentsToDelete,
+                            state,
                             start,
                             end,
                             i
@@ -115,12 +119,25 @@ function setSelectionToBlock(
                 );
             });
 
-            if (segmentsToDelete.length > 0) {
+            if (state.hasSelectedNonMarker) {
+                // This paragraph contains a real (non-marker) selected segment, so any leading/trailing
+                // selection marker of the range is redundant within this paragraph and can be removed.
+                // We only do this within the same paragraph: a boundary marker at a paragraph edge must be
+                // kept to distinguish "selection starts at the beginning of this line" from "selection
+                // starts at the end of the previous line".
+                state.segmentsToDelete.push(...state.boundaryMarkers);
+            }
+
+            if (state.segmentsToDelete.length > 0) {
                 const mutablePara = mutateBlock(block);
 
                 let index: number | undefined;
 
-                while ((index = segmentsToDelete.pop()) !== undefined) {
+                // Sort ascending so the pop()-based splice below always removes the highest index first,
+                // keeping the remaining indices valid (boundary markers may sit before queued deletions).
+                state.segmentsToDelete.sort((a, b) => a - b);
+
+                while ((index = state.segmentsToDelete.pop()) !== undefined) {
                     if (index >= 0) {
                         mutablePara.segments.splice(index, 1);
                     }
@@ -191,22 +208,43 @@ function findCell(
     return { row, col };
 }
 
+interface ParagraphSelectionState {
+    // Indexes of segments to delete after the paragraph is fully processed
+    segmentsToDelete: number[];
+
+    // Indexes of leading/trailing selection markers of the range that are kept for now, but will be
+    // removed if this paragraph also contains a real (non-marker) selected segment
+    boundaryMarkers: number[];
+
+    // Whether this paragraph contains at least one selected segment that is not a selection marker
+    hasSelectedNonMarker: boolean;
+}
+
 function setSelectionToSegment(
     paragraph: ReadonlyContentModelParagraph,
     segment: ReadonlyContentModelSegment,
     isInSelection: boolean,
-    segmentsToDelete: number[],
+    state: ParagraphSelectionState,
     start: ReadonlySelectable | null,
     end: ReadonlySelectable | null,
     i: number
 ) {
+    if (segment.segmentType != 'SelectionMarker' && isInSelection) {
+        state.hasSelectedNonMarker = true;
+    }
+
     switch (segment.segmentType) {
         case 'SelectionMarker':
             if (!isInSelection || (segment != start && segment != end)) {
                 // Delete the selection marker when
                 // 1. It is not in selection any more. Or
                 // 2. It is in middle of selection, so no need to have it
-                segmentsToDelete.push(i);
+                state.segmentsToDelete.push(i);
+            } else {
+                // It is a leading/trailing selection marker of a range selection. Keep it for now, but
+                // remember it so it can be removed later if this same paragraph also contains a real
+                // (non-marker) selected segment, in which case the marker is redundant.
+                state.boundaryMarkers.push(i);
             }
             return isInSelection;
 

--- a/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleBlockGroupChildren.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelToDom/handlers/handleBlockGroupChildren.ts
@@ -44,7 +44,7 @@ export const handleBlockGroupChildren: ContentModelHandler<ContentModelBlockGrou
             }
         });
 
-        cleanUpNodeStack(listFormat.nodeStack, context);
+        cleanUpNodeStack(listFormat.nodeStack, context, parent);
 
         // Remove all rest node if any since they don't appear in content model
         cleanUpRestNodes(refNode, context.rewriteFromModel);
@@ -53,13 +53,25 @@ export const handleBlockGroupChildren: ContentModelHandler<ContentModelBlockGrou
     }
 };
 
-function cleanUpNodeStack(nodeStack: ModelToDomListStackItem[], context: ModelToDomContext) {
+function cleanUpNodeStack(
+    nodeStack: ModelToDomListStackItem[],
+    context: ModelToDomContext,
+    leavingParent?: Node
+) {
     if (nodeStack.length > 0) {
         // Clear list stack, only run to nodeStack[1] because nodeStack[0] is the parent node
         for (let i = nodeStack.length - 1; i > 0; i--) {
             const node = nodeStack.pop()?.refNode ?? null;
 
             cleanUpRestNodes(node, context.rewriteFromModel);
+        }
+
+        if (leavingParent && nodeStack[0].node == leavingParent) {
+            // When leaving a parent node that is the same with the root of node stack
+            // It means the whole list node stack is being invalidated, so we clear it
+            while (nodeStack.length > 0) {
+                nodeStack.pop();
+            }
         }
     }
 }

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/brProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/brProcessorTest.ts
@@ -77,6 +77,7 @@ describe('brProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/entityProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/entityProcessorTest.ts
@@ -262,6 +262,7 @@ describe('entityProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/formatContainerProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/formatContainerProcessorTest.ts
@@ -641,3 +641,122 @@ describe('forceFormatContainerProcessor', () => {
         });
     });
 });
+
+describe('formatContainerProcessor with skipFormatContainerFallbackCheck', () => {
+    let context: DomToModelContext;
+
+    beforeEach(() => {
+        context = createDomToModelContext();
+        context.skipFormatContainerFallbackCheck = true;
+    });
+
+    it('div with single paragraph child should NOT fallback to paragraph', () => {
+        const group = createContentModelDocument();
+        const div = document.createElement('div');
+
+        div.appendChild(document.createTextNode('test'));
+
+        formatContainerProcessor(group, div, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'FormatContainer',
+                    tagName: 'div',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                            isImplicit: true,
+                        },
+                    ],
+                    format: {},
+                },
+                { blockType: 'Paragraph', segments: [], format: {}, isImplicit: true },
+            ],
+        });
+    });
+
+    it('div with id and single paragraph child should NOT fallback to paragraph', () => {
+        const group = createContentModelDocument();
+        const div = document.createElement('div');
+
+        div.id = 'testId';
+        div.appendChild(document.createTextNode('test'));
+
+        formatContainerProcessor(group, div, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'FormatContainer',
+                    tagName: 'div',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'test',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                            isImplicit: true,
+                        },
+                    ],
+                    format: {
+                        id: 'testId',
+                    },
+                },
+                { blockType: 'Paragraph', segments: [], format: {}, isImplicit: true },
+            ],
+        });
+    });
+
+    it('blockquote (non-div) is unaffected and still kept as FormatContainer', () => {
+        const group = createContentModelDocument();
+        const quote = document.createElement('blockquote');
+
+        quote.appendChild(document.createTextNode('test'));
+
+        formatContainerProcessor(group, quote, context);
+
+        expect(group).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'FormatContainer',
+                    tagName: 'blockquote',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [{ segmentType: 'Text', text: 'test', format: {} }],
+                            format: {},
+                            isImplicit: true,
+                        },
+                    ],
+                    format: {
+                        marginTop: '1em',
+                        marginBottom: '1em',
+                        marginRight: '40px',
+                        marginLeft: '40px',
+                    },
+                },
+                { blockType: 'Paragraph', segments: [], format: {}, isImplicit: true },
+            ],
+        });
+    });
+});

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/generalProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/generalProcessorTest.ts
@@ -397,6 +397,7 @@ describe('generalProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/imageProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/imageProcessorTest.ts
@@ -326,6 +326,7 @@ describe('imageProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/tableProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/tableProcessorTest.ts
@@ -298,6 +298,7 @@ describe('tableProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/domToModel/processors/textProcessorTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/processors/textProcessorTest.ts
@@ -580,6 +580,7 @@ describe('textProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };
@@ -619,6 +620,7 @@ describe('textProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };
@@ -669,6 +671,7 @@ describe('textProcessor', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-dom/test/modelApi/selection/setSelectionTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/selection/setSelectionTest.ts
@@ -1004,4 +1004,173 @@ describe('setSelection', () => {
             blocks: [],
         });
     });
+
+    it('Remove leading and trailing markers when paragraph has a real selected segment in between', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const marker1 = createSelectionMarker();
+        const text = createText('test');
+        const marker2 = createSelectionMarker();
+
+        para.segments.push(marker1, text, marker2);
+        model.blocks.push(para);
+
+        setSelection(model, marker1, marker2);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test',
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Keep leading marker at end of paragraph when selected content is in the next paragraph', () => {
+        const model = createContentModelDocument();
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const text1 = createText('test1');
+        const marker = createSelectionMarker();
+        const text2 = createText('test2');
+
+        para1.segments.push(text1, marker);
+        para2.segments.push(text2);
+        model.blocks.push(para1, para2);
+
+        setSelection(model, marker, text2);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test1',
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                    ],
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test2',
+                            isSelected: true,
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Keep trailing marker at start of paragraph when selected content is in the previous paragraph', () => {
+        const model = createContentModelDocument();
+        const para1 = createParagraph();
+        const para2 = createParagraph();
+        const text1 = createText('test1');
+        const marker = createSelectionMarker();
+        const text2 = createText('test2');
+
+        para1.segments.push(text1);
+        para2.segments.push(marker, text2);
+        model.blocks.push(para1, para2);
+
+        setSelection(model, text1, marker);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test1',
+                            isSelected: true,
+                        },
+                    ],
+                },
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test2',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('Keep collapsed selection marker when there is no other selected segment', () => {
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        const text1 = createText('test1');
+        const marker = createSelectionMarker();
+        const text2 = createText('test2');
+
+        para.segments.push(text1, marker, text2);
+        model.blocks.push(para);
+
+        setSelection(model, marker);
+
+        expect(model).toEqual({
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    format: {},
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test1',
+                        },
+                        {
+                            segmentType: 'SelectionMarker',
+                            format: {},
+                            isSelected: true,
+                        },
+                        {
+                            segmentType: 'Text',
+                            format: {},
+                            text: 'test2',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleBlockGroupChildrenTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleBlockGroupChildrenTest.ts
@@ -507,4 +507,55 @@ describe('handleBlockGroupChildren', () => {
         expect(node1.parentNode).toBeNull();
         expect(node2.parentNode).toBeNull();
     });
+
+    it('Allow list cache: clear whole node stack when leaving parent that is root of node stack', () => {
+        const group = createContentModelDocument();
+        const listItem = createListItem([
+            {
+                listType: 'OL',
+                format: {},
+                dataset: {},
+            },
+        ]);
+
+        // The list item is the only (and last) block, and its list element is a direct
+        // child of parent. So while handling it, handleList pushes parent as the root of
+        // the node stack (nodeStack[0].node === parent). When the loop finishes and we
+        // leave parent, the whole node stack should be cleared instead of keeping the root.
+        group.blocks.push(listItem);
+
+        handleBlockGroupChildren(document, parent, group, context);
+
+        expect(context.listFormat.nodeStack).toEqual([]);
+        expect(parent.outerHTML).toBe('<div><ol start="1"><li></li></ol></div>');
+        expect(context.rewriteFromModel).toEqual({
+            addedBlockElements: [parent.firstChild!.firstChild as HTMLElement],
+            removedBlockElements: [],
+        });
+    });
+
+    it('Allow list cache: keep node stack root when leaving a different parent', () => {
+        const group = createContentModelDocument();
+        const listItem = createListItem([
+            {
+                listType: 'OL',
+                format: {},
+                dataset: {},
+            },
+        ]);
+
+        // The root of the node stack is some other node, not the parent we are leaving.
+        // In this case the cleanup should keep the root entry (nodeStack[0]) and only
+        // pop the inner list levels.
+        const otherRoot = document.createElement('div');
+        const nodeStack = [{ node: otherRoot, refNode: null } as any];
+
+        group.blocks.push(listItem);
+        context.listFormat.nodeStack = nodeStack;
+
+        handleBlockGroupChildren(document, parent, group, context);
+
+        expect(context.listFormat.nodeStack).toBe(nodeStack);
+        expect(context.listFormat.nodeStack).toEqual([{ node: otherRoot, refNode: null } as any]);
+    });
 });

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleParagraphTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleParagraphTest.ts
@@ -691,6 +691,7 @@ describe('handleParagraph', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };
@@ -743,6 +744,7 @@ describe('handleParagraph', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };
@@ -1395,7 +1397,9 @@ describe('Handle paragraph and adjust selections', () => {
             };
             handleParagraph(document, parent, paragraph, context, null);
 
-            expect((context as ModelToDomSegmentContext).noFollowingTextSegmentOrLast).toBeUndefined();
+            expect(
+                (context as ModelToDomSegmentContext).noFollowingTextSegmentOrLast
+            ).toBeUndefined();
         });
     });
 });

--- a/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelToDom/handlers/handleTableTest.ts
@@ -613,6 +613,7 @@ describe('handleTable', () => {
             reconcileChildList: null!,
             onBlockEntity: null!,
             reconcileElementId: null!,
+            reconcileImageAttribute: null!,
             onMergeText: null!,
             clearIndex: null!,
         };

--- a/packages/roosterjs-content-model-markdown/lib/index.ts
+++ b/packages/roosterjs-content-model-markdown/lib/index.ts
@@ -1,4 +1,6 @@
 export { convertMarkdownToContentModel } from './markdownToModel/convertMarkdownToContentModel';
 export { convertContentModelToMarkdown } from './modelToMarkdown/convertContentModelToMarkdown';
+export { isContentMarkdown } from './publicApi/isContentMarkdown';
+export { isPastedContentMarkdown } from './publicApi/isPastedContentMarkdown';
 export { MarkdownLineBreaks } from '../lib/constants/markdownLineBreaks';
 export { MarkdownToModelOptions } from './markdownToModel/types/MarkdownToModelOptions';

--- a/packages/roosterjs-content-model-markdown/lib/index.ts
+++ b/packages/roosterjs-content-model-markdown/lib/index.ts
@@ -4,3 +4,5 @@ export { isContentMarkdown } from './publicApi/isContentMarkdown';
 export { isPastedContentMarkdown } from './publicApi/isPastedContentMarkdown';
 export { MarkdownLineBreaks } from '../lib/constants/markdownLineBreaks';
 export { MarkdownToModelOptions } from './markdownToModel/types/MarkdownToModelOptions';
+export { MarkdownPastePlugin } from './plugins/MarkdownPastePlugin';
+export { MarkdownPasteOptions } from './plugins/MarkdownPasteOptions';

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/utils/parseInlineSegments.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/utils/parseInlineSegments.ts
@@ -55,6 +55,14 @@ export function parseInlineSegments(
     while (i < text.length) {
         const remaining = text.substring(i);
 
+        // Escaped character: a backslash followed by an ASCII punctuation character emits
+        // that character literally (e.g. "\*" -> "*") and is never treated as a marker.
+        if (text[i] === '\\' && i + 1 < text.length && isEscapable(text[i + 1])) {
+            buffer += text[i + 1];
+            i += 2;
+            continue;
+        }
+
         // Image: ![alt](url)
         const imgMatch = imagePattern.exec(remaining);
         if (imgMatch && isValidUrl(imgMatch[2])) {
@@ -136,6 +144,11 @@ function shouldToggleFormatting(
 
 function isWhitespace(char: string): boolean {
     return /\s/.test(char);
+}
+
+function isEscapable(char: string): boolean {
+    // Per CommonMark, any ASCII punctuation character may be backslash-escaped.
+    return /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/.test(char);
 }
 
 function toggleFormatting(state: FormattingState, type: 'bold' | 'italic' | 'strikethrough'): void {

--- a/packages/roosterjs-content-model-markdown/lib/plugins/MarkdownPasteOptions.ts
+++ b/packages/roosterjs-content-model-markdown/lib/plugins/MarkdownPasteOptions.ts
@@ -1,0 +1,12 @@
+/**
+ * Options for MarkdownPastePlugin
+ */
+export interface MarkdownPasteOptions {
+    /**
+     * When true, content that can be interpreted as markdown is automatically converted
+     * into rich content on every paste, without requiring an explicit "Paste as Markdown"
+     * command.
+     * @default false
+     */
+    autoConversion: boolean;
+}

--- a/packages/roosterjs-content-model-markdown/lib/plugins/MarkdownPastePlugin.ts
+++ b/packages/roosterjs-content-model-markdown/lib/plugins/MarkdownPastePlugin.ts
@@ -1,0 +1,83 @@
+import { contentModelToDom, createModelToDomContext } from 'roosterjs-content-model-dom';
+import { convertMarkdownToContentModel } from '../markdownToModel/convertMarkdownToContentModel';
+import { isPastedContentMarkdown } from '../publicApi/isPastedContentMarkdown';
+import type { MarkdownPasteOptions } from './MarkdownPasteOptions';
+import type { EditorPlugin, IEditor, PluginEvent } from 'roosterjs-content-model-types';
+
+const DefaultOptions: MarkdownPasteOptions = {
+    autoConversion: false,
+};
+
+/**
+ * Markdown paste plugin. Handles the BeforePaste event and, when the pasted content
+ * can be interpreted as markdown, converts the plain text into a Content Model and
+ * pastes it as rich markdown content instead of the original clipboard HTML.
+ */
+export class MarkdownPastePlugin implements EditorPlugin {
+    private editor: IEditor | null = null;
+    private options: MarkdownPasteOptions;
+
+    /**
+     * Construct a new instance of MarkdownPastePlugin
+     * @param options Options to control the markdown paste behavior
+     */
+    constructor(options?: MarkdownPasteOptions) {
+        this.options = options ?? DefaultOptions;
+    }
+
+    /**
+     * Get name of this plugin
+     */
+    getName() {
+        return 'MarkdownPaste';
+    }
+
+    /**
+     * The first method that editor will call to a plugin when editor is initializing.
+     * It will pass in the editor instance, plugin should take this chance to save the
+     * editor reference so that it can call to any editor method or format API later.
+     * @param editor The editor object
+     */
+    initialize(editor: IEditor) {
+        this.editor = editor;
+    }
+
+    /**
+     * The last method that editor will call to a plugin before it is disposed.
+     * Plugin can take this chance to clear the reference to editor. After this method is
+     * called, plugin should not call to any editor method since it will result in error.
+     */
+    dispose() {
+        this.editor = null;
+    }
+
+    /**
+     * Core method for a plugin. Once an event happens in editor, editor will call this
+     * method of each plugin to handle the event as long as the event is not handled
+     * exclusively by another plugin.
+     * @param event The event to handle:
+     */
+    onPluginEvent(event: PluginEvent) {
+        if (!this.editor || event.eventType != 'beforePaste') {
+            return;
+        }
+
+        const shouldConvert = event.pasteType === 'asMarkdown' || this.options.autoConversion;
+
+        if (shouldConvert && isPastedContentMarkdown(this.editor, event.clipboardData)) {
+            convertPastedTextToMarkdown(this.editor, event.fragment, event.clipboardData.text);
+        }
+    }
+}
+
+function convertPastedTextToMarkdown(editor: IEditor, fragment: DocumentFragment, text: string) {
+    const model = convertMarkdownToContentModel(text, {
+        emptyLine: 'merge',
+    });
+
+    while (fragment.firstChild) {
+        fragment.removeChild(fragment.firstChild);
+    }
+
+    contentModelToDom(editor.getDocument(), fragment, model, createModelToDomContext());
+}

--- a/packages/roosterjs-content-model-markdown/lib/publicApi/isContentMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/publicApi/isContentMarkdown.ts
@@ -1,0 +1,49 @@
+// Block-level markdown patterns. A line that matches any of these is considered markdown.
+const BlockPatterns: RegExp[] = [
+    /^#{1,6}\s.+/, // heading: "# text" .. "###### text"
+    /^\s*>\s.+/, // blockquote: "> text"
+    /^\s*[\*\-\+]\s.+/, // unordered list: "- item", "* item", "+ item"
+    /^\s*\d+\.\s.+/, // ordered list: "1. item"
+    /^---+$/, // horizontal rule: "---"
+    /^\s*\|.*\|\s*$/, // table row: "| a | b |"
+];
+
+// Inline markdown patterns. The text contains markdown if any of these match anywhere.
+const InlinePatterns: RegExp[] = [
+    /!\[[^\[\]]+\]\([^\)\s]+\)/, // image: ![alt](url)
+    /\[[^\[\]]+\]\([^\)\s]+\)/, // link: [text](url)
+    /\*\*[^\s*][^*]*\*\*/, // bold: **text**
+    /(^|[^*])\*[^\s*][^*]*\*([^*]|$)/, // italic: *text* (not part of **)
+    /~~[^\s~][^~]*~~/, // strikethrough: ~~text~~
+];
+
+/**
+ * Detect whether the given plain text contains any markdown markup.
+ * Recognizes block-level patterns (headings, blockquotes, lists, horizontal rules, tables)
+ * and inline patterns (bold, italic, strikethrough, links, images).
+ * @param text The plain text to check.
+ * @returns True if the text contains any markdown markup, false otherwise.
+ */
+export function isContentMarkdown(text: string): boolean {
+    if (!text || !text.trim()) {
+        return false;
+    }
+
+    const lines = text.split(/\r\n|\r|\n/);
+
+    for (const line of lines) {
+        for (const pattern of BlockPatterns) {
+            if (pattern.test(line)) {
+                return true;
+            }
+        }
+    }
+
+    for (const pattern of InlinePatterns) {
+        if (pattern.test(text)) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/packages/roosterjs-content-model-markdown/lib/publicApi/isPastedContentMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/publicApi/isPastedContentMarkdown.ts
@@ -5,6 +5,8 @@ import type { ClipboardData, DOMCreator, IEditor } from 'roosterjs-content-model
 // around the plain text without applying any real formatting to its content.
 const ThinWrapperTags = new Set<string>(['DIV', 'P', 'BR', 'SPAN']);
 
+const AllowedAttributes = new Set<string>(['class', 'style']);
+
 /**
  * Detect whether the given clipboard content can be interpreted as markdown.
  * @param editor The editor instance.
@@ -45,7 +47,7 @@ function isThinWrapperOfPlainText(fragment: DocumentFragment, text: string): boo
         for (let j = 0; j < element.attributes.length; j++) {
             const attr = element.attributes[j];
 
-            if (attr.name !== 'class' && attr.name !== 'style') {
+            if (!AllowedAttributes.has(attr.name) && !attr.name.startsWith('data-')) {
                 return false;
             }
         }

--- a/packages/roosterjs-content-model-markdown/lib/publicApi/isPastedContentMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/publicApi/isPastedContentMarkdown.ts
@@ -1,0 +1,77 @@
+import { isContentMarkdown } from './isContentMarkdown';
+import type { ClipboardData, DOMCreator, IEditor } from 'roosterjs-content-model-types';
+
+// Tags that are considered "thin wrappers", which only add structure (such as line breaks)
+// around the plain text without applying any real formatting to its content.
+const ThinWrapperTags = new Set<string>(['DIV', 'P', 'BR', 'SPAN']);
+
+/**
+ * Detect whether the given clipboard content can be interpreted as markdown.
+ * @param editor The editor instance.
+ * @param clipboardData The clipboard data to check.
+ * @returns True if the content can be interpreted as markdown, false otherwise.
+ */
+export function isPastedContentMarkdown(editor: IEditor, clipboardData: ClipboardData): boolean {
+    const { text, rawHtml } = clipboardData;
+
+    if (!text || !text.trim()) {
+        return false;
+    }
+
+    if (isContentMarkdown(text)) {
+        if (!rawHtml) {
+            return true;
+        }
+
+        const doc = editor.getDocument();
+        const trustedHTMLHandler = editor.getDOMCreator();
+        const fragment = parseHtmlToFragment(rawHtml, doc, trustedHTMLHandler);
+
+        return isThinWrapperOfPlainText(fragment, text);
+    }
+    return false;
+}
+
+function isThinWrapperOfPlainText(fragment: DocumentFragment, text: string): boolean {
+    const elements = fragment.querySelectorAll('*');
+
+    for (let i = 0; i < elements.length; i++) {
+        const element = elements[i];
+
+        if (!ThinWrapperTags.has(element.tagName)) {
+            return false;
+        }
+
+        for (let j = 0; j < element.attributes.length; j++) {
+            const attr = element.attributes[j];
+
+            if (attr.name !== 'class' && attr.name !== 'style') {
+                return false;
+            }
+        }
+    }
+
+    return removeWhitespace(fragment.textContent || '') === removeWhitespace(text);
+}
+
+function removeWhitespace(text: string): string {
+    return text.replace(/\s/g, '');
+}
+
+function parseHtmlToFragment(
+    html: string,
+    doc: Document,
+    trustedHTMLHandler: DOMCreator
+): DocumentFragment {
+    const parsedDoc = trustedHTMLHandler.htmlToDOM(html);
+    const fragment = doc.createDocumentFragment();
+    const body = parsedDoc?.body;
+
+    if (body) {
+        while (body.firstChild) {
+            fragment.appendChild(body.firstChild);
+        }
+    }
+
+    return fragment;
+}

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/utils/parseInlineSegmentsTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/utils/parseInlineSegmentsTest.ts
@@ -288,6 +288,86 @@ describe('parseInlineSegments', () => {
         ]);
     });
 
+    it('should treat an escaped asterisk as literal and not start italic', () => {
+        runTest('\\*not italic\\*', [
+            {
+                segmentType: 'Text',
+                text: '*not italic*',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should treat an escaped double asterisk as literal and not start bold', () => {
+        runTest('\\*\\*not bold\\*\\*', [
+            {
+                segmentType: 'Text',
+                text: '**not bold**',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should treat escaped tildes as literal and not start strikethrough', () => {
+        runTest('\\~\\~not strike\\~\\~', [
+            {
+                segmentType: 'Text',
+                text: '~~not strike~~',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should emit an escaped backslash as a single backslash', () => {
+        runTest('a\\\\b', [
+            {
+                segmentType: 'Text',
+                text: 'a\\b',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should keep a trailing backslash as a literal backslash', () => {
+        runTest('end\\', [
+            {
+                segmentType: 'Text',
+                text: 'end\\',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should keep a backslash before a non-escapable character', () => {
+        runTest('a\\b', [
+            {
+                segmentType: 'Text',
+                text: 'a\\b',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should still parse formatting around escaped markers', () => {
+        runTest('*italic \\* still italic*', [
+            {
+                segmentType: 'Text',
+                text: 'italic * still italic',
+                format: { italic: true },
+            },
+        ]);
+    });
+
+    it('should treat escaped link brackets as literal text', () => {
+        runTest('\\[text\\](https://example.com)', [
+            {
+                segmentType: 'Text',
+                text: '[text](https://example.com)',
+                format: {},
+            },
+        ]);
+    });
+
     it('should apply provided link to plain text', () => {
         const segments: ContentModelSegment[] = [];
 

--- a/packages/roosterjs-content-model-markdown/test/plugins/MarkdownPastePluginTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/plugins/MarkdownPastePluginTest.ts
@@ -1,0 +1,117 @@
+import { MarkdownPastePlugin } from '../../lib/plugins/MarkdownPastePlugin';
+import type {
+    BeforePasteEvent,
+    ClipboardData,
+    DOMCreator,
+    IEditor,
+    PasteType,
+    PluginEvent,
+} from 'roosterjs-content-model-types';
+
+describe('MarkdownPastePlugin', () => {
+    let doc: Document;
+    let trustedHTMLHandler: DOMCreator;
+    let editor: IEditor;
+
+    beforeEach(() => {
+        doc = document.implementation.createHTMLDocument('test');
+        trustedHTMLHandler = {
+            htmlToDOM: (html: string) => new DOMParser().parseFromString(html, 'text/html'),
+        };
+        editor = ({
+            getDocument: () => doc,
+            getDOMCreator: () => trustedHTMLHandler,
+        } as unknown) as IEditor;
+    });
+
+    function createPlugin(autoConversion?: boolean): MarkdownPastePlugin {
+        const plugin =
+            autoConversion === undefined
+                ? new MarkdownPastePlugin()
+                : new MarkdownPastePlugin({ autoConversion });
+        plugin.initialize(editor);
+        return plugin;
+    }
+
+    function createEvent(
+        clipboardData: Partial<ClipboardData>,
+        pasteType: PasteType
+    ): BeforePasteEvent {
+        const fragment = doc.createDocumentFragment();
+        const placeholder = doc.createElement('span');
+        placeholder.textContent = clipboardData.text || '';
+        fragment.appendChild(placeholder);
+
+        return ({
+            eventType: 'beforePaste',
+            clipboardData: clipboardData as ClipboardData,
+            fragment,
+            pasteType,
+        } as unknown) as BeforePasteEvent;
+    }
+
+    it('has the expected name', () => {
+        const plugin = createPlugin();
+        expect(plugin.getName()).toBe('MarkdownPaste');
+        plugin.dispose();
+    });
+
+    it('ignores non-beforePaste events', () => {
+        const plugin = createPlugin();
+        const event = ({ eventType: 'contentChanged' } as unknown) as PluginEvent;
+
+        expect(() => plugin.onPluginEvent(event)).not.toThrow();
+        plugin.dispose();
+    });
+
+    it('converts the fragment to markdown when pasteType is asMarkdown', () => {
+        const plugin = createPlugin();
+        const event = createEvent({ text: '# Heading', rawHtml: '' }, 'asMarkdown');
+
+        plugin.onPluginEvent(event);
+
+        expect(event.fragment.querySelector('h1')).not.toBeNull();
+        plugin.dispose();
+    });
+
+    it('does not convert non-markdown content even when pasteType is asMarkdown', () => {
+        const plugin = createPlugin();
+        const event = createEvent({ text: 'just plain text', rawHtml: '' }, 'asMarkdown');
+
+        plugin.onPluginEvent(event);
+
+        expect(event.fragment.querySelector('h1')).toBeNull();
+        expect(event.fragment.textContent).toBe('just plain text');
+        plugin.dispose();
+    });
+
+    it('does not convert markdown on normal paste when autoConversion is false (default)', () => {
+        const plugin = createPlugin();
+        const event = createEvent({ text: '# Heading', rawHtml: '' }, 'normal');
+
+        plugin.onPluginEvent(event);
+
+        expect(event.fragment.querySelector('h1')).toBeNull();
+        plugin.dispose();
+    });
+
+    it('converts markdown on normal paste when autoConversion is true', () => {
+        const plugin = createPlugin(true /*autoConversion*/);
+        const event = createEvent({ text: '# Heading', rawHtml: '' }, 'normal');
+
+        plugin.onPluginEvent(event);
+
+        expect(event.fragment.querySelector('h1')).not.toBeNull();
+        plugin.dispose();
+    });
+
+    it('does nothing after dispose', () => {
+        const plugin = createPlugin(true /*autoConversion*/);
+        plugin.dispose();
+        const event = createEvent({ text: '# Heading', rawHtml: '' }, 'asMarkdown');
+
+        plugin.onPluginEvent(event);
+
+        expect(event.fragment.querySelector('h1')).toBeNull();
+    });
+});

--- a/packages/roosterjs-content-model-markdown/test/publicApi/isContentMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/publicApi/isContentMarkdownTest.ts
@@ -1,0 +1,107 @@
+import { isContentMarkdown } from '../../lib/publicApi/isContentMarkdown';
+
+describe('isContentMarkdown', () => {
+    function runTest(text: string, expected: boolean) {
+        expect(isContentMarkdown(text)).toBe(expected);
+    }
+
+    it('should return false for empty text', () => {
+        runTest('', false);
+    });
+
+    it('should return false for whitespace-only text', () => {
+        runTest('   \n\t  ', false);
+    });
+
+    it('should return false for plain text with no markup', () => {
+        runTest('Hello world, this is plain text.', false);
+    });
+
+    it('should return false for plain multi-line text', () => {
+        runTest('First line\nSecond line\nThird line', false);
+    });
+
+    it('should detect heading (h1)', () => {
+        runTest('# Heading', true);
+    });
+
+    it('should detect heading (h6)', () => {
+        runTest('###### Heading', true);
+    });
+
+    it('should not treat a hashtag without a space as a heading', () => {
+        runTest('#hashtag', false);
+    });
+
+    it('should not treat 7 hashes as a heading', () => {
+        runTest('####### too many', false);
+    });
+
+    it('should detect blockquote', () => {
+        runTest('> quoted text', true);
+    });
+
+    it('should detect unordered list with dash', () => {
+        runTest('- item 1\n- item 2', true);
+    });
+
+    it('should detect unordered list with asterisk', () => {
+        runTest('* item 1', true);
+    });
+
+    it('should detect unordered list with plus', () => {
+        runTest('+ item 1', true);
+    });
+
+    it('should detect ordered list', () => {
+        runTest('1. first\n2. second', true);
+    });
+
+    it('should detect horizontal rule', () => {
+        runTest('---', true);
+    });
+
+    it('should detect table row', () => {
+        runTest('| col1 | col2 |', true);
+    });
+
+    it('should detect bold text', () => {
+        runTest('this is **bold** text', true);
+    });
+
+    it('should detect italic text', () => {
+        runTest('this is *italic* text', true);
+    });
+
+    it('should not treat double asterisks at line start with no closing as bold', () => {
+        runTest('** not bold', false);
+    });
+
+    it('should detect strikethrough', () => {
+        runTest('this is ~~struck~~ text', true);
+    });
+
+    it('should detect link', () => {
+        runTest('see [docs](https://example.com) for info', true);
+    });
+
+    it('should detect image', () => {
+        runTest('an ![alt](https://example.com/img.png) image', true);
+    });
+
+    it('should detect markdown when it appears on a later line', () => {
+        runTest('plain text first line\n# heading on second line', true);
+    });
+
+    it('should not be confused by lone asterisks', () => {
+        runTest('a * b * c', false);
+    });
+
+    it('should not be confused by lone tilde', () => {
+        runTest('value ~ approx', false);
+    });
+
+    it('should not match a list pattern without trailing content', () => {
+        runTest('-', false);
+    });
+});

--- a/packages/roosterjs-content-model-markdown/test/publicApi/isPastedContentMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/publicApi/isPastedContentMarkdownTest.ts
@@ -1,0 +1,227 @@
+import { ClipboardData, DOMCreator, IEditor } from 'roosterjs-content-model-types';
+import { isPastedContentMarkdown } from '../../lib/publicApi/isPastedContentMarkdown';
+
+describe('isPastedContentMarkdown', () => {
+    let doc: Document;
+    let trustedHTMLHandler: DOMCreator;
+    let editor: IEditor;
+
+    beforeEach(() => {
+        doc = document.implementation.createHTMLDocument('test');
+        trustedHTMLHandler = {
+            htmlToDOM: (html: string) => new DOMParser().parseFromString(html, 'text/html'),
+        };
+        editor = ({
+            getDocument: () => doc,
+            getDOMCreator: () => trustedHTMLHandler,
+        } as unknown) as IEditor;
+    });
+
+    function runTest(clipboardData: Partial<ClipboardData>, expected: boolean) {
+        const result = isPastedContentMarkdown(editor, clipboardData as ClipboardData);
+        expect(result).toBe(expected);
+    }
+
+    it('should return false when text is undefined', () => {
+        runTest({ text: undefined as any, rawHtml: '<p># Hello</p>' }, false);
+    });
+
+    it('should return false when text is empty string', () => {
+        runTest({ text: '', rawHtml: '<p># Hello</p>' }, false);
+    });
+
+    it('should return false when text contains only whitespace', () => {
+        runTest({ text: '   \n\t  ', rawHtml: '<p>foo</p>' }, false);
+    });
+
+    it('should return false when text contains no markdown patterns', () => {
+        runTest({ text: 'just plain text', rawHtml: '<p>just plain text</p>' }, false);
+    });
+
+    it('should return true when text exists and rawHtml is undefined', () => {
+        runTest({ text: '# Hello', rawHtml: undefined }, true);
+    });
+
+    it('should return true when text exists and rawHtml is empty string', () => {
+        runTest({ text: '# Hello', rawHtml: '' }, true);
+    });
+
+    it('should return true when rawHtml is a thin <p> wrapper of the same plain text', () => {
+        runTest({ text: '# Hello world', rawHtml: '<p># Hello world</p>' }, true);
+    });
+
+    it('should return true when rawHtml is a thin <div> wrapper of the same plain text', () => {
+        runTest({ text: '- item 1', rawHtml: '<div>- item 1</div>' }, true);
+    });
+
+    it('should return true when rawHtml is a <span> wrapper of the same plain text', () => {
+        runTest({ text: '**bold**', rawHtml: '<span>**bold**</span>' }, true);
+    });
+
+    it('should return true when rawHtml uses nested allowed wrapper tags', () => {
+        runTest(
+            {
+                text: '# line1 line2',
+                rawHtml: '<div><p># line1<br/>line2</p></div>',
+            },
+            true
+        );
+    });
+
+    it('should ignore whitespace differences when comparing text content', () => {
+        runTest(
+            {
+                text: '# Hello   world',
+                rawHtml: '<p># Hello world</p>',
+            },
+            true
+        );
+    });
+
+    it('should return true when wrapper element has only a style attribute', () => {
+        runTest(
+            {
+                text: '# Hello',
+                rawHtml: '<p style="color:red"># Hello</p>',
+            },
+            true
+        );
+    });
+
+    it('should return true when wrapper element has only a class attribute', () => {
+        runTest(
+            {
+                text: '# Hello',
+                rawHtml: '<p class="md"># Hello</p>',
+            },
+            true
+        );
+    });
+
+    it('should return false when wrapper element has a non-style/non-class attribute', () => {
+        runTest(
+            {
+                text: '# Hello',
+                rawHtml: '<p id="x"># Hello</p>',
+            },
+            false
+        );
+    });
+
+    it('should return false when rawHtml contains a non-thin-wrapper tag (e.g. <strong>)', () => {
+        runTest(
+            {
+                text: '**bold text**',
+                rawHtml: '<p><strong>**bold text**</strong></p>',
+            },
+            false
+        );
+    });
+
+    it('should return false when rawHtml contains a heading tag', () => {
+        runTest(
+            {
+                text: '# Hello',
+                rawHtml: '<h1># Hello</h1>',
+            },
+            false
+        );
+    });
+
+    it('should return false when rawHtml contains a list element', () => {
+        runTest(
+            {
+                text: '- item',
+                rawHtml: '<ul><li>- item</li></ul>',
+            },
+            false
+        );
+    });
+
+    it('should return false when rawHtml contains an anchor tag', () => {
+        runTest(
+            {
+                text: '[link](url)',
+                rawHtml: '<p><a href="x">[link](url)</a></p>',
+            },
+            false
+        );
+    });
+
+    it('should return false when html text content does not match plain text', () => {
+        runTest(
+            {
+                text: '# Hello',
+                rawHtml: '<p>Goodbye</p>',
+            },
+            false
+        );
+    });
+
+    it('should return false when html text content has extra characters not in plain text', () => {
+        runTest(
+            {
+                text: '# Hello',
+                rawHtml: '<p># Hello world</p>',
+            },
+            false
+        );
+    });
+
+    it('should return true when rawHtml has multiple thin wrappers matching the text', () => {
+        runTest(
+            {
+                text: '# foo bar',
+                rawHtml: '<div><p># foo</p><p>bar</p></div>',
+            },
+            true
+        );
+    });
+
+    it('should return true when <br> is used inside thin wrappers', () => {
+        runTest(
+            {
+                text: '# foo bar',
+                rawHtml: '<p># foo<br/>bar</p>',
+            },
+            true
+        );
+    });
+
+    it('should use the editor-provided trustedHTMLHandler to parse rawHtml', () => {
+        const spyDom = new DOMParser().parseFromString('<p># Hello</p>', 'text/html');
+        const handler: DOMCreator = {
+            htmlToDOM: jasmine.createSpy('htmlToDOM').and.returnValue(spyDom),
+        };
+        const editorWithSpy = ({
+            getDocument: () => doc,
+            getDOMCreator: () => handler,
+        } as unknown) as IEditor;
+
+        const result = isPastedContentMarkdown(editorWithSpy, {
+            text: '# Hello',
+            rawHtml: '<p># Hello</p>',
+        } as ClipboardData);
+
+        expect(handler.htmlToDOM).toHaveBeenCalledWith('<p># Hello</p>');
+        expect(result).toBe(true);
+    });
+
+    it('should return false when trustedHTMLHandler returns a document with no body', () => {
+        const handler: DOMCreator = {
+            htmlToDOM: () => ({} as Document),
+        };
+        const editorWithEmpty = ({
+            getDocument: () => doc,
+            getDOMCreator: () => handler,
+        } as unknown) as IEditor;
+
+        // Empty fragment textContent ('') will not match the non-empty plain text
+        const result = isPastedContentMarkdown(editorWithEmpty, {
+            text: '# Hello',
+            rawHtml: '<p># Hello</p>',
+        } as ClipboardData);
+
+        expect(result).toBe(false);
+    });
+});

--- a/packages/roosterjs-content-model-types/lib/context/DomIndexer.ts
+++ b/packages/roosterjs-content-model-types/lib/context/DomIndexer.ts
@@ -80,6 +80,15 @@ export interface DomIndexer {
     reconcileElementId: (element: HTMLElement) => boolean;
 
     /**
+     * When src or a data-* attribute is changed on an indexed IMG element, update the related
+     * ContentModelImage (src property or dataset) so the cached model stays valid.
+     * @param element The element that has an attribute changed
+     * @param attributeName The name of the changed attribute
+     * @returns True if successfully updated, otherwise false
+     */
+    reconcileImageAttribute: (element: HTMLElement, attributeName: string) => boolean;
+
+    /**
      * When child list of editor content is changed, we can use this method to do sync the change from editor into content model.
      * This is mostly used when user start to type in an empty line. In that case browser will remove the existing BR node in the empty line if any,
      * and create a new TEXT node for the typed text. Here we use these information to remove original Br segment and create a new Text segment

--- a/packages/roosterjs-content-model-types/lib/context/DomToModelOption.ts
+++ b/packages/roosterjs-content-model-types/lib/context/DomToModelOption.ts
@@ -48,6 +48,14 @@ export interface DomToModelOptionForCreateModel extends DomToModelOption {
      * When this option is passed, "tryGetFromCache" will be ignored.
      */
     recalculateTableSize?: boolean | 'all' | 'selected' | 'none';
+
+    /**
+     * When set to true, if a container element could be represented by a FormatContainer, always keep the
+     * FormatContainer and never fall back to a paragraph, even when it only has a single child.
+     * Set this when the intermediate FormatContainer is persisted during DOM to Content Model conversion
+     * and is later used during formatting.
+     */
+    skipFormatContainerFallbackCheck?: boolean;
 }
 
 /**

--- a/packages/roosterjs-content-model-types/lib/context/DomToModelSettings.ts
+++ b/packages/roosterjs-content-model-types/lib/context/DomToModelSettings.ts
@@ -152,4 +152,12 @@ export interface DomToModelSettings {
      * If true elements that has display:none style will be processed
      */
     processNonVisibleElements?: boolean;
+
+    /**
+     * When set to true, if a container element could be represented by a FormatContainer, always keep the
+     * FormatContainer and never fall back to a paragraph, even when it only has a single child.
+     * Set this when the intermediate FormatContainer is persisted during DOM to Content Model conversion
+     * and is later used during formatting.
+     */
+    skipFormatContainerFallbackCheck?: boolean;
 }

--- a/packages/roosterjs-content-model-types/lib/enum/PasteType.ts
+++ b/packages/roosterjs-content-model-types/lib/enum/PasteType.ts
@@ -20,4 +20,9 @@ export type PasteType =
     /**
      * If there is a image uri in the clipboard, paste the content as image element
      */
-    | 'asImage';
+    | 'asImage'
+
+    /**
+     * If the editor includes a markdown plugin @see MarkdownPastePlugin, and there is markdown content in the clipboard, paste it as markdown
+     */
+    | 'asMarkdown';

--- a/packages/roosterjs-content-model-types/lib/event/BeforePasteEvent.ts
+++ b/packages/roosterjs-content-model-types/lib/event/BeforePasteEvent.ts
@@ -57,7 +57,7 @@ export interface BeforePasteEvent extends BasePluginEvent<'beforePaste'> {
     readonly htmlAttributes: Record<string, string>;
 
     /**
-     * Paste type option (as plain text, merge format, normal, as image)
+     * Paste type option (as plain text, merge format, normal, as image, asMarkdown (@see MarkdownPastePlugin ))
      */
     readonly pasteType: PasteType;
 

--- a/packages/roosterjs-editor-adapter/lib/editor/utils/eventConverter.ts
+++ b/packages/roosterjs-editor-adapter/lib/editor/utils/eventConverter.ts
@@ -28,6 +28,8 @@ const PasteTypeNewToOld: Record<NewPasteType, OldPasteType> = {
     asPlainText: OldPasteType.AsPlainText,
     mergeFormat: OldPasteType.MergeFormat,
     normal: OldPasteType.Normal,
+    // The old editor system has no markdown paste concept, fall back to normal paste
+    asMarkdown: OldPasteType.Normal,
 };
 
 const PasteTypeOldToNew: Record<OldPasteType, NewPasteType> = {

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
     "react": "9.0.4",
-    "main": "9.53.0",
+    "main": "9.54.0",
     "legacyAdapter": "8.66.0",
     "overrides": {}
 }


### PR DESCRIPTION

  | Group         | Old Version | New Version |
  | ------------- | ----------- | ----------- |
  | main          | 9.53.0      | 9.54.0      |
  | react         | 9.0.4       | 9.0.4 (no change) |
  
  ## Changes included
  
  - #3363 Add Paste As Markdown support and isPastedContentMarkdown API
  (https://github.com/microsoft/roosterjs/pull/3363)
  - #3362 Remove redundant leading/trailing selection markers within a paragraph
  (https://github.com/microsoft/roosterjs/pull/3362)
  - #3360 Reconcile IMG src and data-* attribute changes in Content Model cache 
  (https://github.com/microsoft/roosterjs/pull/3360)
  - #3358 Add skipFormatContainerFallbackCheck to keep persisted Content Model path valid 
  (https://github.com/microsoft/roosterjs/pull/3358)
  - #3357 Clear whole list node stack when leaving its root parent 
  (https://github.com/microsoft/roosterjs/pull/3357)
 - #3366 Add MarkdownPastePlugin to paste markdown content as rich text (https://github.com/microsoft/roosterjs/pull/3366)
 - #3365 Recognize escaped characters when converting markdown to Content Model (https://github.com/microsoft/roosterjs/pull/3365)
  
