### PR TITLE
Fix markdown horizontal rule detection

### DIFF
--- a/packages/roosterjs-content-model-markdown/lib/publicApi/isContentMarkdown.ts
+++ b/packages/roosterjs-content-model-markdown/lib/publicApi/isContentMarkdown.ts
@@ -4,7 +4,7 @@ const BlockPatterns: RegExp[] = [
     /^\s*>\s.+/, // blockquote: "> text"
     /^\s*[\*\-\+]\s.+/, // unordered list: "- item", "* item", "+ item"
     /^\s*\d+\.\s.+/, // ordered list: "1. item"
-    /^---+$/, // horizontal rule: "---"
+    /^---$/, // horizontal rule: "---"
     /^\s*\|.*\|\s*$/, // table row: "| a | b |"
 ];
 

--- a/packages/roosterjs-content-model-markdown/test/publicApi/isContentMarkdownTest.ts
+++ b/packages/roosterjs-content-model-markdown/test/publicApi/isContentMarkdownTest.ts
@@ -61,6 +61,10 @@ describe('isContentMarkdown', () => {
         runTest('---', true);
     });
 
+    it('should not detect more than three dashes as a horizontal rule', () => {
+        runTest('----', false);
+    });
+
     it('should detect table row', () => {
         runTest('| col1 | col2 |', true);
     });


### PR DESCRIPTION
## Summary

Update `isContentMarkdown` to recognize only exactly three dashes as a Markdown horizontal rule. This prevents four or more dashes from being classified as Markdown content and adds a regression test for the behavior.
<img width="523" height="348" alt="MarkdownPasteConversion" src="https://github.com/user-attachments/assets/d1266482-df2a-47ff-a678-0bf5a70547b5" />


## How to test

1. Verify `isContentMarkdown('---')` returns `true`, while `isContentMarkdown('----')` returns `false`.
