### PR TITLE
Add auto markdown conversion source

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/constants/ChangeSource.ts
+++ b/packages/roosterjs-content-model-dom/lib/constants/ChangeSource.ts
@@ -24,6 +24,10 @@ export const ChangeSource = {
      */
     Paste: 'Paste',
     /**
+     * Content changed by auto markdown conversion
+     */
+    AutoMarkdownConversion: 'AutoMarkdownConversion',
+    /**
      * Content changed by setContent API
      */
     SetContent: 'SetContent',

--- a/packages/roosterjs-content-model-markdown/lib/plugins/MarkdownPastePlugin.ts
+++ b/packages/roosterjs-content-model-markdown/lib/plugins/MarkdownPastePlugin.ts
@@ -28,16 +28,13 @@ const DefaultOptions: MarkdownPasteOptions = {
 export class MarkdownPastePlugin implements EditorPlugin {
     private editor: IEditor | null = null;
     private options: MarkdownPasteOptions;
-    private onAutoConvert?: () => void;
 
     /**
      * Construct a new instance of MarkdownPastePlugin
      * @param options Options to control the markdown paste behavior
-     * @param onAutoConvert Optional callback that runs after auto conversion is applied
      */
-    constructor(options?: MarkdownPasteOptions, onAutoConvert?: () => void) {
+    constructor(options?: MarkdownPasteOptions) {
         this.options = options ?? DefaultOptions;
-        this.onAutoConvert = onAutoConvert;
     }
 
     /**
@@ -105,10 +102,10 @@ export class MarkdownPastePlugin implements EditorPlugin {
                     },
                     {
                         apiName: 'MarkdownConversion',
+                        changeSource: ChangeSource.AutoMarkdownConversion,
                         scrollCaretIntoView: true,
                     }
                 );
-                this.onAutoConvert?.();
             }
         } else if (event.eventType === 'beforePaste' && !event.clipboardData.pasteNativeEvent) {
             const shouldConvert = event.pasteType === 'asMarkdown';

--- a/packages/roosterjs-content-model-markdown/lib/plugins/MarkdownPastePlugin.ts
+++ b/packages/roosterjs-content-model-markdown/lib/plugins/MarkdownPastePlugin.ts
@@ -28,13 +28,16 @@ const DefaultOptions: MarkdownPasteOptions = {
 export class MarkdownPastePlugin implements EditorPlugin {
     private editor: IEditor | null = null;
     private options: MarkdownPasteOptions;
+    private onAutoConvert?: () => void;
 
     /**
      * Construct a new instance of MarkdownPastePlugin
      * @param options Options to control the markdown paste behavior
+     * @param onAutoConvert Optional callback that runs after auto conversion is applied
      */
-    constructor(options?: MarkdownPasteOptions) {
+    constructor(options?: MarkdownPasteOptions, onAutoConvert?: () => void) {
         this.options = options ?? DefaultOptions;
+        this.onAutoConvert = onAutoConvert;
     }
 
     /**
@@ -105,6 +108,7 @@ export class MarkdownPastePlugin implements EditorPlugin {
                         scrollCaretIntoView: true,
                     }
                 );
+                this.onAutoConvert?.();
             }
         } else if (event.eventType === 'beforePaste' && !event.clipboardData.pasteNativeEvent) {
             const shouldConvert = event.pasteType === 'asMarkdown';

--- a/packages/roosterjs-content-model-markdown/test/plugins/MarkdownPastePluginTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/plugins/MarkdownPastePluginTest.ts
@@ -1,4 +1,5 @@
 import { MarkdownPastePlugin } from '../../lib/plugins/MarkdownPastePlugin';
+import { ChangeSource } from 'roosterjs-content-model-dom';
 import type {
     BeforePasteEvent,
     ClipboardData,
@@ -33,21 +34,14 @@ describe('MarkdownPastePlugin', () => {
         } as unknown) as IEditor;
     });
 
-    function createPlugin(
-        autoConversion?: boolean,
-        undoConversion?: boolean,
-        onAutoConvert?: () => void
-    ): MarkdownPastePlugin {
+    function createPlugin(autoConversion?: boolean, undoConversion?: boolean): MarkdownPastePlugin {
         const plugin =
             autoConversion === undefined && undoConversion === undefined
                 ? new MarkdownPastePlugin()
-                : new MarkdownPastePlugin(
-                      {
-                          autoConversion: !!autoConversion,
-                          undoConversion: !!undoConversion,
-                      },
-                      onAutoConvert
-                  );
+                : new MarkdownPastePlugin({
+                      autoConversion: !!autoConversion,
+                      undoConversion: !!undoConversion,
+                  });
         plugin.initialize(editor);
         return plugin;
     }
@@ -97,7 +91,7 @@ describe('MarkdownPastePlugin', () => {
     ): ContentChangedEvent {
         return ({
             eventType: 'contentChanged',
-            source: 'Paste',
+            source: ChangeSource.Paste,
             data: clipboardData as ClipboardData,
         } as unknown) as ContentChangedEvent;
     }
@@ -178,7 +172,11 @@ describe('MarkdownPastePlugin', () => {
             (model: ContentModelDocument) => boolean,
             FormatContentModelOptions
         ];
-        expect(options).toEqual({ apiName: 'MarkdownConversion', scrollCaretIntoView: true });
+        expect(options).toEqual({
+            apiName: 'MarkdownConversion',
+            changeSource: ChangeSource.AutoMarkdownConversion,
+            scrollCaretIntoView: true,
+        });
 
         const target = createEmptyModel();
         expect(callback(target)).toBe(true);
@@ -348,40 +346,6 @@ describe('MarkdownPastePlugin', () => {
 
         expect(takeSnapshotSpy).not.toHaveBeenCalled();
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
-        plugin.dispose();
-    });
-
-    it('calls the optional callback after auto conversion', () => {
-        const callback = jasmine.createSpy('onAutoConvert');
-        const plugin = createPlugin(true /*autoConversion*/, false /*undoConversion*/, callback);
-        const event = createContentChangedPasteEvent({
-            text: '# Heading',
-            rawHtml: '',
-            customValues: {},
-            pasteNativeEvent: true,
-            modelBeforePaste: createEmptyModel(),
-        });
-
-        plugin.onPluginEvent(event);
-
-        expect(callback).toHaveBeenCalledTimes(1);
-        plugin.dispose();
-    });
-
-    it('does not call the optional callback when auto conversion does not run', () => {
-        const callback = jasmine.createSpy('onAutoConvert');
-        const plugin = createPlugin(true /*autoConversion*/, false /*undoConversion*/, callback);
-        const event = createContentChangedPasteEvent({
-            text: 'just plain text',
-            rawHtml: '',
-            customValues: {},
-            pasteNativeEvent: true,
-            modelBeforePaste: createEmptyModel(),
-        });
-
-        plugin.onPluginEvent(event);
-
-        expect(callback).not.toHaveBeenCalled();
         plugin.dispose();
     });
 

--- a/packages/roosterjs-content-model-markdown/test/plugins/MarkdownPastePluginTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/plugins/MarkdownPastePluginTest.ts
@@ -33,14 +33,21 @@ describe('MarkdownPastePlugin', () => {
         } as unknown) as IEditor;
     });
 
-    function createPlugin(autoConversion?: boolean, undoConversion?: boolean): MarkdownPastePlugin {
+    function createPlugin(
+        autoConversion?: boolean,
+        undoConversion?: boolean,
+        onAutoConvert?: () => void
+    ): MarkdownPastePlugin {
         const plugin =
             autoConversion === undefined && undoConversion === undefined
                 ? new MarkdownPastePlugin()
-                : new MarkdownPastePlugin({
-                      autoConversion: !!autoConversion,
-                      undoConversion: !!undoConversion,
-                  });
+                : new MarkdownPastePlugin(
+                      {
+                          autoConversion: !!autoConversion,
+                          undoConversion: !!undoConversion,
+                      },
+                      onAutoConvert
+                  );
         plugin.initialize(editor);
         return plugin;
     }
@@ -341,6 +348,40 @@ describe('MarkdownPastePlugin', () => {
 
         expect(takeSnapshotSpy).not.toHaveBeenCalled();
         expect(formatContentModelSpy).toHaveBeenCalledTimes(1);
+        plugin.dispose();
+    });
+
+    it('calls the optional callback after auto conversion', () => {
+        const callback = jasmine.createSpy('onAutoConvert');
+        const plugin = createPlugin(true /*autoConversion*/, false /*undoConversion*/, callback);
+        const event = createContentChangedPasteEvent({
+            text: '# Heading',
+            rawHtml: '',
+            customValues: {},
+            pasteNativeEvent: true,
+            modelBeforePaste: createEmptyModel(),
+        });
+
+        plugin.onPluginEvent(event);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        plugin.dispose();
+    });
+
+    it('does not call the optional callback when auto conversion does not run', () => {
+        const callback = jasmine.createSpy('onAutoConvert');
+        const plugin = createPlugin(true /*autoConversion*/, false /*undoConversion*/, callback);
+        const event = createContentChangedPasteEvent({
+            text: 'just plain text',
+            rawHtml: '',
+            customValues: {},
+            pasteNativeEvent: true,
+            modelBeforePaste: createEmptyModel(),
+        });
+
+        plugin.onPluginEvent(event);
+
+        expect(callback).not.toHaveBeenCalled();
         plugin.dispose();
     });
 


### PR DESCRIPTION
## Summary

Add `ChangeSource.AutoMarkdownConversion` and use it when `MarkdownPastePlugin` applies automatic markdown conversion after paste. This gives adapters and plugins a specific content changed source for the automatic conversion while keeping explicit Paste as Markdown behavior unchanged.

The Markdown paste plugin tests now verify that auto conversion calls `formatContentModel` with the dedicated change source.

## How to test

1. `yarn test:fast --testPathPattern=MarkdownPastePluginTest`