### PR TITLE
Do not scroll on paste images

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
@@ -7,6 +7,8 @@ import {
     getSelectedSegments,
     mergeModel,
     cloneModelForPaste,
+    isNodeOfType,
+    isElementOfType,
 } from 'roosterjs-content-model-dom';
 import type {
     BeforePasteEvent,
@@ -36,6 +38,8 @@ export function mergePasteContent(
         clipboardData,
         containsBlockElements,
     } = eventResult;
+
+    const shouldScrollCaretIntoView = !isImageFragment(fragment);
 
     editor.formatContentModel(
         (model, context) => {
@@ -80,7 +84,7 @@ export function mergePasteContent(
         {
             changeSource: ChangeSource.Paste,
             getChangeData: () => clipboardData,
-            scrollCaretIntoView: true,
+            scrollCaretIntoView: shouldScrollCaretIntoView,
             apiName: 'paste',
         }
     );
@@ -136,4 +140,23 @@ function getLastSegmentFormat(pasteModel: ContentModelDocument): ContentModelSeg
     }
 
     return {};
+}
+
+function isImageFragment(pasteFragment: DocumentFragment): boolean {
+    const childNodes = pasteFragment.childNodes;
+    if (childNodes.length === 1 && isNodeOfType(childNodes[0], 'ELEMENT_NODE')) {
+        if (isElementOfType(childNodes[0], 'img')) {
+            return true;
+        }
+        if (isElementOfType(childNodes[0], 'span') || isElementOfType(childNodes[0], 'div')) {
+            const child = childNodes[0];
+            return (
+                child.childNodes.length === 1 &&
+                isNodeOfType(child.childNodes[0], 'ELEMENT_NODE') &&
+                isElementOfType(child.childNodes[0], 'img')
+            );
+        }
+    }
+
+    return false;
 }

--- a/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
@@ -7,8 +7,6 @@ import {
     getSelectedSegments,
     mergeModel,
     cloneModelForPaste,
-    isNodeOfType,
-    isElementOfType,
 } from 'roosterjs-content-model-dom';
 import type {
     BeforePasteEvent,
@@ -39,7 +37,7 @@ export function mergePasteContent(
         containsBlockElements,
     } = eventResult;
 
-    const shouldScrollCaretIntoView = !isImageFragment(fragment);
+    const shouldScrollCaretIntoView = !isImageOnlyFragment(fragment);
 
     editor.formatContentModel(
         (model, context) => {
@@ -142,21 +140,11 @@ function getLastSegmentFormat(pasteModel: ContentModelDocument): ContentModelSeg
     return {};
 }
 
-function isImageFragment(pasteFragment: DocumentFragment): boolean {
-    const childNodes = pasteFragment.childNodes;
-    if (childNodes.length === 1 && isNodeOfType(childNodes[0], 'ELEMENT_NODE')) {
-        if (isElementOfType(childNodes[0], 'img')) {
-            return true;
-        }
-        if (isElementOfType(childNodes[0], 'span') || isElementOfType(childNodes[0], 'div')) {
-            const child = childNodes[0];
-            return (
-                child.childNodes.length === 1 &&
-                isNodeOfType(child.childNodes[0], 'ELEMENT_NODE') &&
-                isElementOfType(child.childNodes[0], 'img')
-            );
-        }
-    }
-
-    return false;
+function isImageOnlyFragment(pasteFragment: DocumentFragment): boolean {
+    const images = pasteFragment.querySelectorAll('img');
+    return (
+        images.length === 1 &&
+        pasteFragment.childNodes.length === 1 &&
+        pasteFragment.textContent?.trim() === ''
+    );
 }

--- a/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
@@ -183,6 +183,7 @@ describe('mergePasteContent', () => {
             pasteType: 'normal',
             domToModelOption: { additionalAllowedTags: [] },
             clipboardData: mockedClipboard,
+            fragment: document.createDocumentFragment(),
         } as any;
 
         mergePasteContent(editor, eventResult, true);
@@ -290,6 +291,7 @@ describe('mergePasteContent', () => {
             domToModelOption: { additionalAllowedTags: [] },
             customizedMerge,
             clipboardData: mockedClipboard,
+            fragment: document.createDocumentFragment(),
         } as any;
 
         mergePasteContent(editor, eventResult, true);
@@ -312,6 +314,7 @@ describe('mergePasteContent', () => {
             pasteType: 'mergeFormat',
             domToModelOption: { additionalAllowedTags: [] },
             clipboardData: mockedClipboard,
+            fragment: document.createDocumentFragment(),
         } as any;
 
         mergePasteContent(editor, eventResult, true);

--- a/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
@@ -2145,10 +2145,10 @@ describe('mergePasteContent', () => {
             runTest(createFragment(span), true);
         });
 
-        it('should scroll caret into view when fragment is a single element other than img/span/div', () => {
+        it('should not scroll caret into view when fragment is an anchor wrapping an image', () => {
             const anchor = document.createElement('a');
             anchor.appendChild(document.createElement('img'));
-            runTest(createFragment(anchor), true);
+            runTest(createFragment(anchor), false);
         });
     });
 });

--- a/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
@@ -35,11 +35,18 @@ describe('mergePasteContent', () => {
     let editor: IEditor;
     let mockedClipboard: ClipboardData;
     let mockedDOMHelper: DOMHelper;
+    let formatOptions: FormatContentModelOptions | undefined;
 
     beforeEach(() => {
         formatResult = undefined;
         context = undefined;
-        mockedClipboard = 'CLIPBOARD' as any;
+        formatOptions = undefined;
+        mockedClipboard = {
+            fragment: {
+                childNodes: [],
+                length: 0,
+            },
+        } as any;
 
         formatContentModel = jasmine
             .createSpy('formatContentModel')
@@ -49,6 +56,7 @@ describe('mergePasteContent', () => {
                     deletedEntities: [],
                     newImages: [],
                 };
+                formatOptions = options;
                 formatResult = callback(sourceModel, context);
 
                 const changedData = options.getChangeData!();
@@ -379,7 +387,7 @@ describe('mergePasteContent', () => {
 
         const mockedDomToModelOptions = 'OPTION1' as any;
         const mockedDefaultDomToModelOptions = 'OPTIONS3' as any;
-        const mockedFragment = 'FRAGMENT' as any;
+        const mockedFragment = document.createDocumentFragment();
 
         (editor as any).getEnvironment = () => ({
             domToModelSettings: {
@@ -452,6 +460,7 @@ describe('mergePasteContent', () => {
             domToModelOption: { additionalAllowedTags: [] },
             clipboardData: mockedClipboard,
             containsBlockElements: true,
+            fragment: document.createDocumentFragment(),
         } as any;
 
         mergePasteContent(editor, eventResult, true);
@@ -2042,5 +2051,103 @@ describe('mergePasteContent', () => {
             format: {},
         });
         expect(cloneModelSpy).toHaveBeenCalledTimes(1);
+    });
+
+    describe('scrollCaretIntoView based on paste fragment', () => {
+        function runTest(fragment: DocumentFragment, expectedScrollCaretIntoView: boolean) {
+            spyOn(mergeModelFile, 'mergeModel').and.callThrough();
+            sourceModel = createContentModelDocument();
+            const para = createParagraph();
+            para.segments.push(createSelectionMarker());
+            sourceModel.blocks.push(para);
+
+            mergePasteContent(
+                editor,
+                <any>{
+                    fragment,
+                    domToModelOption: <any>{},
+                    pasteType: 'normal',
+                    clipboardData: mockedClipboard,
+                },
+                true
+            );
+
+            expect(formatOptions).toBeDefined();
+            expect(formatOptions!.scrollCaretIntoView).toBe(expectedScrollCaretIntoView);
+        }
+
+        function createFragment(...nodes: Node[]): DocumentFragment {
+            const fragment = document.createDocumentFragment();
+            nodes.forEach(node => fragment.appendChild(node));
+            return fragment;
+        }
+
+        it('should not scroll caret into view when fragment is a single image', () => {
+            const img = document.createElement('img');
+            img.src = 'test.png';
+
+            runTest(createFragment(img), false);
+        });
+
+        it('should not scroll caret into view when fragment is a span wrapping an image', () => {
+            const span = document.createElement('span');
+            span.appendChild(document.createElement('img'));
+
+            runTest(createFragment(span), false);
+        });
+
+        it('should not scroll caret into view when fragment is a div wrapping an image', () => {
+            const div = document.createElement('div');
+            div.appendChild(document.createElement('img'));
+
+            runTest(createFragment(div), false);
+        });
+
+        it('should scroll caret into view when fragment is a single text node', () => {
+            runTest(createFragment(document.createTextNode('text')), true);
+        });
+
+        it('should scroll caret into view when fragment is a paragraph', () => {
+            const p = document.createElement('p');
+            p.textContent = 'text';
+
+            runTest(createFragment(p), true);
+        });
+
+        it('should scroll caret into view when fragment has multiple children', () => {
+            const img1 = document.createElement('img');
+            const img2 = document.createElement('img');
+
+            runTest(createFragment(img1, img2), true);
+        });
+
+        it('should scroll caret into view when span wraps multiple children', () => {
+            const span = document.createElement('span');
+            span.appendChild(document.createElement('img'));
+            span.appendChild(document.createElement('img'));
+
+            runTest(createFragment(span), true);
+        });
+
+        it('should scroll caret into view when span wraps a non-image element', () => {
+            const span = document.createElement('span');
+            span.appendChild(document.createElement('b'));
+
+            runTest(createFragment(span), true);
+        });
+
+        it('should scroll caret into view when span wraps a text node', () => {
+            const span = document.createElement('span');
+            span.appendChild(document.createTextNode('text'));
+
+            runTest(createFragment(span), true);
+        });
+
+        it('should scroll caret into view when fragment is a single element other than img/span/div', () => {
+            const anchor = document.createElement('a');
+            anchor.appendChild(document.createElement('img'));
+
+            runTest(createFragment(anchor), true);
+        });
     });
 });

--- a/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
@@ -2142,14 +2142,12 @@ describe('mergePasteContent', () => {
         it('should scroll caret into view when span wraps a text node', () => {
             const span = document.createElement('span');
             span.appendChild(document.createTextNode('text'));
-
             runTest(createFragment(span), true);
         });
 
         it('should scroll caret into view when fragment is a single element other than img/span/div', () => {
             const anchor = document.createElement('a');
             anchor.appendChild(document.createElement('img'));
-
             runTest(createFragment(anchor), true);
         });
     });

--- a/packages/roosterjs-content-model-core/test/command/paste/retrieveHtmlInfoTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/retrieveHtmlInfoTest.ts
@@ -217,7 +217,7 @@ describe('retrieveHtmlInfo', () => {
                     {
                         selectors: ['test'],
                         text:
-                            'border-width: medium; border-style: none; border-color: currentcolor; border-image: initial;',
+                            'border-width: medium; border-style: none; border-color: currentcolor; border-image: none;',
                     },
                 ],
                 metadata: {},


### PR DESCRIPTION
Pasting large images can cause the editor to jump far into view, which forces the user to scroll back to where the cursor was. When images are pasted, the caret should not be scrolled into view.