### PR TITLE
[Table] Support dragging content from a selected table cell range

### DIFF
--- a/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setTableCellsStyle.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/setTableCellsStyle.ts
@@ -2,7 +2,10 @@ import { ensureUniqueId } from '../setEditorStyle/ensureUniqueId';
 import { getSafeIdSelector, isNodeOfType, toArray } from 'roosterjs-content-model-dom';
 import type { EditorCore, ParsedTable, TableCellCoordinate } from 'roosterjs-content-model-types';
 
-const DOM_SELECTION_CSS_KEY = '_DOMSelection';
+/**
+ * @internal
+ */
+export const DOM_SELECTION_CSS_KEY = '_DOMSelection';
 const TABLE_ID = 'table';
 
 /**

--- a/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/toggleCaret.ts
+++ b/packages/roosterjs-content-model-core/lib/coreApi/setDOMSelection/toggleCaret.ts
@@ -1,7 +1,10 @@
 import type { EditorCore } from 'roosterjs-content-model-types';
 
 const CARET_CSS_RULE = 'caret-color: transparent';
-const HIDE_CURSOR_CSS_KEY = '_DOMSelectionHideCursor';
+/**
+ * @internal
+ */
+export const HIDE_CURSOR_CSS_KEY = '_DOMSelectionHideCursor';
 
 /**
  * @internal Show/Hide caret in editor

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -3,6 +3,7 @@ import { findTableCellElement } from '../../coreApi/setDOMSelection/findTableCel
 import { isSingleImageInSelection } from './isSingleImageInSelection';
 import { normalizePos } from './normalizePos';
 import {
+    ChangeSource,
     getDOMInsertPointRect,
     getNodePositionFromEvent,
     isCharacterValue,
@@ -23,6 +24,7 @@ import type {
     ParsedTable,
     TableSelectionInfo,
     TableCellCoordinate,
+    TableSelection,
 } from 'roosterjs-content-model-types';
 
 const MouseLeftButton = 0;
@@ -50,6 +52,7 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
     private logicalRootDisposer: (() => void) | null = null;
     private isSafari = false;
     private scrollTopCache: number = 0;
+    private isInsideSelection: boolean = false;
 
     constructor(options: EditorOptions) {
         this.state = {
@@ -152,6 +155,10 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                 break;
 
             case 'contentChanged':
+                if (event.source == ChangeSource.Drop && this.isInsideSelection) {
+                    this.setDOMSelection(null /* DOMSelection  */, null /* tableSelection */);
+                }
+
                 this.state.tableSelection = null;
                 break;
 
@@ -211,18 +218,31 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
         }
 
         // Table selection
+        const target = rawEvent.target as Node;
+        let tableSelection: TableSelectionInfo | null = this.parseTableSelection(
+            target,
+            target,
+            editor.getDOMHelper()
+        );
+
+        this.isInsideSelection = false;
+
+        if (
+            selection?.type == 'table' &&
+            tableSelection &&
+            this.isInsideTableSelection(selection, tableSelection) &&
+            rawEvent.detail == 1
+        ) {
+            this.isInsideSelection = true;
+            this.setTableDragSelection(editor, rawEvent);
+            return;
+        }
+
         if (selection?.type == 'table' && rawEvent.button == MouseLeftButton) {
             this.setDOMSelection(null /*domSelection*/, null /*tableSelection*/);
         }
 
-        let tableSelection: TableSelectionInfo | null;
-        const target = rawEvent.target as Node;
-
-        if (
-            target &&
-            rawEvent.button == MouseLeftButton &&
-            (tableSelection = this.parseTableSelection(target, target, editor.getDOMHelper()))
-        ) {
+        if (target && rawEvent.button == MouseLeftButton && tableSelection) {
             this.state.tableSelection = tableSelection;
 
             if (rawEvent.detail >= 3) {
@@ -310,6 +330,11 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
     };
 
     private onMouseUp() {
+        if (this.isInsideSelection) {
+            this.setDOMSelection(null /*domSelection*/, null /*tableSelection*/);
+            this.isInsideSelection = false;
+        }
+
         this.detachMouseEvent();
     }
 
@@ -580,6 +605,33 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
                 this.state.tableSelection = tableSel;
                 this.updateTableSelection(lastCo);
             }
+        }
+    }
+
+    private isInsideTableSelection(
+        prevSelection: TableSelection,
+        tableSelection: TableSelectionInfo
+    ) {
+        const selectedCell = tableSelection.firstCo;
+
+        return (
+            selectedCell.row >= prevSelection.firstRow &&
+            selectedCell.row <= prevSelection.lastRow &&
+            selectedCell.col >= prevSelection.firstColumn &&
+            selectedCell.col <= prevSelection.lastColumn
+        );
+    }
+
+    private setTableDragSelection(editor: IEditor, rawEvent: MouseEvent) {
+        const doc = editor.getDocument();
+        const cell = editor
+            .getDOMHelper()
+            .findClosestElementAncestor(rawEvent.target as Node, 'td,th');
+        if (cell) {
+            const range = doc.createRange();
+            console.log(cell);
+            range.selectNodeContents(cell);
+            editor.getDOMHelper().setSelectionRange(range);
         }
     }
 

--- a/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
+++ b/packages/roosterjs-content-model-core/lib/corePlugin/selection/SelectionPlugin.ts
@@ -26,6 +26,8 @@ import type {
     TableCellCoordinate,
     TableSelection,
 } from 'roosterjs-content-model-types';
+import { DOM_SELECTION_CSS_KEY } from '../../coreApi/setDOMSelection/setTableCellsStyle';
+import { HIDE_CURSOR_CSS_KEY } from '../../coreApi/setDOMSelection/toggleCaret';
 
 const MouseLeftButton = 0;
 const MouseRightButton = 2;
@@ -157,8 +159,8 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
             case 'contentChanged':
                 if (event.source == ChangeSource.Drop && this.isInsideSelection) {
                     this.setDOMSelection(null /* DOMSelection  */, null /* tableSelection */);
+                    this.isInsideSelection = false;
                 }
-
                 this.state.tableSelection = null;
                 break;
 
@@ -219,13 +221,9 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
 
         // Table selection
         const target = rawEvent.target as Node;
-        let tableSelection: TableSelectionInfo | null = this.parseTableSelection(
-            target,
-            target,
-            editor.getDOMHelper()
-        );
-
-        this.isInsideSelection = false;
+        const tableSelection: TableSelectionInfo | null = target
+            ? this.parseTableSelection(target, target, editor.getDOMHelper())
+            : null;
 
         if (
             selection?.type == 'table' &&
@@ -628,8 +626,14 @@ class SelectionPlugin implements PluginWithState<SelectionPluginState> {
             .getDOMHelper()
             .findClosestElementAncestor(rawEvent.target as Node, 'td,th');
         if (cell) {
+            // Hide the table cell selection styles (grey cell background applied by
+            // setDOMSelection) and the native selection highlight so that only the
+            // dragged content is visible while dragging. Also restore the caret which
+            // is hidden while a table selection is active.
+            editor.setEditorStyle(DOM_SELECTION_CSS_KEY, null /*cssRule*/);
+            editor.setEditorStyle(HIDE_CURSOR_CSS_KEY, null /*cssRule*/);
+
             const range = doc.createRange();
-            console.log(cell);
             range.selectNodeContents(cell);
             editor.getDOMHelper().setSelectionRange(range);
         }

--- a/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/toggleTableSelectionTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/toggleTableSelectionTest.ts
@@ -1,7 +1,7 @@
 import { EditorCore, TableSelection } from 'roosterjs-content-model-types';
 import { toggleTableSelection } from '../../../lib/coreApi/setDOMSelection/toggleTableSelection';
 
-const DOM_SELECTION_CSS_KEY = '_DOMSelection';
+export const DOM_SELECTION_CSS_KEY = '_DOMSelection';
 
 describe('toggleTableSelection', () => {
     let core: EditorCore;

--- a/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/toggleTableSelectionTest.ts
+++ b/packages/roosterjs-content-model-core/test/coreApi/setDOMSelection/toggleTableSelectionTest.ts
@@ -1,7 +1,7 @@
 import { EditorCore, TableSelection } from 'roosterjs-content-model-types';
 import { toggleTableSelection } from '../../../lib/coreApi/setDOMSelection/toggleTableSelection';
 
-export const DOM_SELECTION_CSS_KEY = '_DOMSelection';
+const DOM_SELECTION_CSS_KEY = '_DOMSelection';
 
 describe('toggleTableSelection', () => {
     let core: EditorCore;

--- a/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
+++ b/packages/roosterjs-content-model-core/test/corePlugin/selection/SelectionPluginTest.ts
@@ -791,6 +791,7 @@ describe('SelectionPlugin handle table selection', () => {
             isExperimentalFeatureEnabled: () => {
                 return false;
             },
+            setEditorStyle: jasmine.createSpy('setEditorStyle'),
             getSnapshotsManager: () => {
                 return { hasNewContent: false };
             },

--- a/packages/roosterjs-content-model-plugins/lib/dragAndDrop/DragAndDropPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/dragAndDrop/DragAndDropPlugin.ts
@@ -85,13 +85,12 @@ export class DragAndDropPlugin implements EditorPlugin {
      * @param event The event to handle:
      */
     onPluginEvent(event: PluginEvent) {
-        if (
-            this.editor &&
-            event.eventType == 'beforeDrop' &&
-            this.editor.isExperimentalFeatureEnabled('HandleDropInternalContent')
-        ) {
+        if (this.editor && event.eventType == 'beforeDrop') {
             const dropEvent = event.rawEvent;
-            if (this.internalDrag) {
+            if (
+                this.internalDrag &&
+                this.editor.isExperimentalFeatureEnabled('HandleDropInternalContent')
+            ) {
                 handleDroppedInternalContent(this.editor, dropEvent);
             } else if (!this.internalDrag) {
                 const html = dropEvent.dataTransfer?.getData('text/html');

--- a/packages/roosterjs-content-model-plugins/lib/dragAndDrop/DragAndDropPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/dragAndDrop/DragAndDropPlugin.ts
@@ -51,8 +51,14 @@ export class DragAndDropPlugin implements EditorPlugin {
         this.editor = editor;
         this.disposer = editor.attachDomEvent({
             dragstart: {
-                beforeDispatch: _ev => {
+                beforeDispatch: ev => {
                     this.internalDrag = true;
+                    if (
+                        this.editor &&
+                        this.editor.isExperimentalFeatureEnabled('HandleDropInternalContent')
+                    ) {
+                        this.adjustDraggingCursor(this.editor, ev as DragEvent);
+                    }
                 },
             },
         });
@@ -79,7 +85,11 @@ export class DragAndDropPlugin implements EditorPlugin {
      * @param event The event to handle:
      */
     onPluginEvent(event: PluginEvent) {
-        if (this.editor && event.eventType == 'beforeDrop') {
+        if (
+            this.editor &&
+            event.eventType == 'beforeDrop' &&
+            this.editor.isExperimentalFeatureEnabled('HandleDropInternalContent')
+        ) {
             const dropEvent = event.rawEvent;
             if (this.internalDrag) {
                 handleDroppedInternalContent(this.editor, dropEvent);
@@ -95,6 +105,20 @@ export class DragAndDropPlugin implements EditorPlugin {
                 }
             }
             this.internalDrag = false;
+        }
+    }
+
+    private adjustDraggingCursor(editor: IEditor, dragEvent: DragEvent) {
+        const selection = editor.getDOMSelection();
+        if (selection?.type == 'table') {
+            const doc = this.editor?.getDocument();
+            if (doc && dragEvent.dataTransfer) {
+                const ghost = doc.createElement('span');
+                ghost.textContent = '|';
+                doc.body.appendChild(ghost);
+                dragEvent.dataTransfer.setDragImage(ghost, 0, 0);
+                doc.defaultView?.requestAnimationFrame(() => ghost.remove());
+            }
         }
     }
 }

--- a/packages/roosterjs-content-model-plugins/test/dragAndDrop/DragAndDropPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/dragAndDrop/DragAndDropPluginTest.ts
@@ -10,6 +10,7 @@ describe('DragAndDropPlugin', () => {
     let disposerSpy: jasmine.Spy;
     let isExperimentalFeatureEnabledSpy: jasmine.Spy;
     let eventMap: Record<string, any>;
+    let getDOMSelectionSpy: jasmine.Spy;
 
     beforeEach(() => {
         disposerSpy = jasmine.createSpy('disposer');
@@ -20,10 +21,12 @@ describe('DragAndDropPlugin', () => {
         isExperimentalFeatureEnabledSpy = jasmine
             .createSpy('isExperimentalFeatureEnabled')
             .and.returnValue(true);
+        getDOMSelectionSpy = jasmine.createSpy('getDOMSelection');
 
         editor = ({
             attachDomEvent: attachDomEventSpy,
             isExperimentalFeatureEnabled: isExperimentalFeatureEnabledSpy,
+            getDOMSelection: getDOMSelectionSpy,
         } as any) as IEditor;
     });
 

--- a/packages/roosterjs-content-model-plugins/test/dragAndDrop/DragAndDropPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/dragAndDrop/DragAndDropPluginTest.ts
@@ -19,6 +19,8 @@ describe('DragAndDropPlugin', () => {
 
         editor = ({
             attachDomEvent: attachDomEventSpy,
+            isExperimentalFeatureEnabled: () => true,
+            getDOMSelection: () => null,
         } as any) as IEditor;
     });
 


### PR DESCRIPTION
## Summary

Adds support for dragging content out of a selected table cell range. When the user presses down inside an existing table selection with a single click, the selection is converted into a native range selection so the highlighted content can be dragged and dropped elsewhere, gated behind the `HandleDropInternalContent` experimental feature.

Experimental Feature enabled:
<img width="556" height="474" alt="DragCellsFlightOn" src="https://github.com/user-attachments/assets/e6a73381-78b0-4804-9659-b791ba808564" />

Experimental Feature disabled: 
<img width="569" height="322" alt="DragCellsFlightOff" src="https://github.com/user-attachments/assets/d1dc01f5-9a81-4e70-b506-91efbb211c14" />


Key changes:
- `SelectionPlugin`: detect mouse-down inside an active table selection (`isInsideTableSelection`) and switch to a draggable native range (`setTableDragSelection`), clearing the grey table-cell highlight and restoring the caret. On drop (via `ChangeSource.Drop`) or mouse-up, the temporary selection is cleared.
- `DragAndDropPlugin`: gate `handleDroppedInternalContent` behind the `HandleDropInternalContent` experimental feature and show a thin caret-like drag image when dragging from a table selection (`adjustDraggingCursor`).
- Export `DOM_SELECTION_CSS_KEY` and `HIDE_CURSOR_CSS_KEY` as `@internal` so the selection plugin can reset those editor styles while dragging.

## How to test

1. Run the unit tests:
   - `yarn test:fast --testPathPattern=SelectionPluginTest`
   - `yarn test:fast --testPathPattern=DragAndDropPluginTest`
2. Manual test (requires the `HandleDropInternalContent` experimental feature enabled):
   - Select a range of table cells so the grey table selection appears.
   - Press and hold inside the selection with a single click, then drag to another location and drop.
   - Before this change: the table selection is cleared immediately on mouse-down and the content cannot be dragged.
   - After this change: the highlighted content stays draggable, a thin caret drag image follows the cursor, and dropping moves the content; the temporary selection is cleared on drop/mouse-up.
