### PR TITLE
Support dropping external plain text

### DIFF
--- a/packages/roosterjs-content-model-core/lib/command/paste/createPasteFragment.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/createPasteFragment.ts
@@ -15,7 +15,7 @@ export function createPasteFragment(
     }
 
     const { imageDataUri, text } = clipboardData;
-    let fragment = document.createDocumentFragment();
+    const fragment = document.createDocumentFragment();
 
     if (
         (pasteType == 'asImage' && imageDataUri) ||
@@ -29,7 +29,7 @@ export function createPasteFragment(
     } else if (pasteType != 'asPlainText' && root) {
         moveChildNodes(fragment, root);
     } else if (text) {
-        fragment = textToFragment(text, document);
+        return textToFragment(text, document);
     }
 
     return fragment;

--- a/packages/roosterjs-content-model-core/lib/command/paste/createPasteFragment.ts
+++ b/packages/roosterjs-content-model-core/lib/command/paste/createPasteFragment.ts
@@ -1,9 +1,5 @@
-import { moveChildNodes, wrap } from 'roosterjs-content-model-dom';
+import { moveChildNodes, textToFragment } from 'roosterjs-content-model-dom';
 import type { ClipboardData, PasteType } from 'roosterjs-content-model-types';
-
-const NBSP_HTML = '\u00A0';
-const ENSP_HTML = '\u2002';
-const TAB_SPACES = 6;
 
 /**
  * @internal
@@ -19,7 +15,7 @@ export function createPasteFragment(
     }
 
     const { imageDataUri, text } = clipboardData;
-    const fragment = document.createDocumentFragment();
+    let fragment = document.createDocumentFragment();
 
     if (
         (pasteType == 'asImage' && imageDataUri) ||
@@ -33,56 +29,8 @@ export function createPasteFragment(
     } else if (pasteType != 'asPlainText' && root) {
         moveChildNodes(fragment, root);
     } else if (text) {
-        text.split('\n').forEach((line, index, lines) => {
-            line = line
-                .replace(/^ /g, NBSP_HTML)
-                .replace(/ $/g, NBSP_HTML)
-                .replace(/\r/g, '')
-                .replace(/ {2}/g, ' ' + NBSP_HTML);
-
-            if (line.includes('\t')) {
-                line = transformTabCharacters(line);
-            }
-
-            const textNode = document.createTextNode(line);
-
-            // There are 3 scenarios:
-            // 1. Single line: Paste as it is
-            // 2. Two lines: Add <br> between the lines
-            // 3. 3 or More lines, For first and last line, paste as it is. For middle lines, wrap with DIV, and add BR if it is empty line
-            if (lines.length == 2 && index == 0) {
-                // 1 of 2 lines scenario, add BR
-                fragment.appendChild(textNode);
-                fragment.appendChild(document.createElement('br'));
-            } else if (index > 0 && index < lines.length - 1) {
-                // Middle line of >=3 lines scenario, wrap with DIV
-                fragment.appendChild(
-                    wrap(document, line == '' ? document.createElement('br') : textNode, 'div')
-                );
-            } else {
-                // All others, paste as it is
-                fragment.appendChild(textNode);
-            }
-        });
+        fragment = textToFragment(text, document);
     }
 
     return fragment;
-}
-
-/**
- * Transform \t characters into EN SPACE characters
- * @param input string NOT containing \n characters
- * @example t("\thello", 2) => "&ensp;&ensp;&ensp;&ensp;hello"
- */
-function transformTabCharacters(input: string, initialOffset: number = 0) {
-    let line = input;
-    let tIndex: number;
-    while ((tIndex = line.indexOf('\t')) != -1) {
-        const lineBefore = line.slice(0, tIndex);
-        const lineAfter = line.slice(tIndex + 1);
-        const tabCount = TAB_SPACES - ((lineBefore.length + initialOffset) % TAB_SPACES);
-        const tabStr = Array(tabCount).fill(ENSP_HTML).join('');
-        line = lineBefore + tabStr + lineAfter;
-    }
-    return line;
 }

--- a/packages/roosterjs-content-model-dom/lib/domUtils/textToFragment.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/textToFragment.ts
@@ -1,0 +1,61 @@
+import { wrap } from './wrap';
+
+const NBSP_HTML = '\u00A0';
+const ENSP_HTML = '\u2002';
+const TAB_SPACES = 6;
+/**
+ * Wrap plain text content in a Document Fragment
+ * @param text the text content to wrapped
+ * @param doc the document to create the fragment
+ */
+export function textToFragment(text: string, doc: Document): DocumentFragment {
+    const fragment = doc.createDocumentFragment();
+    text.split('\n').forEach((line, index, lines) => {
+        line = line
+            .replace(/^ /g, NBSP_HTML)
+            .replace(/ $/g, NBSP_HTML)
+            .replace(/\r/g, '')
+            .replace(/ {2}/g, ' ' + NBSP_HTML);
+
+        if (line.includes('\t')) {
+            line = transformTabCharacters(line);
+        }
+
+        const textNode = doc.createTextNode(line);
+
+        // There are 3 scenarios:
+        // 1. Single line: Paste as it is
+        // 2. Two lines: Add <br> between the lines
+        // 3. 3 or More lines, For first and last line, paste as it is. For middle lines, wrap with DIV, and add BR if it is empty line
+        if (lines.length == 2 && index == 0) {
+            // 1 of 2 lines scenario, add BR
+            fragment.appendChild(textNode);
+            fragment.appendChild(doc.createElement('br'));
+        } else if (index > 0 && index < lines.length - 1) {
+            // Middle line of >=3 lines scenario, wrap with DIV
+            fragment.appendChild(wrap(doc, line == '' ? doc.createElement('br') : textNode, 'div'));
+        } else {
+            // All others, paste as it is
+            fragment.appendChild(textNode);
+        }
+    });
+    return fragment;
+}
+
+/**
+ * Transform \t characters into EN SPACE characters
+ * @param input string NOT containing \n characters
+ * @example t("\thello", 2) => "&ensp;&ensp;&ensp;&ensp;hello"
+ */
+function transformTabCharacters(input: string, initialOffset: number = 0) {
+    let line = input;
+    let tIndex: number;
+    while ((tIndex = line.indexOf('\t')) != -1) {
+        const lineBefore = line.slice(0, tIndex);
+        const lineAfter = line.slice(tIndex + 1);
+        const tabCount = TAB_SPACES - ((lineBefore.length + initialOffset) % TAB_SPACES);
+        const tabStr = Array(tabCount).fill(ENSP_HTML).join('');
+        line = lineBefore + tabStr + lineAfter;
+    }
+    return line;
+}

--- a/packages/roosterjs-content-model-dom/lib/domUtils/textToFragment.ts
+++ b/packages/roosterjs-content-model-dom/lib/domUtils/textToFragment.ts
@@ -4,8 +4,8 @@ const NBSP_HTML = '\u00A0';
 const ENSP_HTML = '\u2002';
 const TAB_SPACES = 6;
 /**
- * Wrap plain text content in a Document Fragment
- * @param text the text content to wrapped
+ * Wrap plain text content in a DocumentFragment
+ * @param text the text content to wrap
  * @param doc the document to create the fragment
  */
 export function textToFragment(text: string, doc: Document): DocumentFragment {

--- a/packages/roosterjs-content-model-dom/lib/index.ts
+++ b/packages/roosterjs-content-model-dom/lib/index.ts
@@ -40,6 +40,7 @@ export { reuseCachedElement } from './domUtils/reuseCachedElement';
 export { isWhiteSpacePreserved } from './domUtils/isWhiteSpacePreserved';
 export { normalizeRect } from './domUtils/normalizeRect';
 export { scrollRectIntoView } from './domUtils/scrollRectIntoView';
+export { textToFragment } from './domUtils/textToFragment';
 
 export { setLinkUndeletable, isLinkUndeletable } from './domUtils/hiddenProperties/undeletableLink';
 

--- a/packages/roosterjs-content-model-dom/test/domUtils/textToFragmentTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domUtils/textToFragmentTest.ts
@@ -1,0 +1,54 @@
+import { expectHtml } from '../testUtils';
+import { textToFragment } from '../../lib/domUtils/textToFragment';
+
+describe('textToFragment', () => {
+    function runTest(text: string, expectedHtml: string | string[]) {
+        const tempDiv = document.createElement('div');
+
+        const fragment = textToFragment(text, document);
+        tempDiv.appendChild(fragment);
+
+        expectHtml(tempDiv.innerHTML, expectedHtml);
+    }
+
+    it('empty string', () => {
+        runTest('', '');
+    });
+
+    it('single line', () => {
+        runTest('text', 'text');
+    });
+
+    it('two lines', () => {
+        runTest('line1\r\nline2', 'line1<br>line2');
+    });
+
+    it('three lines', () => {
+        runTest('line1\r\nline2\r\nline3', 'line1<div>line2</div>line3');
+    });
+
+    it('four lines', () => {
+        runTest('line1\r\nline2\r\nline3\r\nline4', 'line1<div>line2</div><div>line3</div>line4');
+    });
+
+    it('empty middle line is wrapped with br', () => {
+        runTest('line1\r\n\r\nline3', 'line1<div><br></div>line3');
+    });
+
+    it('single line with leading and trailing spaces', () => {
+        runTest('  line    1   ', '&nbsp; line &nbsp; &nbsp;1 &nbsp;&nbsp;');
+    });
+
+    it('two lines with tab characters', () => {
+        const ensp = '\u2002';
+        runTest(
+            '\tline 1\r\n  line\t2',
+            ensp.repeat(6) + 'line 1<br>&nbsp; line' + ensp.repeat(6) + '2'
+        );
+    });
+
+    it('single line with two tabs', () => {
+        const ensp = '\u2002';
+        runTest('1\t234\t5', '1' + ensp.repeat(5) + '234' + ensp.repeat(3) + '5');
+    });
+});

--- a/packages/roosterjs-content-model-plugins/lib/dragAndDrop/DragAndDropPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/dragAndDrop/DragAndDropPlugin.ts
@@ -95,13 +95,13 @@ export class DragAndDropPlugin implements EditorPlugin {
             } else if (!this.internalDrag) {
                 const html = dropEvent.dataTransfer?.getData('text/html');
                 const text = html ? undefined : dropEvent.dataTransfer?.getData('text/plain');
-                const droppedContent = html || text;
+                const droppedRoot = html || text;
 
-                if (droppedContent) {
+                if (droppedRoot) {
                     handleDroppedExternalContent(
                         this.editor,
                         dropEvent,
-                        droppedContent,
+                        droppedRoot,
                         this.forbiddenElements,
                         !!text
                     );

--- a/packages/roosterjs-content-model-plugins/lib/dragAndDrop/DragAndDropPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/dragAndDrop/DragAndDropPlugin.ts
@@ -94,12 +94,16 @@ export class DragAndDropPlugin implements EditorPlugin {
                 handleDroppedInternalContent(this.editor, dropEvent);
             } else if (!this.internalDrag) {
                 const html = dropEvent.dataTransfer?.getData('text/html');
-                if (html) {
+                const text = html ? undefined : dropEvent.dataTransfer?.getData('text/plain');
+                const droppedContent = html || text;
+
+                if (droppedContent) {
                     handleDroppedExternalContent(
                         this.editor,
                         dropEvent,
-                        html,
-                        this.forbiddenElements
+                        droppedContent,
+                        this.forbiddenElements,
+                        !!text
                     );
                 }
             }

--- a/packages/roosterjs-content-model-plugins/lib/dragAndDrop/utils/handleDroppedExternalContent.ts
+++ b/packages/roosterjs-content-model-plugins/lib/dragAndDrop/utils/handleDroppedExternalContent.ts
@@ -4,6 +4,7 @@ import {
     domToContentModel,
     getNodePositionFromEvent,
     mergeModel,
+    textToFragment,
 } from 'roosterjs-content-model-dom';
 import type { IEditor } from 'roosterjs-content-model-types';
 
@@ -14,8 +15,9 @@ import type { IEditor } from 'roosterjs-content-model-types';
 export function handleDroppedExternalContent(
     editor: IEditor,
     event: DragEvent,
-    html: string,
-    forbiddenElements: string[]
+    droppedContent: string,
+    forbiddenElements: string[],
+    isPlainText: boolean
 ): void {
     const doc = editor.getDocument();
     const domPosition = getNodePositionFromEvent(doc, editor.getDOMHelper(), event.x, event.y);
@@ -27,11 +29,16 @@ export function handleDroppedExternalContent(
         const range = doc.createRange();
         range.setStart(domPosition.node, domPosition.offset);
         range.collapse(true);
+        let droppedHTML: HTMLElement | DocumentFragment;
+        if (isPlainText) {
+            droppedHTML = textToFragment(droppedContent, doc);
+        } else {
+            const parsedHtml = editor.getDOMCreator().htmlToDOM(droppedContent);
+            cleanForbiddenElements(parsedHtml, forbiddenElements);
+            droppedHTML = parsedHtml.body;
+        }
 
-        const parsedHtml = editor.getDOMCreator().htmlToDOM(html);
-        cleanForbiddenElements(parsedHtml, forbiddenElements);
-
-        const droppedModel = domToContentModel(parsedHtml.body, createDomToModelContext());
+        const droppedModel = domToContentModel(droppedHTML, createDomToModelContext());
 
         editor.formatContentModel(
             (model, context) => {

--- a/packages/roosterjs-content-model-plugins/test/dragAndDrop/DragAndDropPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/dragAndDrop/DragAndDropPluginTest.ts
@@ -120,9 +120,13 @@ describe('DragAndDropPlugin', () => {
                 rawEvent: dropEvent,
             });
 
-            expect(handleDroppedExternalContentSpy).toHaveBeenCalledWith(editor, dropEvent, html, [
-                'iframe',
-            ]);
+            expect(handleDroppedExternalContentSpy).toHaveBeenCalledWith(
+                editor,
+                dropEvent,
+                html,
+                ['iframe'],
+                false
+            );
         });
 
         it('should use custom forbidden elements', () => {
@@ -142,10 +146,13 @@ describe('DragAndDropPlugin', () => {
                 rawEvent: dropEvent,
             });
 
-            expect(handleDroppedExternalContentSpy).toHaveBeenCalledWith(editor, dropEvent, html, [
-                'script',
-                'object',
-            ]);
+            expect(handleDroppedExternalContentSpy).toHaveBeenCalledWith(
+                editor,
+                dropEvent,
+                html,
+                ['script', 'object'],
+                false
+            );
         });
 
         it('should not call handleDroppedContent when no HTML in dataTransfer', () => {
@@ -161,6 +168,51 @@ describe('DragAndDropPlugin', () => {
             });
 
             expect(handleDroppedExternalContentSpy).not.toHaveBeenCalled();
+        });
+
+        it('should call handleDroppedContent with plain text flag when only plain text is dropped', () => {
+            const text = 'dropped plain text';
+            const dropEvent = {
+                dataTransfer: {
+                    getData: (format: string) => (format == 'text/plain' ? text : ''),
+                },
+            } as any;
+
+            plugin.onPluginEvent({
+                eventType: 'beforeDrop',
+                rawEvent: dropEvent,
+            });
+
+            expect(handleDroppedExternalContentSpy).toHaveBeenCalledWith(
+                editor,
+                dropEvent,
+                text,
+                ['iframe'],
+                true
+            );
+        });
+
+        it('should prefer HTML over plain text when both are present', () => {
+            const html = '<div>dropped html</div>';
+            const text = 'dropped plain text';
+            const dropEvent = {
+                dataTransfer: {
+                    getData: (format: string) => (format == 'text/html' ? html : text),
+                },
+            } as any;
+
+            plugin.onPluginEvent({
+                eventType: 'beforeDrop',
+                rawEvent: dropEvent,
+            });
+
+            expect(handleDroppedExternalContentSpy).toHaveBeenCalledWith(
+                editor,
+                dropEvent,
+                html,
+                ['iframe'],
+                false
+            );
         });
 
         it('should not call handleDroppedContent when dataTransfer is null', () => {
@@ -342,7 +394,8 @@ describe('DragAndDropPlugin', () => {
                 editor,
                 dropEvent,
                 html,
-                []
+                [],
+                false
             );
         });
     });

--- a/packages/roosterjs-content-model-plugins/test/dragAndDrop/utils/handleDroppedExternalContentTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/dragAndDrop/utils/handleDroppedExternalContentTest.ts
@@ -60,7 +60,7 @@ describe('handleDroppedExternalContent', () => {
             stopPropagation: stopPropagationSpy,
         } as any;
 
-        handleDroppedExternalContent(editor, event, '<p>test</p>', ['iframe']);
+        handleDroppedExternalContent(editor, event, '<p>test</p>', ['iframe'], false);
 
         expect(getNodePositionFromEventSpy).toHaveBeenCalledWith(doc, {}, 100, 200);
         expect(preventDefaultSpy).not.toHaveBeenCalled();
@@ -90,7 +90,13 @@ describe('handleDroppedExternalContent', () => {
             stopPropagation: stopPropagationSpy,
         } as any;
 
-        handleDroppedExternalContent(editor, event, '<p>dropped content</p>', ['iframe', 'script']);
+        handleDroppedExternalContent(
+            editor,
+            event,
+            '<p>dropped content</p>',
+            ['iframe', 'script'],
+            false
+        );
 
         expect(preventDefaultSpy).toHaveBeenCalled();
         expect(stopPropagationSpy).toHaveBeenCalled();
@@ -125,7 +131,7 @@ describe('handleDroppedExternalContent', () => {
             stopPropagation: jasmine.createSpy('stopPropagation'),
         } as any;
 
-        handleDroppedExternalContent(editor, event, '<span>inserted</span>', []);
+        handleDroppedExternalContent(editor, event, '<span>inserted</span>', [], false);
 
         const formatCall = formatContentModelSpy.calls.mostRecent();
         const options = formatCall.args[1];
@@ -159,10 +165,42 @@ describe('handleDroppedExternalContent', () => {
             editor,
             event,
             '<div><iframe></iframe></div>',
-            forbiddenElements
+            forbiddenElements,
+            false
         );
 
         expect(cleanForbiddenElementsSpy).toHaveBeenCalledWith(parsedDoc, forbiddenElements);
+    });
+
+    it('should insert plain text content when isPlainText is true', () => {
+        const textNode = document.createTextNode('test');
+        getNodePositionFromEventSpy.and.returnValue({
+            node: textNode,
+            offset: 0,
+        });
+
+        const preventDefaultSpy = jasmine.createSpy('preventDefault');
+        const stopPropagationSpy = jasmine.createSpy('stopPropagation');
+
+        const event = {
+            x: 100,
+            y: 200,
+            preventDefault: preventDefaultSpy,
+            stopPropagation: stopPropagationSpy,
+        } as any;
+
+        handleDroppedExternalContent(editor, event, 'plain text content', ['iframe'], true);
+
+        expect(preventDefaultSpy).toHaveBeenCalled();
+        expect(stopPropagationSpy).toHaveBeenCalled();
+        expect(htmlToDOMSpy).not.toHaveBeenCalled();
+        expect(cleanForbiddenElementsSpy).not.toHaveBeenCalled();
+        expect(formatContentModelSpy).toHaveBeenCalled();
+
+        const formatCall = formatContentModelSpy.calls.mostRecent();
+        const options = formatCall.args[1];
+        expect(options.selectionOverride.type).toBe('range');
+        expect(options.selectionOverride.isReverted).toBe(false);
     });
 
     it('should handle empty forbidden elements list', () => {
@@ -183,7 +221,7 @@ describe('handleDroppedExternalContent', () => {
             stopPropagation: jasmine.createSpy('stopPropagation'),
         } as any;
 
-        handleDroppedExternalContent(editor, event, '<p>content</p>', []);
+        handleDroppedExternalContent(editor, event, '<p>content</p>', [], false);
 
         expect(cleanForbiddenElementsSpy).toHaveBeenCalledWith(parsedDoc, []);
         expect(formatContentModelSpy).toHaveBeenCalled();
@@ -242,7 +280,7 @@ describe('handleDroppedExternalContent - model verification', () => {
             stopPropagation: jasmine.createSpy('stopPropagation'),
         } as any;
 
-        handleDroppedExternalContent(editor, event, '<p>dropped text</p>', []);
+        handleDroppedExternalContent(editor, event, '<p>dropped text</p>', [], false);
 
         // Create a model to merge into
         const model = createContentModelDocument();
@@ -292,7 +330,7 @@ describe('handleDroppedExternalContent - model verification', () => {
             stopPropagation: jasmine.createSpy('stopPropagation'),
         } as any;
 
-        handleDroppedExternalContent(editor, event, '<p><b>bold text</b></p>', []);
+        handleDroppedExternalContent(editor, event, '<p><b>bold text</b></p>', [], false);
 
         // Create initial model with selection
         const model = createContentModelDocument();
@@ -341,7 +379,7 @@ describe('handleDroppedExternalContent - model verification', () => {
             stopPropagation: jasmine.createSpy('stopPropagation'),
         } as any;
 
-        handleDroppedExternalContent(editor, event, '<p>new content</p>', []);
+        handleDroppedExternalContent(editor, event, '<p>new content</p>', [], false);
 
         // Create model with existing text
         const model = createContentModelDocument();
@@ -397,7 +435,8 @@ describe('handleDroppedExternalContent - model verification', () => {
             editor,
             event,
             '<p>safe content</p><iframe src="bad.com"></iframe>',
-            ['iframe']
+            ['iframe'],
+            false
         );
 
         // Create model
@@ -462,7 +501,8 @@ describe('handleDroppedExternalContent - model verification', () => {
             editor,
             event,
             '<p>first paragraph</p><p>second paragraph</p>',
-            []
+            [],
+            false
         );
 
         // Create model
@@ -491,5 +531,51 @@ describe('handleDroppedExternalContent - model verification', () => {
 
         expect(allText.some(text => text === 'first paragraph')).toBe(true);
         expect(allText.some(text => text === 'second paragraph')).toBe(true);
+    });
+
+    it('should merge dropped plain text into model when isPlainText is true', () => {
+        const textNode = document.createTextNode('existing');
+        getNodePositionFromEventSpy.and.returnValue({
+            node: textNode,
+            offset: 0,
+        });
+
+        const event = {
+            x: 0,
+            y: 0,
+            preventDefault: jasmine.createSpy('preventDefault'),
+            stopPropagation: jasmine.createSpy('stopPropagation'),
+        } as any;
+
+        handleDroppedExternalContent(editor, event, 'plain dropped text', ['iframe'], true);
+
+        // htmlToDOM should not be used for plain text
+        expect(htmlToDOMSpy).not.toHaveBeenCalled();
+
+        // Create a model to merge into
+        const model = createContentModelDocument();
+        const para = createParagraph();
+        para.segments.push(createSelectionMarker());
+        model.blocks.push(para);
+
+        // Execute the captured callback
+        expect(capturedCallback).not.toBeNull();
+        const result = capturedCallback!(model, {});
+
+        expect(result).toBe(true);
+
+        // Find text segments in the model
+        const textSegments: ContentModelText[] = [];
+        model.blocks.forEach(block => {
+            if (block.blockType === 'Paragraph') {
+                (block as ContentModelParagraph).segments.forEach(segment => {
+                    if (segment.segmentType === 'Text') {
+                        textSegments.push(segment as ContentModelText);
+                    }
+                });
+            }
+        });
+
+        expect(textSegments.some(seg => seg.text === 'plain dropped text')).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary

Support dropping external plain-text content when no HTML representation is available, while continuing to prefer HTML when both formats exist. Extract plain-text conversion into the shared `textToFragment` DOM utility so paste and drag-and-drop paths preserve line breaks, spaces, and tabs consistently.
<img width="886" height="834" alt="DragAndDropPlainText" src="https://github.com/user-attachments/assets/5c6d9c75-3823-4362-a365-8c2585d4c321" />

## How to test

1. Run `yarn test:fast --testPathPattern="textToFragment|DragAndDropPlugin|handleDroppedExternalContent"`.
2. Drag plain text from an external application into the editor and verify it is inserted at the drop position with line breaks and whitespace preserved; when the drag payload also contains HTML, verify the formatted HTML is inserted instead.
