### PR TITLE
Fix image selection for context menu on Shift+F10

### DIFF
--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -176,16 +176,15 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             },
             activeTab: 'all',
         };
+    }
 
+    render() {
+        const theme = getTheme(this.state.isDarkMode);
         this.imageEditPlugin = this.state.initState.pluginList.imageEditPlugin
             ? new ImageEditPlugin({
                   disableSideResize: this.state.initState.disableSideResize,
               })
             : undefined;
-    }
-
-    render() {
-        const theme = getTheme(this.state.isDarkMode);
 
         return (
             <ThemeProvider applyTo="body" theme={theme} className={styles.mainPane}>

--- a/demo/scripts/controlsV2/mainPane/MainPane.tsx
+++ b/demo/scripts/controlsV2/mainPane/MainPane.tsx
@@ -180,11 +180,6 @@ export class MainPane extends React.Component<{}, MainPaneState> {
 
     render() {
         const theme = getTheme(this.state.isDarkMode);
-        this.imageEditPlugin = this.state.initState.pluginList.imageEditPlugin
-            ? new ImageEditPlugin({
-                  disableSideResize: this.state.initState.disableSideResize,
-              })
-            : undefined;
 
         return (
             <ThemeProvider applyTo="body" theme={theme} className={styles.mainPane}>
@@ -237,10 +232,12 @@ export class MainPane extends React.Component<{}, MainPaneState> {
 
     resetEditorPlugin(pluginState: OptionState) {
         this.updateContentPlugin.update();
-        this.setState({
-            initState: pluginState,
-        });
-        this.resetEditor();
+        this.setState(
+            {
+                initState: pluginState,
+            },
+            () => this.resetEditor()
+        );
     }
 
     setScale(scale: number): void {
@@ -354,6 +351,8 @@ export class MainPane extends React.Component<{}, MainPaneState> {
 
     private shadowDomEditorDiv: HTMLDivElement | undefined;
     private resetEditor() {
+        this.createImageEditPlugin();
+
         const useShadowDom = this.editorOptionPlugin
             .getBuildInPluginState()
             .experimentalFeatures.has('ShadowDom');
@@ -554,6 +553,14 @@ export class MainPane extends React.Component<{}, MainPaneState> {
             this.presetPlugin,
             this.markdownPanePlugin,
         ];
+    }
+
+    private createImageEditPlugin() {
+        this.imageEditPlugin = this.state.initState.pluginList.imageEditPlugin
+            ? new ImageEditPlugin({
+                  disableSideResize: this.state.initState.disableSideResize,
+              })
+            : undefined;
     }
 
     private getToggleablePlugins(): EditorPlugin[] {

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -32,6 +32,7 @@ const Down = 'ArrowDown';
 const Left = 'ArrowLeft';
 const Right = 'ArrowRight';
 const Tab = 'Tab';
+const F10 = 'F10';
 
 /**
  * @internal
@@ -353,6 +354,8 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                 break;
 
             case 'range':
+                let image: HTMLImageElement | null;
+
                 if (key == Up || key == Down || key == Left || key == Right || key == Tab) {
                     const start = selection.range.startContainer;
                     this.state.tableSelection = this.parseTableSelection(
@@ -371,7 +374,20 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                             );
                         }
                     }
+                } else if (
+                    key == F10 &&
+                    rawEvent.shiftKey &&
+                    (image = isSingleImageInSelection(selection.range))
+                ) {
+                    this.setDOMSelection(
+                        {
+                            type: 'image',
+                            image,
+                        },
+                        null /* tableSelection */
+                    );
                 }
+
                 break;
 
             case 'table':

--- a/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
@@ -3226,6 +3226,101 @@ describe('SelectionPlugin handle table selection', () => {
             });
             expect(preventDefaultSpy).toHaveBeenCalled();
         });
+
+        it('From Range, Press Shift+F10 with a single image in selection', () => {
+            const image = document.createElement('img');
+            const mockedRange = {
+                startContainer: div,
+                startOffset: 0,
+                endContainer: div,
+                endOffset: 0,
+            } as any;
+
+            spyOn(isSingleImageInSelection, 'isSingleImageInSelection').and.returnValue(image);
+
+            getDOMSelectionSpy.and.returnValue({
+                type: 'range',
+                range: mockedRange,
+                isReverted: false,
+            });
+
+            plugin.onPluginEvent!({
+                eventType: 'keyDown',
+                rawEvent: {
+                    key: 'F10',
+                    shiftKey: true,
+                } as any,
+            });
+
+            expect(isSingleImageInSelection.isSingleImageInSelection).toHaveBeenCalledWith(
+                mockedRange
+            );
+            expect(setDOMSelectionSpy).toHaveBeenCalledTimes(1);
+            expect(setDOMSelectionSpy).toHaveBeenCalledWith({
+                type: 'image',
+                image,
+            });
+        });
+
+        it('From Range, Press Shift+F10 without a single image in selection', () => {
+            const mockedRange = {
+                startContainer: div,
+                startOffset: 0,
+                endContainer: div,
+                endOffset: 0,
+            } as any;
+
+            spyOn(isSingleImageInSelection, 'isSingleImageInSelection').and.returnValue(null);
+
+            getDOMSelectionSpy.and.returnValue({
+                type: 'range',
+                range: mockedRange,
+                isReverted: false,
+            });
+
+            plugin.onPluginEvent!({
+                eventType: 'keyDown',
+                rawEvent: {
+                    key: 'F10',
+                    shiftKey: true,
+                } as any,
+            });
+
+            expect(isSingleImageInSelection.isSingleImageInSelection).toHaveBeenCalledWith(
+                mockedRange
+            );
+            expect(setDOMSelectionSpy).not.toHaveBeenCalled();
+        });
+
+        it('From Range, Press F10 without shift key does not set image selection', () => {
+            const image = document.createElement('img');
+            const isSingleImageSpy = spyOn(
+                isSingleImageInSelection,
+                'isSingleImageInSelection'
+            ).and.returnValue(image);
+
+            getDOMSelectionSpy.and.returnValue({
+                type: 'range',
+                range: {
+                    startContainer: div,
+                    startOffset: 0,
+                    endContainer: div,
+                    endOffset: 0,
+                } as any,
+                isReverted: false,
+            });
+
+            plugin.onPluginEvent!({
+                eventType: 'keyDown',
+                rawEvent: {
+                    key: 'F10',
+                    shiftKey: false,
+                } as any,
+            });
+
+            expect(isSingleImageSpy).not.toHaveBeenCalled();
+            expect(setDOMSelectionSpy).not.toHaveBeenCalled();
+        });
     });
 });
 


### PR DESCRIPTION
## Summary

When a range selection contains a single image, pressing **Shift+F10** (the keyboard shortcut that opens the context menu) now promotes the selection to an image selection before the menu opens. This ensures the context menu operates on the image rather than the surrounding text range. Implemented in `SelectionPlugin.ts` by detecting `Shift+F10` on a range selection and, when `isSingleImageInSelection` returns an image, calling `setDOMSelection` with an `image` selection.

<img width="930" height="784" alt="ImageContextMenuF10" src="https://github.com/user-attachments/assets/358ae451-e561-42a9-807d-e52cc4827315" />

The demo `MainPane.tsx` change moves `imageEditPlugin` initialization into `render()` so it reflects current init state.

## How to test

1. Manual check: In the demo editor, click just before/around a single image so it's within a range selection, then press **Shift+F10**.
   - Before this fix: the context menu opens against the text range.
   - After this fix: the image becomes selected (image selection) before the context menu opens.
