### PR TITLE
[Selection]  keep image selection when 'selectionchange' range is collapsed

### DIFF
--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -738,11 +738,11 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
             const newSelection = this.editor.getDOMSelection();
             const domHelper = this.editor.getDOMHelper();
 
-            //If am image selection changed to a wider range due a keyboard event, we should update the selection
+            // If an image selection changed to a wider range due to a keyboard event, we should update the selection
             const range = domHelper.getSelectionRange();
             if (range) {
                 const image = isSingleImageInSelection(range);
-                if (newSelection?.type == 'image' && !image) {
+                if (newSelection?.type == 'image' && !image && !range.collapsed) {
                     const sel = this.editor.getDocument().defaultView?.getSelection();
                     const isReverted = sel
                         ? sel.focusNode != range.endContainer || sel.focusOffset != range.endOffset

--- a/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
@@ -3698,6 +3698,38 @@ describe('SelectionPlugin selectionChange on image selected', () => {
         });
         expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('onSelectionChange on image | 5, keeps image selection when range is collapsed', () => {
+        spyOn(isSingleImageInSelection, 'isSingleImageInSelection').and.returnValue(null);
+
+        mockedRange = { startContainer: {}, collapsed: true } as any;
+
+        const plugin = createSelectionPlugin({});
+        const state = plugin.getState();
+        const mockedOldSelection = {
+            type: 'image',
+            image: {} as any,
+        } as DOMSelection;
+
+        state.selection = mockedOldSelection;
+
+        plugin.initialize(editor);
+
+        const onSelectionChange = addEventListenerSpy.calls.argsFor(0)[1] as Function;
+        const mockedNewSelection = {
+            type: 'image',
+            image: {} as any,
+        } as any;
+
+        hasFocusSpy.and.returnValue(true);
+        isInShadowEditSpy.and.returnValue(false);
+        getDOMSelectionSpy.and.returnValue(mockedNewSelection);
+
+        onSelectionChange();
+
+        expect(setDOMSelectionSpy).not.toHaveBeenCalled();
+        expect(getDOMSelectionSpy).toHaveBeenCalledTimes(1);
+    });
 });
 
 describe('SelectionPlugin handle logical root change', () => {


### PR DESCRIPTION
### Summary

This change is to prevent `SelectionPlugin` from converting an image selection into a range selection when the browser reports a collapsed range during "selectionchange".

### Issue

> [Fix selection with ctrl+a #2556](https://github.com/microsoft/roosterjs/pull/2556)
>
> // If am image selection changed to a wider range due a keyboard event, we should update the selection

The logic for converting image selection to a range was first introduced in #2566. According to its description, this change was intended to correct the selection to a range when it expands to cover a wider area, such as when triggered by keyboard shortcuts like Ctrl+A.

However, on Mac, right-clicking an image while it is in editing mode converts the collapsed image selection to a range selection, causing the subsequent 'Crop' action from the context menu to fail.

<img width="1168" height="450" alt="image" src="https://github.com/user-attachments/assets/ae4c1822-6112-474e-829d-4c28df8bcdc1" />

<img width="1185" height="623" alt="image" src="https://github.com/user-attachments/assets/65ff2aa9-65c1-4f99-83ec-045b29b64540" />

`onSelectionChange` currently converts image selection to range whenever `isSingleImageInSelection(range)` returns null.
For collapsed ranges, that helper correctly returns null, but this was treated as a wider-range transition and caused an unintended downgrade from image selection to collapsed range selection.

### Fix

The intended conversion is for wider range transitions only. **A collapsed range is an empty caret state, not a wider selection**, so converting image selection in that case is not semantically correct and causes product regressions.

So, this change updated `SelectionPlugin.onSelectionChange` and image to range conversion only happens when the current range is not collapsed.

// local host demo behaves same with demo site.
<img width="396" height="409" alt="ImageSelectionFix" src="https://github.com/user-attachments/assets/1c3415ba-2902-4d5a-8da4-2534d22024f0" />