### PR TITLE
Fix ordered list numbering when converting markdown to Content Model

### DIFF
--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createBlockGroupFromMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createBlockGroupFromMarkdown.ts
@@ -20,10 +20,16 @@ export function createBlockGroupFromMarkdown(
     text: string,
     patternName: string,
     options: MarkdownToModelOptions,
-    group?: ContentModelFormatContainer
+    group?: ContentModelFormatContainer,
+    list?: ContentModelListItem
 ): ContentModelFormatContainer | ContentModelListItem {
     if (MarkdownBlockGroupType[patternName] === 'ListItem') {
-        return createListFromMarkdown(text, patternName === 'ordered_list' ? 'OL' : 'UL', options);
+        return createListFromMarkdown(
+            text,
+            patternName === 'ordered_list' ? 'OL' : 'UL',
+            options,
+            list
+        );
     } else {
         return createBlockQuoteFromMarkdown(text, options, group);
     }

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createListFromMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/creators/createListFromMarkdown.ts
@@ -9,13 +9,16 @@ import type { MarkdownToModelOptions } from '../types/MarkdownToModelOptions';
 export function createListFromMarkdown(
     text: string,
     listType: 'OL' | 'UL',
-    options: MarkdownToModelOptions
+    options: MarkdownToModelOptions,
+    list?: ContentModelListItem
 ): ContentModelListItem {
     const marker = text.trim().split(' ')[0];
     const isDummy = isDummyListItem(marker);
+    const startNumber = listType === 'OL' && !list ? parseInt(marker, 10) : undefined;
     const itemText = isDummy ? text : text.trim().substring(marker.length);
     const paragraph = createParagraphFromMarkdown(itemText.trim(), options);
-    const levels = createLevels(text, listType, isDummy, options);
+    const levels = createLevels(text, listType, isDummy, options, startNumber);
+
     const listModel = createListItem(levels);
     if (options.direction) {
         listModel.format.direction = options.direction;
@@ -29,12 +32,17 @@ function createLevels(
     text: string,
     listType: 'OL' | 'UL',
     isDummy: boolean,
-    options: MarkdownToModelOptions
+    options: MarkdownToModelOptions,
+    startNumberOverride?: number
 ) {
     const level = createListLevel(
         listType,
         options.direction ? { direction: options.direction } : undefined
     );
+    if (startNumberOverride) {
+        level.format.startNumberOverride = startNumberOverride;
+    }
+
     if (isDummy) {
         level.format.displayForDummyItem = 'block';
     }

--- a/packages/roosterjs-content-model-markdown/lib/markdownToModel/processor/markdownProcessor.ts
+++ b/packages/roosterjs-content-model-markdown/lib/markdownToModel/processor/markdownProcessor.ts
@@ -175,7 +175,8 @@ function addMarkdownBlockToModel(
                 markdown,
                 patternName,
                 options,
-                markdownContext.lastQuote
+                markdownContext.lastQuote,
+                markdownContext.lastList
             );
             if (!markdownContext.lastQuote) {
                 model.blocks.push(blockGroup);

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/convertMarkdownToContentModelTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/convertMarkdownToContentModelTest.ts
@@ -1157,7 +1157,7 @@ describe('convertMarkdownToContentModel', () => {
                     levels: [
                         {
                             listType: 'OL',
-                            format: {},
+                            format: { startNumberOverride: 1 },
                             dataset: {},
                         },
                     ],
@@ -1840,5 +1840,167 @@ describe('convertMarkdownToContentModel', () => {
         };
 
         runTest(markdown, sample);
+    });
+
+    it('should restart numbering for a new ordered list separated by a paragraph', () => {
+        const markdown =
+            '### Ordered List\n\n1. Step one\n2. Step two\n\nTest  \n\n1. Step three\n2. Step one';
+
+        const expectedContentModel: ContentModelDocument = {
+            blockGroupType: 'Document',
+            blocks: [
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Ordered List',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                    decorator: {
+                        tagName: 'h3',
+                        format: {
+                            fontWeight: 'bold',
+                            fontSize: '1.17em',
+                        },
+                    },
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'Step one',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: { startNumberOverride: 1 },
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: false,
+                        format: {},
+                    },
+                    format: {},
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'Step two',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {},
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: false,
+                        format: {},
+                    },
+                    format: {},
+                },
+                {
+                    blockType: 'Paragraph',
+                    segments: [
+                        {
+                            segmentType: 'Text',
+                            text: 'Test  ',
+                            format: {},
+                        },
+                    ],
+                    format: {},
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'Step three',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: { startNumberOverride: 1 },
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: false,
+                        format: {},
+                    },
+                    format: {},
+                },
+                {
+                    blockType: 'BlockGroup',
+                    blockGroupType: 'ListItem',
+                    blocks: [
+                        {
+                            blockType: 'Paragraph',
+                            segments: [
+                                {
+                                    segmentType: 'Text',
+                                    text: 'Step one',
+                                    format: {},
+                                },
+                            ],
+                            format: {},
+                        },
+                    ],
+                    levels: [
+                        {
+                            listType: 'OL',
+                            format: {},
+                            dataset: {},
+                        },
+                    ],
+                    formatHolder: {
+                        segmentType: 'SelectionMarker',
+                        isSelected: false,
+                        format: {},
+                    },
+                    format: {},
+                },
+            ],
+        };
+
+        runTest(markdown, expectedContentModel);
     });
 });

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createBlockGroupFromMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createBlockGroupFromMarkdownTest.ts
@@ -70,7 +70,7 @@ describe('createBlockGroupFromMarkdown', () => {
     });
 
     it('should return list item for ordered_list', () => {
-        const listItem = createListItem([createListLevel('OL')]);
+        const listItem = createListItem([createListLevel('OL', { startNumberOverride: 1 })]);
         const paragraph = createParagraph();
         const text = createText('text');
         paragraph.segments.push(text);
@@ -80,7 +80,10 @@ describe('createBlockGroupFromMarkdown', () => {
     });
 
     it('should return a second level list item for ordered_list', () => {
-        const listItem = createListItem([createListLevel('OL'), createListLevel('OL')]);
+        const listItem = createListItem([
+            createListLevel('OL', { startNumberOverride: 1 }),
+            createListLevel('OL', { startNumberOverride: 1 }),
+        ]);
         const paragraph = createParagraph();
         const text = createText('text');
         paragraph.segments.push(text);

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createListFromMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/creators/createListFromMarkdownTest.ts
@@ -13,7 +13,8 @@ describe('createListFromMarkdown', () => {
         text: string,
         patternName: 'OL' | 'UL',
         expectedBlockGroup: ContentModelListItem,
-        isRTL?: boolean
+        isRTL?: boolean,
+        list?: ContentModelListItem
     ) {
         const options: MarkdownToModelOptions = isRTL
             ? {
@@ -21,7 +22,7 @@ describe('createListFromMarkdown', () => {
               }
             : {};
         // Act
-        const result = createListFromMarkdown(text, patternName, options);
+        const result = createListFromMarkdown(text, patternName, options, list);
 
         // Assert
         expect(result.blocks).toEqual(expectedBlockGroup.blocks);
@@ -59,7 +60,7 @@ describe('createListFromMarkdown', () => {
     });
 
     it('should return list item for OL', () => {
-        const listItem = createListItem([createListLevel('OL')]);
+        const listItem = createListItem([createListLevel('OL', { startNumberOverride: 1 })]);
         const paragraph = createParagraph();
         const text = createText('text');
         paragraph.segments.push(text);
@@ -69,7 +70,10 @@ describe('createListFromMarkdown', () => {
     });
 
     it('should return a second level list item for OL', () => {
-        const listItem = createListItem([createListLevel('OL'), createListLevel('OL')]);
+        const listItem = createListItem([
+            createListLevel('OL', { startNumberOverride: 1 }),
+            createListLevel('OL', { startNumberOverride: 1 }),
+        ]);
         const paragraph = createParagraph();
         const text = createText('text');
         paragraph.segments.push(text);
@@ -126,7 +130,7 @@ describe('createListFromMarkdown', () => {
     });
 
     it('should return list item for OL', () => {
-        const listItem = createListItem([createListLevel('OL')]);
+        const listItem = createListItem([createListLevel('OL', { startNumberOverride: 1 })]);
         const paragraph = createParagraph();
         const text = createText('text');
         paragraph.segments.push(text);
@@ -142,7 +146,9 @@ describe('createListFromMarkdown', () => {
     });
 
     it('should return list item for OL - RTL', () => {
-        const listItem = createListItem([createListLevel('OL', { direction: 'rtl' })]);
+        const listItem = createListItem([
+            createListLevel('OL', { direction: 'rtl', startNumberOverride: 1 }),
+        ]);
         const paragraph = createParagraph();
         paragraph.format.direction = 'rtl';
         listItem.format.direction = 'rtl';
@@ -157,5 +163,26 @@ describe('createListFromMarkdown', () => {
         };
         listItem.blocks.push(paragraph);
         runTest('1. # text', 'OL', listItem, true /* isRTL */);
+    });
+
+    it('should use the marker number as startNumberOverride for OL', () => {
+        const listItem = createListItem([createListLevel('OL', { startNumberOverride: 3 })]);
+        const paragraph = createParagraph();
+        const text = createText('text');
+        paragraph.segments.push(text);
+
+        listItem.blocks.push(paragraph);
+        runTest('3. text', 'OL', listItem);
+    });
+
+    it('should not set startNumberOverride for OL when a list is provided', () => {
+        const listItem = createListItem([createListLevel('OL')]);
+        const paragraph = createParagraph();
+        const text = createText('text');
+        paragraph.segments.push(text);
+
+        listItem.blocks.push(paragraph);
+        const existingList = createListItem([createListLevel('OL', { startNumberOverride: 1 })]);
+        runTest('2. text', 'OL', listItem, undefined /* isRTL */, existingList);
     });
 });

--- a/packages/roosterjs-content-model-markdown/test/markdownToModel/processor/markdownProcessorTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/markdownToModel/processor/markdownProcessorTest.ts
@@ -242,7 +242,7 @@ describe('markdownProcessor: removeEmptyLines', () => {
                         {
                             listType: 'OL',
                             dataset: {},
-                            format: {},
+                            format: { startNumberOverride: 1 },
                         },
                     ],
                     format: {},


### PR DESCRIPTION
## Summary

Fix ordered-list numbering when converting markdown to the Content Model. `createListFromMarkdown` / `createBlockGroupFromMarkdown` now receive the current list context (`lastList`) from `markdownProcessor`, and when a new ordered list starts (no preceding list item), the leading marker number is parsed and applied as `startNumberOverride` on the list level. Previously a new ordered list that followed a paragraph did not restart its numbering from the markdown marker; now it does, while continuation items within the same list keep flowing without an override.

## How to test

1. Run the markdown conversion unit tests:
   `yarn test:fast --testPathPattern=convertMarkdownToContentModel`
   `yarn test:fast --testPathPattern=createListFromMarkdown`
2. Manual check: convert a markdown document containing two separate ordered lists split by a paragraph, e.g.

   ```
   1. Step one
   2. Step two

   Test

   1. Step three
   2. Step four
   ```

   Before this fix: the second list did not restart numbering from its marker. After this fix: the first item of the new ordered list carries `startNumberOverride` (e.g. `1`) so numbering restarts as written in the markdown.
