### PR TITLE
Fix applyChange tests to pass at all screen scales

### DIFF
--- a/packages/roosterjs-content-model-plugins/test/imageEdit/utils/applyChangeTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/utils/applyChangeTest.ts
@@ -57,8 +57,20 @@ describe('applyChange', () => {
     let img: HTMLImageElement;
     let editor: IEditor;
     let triggerEvent: jasmine.Spy;
+    let originalDevicePixelRatio: PropertyDescriptor | undefined;
 
     beforeEach(async () => {
+        // generateDataURL sizes the output canvas as targetWidth/Height * window.devicePixelRatio
+        // ("Adjust the canvas size and scaling for high display resolution"). The expected newSrc
+        // values below were captured at 100% screen scale (devicePixelRatio === 1), so on a host
+        // running at any other scale the generated PNG would be larger and the dimension assertions
+        // would fail. Pin devicePixelRatio to 1 so these tests are deterministic at any screen scale.
+        originalDevicePixelRatio = Object.getOwnPropertyDescriptor(window, 'devicePixelRatio');
+        Object.defineProperty(window, 'devicePixelRatio', {
+            configurable: true,
+            get: () => 1,
+        });
+
         // Create a fresh model image per test. It is otherwise shared module-level state, and
         // applyChange persists/clears editingInfo on it, so a stale rotation/crop from a prior
         // test would make checkEditInfoState misclassify the next one (flaky across spec order).
@@ -80,6 +92,12 @@ describe('applyChange', () => {
 
     afterEach(() => {
         img?.parentNode?.removeChild(img);
+
+        if (originalDevicePixelRatio) {
+            Object.defineProperty(window, 'devicePixelRatio', originalDevicePixelRatio);
+        } else {
+            delete (window as any).devicePixelRatio;
+        }
     });
 
     function runTest(input: ContentModelDocument, callback: () => boolean) {


### PR DESCRIPTION
## Summary

The `applyChange` image-edit tests in `applyChangeTest.ts` (rotate/crop/resize cases) failed on any host whose screen scale was not 100%. `generateDataURL.ts` sizes the output canvas as `targetWidth/Height * window.devicePixelRatio`, but the hardcoded expected `newSrc` images were captured at 100% scale (`devicePixelRatio === 1`). At other scales the generated PNG was larger, so the IHDR dimension assertions failed.

This pins `window.devicePixelRatio` to `1` for the duration of these tests (set in `beforeEach`, original descriptor restored in `afterEach`), making the canvas output deterministic regardless of the host screen scale. Only the test file changes; production code is untouched.

## How to test

1. Run the tests: `yarn test:fast --testPathPattern=applyChange` — all 11 should pass.
2. To verify scale-independence, force a non-100% scale by launching Chrome with `--force-device-scale-factor=2`:
   - Before this fix: 8 tests fail (canvas dimensions doubled, e.g. width 20 vs expected 10).
   - After this fix: all 11 pass at both 200% and 100% scale.
