### PR TITLE
[Table Borders] Pass experimental features to paste sanitizing context

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createDomToModelContextForSanitizing.ts
+++ b/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createDomToModelContextForSanitizing.ts
@@ -13,6 +13,7 @@ import type {
     DomToModelContext,
     DomToModelOption,
     DomToModelOptionForSanitizing,
+    ExperimentalFeature,
 } from 'roosterjs-content-model-types';
 
 const DefaultSanitizingOption: DomToModelOptionForSanitizing = {
@@ -35,7 +36,7 @@ export function createDomToModelContextForSanitizing(
     defaultOption?: DomToModelOption,
     additionalSanitizingOption?: Partial<DomToModelOptionForSanitizing>,
     domHelper?: DOMHelper,
-    experimentalFeatures?: string[]
+    experimentalFeatures?: ExperimentalFeature[]
 ): DomToModelContext {
     const sanitizingOption: DomToModelOptionForSanitizing = {
         ...DefaultSanitizingOption,

--- a/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createDomToModelContextForSanitizing.ts
+++ b/packages/roosterjs-content-model-core/lib/command/createModelFromHtml/createDomToModelContextForSanitizing.ts
@@ -34,7 +34,8 @@ export function createDomToModelContextForSanitizing(
     defaultFormat?: ContentModelSegmentFormat,
     defaultOption?: DomToModelOption,
     additionalSanitizingOption?: Partial<DomToModelOptionForSanitizing>,
-    domHelper?: DOMHelper
+    domHelper?: DOMHelper,
+    experimentalFeatures?: string[]
 ): DomToModelContext {
     const sanitizingOption: DomToModelOptionForSanitizing = {
         ...DefaultSanitizingOption,
@@ -45,7 +46,7 @@ export function createDomToModelContextForSanitizing(
         {
             defaultFormat,
             ...getRootComputedStyleForContext(document),
-            experimentalFeatures: [],
+            experimentalFeatures: experimentalFeatures ?? [],
             editorViewWidth: domHelper?.getClientWidth(),
         },
         defaultOption,

--- a/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
@@ -49,7 +49,10 @@ export function mergePasteContent(
                 undefined /*defaultFormat*/,
                 editor.getEnvironment().domToModelSettings.customized,
                 domToModelOption,
-                editor.getDOMHelper()
+                editor.getDOMHelper(),
+                editor.isExperimentalFeatureEnabled('TransformTableBorderColors')
+                    ? ['TransformTableBorderColors']
+                    : undefined
             );
 
             domToModelContext.segmentFormat = getSegmentFormatForPaste(model, pasteType);

--- a/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/mergePasteContent.ts
@@ -50,9 +50,7 @@ export function mergePasteContent(
                 editor.getEnvironment().domToModelSettings.customized,
                 domToModelOption,
                 editor.getDOMHelper(),
-                editor.isExperimentalFeatureEnabled('TransformTableBorderColors')
-                    ? ['TransformTableBorderColors']
-                    : undefined
+                editor.getExperimentalFeatures()
             );
 
             domToModelContext.segmentFormat = getSegmentFormatForPaste(model, pasteType);

--- a/packages/roosterjs-content-model-core/lib/editor/Editor.ts
+++ b/packages/roosterjs-content-model-core/lib/editor/Editor.ts
@@ -436,6 +436,14 @@ export class Editor implements IEditor {
     }
 
     /**
+     * Get all experimental features enabled in this editor
+     * @returns An array of experimental feature names
+     * */
+    getExperimentalFeatures(): ExperimentalFeature[] {
+        return this.getCore().experimentalFeatures as ExperimentalFeature[];
+    }
+
+    /**
      * @returns the current EditorCore object
      * @throws a standard Error if there's no core object
      */

--- a/packages/roosterjs-content-model-core/test/command/createModelFromHtml/createDomToModelContextForSanitizingTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/createModelFromHtml/createDomToModelContextForSanitizingTest.ts
@@ -118,4 +118,46 @@ describe('createDomToModelContextForSanitizing', () => {
         expect(createPasteGeneralProcessorSpy).toHaveBeenCalledWith(additionalOption);
         expect(createPasteEntityProcessorSpy).toHaveBeenCalledWith(additionalOption);
     });
+
+    it('with experimentalFeatures', () => {
+        const mockedExperimentalFeatures = ['feature1', 'feature2'] as any;
+
+        const context = createDomToModelContextForSanitizing(
+            document,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            mockedExperimentalFeatures
+        );
+
+        expect(context).toBe(mockedResult);
+        expect(createDomToModelContextSpy).toHaveBeenCalledWith(
+            {
+                defaultFormat: undefined,
+                rootFontSize: 16,
+                experimentalFeatures: mockedExperimentalFeatures,
+                editorViewWidth: undefined,
+            },
+            undefined,
+            {
+                processorOverride: {
+                    '#text': pasteTextProcessor,
+                    entity: mockedPasteEntityProcessor,
+                    '*': mockedPasteGeneralProcessor,
+                },
+                formatParserOverride: {
+                    display: pasteDisplayFormatParser,
+                    whiteSpace: pasteWhiteSpaceFormatParser,
+                },
+                additionalFormatParsers: {
+                    container: [containerSizeFormatParser],
+                    entity: [pasteBlockEntityParser],
+                },
+            },
+            defaultOptions
+        );
+        expect(createPasteGeneralProcessorSpy).toHaveBeenCalledWith(defaultOptions);
+        expect(createPasteEntityProcessorSpy).toHaveBeenCalledWith(defaultOptions);
+    });
 });

--- a/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
@@ -67,6 +67,7 @@ describe('mergePasteContent', () => {
             }),
             getDocument: () => document,
             getDOMHelper: () => mockedDOMHelper,
+            isExperimentalFeatureEnabled: () => false,
         } as any;
     });
 
@@ -428,7 +429,8 @@ describe('mergePasteContent', () => {
             undefined,
             mockedDomToModelOptions,
             mockedDefaultDomToModelOptions,
-            mockedDOMHelper
+            mockedDOMHelper,
+            undefined
         );
         expect(mockedDomToModelContext.segmentFormat).toEqual({ lineHeight: '1pt' });
     });

--- a/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
@@ -68,6 +68,7 @@ describe('mergePasteContent', () => {
             getDocument: () => document,
             getDOMHelper: () => mockedDOMHelper,
             isExperimentalFeatureEnabled: () => false,
+            getExperimentalFeatures: () => [],
         } as any;
     });
 
@@ -430,7 +431,7 @@ describe('mergePasteContent', () => {
             mockedDomToModelOptions,
             mockedDefaultDomToModelOptions,
             mockedDOMHelper,
-            undefined
+            []
         );
         expect(mockedDomToModelContext.segmentFormat).toEqual({ lineHeight: '1pt' });
     });

--- a/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
+++ b/packages/roosterjs-content-model-core/test/command/paste/mergePasteContentTest.ts
@@ -25,6 +25,7 @@ import {
     IEditor,
     ClipboardData,
     DOMHelper,
+    ExperimentalFeature,
 } from 'roosterjs-content-model-types';
 
 describe('mergePasteContent', () => {
@@ -68,7 +69,9 @@ describe('mergePasteContent', () => {
             getDocument: () => document,
             getDOMHelper: () => mockedDOMHelper,
             isExperimentalFeatureEnabled: () => false,
-            getExperimentalFeatures: () => [],
+            getExperimentalFeatures: () => {
+                return [] as ExperimentalFeature[];
+            },
         } as any;
     });
 

--- a/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
@@ -14,6 +14,7 @@ import {
     EditorCore,
     EditorOptions,
     Rect,
+    ExperimentalFeature,
 } from 'roosterjs-content-model-types';
 
 describe('Editor', () => {
@@ -1211,7 +1212,10 @@ describe('Editor', () => {
             api: {
                 setContentModel: setContentModelSpy,
             },
-            experimentalFeatures: ['Feature1', 'Feature2'],
+            experimentalFeatures: [
+                'TransformTableBorderColors',
+                'ShadowDom',
+            ] as ExperimentalFeature[],
             format: {
                 defaultFormat: {},
             },
@@ -1221,8 +1225,8 @@ describe('Editor', () => {
 
         const editor = new Editor(div);
 
-        const result1 = editor.isExperimentalFeatureEnabled('Feature1');
-        const result2 = editor.isExperimentalFeatureEnabled('Feature2');
+        const result1 = editor.isExperimentalFeatureEnabled('TransformTableBorderColors');
+        const result2 = editor.isExperimentalFeatureEnabled('ShadowDom');
         const result3 = editor.isExperimentalFeatureEnabled('Feature3');
 
         expect(result1).toBeTrue();
@@ -1246,7 +1250,10 @@ describe('Editor', () => {
             api: {
                 setContentModel: setContentModelSpy,
             },
-            experimentalFeatures: ['Feature1', 'Feature2'],
+            experimentalFeatures: [
+                'TransformTableBorderColors',
+                'ShadowDom',
+            ] as ExperimentalFeature[],
             format: {
                 defaultFormat: {},
             },
@@ -1258,7 +1265,7 @@ describe('Editor', () => {
 
         const result = editor.getExperimentalFeatures();
 
-        expect(result).toEqual(['Feature1', 'Feature2']);
+        expect(result).toEqual(['TransformTableBorderColors', 'ShadowDom']);
 
         editor.dispose();
         expect(resetSpy).toHaveBeenCalledWith();

--- a/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
+++ b/packages/roosterjs-content-model-core/test/editor/EditorTest.ts
@@ -1233,4 +1233,35 @@ describe('Editor', () => {
         expect(resetSpy).toHaveBeenCalledWith();
         expect(() => editor.isExperimentalFeatureEnabled('Feature4')).toThrow();
     });
+
+    it('getExperimentalFeatures', () => {
+        const div = document.createElement('div');
+        const resetSpy = jasmine.createSpy('reset');
+        const mockedCore = {
+            plugins: [],
+            darkColorHandler: {
+                updateKnownColor: updateKnownColorSpy,
+                reset: resetSpy,
+            },
+            api: {
+                setContentModel: setContentModelSpy,
+            },
+            experimentalFeatures: ['Feature1', 'Feature2'],
+            format: {
+                defaultFormat: {},
+            },
+        } as any;
+
+        createEditorCoreSpy.and.returnValue(mockedCore);
+
+        const editor = new Editor(div);
+
+        const result = editor.getExperimentalFeatures();
+
+        expect(result).toEqual(['Feature1', 'Feature2']);
+
+        editor.dispose();
+        expect(resetSpy).toHaveBeenCalledWith();
+        expect(() => editor.getExperimentalFeatures()).toThrow();
+    });
 });

--- a/packages/roosterjs-content-model-types/lib/editor/IEditor.ts
+++ b/packages/roosterjs-content-model-types/lib/editor/IEditor.ts
@@ -243,4 +243,10 @@ export interface IEditor {
      * @param featureName The name of feature to check
      */
     isExperimentalFeatureEnabled(featureName: ExperimentalFeature | string): boolean;
+
+    /**
+     * Get all experimental features enabled in this editor
+     * @returns An array of experimental feature names
+     */
+    getExperimentalFeatures(): ExperimentalFeature[];
 }


### PR DESCRIPTION
## Summary

Forward the editor's experimental features into `createDomToModelContextForSanitizing` so that the `TransformTableBorderColors` experimental feature is honored while sanitizing pasted content. Previously `experimentalFeatures` was hard-coded to an empty array in the sanitizing context, so table border color transformation never ran during paste. `mergePasteContent now passes all editor experimental features.

## How to test

1. Run the affected unit tests:
   ```
   yarn test:fast --testPathPattern=createDomToModelContextForSanitizing
   ```
2. Manual check: enable the `TransformTableBorderColors` experimental feature on the editor, then copy a table with themed/`currentColor` borders from another source and paste it into the editor.
   - Before this fix: pasted table border colors are not transformed (feature ignored during paste).
   - After this fix: pasted table border colors are transformed as expected.
