### PR TITLE
Fix editor jump when entering image edit mode

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
@@ -62,16 +62,38 @@ export function createImageWrapper(
         rotators,
         croppers
     );
+    // Capture the image footprint before attaching the shadow root, since the light-DOM image
+    // stops being rendered once the shadow root takes over.
+    const imageWidth = image.offsetWidth;
+    const imageHeight = image.offsetHeight;
     const imageSpan = wrap(doc, image, 'span');
-    const shadowSpan = createShadowSpan(wrapper, imageSpan);
+    const shadowSpan = createShadowSpan(wrapper, imageSpan, imageWidth, imageHeight);
     return { wrapper, shadowSpan, imageClone, resizers, rotators, croppers };
 }
 
-const createShadowSpan = (wrapper: HTMLElement, imageSpan: HTMLSpanElement) => {
+const createShadowSpan = (
+    wrapper: HTMLElement,
+    imageSpan: HTMLSpanElement,
+    imageWidth: number,
+    imageHeight: number
+) => {
     const shadowRoot = imageSpan.attachShadow({
         mode: 'open',
     });
     imageSpan.id = IMAGE_EDIT_SHADOW_ROOT;
+
+    // Pin the shadow host to the original image's box so that wrapping the image does not grow the
+    // surrounding line box. Without this, the taller edit wrapper enlarges the line and the browser
+    // scrolls the selection back into view, making the editor jump. The wrapper and handles still
+    // overflow the host visually because overflow is left visible.
+    if (imageWidth > 0 && imageHeight > 0) {
+        imageSpan.style.display = 'inline-block';
+        imageSpan.style.width = `${imageWidth}px`;
+        imageSpan.style.height = `${imageHeight}px`;
+        imageSpan.style.verticalAlign = 'bottom';
+        imageSpan.style.overflow = 'visible';
+    }
+
     shadowRoot.appendChild(wrapper);
     return imageSpan;
 };

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/utils/createImageWrapperTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/utils/createImageWrapperTest.ts
@@ -175,6 +175,74 @@ describe('createImageWrapper', () => {
         });
         imageSpan.remove();
     });
+
+    function createImageWithSize(width: number, height: number) {
+        const image = document.createElement('img');
+        const imageSpan = document.createElement('span');
+        imageSpan.append(image);
+        document.body.appendChild(imageSpan);
+        Object.defineProperty(image, 'offsetWidth', { value: width, configurable: true });
+        Object.defineProperty(image, 'offsetHeight', { value: height, configurable: true });
+        return { image, imageSpan };
+    }
+
+    const options: ImageEditOptions = {
+        borderColor: '#DB626C',
+        minWidth: 10,
+        minHeight: 10,
+        preserveRatio: true,
+        disableRotate: false,
+        disableSideResize: false,
+        onSelectState: ['resize'],
+    };
+    const editInfo = {
+        src: 'test',
+        widthPx: 20,
+        heightPx: 20,
+        naturalWidth: 10,
+        naturalHeight: 10,
+        leftPercent: 0,
+        rightPercent: 0,
+        topPercent: 0.1,
+        bottomPercent: 0,
+        angleRad: 0,
+    };
+    const htmlOptions = {
+        borderColor: '#DB626C',
+        rotateHandleBackColor: 'white',
+        isSmallImage: false,
+        disableSideResize: false,
+    };
+
+    it('pins the shadow host to the original image footprint', () => {
+        const { image, imageSpan } = createImageWithSize(120, 80);
+
+        const result = createImageWrapper(editor, image, options, editInfo, htmlOptions, [
+            'resize',
+        ]);
+
+        expect(result.shadowSpan.style.display).toBe('inline-block');
+        expect(result.shadowSpan.style.width).toBe('120px');
+        expect(result.shadowSpan.style.height).toBe('80px');
+        expect(result.shadowSpan.style.verticalAlign).toBe('bottom');
+        expect(result.shadowSpan.style.overflow).toBe('visible');
+        imageSpan.remove();
+    });
+
+    it('does not pin the shadow host when the image has no footprint', () => {
+        const { image, imageSpan } = createImageWithSize(0, 0);
+
+        const result = createImageWrapper(editor, image, options, editInfo, htmlOptions, [
+            'resize',
+        ]);
+
+        expect(result.shadowSpan.style.display).toBe('');
+        expect(result.shadowSpan.style.width).toBe('');
+        expect(result.shadowSpan.style.height).toBe('');
+        expect(result.shadowSpan.style.verticalAlign).toBe('');
+        expect(result.shadowSpan.style.overflow).toBe('');
+        imageSpan.remove();
+    });
 });
 
 const cloneImage = (image: HTMLImageElement, editInfo: ImageMetadataFormat) => {


### PR DESCRIPTION
## Summary

Fixes the editor jumping/scrolling when an image is selected for editing. In `createImageWrapper.ts`, attaching the shadow root replaces the rendered light-DOM image with a taller edit wrapper (border + resize/rotate/crop handles), which grows the surrounding line box and causes the browser to scroll the selection back into view.

This pins the shadow host span to the original image's footprint — captured from `image.offsetWidth`/`offsetHeight` **before** the shadow root takes over — by setting `display: inline-block`, fixed `width`/`height`, `vertical-align: bottom`, and `overflow: visible`. The handles and wrapper still overflow the host visually, but the line box no longer grows, so the editor stays put. Pinning is skipped when the image has no measurable footprint (`offsetWidth`/`offsetHeight` of 0).

## How to test

1. Run the unit tests:
   ```
   yarn test:fast --testPathPattern=createImageWrapper
   ```
   New tests cover both branches: the shadow host is pinned to the image footprint when dimensions are non-zero, and left untouched when they are 0.
2. Manual check: insert a tall image into the editor and place the caret/scroll so the image sits near the viewport edge, then click the image to enter edit mode.
   - Before this fix: the editor scrolls/jumps as the edit wrapper enlarges the line box.
   - After this fix: the image edit handles appear in place without the editor scrolling.
