### PR TITLE
Skip DOM selection when starting image editing

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/formatContentModel/formatContentModel.ts
@@ -62,7 +62,7 @@ export const formatContentModel: FormatContentModel = (
                 core.api.setContentModel(
                     core,
                     model,
-                    hasFocus ? undefined : { ignoreSelection: true }, // If editor did not have focus before format, do not set focus after format
+                    hasFocus && !options?.skipDOMSelection ? undefined : { ignoreSelection: true }, // If editor did not have focus before format, do not set focus after format
                     onNodeCreated
                 ) ?? undefined;
 

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -48,7 +48,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
     private disposer: (() => void) | null = null;
     private logicalRootDisposer: (() => void) | null = null;
     private isSafari = false;
-    private isMac = false;
+
     private scrollTopCache: number = 0;
 
     constructor(options: EditorOptions) {
@@ -99,7 +99,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         const document = this.editor.getDocument();
 
         this.isSafari = !!env.isSafari;
-        this.isMac = !!env.isMac;
+
         document.addEventListener('selectionchange', this.onSelectionChange);
         if (this.isSafari) {
             this.disposer = this.editor.attachDomEvent({
@@ -691,7 +691,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         event: MouseEvent,
         previousSelection: DOMSelection | null
     ): HTMLImageElement | null => {
-        if (!this.isMac || !previousSelection || previousSelection.type !== 'image') {
+        if (!previousSelection || previousSelection.type !== 'image') {
             return null;
         }
 

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -48,7 +48,6 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
     private disposer: (() => void) | null = null;
     private logicalRootDisposer: (() => void) | null = null;
     private isSafari = false;
-    private isMac = false;
     private scrollTopCache: number = 0;
 
     constructor(options: EditorOptions) {
@@ -99,7 +98,6 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         const document = this.editor.getDocument();
 
         this.isSafari = !!env.isSafari;
-        this.isMac = !!env.isMac;
         document.addEventListener('selectionchange', this.onSelectionChange);
         if (this.isSafari) {
             this.disposer = this.editor.attachDomEvent({
@@ -691,7 +689,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         event: MouseEvent,
         previousSelection: DOMSelection | null
     ): HTMLImageElement | null => {
-        if (!this.isMac || !previousSelection || previousSelection.type !== 'image') {
+        if (!previousSelection || previousSelection.type !== 'image') {
             return null;
         }
 

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -48,7 +48,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
     private disposer: (() => void) | null = null;
     private logicalRootDisposer: (() => void) | null = null;
     private isSafari = false;
-
+    private isMac = false;
     private scrollTopCache: number = 0;
 
     constructor(options: EditorOptions) {
@@ -99,7 +99,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         const document = this.editor.getDocument();
 
         this.isSafari = !!env.isSafari;
-
+        this.isMac = !!env.isMac;
         document.addEventListener('selectionchange', this.onSelectionChange);
         if (this.isSafari) {
             this.disposer = this.editor.attachDomEvent({
@@ -691,7 +691,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         event: MouseEvent,
         previousSelection: DOMSelection | null
     ): HTMLImageElement | null => {
-        if (!previousSelection || previousSelection.type !== 'image') {
+        if (!this.isMac || !previousSelection || previousSelection.type !== 'image') {
             return null;
         }
 

--- a/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/formatContentModel/formatContentModelTest.ts
@@ -793,6 +793,49 @@ describe('formatContentModel', () => {
         });
     });
 
+    describe('skipDOMSelection', () => {
+        it('skipDOMSelection is true, do not set DOM selection even when editor has focus', () => {
+            hasFocus.and.returnValue(true);
+
+            formatContentModel(
+                core,
+                (model, context) => {
+                    return true;
+                },
+                {
+                    apiName,
+                    skipDOMSelection: true,
+                }
+            );
+
+            expect(setContentModel).toHaveBeenCalledWith(
+                core,
+                mockedModel,
+                {
+                    ignoreSelection: true,
+                },
+                undefined
+            );
+        });
+
+        it('skipDOMSelection is false, set DOM selection when editor has focus', () => {
+            hasFocus.and.returnValue(true);
+
+            formatContentModel(
+                core,
+                (model, context) => {
+                    return true;
+                },
+                {
+                    apiName,
+                    skipDOMSelection: false,
+                }
+            );
+
+            expect(setContentModel).toHaveBeenCalledWith(core, mockedModel, undefined, undefined);
+        });
+    });
+
     describe('Pending format', () => {
         const mockedStartContainer1 = 'CONTAINER1' as any;
         const mockedStartOffset1 = 'OFFSET1' as any;

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/ImageEditPlugin.ts
@@ -35,6 +35,7 @@ import type {
     ContentChangedEvent,
     ContentModelImage,
     EditorPlugin,
+    FormatContentModelOptions,
     IEditor,
     ImageEditOperation,
     ImageEditor,
@@ -290,7 +291,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                 this.applyFormatWithContentModel(
                     editor,
                     this.isCropMode,
-                    true /** should selectImage */,
+                    false /** should selectImage */,
                     false /* isApiOperation */
                 );
             }
@@ -340,6 +341,29 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
         let editingImageModel: ContentModelImage | undefined;
         const selection = editor.getDOMSelection();
         let isRTL: boolean = false;
+
+        const formatContentModelOptions: FormatContentModelOptions = {
+            onNodeCreated: (model, node) => {
+                if (
+                    !isApiOperation &&
+                    editingImageModel &&
+                    editingImageModel == model &&
+                    editingImageModel.format.imageState == EDITING_MARKER &&
+                    isNodeOfType(node, 'ELEMENT_NODE') &&
+                    isElementOfType(node, 'img')
+                ) {
+                    if (this.isCropMode) {
+                        this.startCropMode(editor, node, isRTL);
+                    } else {
+                        editor.getDocument().defaultView?.requestAnimationFrame(() => {
+                            this.startRotateAndResize(editor, node, isRTL);
+                        });
+                    }
+                }
+            },
+            apiName: IMAGE_EDIT_FORMAT_EVENT,
+            skipDOMSelection: false,
+        };
 
         editor.formatContentModel(
             (model, context) => {
@@ -427,6 +451,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
                             this.imageEditInfo = updateImageEditInfo(image, selection.image);
                             image.format.imageState = 'isEditing';
                         });
+                        formatContentModelOptions.skipDOMSelection = !isCropMode;
 
                         result = true;
                     }
@@ -434,25 +459,7 @@ export class ImageEditPlugin implements ImageEditor, EditorPlugin {
 
                 return result;
             },
-            {
-                onNodeCreated: (model, node) => {
-                    if (
-                        !isApiOperation &&
-                        editingImageModel &&
-                        editingImageModel == model &&
-                        editingImageModel.format.imageState == EDITING_MARKER &&
-                        isNodeOfType(node, 'ELEMENT_NODE') &&
-                        isElementOfType(node, 'img')
-                    ) {
-                        if (isCropMode) {
-                            this.startCropMode(editor, node, isRTL);
-                        } else {
-                            this.startRotateAndResize(editor, node, isRTL);
-                        }
-                    }
-                },
-                apiName: IMAGE_EDIT_FORMAT_EVENT,
-            },
+            formatContentModelOptions,
             {
                 tryGetFromCache: true,
             }

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
@@ -76,7 +76,7 @@ const createShadowSpan = (
     imageHeight: number
 ) => {
     const shadowRoot = imageSpan.attachShadow({
-        mode: 'open',
+        mode: 'closed',
     });
 
     if (imageWidth > 0 && imageHeight > 0) {

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/createImageWrapper.ts
@@ -76,7 +76,7 @@ const createShadowSpan = (
     imageHeight: number
 ) => {
     const shadowRoot = imageSpan.attachShadow({
-        mode: 'closed',
+        mode: 'open',
     });
 
     if (imageWidth > 0 && imageHeight > 0) {

--- a/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/updateImageEditInfo.ts
+++ b/packages/roosterjs-content-model-plugins/lib/imageEdit/utils/updateImageEditInfo.ts
@@ -58,7 +58,7 @@ export function getSelectedImageMetadata(
                 imageMetadata = updateImageEditInfo(modelImage, image);
             });
 
-            return true;
+            return false;
         }
         return false;
     });

--- a/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/imageEdit/ImageEditPluginTest.ts
@@ -253,6 +253,41 @@ describe('ImageEditPlugin', () => {
         plugin.dispose();
     });
 
+    it('keyDown - other key (not Escape, Delete or Backspace)', () => {
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
+        };
+        const plugin = new TestPlugin();
+        plugin.initialize(editor);
+        plugin.setIsEditing(true);
+        const cleanInfoSpy = spyOn(plugin as any, 'cleanInfo');
+        const removeImageWrapperSpy = spyOn(plugin as any, 'removeImageWrapper');
+        const applyFormatWithContentModelSpy = spyOn(plugin, 'applyFormatWithContentModel');
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        const preventDefaultSpy = jasmine.createSpy('preventDefault');
+        plugin.onPluginEvent({
+            eventType: 'keyDown',
+            rawEvent: {
+                key: 'a',
+                target: mockedImage,
+                preventDefault: preventDefaultSpy,
+            } as any,
+        });
+        expect(cleanInfoSpy).not.toHaveBeenCalled();
+        expect(removeImageWrapperSpy).not.toHaveBeenCalled();
+        expect(preventDefaultSpy).not.toHaveBeenCalled();
+        expect(applyFormatWithContentModelSpy).toHaveBeenCalledWith(
+            editor,
+            false /** isCropMode */,
+            false /** shouldSelectImage */,
+            false /** isApiOperation */
+        );
+        plugin.dispose();
+    });
+
     it('mouseUp', () => {
         const mockedImage = {
             getAttribute: getAttributeSpy,
@@ -272,6 +307,53 @@ describe('ImageEditPlugin', () => {
             } as any,
         });
         expect(formatContentModelSpy).toHaveBeenCalled();
+        plugin.dispose();
+    });
+
+    it('formatContentModel called with skipDOMSelection true when starting editing', () => {
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
+        };
+        const plugin = new ImageEditPlugin();
+        plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        plugin.onPluginEvent({
+            eventType: 'mouseUp',
+            rawEvent: {
+                button: 0,
+                target: mockedImage,
+            } as any,
+        });
+        const options = formatContentModelSpy.calls.mostRecent()
+            .args[1] as FormatContentModelOptions;
+        expect(options.skipDOMSelection).toBe(true);
+        plugin.dispose();
+    });
+
+    it('formatContentModel called with skipDOMSelection false when selecting image', () => {
+        const mockedImage = {
+            getAttribute: getAttributeSpy,
+        };
+        const plugin = new ImageEditPlugin();
+        plugin.initialize(editor);
+        getDOMSelectionSpy.and.returnValue({
+            type: 'image',
+            image: mockedImage,
+        });
+        const target = document.createElement('img');
+        plugin.onPluginEvent({
+            eventType: 'mouseUp',
+            rawEvent: {
+                button: 2,
+                target,
+            } as any,
+        });
+        const options = formatContentModelSpy.calls.mostRecent()
+            .args[1] as FormatContentModelOptions;
+        expect(options.skipDOMSelection).toBe(false);
         plugin.dispose();
     });
 

--- a/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelOptions.ts
+++ b/packages/roosterjs-content-model-types/lib/parameter/FormatContentModelOptions.ts
@@ -43,6 +43,11 @@ export interface FormatContentModelOptions {
      * When pass to true, scroll the editing caret into view after write DOM tree if need
      */
     scrollCaretIntoView?: boolean;
+
+    /**
+     * When pass to true, skip setting DOM selection after write DOM tree. @default false
+     */
+    skipDOMSelection?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

When a user starts editing an image (rotate/resize handles), the editor no longer forces a DOM image selection on the edited image. The setDOMSelection function will reselect the image due the isEditingImage hidden property, causing the same image to be selected again as new image, then we should skip DOM Selection for this scenario.    
<img width="575" height="170" alt="Screenshot 2026-07-27 154023" src="https://github.com/user-attachments/assets/c537daa1-21ab-4612-852a-c9fba1605440" />

Key changes:
- Add a new `skipDOMSelection` option to `FormatContentModelOptions`. When `true`, `formatContentModel` passes `{ ignoreSelection: true }` to `setContentModel` even if the editor has focus, so the DOM selection is not rewritten after applying the model.
- `ImageEditPlugin` now sets `skipDOMSelection = !isCropMode` when entering edit mode, and no longer requests `shouldSelectImage` on generic key-down. The rotate/resize start is scheduled via `requestAnimationFrame`.
- Remove the Mac-only guard (`isMac`) in `SelectionPlugin` so image reselection behavior is consistent across platforms.

## How to test

1. Run the unit tests:
   - `yarn test:fast --testPathPattern=formatContentModel`
   - `yarn test:fast --testPathPattern=ImageEditPlugin`
2. Manual check: insert an image, click it to enter edit mode (rotate/resize), and confirm:
   - Before this fix: the image gets re-selected (blue selection box) when editing starts.
   - After this fix: editing starts without re-selecting the underlying image; right-click / selecting the image (crop mode) still applies DOM selection as before.
