### PR TITLE
Preserve new event pasteType when converting BeforePaste event

### DIFF
--- a/packages/roosterjs-editor-adapter/lib/editor/utils/eventConverter.ts
+++ b/packages/roosterjs-editor-adapter/lib/editor/utils/eventConverter.ts
@@ -178,7 +178,7 @@ export function oldEventToNewEvent<TOldEvent extends OldEvent>(
                 htmlAfter: input.htmlAfter,
                 htmlAttributes: input.htmlAttributes,
                 htmlBefore: input.htmlBefore,
-                pasteType: PasteTypeOldToNew[input.pasteType],
+                pasteType: refBeforePasteEvent?.pasteType ?? PasteTypeOldToNew[input.pasteType],
             };
 
         case PluginEventType.BeforeSetContent:

--- a/packages/roosterjs-editor-adapter/test/editor/utils/eventConverterTest.ts
+++ b/packages/roosterjs-editor-adapter/test/editor/utils/eventConverterTest.ts
@@ -161,7 +161,7 @@ describe('oldEventToNewEvent', () => {
                 htmlAfter: mockedHtmlAfter,
                 htmlBefore: mockedHtmlBefore,
                 htmlAttributes: mockedHTmlAttributes,
-                pasteType: 'asPlainText',
+                pasteType: 'asImage',
             }
         );
     });


### PR DESCRIPTION
## Summary

When converting a legacy `BeforePaste` event (`PluginEventType.BeforePaste`) into the new Content Model event in `eventConverter.ts`, the `pasteType` was always derived from the old event via `PasteTypeOldToNew[input.pasteType]`. This discarded any `pasteType` already set on the new (ref) event — so when a plugin updated `pasteType` on the new event, the converter overwrote it with the stale value mapped from the old event.

This change makes the converter prefer the `pasteType` already present on the new event, only falling back to the mapping from the old event when the new event doesn't have one:

```ts
pasteType: refBeforePasteEvent?.pasteType ?? PasteTypeOldToNew[input.pasteType],
```

This matches the pattern already used for the other fields on this event (`customizedMerge`, `domToModelOption`).

## How to test

1. Run the unit tests for the event converter:
   ```bash
   yarn test:fast --testPathPattern=eventConverter
   ```
2. Manual / integration check in an editor that uses `roosterjs-editor-adapter`:
   - Set up a plugin (or paste handler) that modifies `pasteType` on the new `beforePaste` event (e.g. forces `pasteType: 'asPlainText'` or `'mergeFormat'`).
   - Trigger a paste.
   - **Before this fix:** the modified `pasteType` is lost and the value mapped from the old event is used instead.
   - **After this fix:** the `pasteType` set on the new event is respected, and only falls back to the old event's mapped value when the new event has none.
