### PR TITLE
Hotfix version bump legacyAdapter: 8.66.0 → 8.66.1

### DIFF
--- a/packages/roosterjs-editor-adapter/lib/editor/utils/eventConverter.ts
+++ b/packages/roosterjs-editor-adapter/lib/editor/utils/eventConverter.ts
@@ -178,7 +178,7 @@ export function oldEventToNewEvent<TOldEvent extends OldEvent>(
                 htmlAfter: input.htmlAfter,
                 htmlAttributes: input.htmlAttributes,
                 htmlBefore: input.htmlBefore,
-                pasteType: PasteTypeOldToNew[input.pasteType],
+                pasteType: refBeforePasteEvent?.pasteType ?? PasteTypeOldToNew[input.pasteType],
             };
 
         case PluginEventType.BeforeSetContent:

--- a/packages/roosterjs-editor-adapter/test/editor/utils/eventConverterTest.ts
+++ b/packages/roosterjs-editor-adapter/test/editor/utils/eventConverterTest.ts
@@ -161,7 +161,7 @@ describe('oldEventToNewEvent', () => {
                 htmlAfter: mockedHtmlAfter,
                 htmlBefore: mockedHtmlBefore,
                 htmlAttributes: mockedHTmlAttributes,
-                pasteType: 'asPlainText',
+                pasteType: 'asImage',
             }
         );
     });

--- a/versions.json
+++ b/versions.json
@@ -1,6 +1,6 @@
 {
     "react": "9.0.4",
     "main": "9.54.0",
-    "legacyAdapter": "8.66.0",
+    "legacyAdapter": "8.66.1",
     "overrides": {}
 }


### PR DESCRIPTION
## Versions

| Group         | Old Version | New Version |
| ------------- | ----------- | ----------- |
| legacyAdapter | 8.66.0      | 8.66.1      |

## Hotfix commits

-   5142b51 Preserve new event pasteType when converting BeforePaste event (#3367)

## Affected packages

-   roosterjs-editor-adapter → legacyAdapter

Patch bump — implementation-only change to `eventConverter.ts` (+ test), no public API changes. `main` and `react` left untouched.