### PR TITLE
[Drag and Drop] Fix list reordering

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/dragAndDrop/utils/handleDroppedInternalContent.ts
+++ b/packages/roosterjs-content-model-plugins/lib/dragAndDrop/utils/handleDroppedInternalContent.ts
@@ -11,6 +11,7 @@ import {
     trimModelForSelection,
 } from 'roosterjs-content-model-dom';
 import type { IEditor } from 'roosterjs-content-model-types';
+import { reorderList } from './reorderList';
 
 /**
  * @internal
@@ -30,7 +31,7 @@ export function handleDroppedInternalContent(editor: IEditor, event: DragEvent):
                 trimModelForSelection(cloneModel, selection);
 
                 if (!event.ctrlKey && !event.metaKey) {
-                    if (deleteSelection(model, [], context).deleteResult == 'range') {
+                    if (deleteSelection(model, [reorderList], context).deleteResult == 'range') {
                         normalizeContentModel(model);
                     }
                 }

--- a/packages/roosterjs-content-model-plugins/lib/dragAndDrop/utils/reorderList.ts
+++ b/packages/roosterjs-content-model-plugins/lib/dragAndDrop/utils/reorderList.ts
@@ -1,0 +1,21 @@
+import { getListItemFromInsertPoint } from '../../edit/utils/getListItemFromInsertPoint';
+import { mutateBlock } from 'roosterjs-content-model-dom';
+import type { DeleteSelectionStep } from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ */
+export const reorderList: DeleteSelectionStep = context => {
+    if (context.deleteResult != 'range') {
+        return;
+    }
+
+    const { paragraph } = context.insertPoint;
+    const listItemAndParent = getListItemFromInsertPoint(context.insertPoint);
+
+    if (listItemAndParent) {
+        const [item] = listItemAndParent;
+        const mutableList = mutateBlock(item);
+        mutableList.blocks.splice(mutableList.blocks.indexOf(paragraph), mutableList.blocks.length);
+    }
+};

--- a/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteList.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteList.ts
@@ -1,13 +1,6 @@
-import {
-    createListItem,
-    getClosestAncestorBlockGroupIndex,
-    mutateBlock,
-} from 'roosterjs-content-model-dom';
-import type {
-    DeleteSelectionStep,
-    ContentModelListItem,
-    ContentModelBlock,
-} from 'roosterjs-content-model-types';
+import { getListItemFromInsertPoint } from '../utils/getListItemFromInsertPoint';
+import { createListItem, mutateBlock } from 'roosterjs-content-model-dom';
+import type { DeleteSelectionStep, ContentModelBlock } from 'roosterjs-content-model-types';
 
 /**
  * @internal
@@ -17,21 +10,11 @@ export const deleteList: DeleteSelectionStep = context => {
         return;
     }
 
-    const { paragraph, marker, path } = context.insertPoint;
-    const index = getClosestAncestorBlockGroupIndex<ContentModelListItem>(
-        path,
-        ['ListItem'],
-        ['TableCell', 'FormatContainer']
-    );
-    const item = path[index];
-    const parent = path[index + 1];
+    const { paragraph } = context.insertPoint;
+    const listItemAndParent = getListItemFromInsertPoint(context.insertPoint);
 
-    if (
-        item?.blockGroupType == 'ListItem' &&
-        item.levels.length > 0 &&
-        paragraph.segments[0] == marker &&
-        parent
-    ) {
+    if (listItemAndParent) {
+        const [item, parent] = listItemAndParent;
         const mutableList = mutateBlock(item);
         const lastLevel = mutableList.levels[mutableList.levels.length - 1];
         const listItemIndex = parent.blocks.indexOf(item);

--- a/packages/roosterjs-content-model-plugins/lib/edit/utils/getListItemFromInsertPoint.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/utils/getListItemFromInsertPoint.ts
@@ -1,0 +1,30 @@
+import { getClosestAncestorBlockGroupIndex } from 'roosterjs-content-model-dom';
+import type {
+    ContentModelBlockGroup,
+    InsertPoint,
+    ReadonlyContentModelBlockGroup,
+    ReadonlyContentModelListItem,
+} from 'roosterjs-content-model-types';
+
+/**
+ * @internal
+ */
+export function getListItemFromInsertPoint(
+    insertPoint: InsertPoint
+): [ReadonlyContentModelListItem, ReadonlyContentModelBlockGroup] | null {
+    const { paragraph, marker, path } = insertPoint;
+    const index = getClosestAncestorBlockGroupIndex<ContentModelBlockGroup>(
+        path,
+        ['ListItem'],
+        ['TableCell', 'FormatContainer']
+    );
+    const item = path[index];
+    const parent = path[index + 1];
+
+    return item?.blockGroupType == 'ListItem' &&
+        item.levels.length > 0 &&
+        paragraph.segments[0] == marker &&
+        parent
+        ? [item, parent]
+        : null;
+}

--- a/packages/roosterjs-content-model-plugins/test/dragAndDrop/utils/handleDroppedInternalContentTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/dragAndDrop/utils/handleDroppedInternalContentTest.ts
@@ -17,14 +17,18 @@ import {
     InsertPoint,
 } from 'roosterjs-content-model-types';
 import {
+    createBr,
     createContentModelDocument,
     createEntity,
+    createListItem,
+    createListLevel,
     createParagraph,
     createSelectionMarker,
     createTable,
     createTableCell,
     createText,
 } from 'roosterjs-content-model-dom';
+import { reorderList } from '../../../lib/dragAndDrop/utils/reorderList';
 
 describe('handleDroppedInternalContent', () => {
     let editor: IEditor;
@@ -1004,6 +1008,6 @@ describe('handleDroppedInternalContent - ctrl key', () => {
     it('should delete the original selection when ctrl key is not pressed', () => {
         const model = runWithCtrlKey(false);
 
-        expect(deleteSelectionSpy).toHaveBeenCalledWith(model, [], jasmine.anything());
+        expect(deleteSelectionSpy).toHaveBeenCalledWith(model, [reorderList], jasmine.anything());
     });
 });

--- a/packages/roosterjs-content-model-plugins/test/dragAndDrop/utils/handleDroppedInternalContentTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/dragAndDrop/utils/handleDroppedInternalContentTest.ts
@@ -461,6 +461,62 @@ describe('handleDroppedInternalContent - model verification', () => {
         expect(allText.some(text => text === 'second paragraph')).toBe(true);
     });
 
+    it('should reorder list items when moving a list item out of the list', () => {
+        const textNode = document.createTextNode('existing');
+        getNodePositionFromEventSpy.and.returnValue({
+            node: textNode,
+            offset: 0,
+        });
+
+        const droppedModel = createContentModelDocument();
+        const droppedListItem = createListItem([createListLevel('UL')]);
+        const droppedParagraph = createParagraph();
+
+        droppedParagraph.segments.push(createText('item 2'));
+        droppedListItem.blocks.push(droppedParagraph);
+        droppedModel.blocks.push(droppedListItem);
+        cloneModelForPasteSpy.and.returnValue(droppedModel);
+
+        const event = {
+            x: 0,
+            y: 0,
+            preventDefault: jasmine.createSpy('preventDefault'),
+            stopPropagation: jasmine.createSpy('stopPropagation'),
+        } as any;
+
+        handleDroppedInternalContent(editor, event);
+
+        expect(capturedCallback).not.toBeNull();
+
+        const model = createContentModelDocument();
+        const firstListItem = createListItem([createListLevel('UL')]);
+        const secondListItem = createListItem([createListLevel('UL')]);
+        const firstParagraph = createParagraph();
+        const secondParagraph = createParagraph();
+        const targetParagraph = createParagraph();
+        const marker = createSelectionMarker();
+        const selectedText = createText('item 2');
+
+        marker.isSelected = false;
+        selectedText.isSelected = true;
+        firstParagraph.segments.push(createText('item 1'));
+        secondParagraph.segments.push(selectedText);
+        targetParagraph.segments.push(createText('outside list'), marker, createBr());
+        firstListItem.blocks.push(firstParagraph);
+        secondListItem.blocks.push(secondParagraph);
+        model.blocks.push(firstListItem, secondListItem, targetParagraph);
+
+        const insertPoint: InsertPoint = {
+            marker,
+            paragraph: targetParagraph,
+            path: [model],
+        };
+
+        capturedCallback!(model, createMergeContext(), insertPoint);
+
+        expect(getAllTextDeep(model)).toEqual(['item 1', 'outside list', 'item 2']);
+    });
+
     it('should set selection after merging dropped content', () => {
         const textNode = document.createTextNode('existing');
         getNodePositionFromEventSpy.and.returnValue({

--- a/packages/roosterjs-content-model-plugins/test/dragAndDrop/utils/reorderListTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/dragAndDrop/utils/reorderListTest.ts
@@ -1,0 +1,88 @@
+import { reorderList } from '../../../lib/dragAndDrop/utils/reorderList';
+import {
+    createContentModelDocument,
+    createListItem,
+    createListLevel,
+    createParagraph,
+    createSelectionMarker,
+    createText,
+} from 'roosterjs-content-model-dom';
+import type { ValidDeleteSelectionContext } from 'roosterjs-content-model-types';
+
+describe('reorderList', () => {
+    it('removes the selected paragraph and following blocks from the list item', () => {
+        const document = createContentModelDocument();
+        const listItem = createListItem([createListLevel('UL')]);
+        const paragraphBefore = createParagraph();
+        const selectedParagraph = createParagraph();
+        const paragraphAfter = createParagraph();
+        const marker = createSelectionMarker();
+        const context: ValidDeleteSelectionContext = {
+            deleteResult: 'range',
+            insertPoint: {
+                marker,
+                paragraph: selectedParagraph,
+                path: [listItem, document],
+            },
+        };
+
+        paragraphBefore.segments.push(createText('before'));
+        selectedParagraph.segments.push(marker, createText('selected'));
+        paragraphAfter.segments.push(createText('after'));
+        listItem.blocks.push(paragraphBefore, selectedParagraph, paragraphAfter);
+        document.blocks.push(listItem);
+
+        reorderList(context);
+
+        expect(listItem.blocks).toEqual([paragraphBefore]);
+        expect(context.deleteResult).toBe('range');
+    });
+
+    it('does nothing when delete result is not range', () => {
+        const document = createContentModelDocument();
+        const listItem = createListItem([createListLevel('UL')]);
+        const paragraph = createParagraph();
+        const marker = createSelectionMarker();
+        const context: ValidDeleteSelectionContext = {
+            deleteResult: 'notDeleted',
+            insertPoint: {
+                marker,
+                paragraph,
+                path: [listItem, document],
+            },
+        };
+
+        paragraph.segments.push(marker, createText('test'));
+        listItem.blocks.push(paragraph);
+        document.blocks.push(listItem);
+
+        reorderList(context);
+
+        expect(listItem.blocks).toEqual([paragraph]);
+        expect(context.deleteResult).toBe('notDeleted');
+    });
+
+    it('does nothing when marker is not at the beginning of the paragraph', () => {
+        const document = createContentModelDocument();
+        const listItem = createListItem([createListLevel('UL')]);
+        const paragraph = createParagraph();
+        const marker = createSelectionMarker();
+        const context: ValidDeleteSelectionContext = {
+            deleteResult: 'range',
+            insertPoint: {
+                marker,
+                paragraph,
+                path: [listItem, document],
+            },
+        };
+
+        paragraph.segments.push(createText('test'), marker);
+        listItem.blocks.push(paragraph);
+        document.blocks.push(listItem);
+
+        reorderList(context);
+
+        expect(listItem.blocks).toEqual([paragraph]);
+        expect(context.deleteResult).toBe('range');
+    });
+});

--- a/packages/roosterjs-content-model-plugins/test/edit/utils/getListItemFromInsertPointTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/utils/getListItemFromInsertPointTest.ts
@@ -1,0 +1,87 @@
+import { getListItemFromInsertPoint } from '../../../lib/edit/utils/getListItemFromInsertPoint';
+import {
+    createContentModelDocument,
+    createFormatContainer,
+    createListItem,
+    createListLevel,
+    createParagraph,
+    createSelectionMarker,
+    createText,
+} from 'roosterjs-content-model-dom';
+import type { InsertPoint } from 'roosterjs-content-model-types';
+
+describe('getListItemFromInsertPoint', () => {
+    it('returns the list item and its parent when marker is at the beginning', () => {
+        const document = createContentModelDocument();
+        const listItem = createListItem([createListLevel('UL')]);
+        const paragraph = createParagraph();
+        const marker = createSelectionMarker();
+        const insertPoint: InsertPoint = {
+            marker,
+            paragraph,
+            path: [listItem, document],
+        };
+
+        paragraph.segments.push(marker, createText('test'));
+        listItem.blocks.push(paragraph);
+        document.blocks.push(listItem);
+
+        expect(getListItemFromInsertPoint(insertPoint)).toEqual([listItem, document]);
+    });
+
+    it('returns null when marker is not at the beginning', () => {
+        const document = createContentModelDocument();
+        const listItem = createListItem([createListLevel('UL')]);
+        const paragraph = createParagraph();
+        const marker = createSelectionMarker();
+        const insertPoint: InsertPoint = {
+            marker,
+            paragraph,
+            path: [listItem, document],
+        };
+
+        paragraph.segments.push(createText('test'), marker);
+        listItem.blocks.push(paragraph);
+        document.blocks.push(listItem);
+
+        expect(getListItemFromInsertPoint(insertPoint)).toBeNull();
+    });
+
+    it('returns null when list item has no levels', () => {
+        const document = createContentModelDocument();
+        const listItem = createListItem([]);
+        const paragraph = createParagraph();
+        const marker = createSelectionMarker();
+        const insertPoint: InsertPoint = {
+            marker,
+            paragraph,
+            path: [listItem, document],
+        };
+
+        paragraph.segments.push(marker);
+        listItem.blocks.push(paragraph);
+        document.blocks.push(listItem);
+
+        expect(getListItemFromInsertPoint(insertPoint)).toBeNull();
+    });
+
+    it('does not find a list item across a format container boundary', () => {
+        const document = createContentModelDocument();
+        const listItem = createListItem([createListLevel('UL')]);
+        const container = createFormatContainer('blockquote');
+        const paragraph = createParagraph();
+        const marker = createSelectionMarker();
+        const insertPoint: InsertPoint = {
+            marker,
+            paragraph,
+            path: [container, listItem, document],
+        };
+
+        paragraph.segments.push(marker);
+        container.blocks.push(paragraph);
+        listItem.blocks.push(container);
+        document.blocks.push(listItem);
+
+        expect(getListItemFromInsertPoint(insertPoint)).toBeNull();
+    });
+});

--- a/packages/roosterjs-react/lib/ribbon/buttons/numberedListButton.ts
+++ b/packages/roosterjs-react/lib/ribbon/buttons/numberedListButton.ts
@@ -11,6 +11,6 @@ export const numberedListButton: RibbonButton<NumberedListButtonStringKey> = {
     iconName: 'NumberedList',
     isChecked: formatState => !!formatState.isNumbering,
     onClick: editor => {
-        toggleNumbering(editor);
+        toggleNumbering(editor, true /* removeLisMargins */);
     },
 };


### PR DESCRIPTION
## Summary

Preserve list structure when moving internal content by removing the moved paragraph and following blocks from their original list item. Share list-item lookup logic with the existing delete-list step and remove list margins when applying numbering from the ribbon.
Before: 
<img width="310" height="331" alt="BugDragList" src="https://github.com/user-attachments/assets/22521215-e859-421b-b9b9-c5361a4795d6" />

After: 
<img width="310" height="331" alt="FixDragList" src="https://github.com/user-attachments/assets/5da3526a-241e-4177-a561-7faeb9e7a56a" />


## How to test
Drag list content to a new position without holding Ctrl or Command and verify the content moves without leaving duplicate or trailing list blocks behind.
