### PR TITLE
Recognize escaped characters when converting markdown to Content Model

### DIFF
--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/utils/parseInlineSegments.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/utils/parseInlineSegments.ts
@@ -55,6 +55,14 @@ export function parseInlineSegments(
     while (i < text.length) {
         const remaining = text.substring(i);
 
+        // Escaped character: a backslash followed by an ASCII punctuation character emits
+        // that character literally (e.g. "\*" -> "*") and is never treated as a marker.
+        if (text[i] === '\\' && i + 1 < text.length && isEscapable(text[i + 1])) {
+            buffer += text[i + 1];
+            i += 2;
+            continue;
+        }
+
         // Image: ![alt](url)
         const imgMatch = imagePattern.exec(remaining);
         if (imgMatch && isValidUrl(imgMatch[2])) {
@@ -136,6 +144,11 @@ function shouldToggleFormatting(
 
 function isWhitespace(char: string): boolean {
     return /\s/.test(char);
+}
+
+function isEscapable(char: string): boolean {
+    // Per CommonMark, any ASCII punctuation character may be backslash-escaped.
+    return /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/.test(char);
 }
 
 function toggleFormatting(state: FormattingState, type: 'bold' | 'italic' | 'strikethrough'): void {

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/utils/parseInlineSegmentsTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/utils/parseInlineSegmentsTest.ts
@@ -288,6 +288,86 @@ describe('parseInlineSegments', () => {
         ]);
     });
 
+    it('should treat an escaped asterisk as literal and not start italic', () => {
+        runTest('\\*not italic\\*', [
+            {
+                segmentType: 'Text',
+                text: '*not italic*',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should treat an escaped double asterisk as literal and not start bold', () => {
+        runTest('\\*\\*not bold\\*\\*', [
+            {
+                segmentType: 'Text',
+                text: '**not bold**',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should treat escaped tildes as literal and not start strikethrough', () => {
+        runTest('\\~\\~not strike\\~\\~', [
+            {
+                segmentType: 'Text',
+                text: '~~not strike~~',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should emit an escaped backslash as a single backslash', () => {
+        runTest('a\\\\b', [
+            {
+                segmentType: 'Text',
+                text: 'a\\b',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should keep a trailing backslash as a literal backslash', () => {
+        runTest('end\\', [
+            {
+                segmentType: 'Text',
+                text: 'end\\',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should keep a backslash before a non-escapable character', () => {
+        runTest('a\\b', [
+            {
+                segmentType: 'Text',
+                text: 'a\\b',
+                format: {},
+            },
+        ]);
+    });
+
+    it('should still parse formatting around escaped markers', () => {
+        runTest('*italic \\* still italic*', [
+            {
+                segmentType: 'Text',
+                text: 'italic * still italic',
+                format: { italic: true },
+            },
+        ]);
+    });
+
+    it('should treat escaped link brackets as literal text', () => {
+        runTest('\\[text\\](https://example.com)', [
+            {
+                segmentType: 'Text',
+                text: '[text](https://example.com)',
+                format: {},
+            },
+        ]);
+    });
+
     it('should apply provided link to plain text', () => {
         const segments: ContentModelSegment[] = [];
 


### PR DESCRIPTION
@
## Summary
When converting markdown to the Content Model, backslash-escaped characters are now recognized. For example, `\*` is treated as a literal `*` rather than the start of an italic span.

## Change
- [parseInlineSegments.ts](packages/roosterjs-content-model-markdown/lib/markdownToModel/utils/parseInlineSegments.ts): at the top of the inline scan loop (before image/link/marker detection), a backslash followed by an ASCII punctuation character emits that character literally and consumes both characters. Added an `isEscapable` helper matching CommonMark backslash-escape rules.
- Because the escape check runs first, the escaped marker character is buffered before marker detection sees it, so it cannot open/close formatting. A trailing or non-punctuation backslash is preserved as-is.

## Tests
Added 8 cases to [parseInlineSegmentsTest.ts](packages/roosterjs-content-model-markdown/test/markdownToModel/utils/parseInlineSegmentsTest.ts): escaped `\*` (no italic), `\*\*` (no bold), `\~~` (no strikethrough), `\` → single backslash, trailing backslash, backslash before a non-escapable char, escaped markers nested inside real italic, and escaped link brackets.

All 30 tests in the file pass; `yarn eslint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@