### PR TITLE
Revert "[Image Edit] Skip DOM selection during image edit to prevent editor jump"

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -62,7 +62,7 @@ export const formatContentModel: FormatContentModel = (
                 core.api.setContentModel(
                     core,
                     model,
-                    hasFocus && !options?.skipDOMSelection ? undefined : { ignoreSelection: true }, // If editor did not have focus before format, do not set focus after format
+                    hasFocus ? undefined : { ignoreSelection: true }, // If editor did not have focus before format, do not set focus after format
                     onNodeCreated
                 ) ?? undefined;
 

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -793,49 +793,6 @@ describe('formatContentModel', () => {
         });
     });
 
-    describe('skipDOMSelection', () => {
-        it('skipDOMSelection is true, do not set DOM selection even when editor has focus', () => {
-            hasFocus.and.returnValue(true);
-
-            formatContentModel(
-                core,
-                (model, context) => {
-                    return true;
-                },
-                {
-                    apiName,
-                    skipDOMSelection: true,
-                }
-            );
-
-            expect(setContentModel).toHaveBeenCalledWith(
-                core,
-                mockedModel,
-                {
-                    ignoreSelection: true,
-                },
-                undefined
-            );
-        });
-
-        it('skipDOMSelection is false, set DOM selection when editor has focus', () => {
-            hasFocus.and.returnValue(true);
-
-            formatContentModel(
-                core,
-                (model, context) => {
-                    return true;
-                },
-                {
-                    apiName,
-                    skipDOMSelection: false,
-                }
-            );
-
-            expect(setContentModel).toHaveBeenCalledWith(core, mockedModel, undefined, undefined);
-        });
-    });
-
     describe('Pending format', () => {
         const mockedStartContainer1 = 'CONTAINER1' as any;
         const mockedStartOffset1 = 'OFFSET1' as any;

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -35,7 +35,6 @@ import type {
     ContentChangedEvent,
     ContentModelImage,
     EditorPlugin,
-    FormatContentModelOptions,
     IEditor,
     ImageEditOperation,
     ImageEditor,
@@ -339,29 +338,8 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         isApiOperation?: boolean
     ) {
         let editingImageModel: ContentModelImage | undefined;
-
         const selection = editor.getDOMSelection();
         let isRTL: boolean = false;
-        const formatContentModelOptions: FormatContentModelOptions = {
-            onNodeCreated: (model, node) => {
-                if (
-                    !isApiOperation &&
-                    editingImageModel &&
-                    editingImageModel == model &&
-                    editingImageModel.format.imageState == EDITING_MARKER &&
-                    isNodeOfType(node, 'ELEMENT_NODE') &&
-                    isElementOfType(node, 'img')
-                ) {
-                    if (this.isCropMode) {
-                        this.startCropMode(editor, node, isRTL);
-                    } else {
-                        this.startRotateAndResize(editor, node, isRTL);
-                    }
-                }
-            },
-            apiName: IMAGE_EDIT_FORMAT_EVENT,
-            skipDOMSelection: false,
-        };
 
         editor.formatContentModel(
             (model, context) => {
@@ -449,7 +427,6 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                             this.imageEditInfo = updateImageEditInfo(image, selection.image);
                             image.format.imageState = 'isEditing';
                         });
-                        formatContentModelOptions.skipDOMSelection = !isCropMode;
 
                         result = true;
                     }
@@ -457,7 +434,25 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
 
                 return result;
             },
-            formatContentModelOptions,
+            {
+                onNodeCreated: (model, node) => {
+                    if (
+                        !isApiOperation &&
+                        editingImageModel &&
+                        editingImageModel == model &&
+                        editingImageModel.format.imageState == EDITING_MARKER &&
+                        isNodeOfType(node, 'ELEMENT_NODE') &&
+                        isElementOfType(node, 'img')
+                    ) {
+                        if (isCropMode) {
+                            this.startCropMode(editor, node, isRTL);
+                        } else {
+                            this.startRotateAndResize(editor, node, isRTL);
+                        }
+                    }
+                },
+                apiName: IMAGE_EDIT_FORMAT_EVENT,
+            },
             {
                 tryGetFromCache: true,
             }

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
@@ -11,6 +11,8 @@ import type {
 import type { ImageEditOptions } from '../types/ImageEditOptions';
 import type { ImageHtmlOptions } from '../types/ImageHtmlOptions';
 
+const IMAGE_EDIT_SHADOW_ROOT = 'ImageEditShadowRoot';
+
 /**
  * @internal
  */
@@ -78,9 +80,16 @@ const createShadowSpan = (
     const shadowRoot = imageSpan.attachShadow({
         mode: 'open',
     });
+    imageSpan.id = IMAGE_EDIT_SHADOW_ROOT;
 
+    // Pin the shadow host to the original image's box so that wrapping the image does not grow the
+    // surrounding line box. Without this, the taller edit wrapper enlarges the line and the browser
+    // scrolls the selection back into view, making the editor jump. The wrapper and handles still
+    // overflow the host visually because overflow is left visible.
     if (imageWidth > 0 && imageHeight > 0) {
         imageSpan.style.display = 'inline-block';
+        imageSpan.style.width = `${imageWidth}px`;
+        imageSpan.style.height = `${imageHeight}px`;
         imageSpan.style.verticalAlign = 'bottom';
         imageSpan.style.overflow = 'visible';
     }

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -275,53 +275,6 @@ describe('ImageEditPlugin', () => {
         plugin.dispose();
     });
 
-    it('formatContentModel called with skipDOMSelection true when starting editing', () => {
-        const mockedImage = {
-            getAttribute: getAttributeSpy,
-        };
-        const plugin = new ImageEditPlugin();
-        plugin.initialize(editor);
-        getDOMSelectionSpy.and.returnValue({
-            type: 'image',
-            image: mockedImage,
-        });
-        plugin.onPluginEvent({
-            eventType: 'mouseUp',
-            rawEvent: {
-                button: 0,
-                target: mockedImage,
-            } as any,
-        });
-        const options = formatContentModelSpy.calls.mostRecent()
-            .args[1] as FormatContentModelOptions;
-        expect(options.skipDOMSelection).toBe(true);
-        plugin.dispose();
-    });
-
-    it('formatContentModel called with skipDOMSelection false when selecting image', () => {
-        const mockedImage = {
-            getAttribute: getAttributeSpy,
-        };
-        const plugin = new ImageEditPlugin();
-        plugin.initialize(editor);
-        getDOMSelectionSpy.and.returnValue({
-            type: 'image',
-            image: mockedImage,
-        });
-        const target = document.createElement('img');
-        plugin.onPluginEvent({
-            eventType: 'mouseUp',
-            rawEvent: {
-                button: 2,
-                target,
-            } as any,
-        });
-        const options = formatContentModelSpy.calls.mostRecent()
-            .args[1] as FormatContentModelOptions;
-        expect(options.skipDOMSelection).toBe(false);
-        plugin.dispose();
-    });
-
     it('mouseUp - left click - remove selection', () => {
         const mockedImage = {
             getAttribute: getAttributeSpy,

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/utils/createImageWrapperTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/utils/createImageWrapperTest.ts
@@ -175,6 +175,74 @@ describe('createImageWrapper', () => {
         });
         imageSpan.remove();
     });
+
+    function createImageWithSize(width: number, height: number) {
+        const image = document.createElement('img');
+        const imageSpan = document.createElement('span');
+        imageSpan.append(image);
+        document.body.appendChild(imageSpan);
+        Object.defineProperty(image, 'offsetWidth', { value: width, configurable: true });
+        Object.defineProperty(image, 'offsetHeight', { value: height, configurable: true });
+        return { image, imageSpan };
+    }
+
+    const options: ImageEditOptions = {
+        borderColor: '#DB626C',
+        minWidth: 10,
+        minHeight: 10,
+        preserveRatio: true,
+        disableRotate: false,
+        disableSideResize: false,
+        onSelectState: ['resize'],
+    };
+    const editInfo = {
+        src: 'test',
+        widthPx: 20,
+        heightPx: 20,
+        naturalWidth: 10,
+        naturalHeight: 10,
+        leftPercent: 0,
+        rightPercent: 0,
+        topPercent: 0.1,
+        bottomPercent: 0,
+        angleRad: 0,
+    };
+    const htmlOptions = {
+        borderColor: '#DB626C',
+        rotateHandleBackColor: 'white',
+        isSmallImage: false,
+        disableSideResize: false,
+    };
+
+    it('pins the shadow host to the original image footprint', () => {
+        const { image, imageSpan } = createImageWithSize(120, 80);
+
+        const result = createImageWrapper(editor, image, options, editInfo, htmlOptions, [
+            'resize',
+        ]);
+
+        expect(result.shadowSpan.style.display).toBe('inline-block');
+        expect(result.shadowSpan.style.width).toBe('120px');
+        expect(result.shadowSpan.style.height).toBe('80px');
+        expect(result.shadowSpan.style.verticalAlign).toBe('bottom');
+        expect(result.shadowSpan.style.overflow).toBe('visible');
+        imageSpan.remove();
+    });
+
+    it('does not pin the shadow host when the image has no footprint', () => {
+        const { image, imageSpan } = createImageWithSize(0, 0);
+
+        const result = createImageWrapper(editor, image, options, editInfo, htmlOptions, [
+            'resize',
+        ]);
+
+        expect(result.shadowSpan.style.display).toBe('');
+        expect(result.shadowSpan.style.width).toBe('');
+        expect(result.shadowSpan.style.height).toBe('');
+        expect(result.shadowSpan.style.verticalAlign).toBe('');
+        expect(result.shadowSpan.style.overflow).toBe('');
+        imageSpan.remove();
+    });
 });
 
 const cloneImage = (image: HTMLImageElement, editInfo: ImageMetadataFormat) => {

--- a/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelOptions.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelOptions.ts
@@ -43,11 +43,6 @@ export interface FormatContentModelOptions {
      * When pass to true, scroll the editing caret into view after write DOM tree if need
      */
     scrollCaretIntoView?: boolean;
-
-    /**
-     * When pass to true, skip setting DOM selection after write DOM tree. @default false
-     */
-    skipDOMSelection?: boolean;
 }
 
 /**


### PR DESCRIPTION
Reverts microsoft/roosterjs#3404