### PR TITLE
Gate internal drop handling behind HandleDropInternalContent experiment

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/dragAndDrop/DragAndDropPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/dragAndDrop/DragAndDropPlugin.ts
@@ -81,7 +81,10 @@ export class DragAndDropPlugin implements EditorPlugin {
     onPluginEvent(event: PluginEvent) {
         if (this.editor && event.eventType == 'beforeDrop') {
             const dropEvent = event.rawEvent;
-            if (this.internalDrag) {
+            if (
+                this.internalDrag &&
+                this.editor.isExperimentalFeatureEnabled('HandleDropInternalContent')
+            ) {
                 handleDroppedInternalContent(this.editor, dropEvent);
             } else if (!this.internalDrag) {
                 const html = dropEvent.dataTransfer?.getData('text/html');

--- a/packages/roosterjs-content-model-plugins/test/dragAndDrop/DragAndDropPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/dragAndDrop/DragAndDropPluginTest.ts
@@ -8,6 +8,7 @@ describe('DragAndDropPlugin', () => {
     let editor: IEditor;
     let attachDomEventSpy: jasmine.Spy;
     let disposerSpy: jasmine.Spy;
+    let isExperimentalFeatureEnabledSpy: jasmine.Spy;
     let eventMap: Record<string, any>;
 
     beforeEach(() => {
@@ -16,9 +17,13 @@ describe('DragAndDropPlugin', () => {
             eventMap = map;
             return disposerSpy;
         });
+        isExperimentalFeatureEnabledSpy = jasmine
+            .createSpy('isExperimentalFeatureEnabled')
+            .and.returnValue(true);
 
         editor = ({
             attachDomEvent: attachDomEventSpy,
+            isExperimentalFeatureEnabled: isExperimentalFeatureEnabledSpy,
         } as any) as IEditor;
     });
 
@@ -231,7 +236,34 @@ describe('DragAndDropPlugin', () => {
                 rawEvent: dropEvent,
             });
 
+            expect(isExperimentalFeatureEnabledSpy).toHaveBeenCalledWith(
+                'HandleDropInternalContent'
+            );
             expect(handleDroppedInternalContentSpy).toHaveBeenCalledWith(editor, dropEvent);
+            expect(handleDroppedExternalContentSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not call handleDroppedInternalContent when the experiment is disabled', () => {
+            isExperimentalFeatureEnabledSpy.and.returnValue(false);
+
+            const target = document.createElement('div');
+            eventMap.dragstart.beforeDispatch({ target } as any);
+
+            const dropEvent = {
+                dataTransfer: {
+                    getData: () => '<div>internal content</div>',
+                },
+            } as any;
+
+            plugin.onPluginEvent({
+                eventType: 'beforeDrop',
+                rawEvent: dropEvent,
+            });
+
+            expect(isExperimentalFeatureEnabledSpy).toHaveBeenCalledWith(
+                'HandleDropInternalContent'
+            );
+            expect(handleDroppedInternalContentSpy).not.toHaveBeenCalled();
             expect(handleDroppedExternalContentSpy).not.toHaveBeenCalled();
         });
 


### PR DESCRIPTION
## Summary

Gate the internal drag-and-drop handling in `DragAndDropPlugin` behind the new `HandleDropInternalContent` experimental feature. Previously, on a `beforeDrop` event originating from an internal drag, the plugin always called `handleDroppedInternalContent`. Now that path only runs when `editor.isExperimentalFeatureEnabled('HandleDropInternalContent')` returns `true`, allowing the behavior to be rolled out safely behind a flag. External-content handling is unchanged.

## How to test

1. Run the plugin tests:
   `yarn test:fast --testPathPattern=DragAndDropPluginTest`
2. Manual verification:
   - Enable the `HandleDropInternalContent` experimental feature, perform an internal drag-and-drop within the editor, and confirm the internal content is handled (as before).
   - With the experiment disabled, perform the same internal drag-and-drop and confirm `handleDroppedInternalContent` is **not** invoked. External drag-and-drop continues to work regardless of the flag.
