### PR TITLE
Fix normalizeSingleSegment to preserve leading space for word separation

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelApi/common/normalizeSegment.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/common/normalizeSegment.ts
@@ -53,6 +53,13 @@ export function normalizeSingleSegment(
                 }
                 break;
             }
+        } else if (s.segmentType == 'Image') {
+            // If the previous segment is an image, we should keep the leading space of the current segment to maintain word separation.
+            context.ignoreLeadingSpaces = false;
+            break;
+        } else if (s.segmentType == 'Br') {
+            // If the previous segment is a line break, we should ignore the leading space of the current segment.
+            context.ignoreLeadingSpaces = true;
         } else if (s.segmentType != 'SelectionMarker') {
             break;
         }

--- a/packages/roosterjs-content-model-dom/lib/modelApi/common/normalizeSegment.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/common/normalizeSegment.ts
@@ -36,8 +36,28 @@ export function normalizeSingleSegment(
     ignoreTrailingSpaces: boolean = false
 ) {
     const context = resetNormalizeSegmentContext();
+    const index = paragraph.segments.indexOf(segment);
 
     context.ignoreTrailingSpaces = ignoreTrailingSpaces;
+
+    // Search backward for the nearest non-empty text segment (skipping SelectionMarkers and empty text),
+    // to determine whether leading spaces of the current segment should be preserved.
+    // If the previous text doesn't end with a space, keep the leading space to maintain word separation.
+    for (let i = index - 1; i >= 0; i--) {
+        const s = paragraph.segments[i];
+
+        if (s.segmentType == 'Text') {
+            if (s.text.length > 0) {
+                if (s.text.substr(-1) != SPACE) {
+                    context.ignoreLeadingSpaces = false;
+                }
+                break;
+            }
+        } else if (s.segmentType != 'SelectionMarker') {
+            break;
+        }
+    }
+
     normalizeSegment(paragraph, segment, context);
 }
 
@@ -99,6 +119,11 @@ export function normalizeSegment(
             break;
 
         case 'Text':
+            // Skip empty text segments to avoid affecting normalization context
+            if (segment.text.length == 0) {
+                break;
+            }
+
             context.textSegments.push(segment);
             context.lastInlineSegment = segment;
             context.lastTextSegment = segment;
@@ -108,11 +133,11 @@ export function normalizeSegment(
 
             if (!hasSpacesOnly(segment.text)) {
                 if (first == SPACE) {
-                    // 1. Multiple leading space => single &nbsp; or empty (depends on if previous segment ends with space)
+                    // 1. Multiple leading space => single space or empty (depends on if previous segment ends with space)
                     mutateSegment(paragraph, segment, textSegment => {
                         textSegment.text = textSegment.text.replace(
                             LEADING_SPACE_REGEX,
-                            context.ignoreLeadingSpaces ? '' : NONE_BREAK_SPACE
+                            context.ignoreLeadingSpaces ? '' : SPACE
                         );
                     });
                 }

--- a/packages/roosterjs-content-model-dom/test/modelApi/common/normalizeParagraphTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/common/normalizeParagraphTest.ts
@@ -46,7 +46,7 @@ describe('Normalize text that contains space', () => {
     });
 
     it('Only second text with space', () => {
-        runTest(['a', '', '  b '], ['a', '', '\u00A0b']);
+        runTest(['a', '', '  b '], ['a', '', ' b']);
     });
 
     it('Text with multiple spaces', () => {
@@ -103,7 +103,7 @@ describe('Normalize text that contains space', () => {
                         },
                         {
                             segmentType: 'Text',
-                            text: '\u00A0b',
+                            text: ' b',
                             format: {},
                         },
                     ],
@@ -171,7 +171,7 @@ describe('Normalize text that contains space', () => {
                         },
                         {
                             segmentType: 'Text',
-                            text: '\u00A0b',
+                            text: 'b',
                             format: {},
                         },
                     ],

--- a/packages/roosterjs-content-model-dom/test/modelApi/common/normalizeSegmentTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/common/normalizeSegmentTest.ts
@@ -97,11 +97,11 @@ describe('normalizeSegment', () => {
         });
 
         expect(context).toEqual({
-            textSegments: [text],
-            ignoreLeadingSpaces: false,
+            textSegments: [],
+            ignoreLeadingSpaces: true,
             ignoreTrailingSpaces: true,
-            lastInlineSegment: text,
-            lastTextSegment: text,
+            lastInlineSegment: undefined,
+            lastTextSegment: undefined,
         });
     });
 
@@ -167,7 +167,7 @@ describe('normalizeSegment', () => {
         expect(text).toEqual({
             segmentType: 'Text',
             format: {},
-            text: '\u00A0aa ',
+            text: ' aa ',
         });
 
         expect(context).toEqual({

--- a/packages/roosterjs-content-model-dom/test/modelApi/common/normalizeSingleSegmentTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/common/normalizeSingleSegmentTest.ts
@@ -1,0 +1,163 @@
+import { createParagraph } from '../../../lib/modelApi/creators/createParagraph';
+import { createSelectionMarker } from '../../../lib/modelApi/creators/createSelectionMarker';
+import { createText } from '../../../lib/modelApi/creators/createText';
+import { createImage } from '../../../lib/modelApi/creators/createImage';
+import { normalizeSingleSegment } from '../../../lib/modelApi/common/normalizeSegment';
+import { ReadonlyContentModelParagraph } from 'roosterjs-content-model-types';
+
+describe('normalizeSingleSegment', () => {
+    it('should ignore leading spaces when no previous segment', () => {
+        const para = createParagraph();
+        const text = createText('  hello');
+
+        para.segments.push(text);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        expect(text.text).toBe('hello');
+    });
+
+    it('should keep leading space when previous text does not end with space', () => {
+        const para = createParagraph();
+        const prev = createText('world');
+        const text = createText('  hello');
+
+        para.segments.push(prev, text);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        expect(text.text).toBe(' hello');
+    });
+
+    it('should ignore leading spaces when previous text ends with space', () => {
+        const para = createParagraph();
+        const prev = createText('world ');
+        const text = createText('  hello');
+
+        para.segments.push(prev, text);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        expect(text.text).toBe('hello');
+    });
+
+    it('should skip SelectionMarker when searching for previous text', () => {
+        const para = createParagraph();
+        const prev = createText('world');
+        const marker = createSelectionMarker();
+        const text = createText('  hello');
+
+        para.segments.push(prev, marker, text);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        expect(text.text).toBe(' hello');
+    });
+
+    it('should skip empty text segments when searching for previous text', () => {
+        const para = createParagraph();
+        const prev = createText('world');
+        const empty = createText('');
+        const text = createText('  hello');
+
+        para.segments.push(prev, empty, text);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        // Empty text is skipped, prev "world" is found (doesn't end with space) => keep leading space
+        expect(text.text).toBe(' hello');
+    });
+
+    it('should not look past non-text non-marker segments', () => {
+        const para = createParagraph();
+        const prev = createText('world');
+        const image = createImage('img');
+        const text = createText('  hello');
+
+        para.segments.push(prev, image, text);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        // Image breaks the backward search, no prev text found => ignoreLeadingSpaces stays true
+        expect(text.text).toBe('hello');
+    });
+
+    it('should handle ignoreTrailingSpaces parameter', () => {
+        const para = createParagraph();
+        const text = createText('hello   ');
+
+        para.segments.push(text);
+
+        normalizeSingleSegment(
+            para as ReadonlyContentModelParagraph,
+            text,
+            true /*ignoreTrailingSpaces*/
+        );
+
+        expect(text.text).toBe('hello ');
+    });
+
+    it('should handle text with no leading or trailing spaces', () => {
+        const para = createParagraph();
+        const text = createText('hello');
+
+        para.segments.push(text);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        expect(text.text).toBe('hello');
+    });
+
+    it('should skip empty text segment without error', () => {
+        const para = createParagraph();
+        const empty = createText('');
+
+        para.segments.push(empty);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, empty);
+
+        expect(empty.text).toBe('');
+    });
+
+    it('should handle segment in middle with prev ending in non-space and next text', () => {
+        const para = createParagraph();
+        const prev = createText('before');
+        const text = createText('  middle  ');
+        const next = createText('after');
+
+        para.segments.push(prev, text, next);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        // prev doesn't end with space => ignoreLeadingSpaces = false => leading spaces become single space
+        // ignoreTrailingSpaces defaults to false => trailing spaces become nbsp
+        expect(text.text).toBe(' middle\u00A0');
+    });
+
+    it('should handle multiple SelectionMarkers between prev text and current', () => {
+        const para = createParagraph();
+        const prev = createText('abc');
+        const marker1 = createSelectionMarker();
+        const marker2 = createSelectionMarker();
+        const text = createText('  def');
+
+        para.segments.push(prev, marker1, marker2, text);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        expect(text.text).toBe(' def');
+    });
+
+    it('should ignore leading spaces when prev text ends with space after skipping markers', () => {
+        const para = createParagraph();
+        const prev = createText('abc ');
+        const marker = createSelectionMarker();
+        const text = createText('  def');
+
+        para.segments.push(prev, marker, text);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        expect(text.text).toBe('def');
+    });
+});

--- a/packages/roosterjs-content-model-dom/test/modelApi/common/normalizeSingleSegmentTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/common/normalizeSingleSegmentTest.ts
@@ -1,7 +1,7 @@
+import { createImage } from '../../../lib/modelApi/creators/createImage';
 import { createParagraph } from '../../../lib/modelApi/creators/createParagraph';
 import { createSelectionMarker } from '../../../lib/modelApi/creators/createSelectionMarker';
 import { createText } from '../../../lib/modelApi/creators/createText';
-import { createImage } from '../../../lib/modelApi/creators/createImage';
 import { normalizeSingleSegment } from '../../../lib/modelApi/common/normalizeSegment';
 import { ReadonlyContentModelParagraph } from 'roosterjs-content-model-types';
 
@@ -79,6 +79,19 @@ describe('normalizeSingleSegment', () => {
         normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
 
         // Image breaks the backward search, no prev text found => ignoreLeadingSpaces stays true
+        expect(text.text).toBe(' hello');
+    });
+
+    it('should ignore leading spaces when previous segment is a line break', () => {
+        const para = createParagraph();
+        const prev = { segmentType: 'Br' } as any;
+        const text = createText('  hello');
+
+        para.segments.push(prev, text);
+
+        normalizeSingleSegment(para as ReadonlyContentModelParagraph, text);
+
+        // Line break before, leading spaces should be ignored
         expect(text.text).toBe('hello');
     });
 

--- a/packages/roosterjs-content-model-markdown/test/modelToMarkdown/convertContentModelToMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/modelToMarkdown/convertContentModelToMarkdownTest.ts
@@ -109,7 +109,7 @@ describe('convertContentModelToMarkdown', () => {
     });
 
     it('should convert simple html to markdown', () => {
-        const markdown = 'hello **world** how are you?';
+        const markdown = 'hello **world** how are you?';
         const model = createModelFromHtml('<p>hello <b>world</b> how are you?</p>');
         const md = convertContentModelToMarkdown(model).trim();
         expect(md).toEqual(markdown);


### PR DESCRIPTION
[Bug 438613](https://outlookweb.visualstudio.com/Outlook%20Web/_workitems/edit/438613): Spaces between words get deleted after applying Italics format in OWA and New Outlook

## Summary

Fix `normalizeSingleSegment` to correctly determine whether leading spaces should be preserved based on the previous text segment's trailing character. Previously, leading spaces were always stripped (`ignoreLeadingSpaces` defaulted to `true`). Now the function searches backward (skipping SelectionMarkers and empty text segments) to find the nearest text, and preserves a single space when the previous text doesn't end with one — maintaining proper word separation. Also changes the preserved leading space from `&nbsp;` to a regular space to allow word wrapping.

## How to test

1. `yarn test:fast --testPathPattern=normalizeSingleSegmentTest`
2. `yarn test:fast --testPathPattern="normalizeParagraphTest|normalizeSegmentTest|convertContentModelToMarkdownTest"`
3. Full suite: `yarn test:fast`

