### PR TITLE
Fix Safari focus after Command+Delete in list items

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteAllSegmentBefore.ts
+++ b/packages/roosterjs-content-model-plugins/lib/edit/deleteSteps/deleteAllSegmentBefore.ts
@@ -1,4 +1,4 @@
-import { deleteSegment, mutateBlock } from 'roosterjs-content-model-dom';
+import { createBr, deleteSegment, mutateBlock } from 'roosterjs-content-model-dom';
 import type { DeleteSelectionStep } from 'roosterjs-content-model-types';
 
 /**
@@ -21,5 +21,9 @@ export const deleteAllSegmentBefore: DeleteSelectionStep = context => {
         if (deleteSegment(paragraph, segment, context.formatContext)) {
             context.deleteResult = 'range';
         }
+    }
+
+    if (mutableParagraph.segments.length == 1 && mutableParagraph.segments[0] == marker) {
+        mutableParagraph.segments.push(createBr(marker.format));
     }
 };

--- a/packages/roosterjs-content-model-plugins/test/edit/deleteSteps/deleteAllSegmentBeforeTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/edit/deleteSteps/deleteAllSegmentBeforeTest.ts
@@ -1,0 +1,32 @@
+import {
+    createBr,
+    createContentModelDocument,
+    createListItem,
+    createListLevel,
+    createParagraph,
+    createSelectionMarker,
+    createText,
+    deleteSelection,
+    normalizeContentModel,
+} from 'roosterjs-content-model-dom';
+import { deleteAllSegmentBefore } from '../../../lib/edit/deleteSteps/deleteAllSegmentBefore';
+
+describe('deleteAllSegmentBefore', () => {
+    it('keeps an implicit list paragraph focusable after deleting all content', () => {
+        const model = createContentModelDocument();
+        const listItem = createListItem([createListLevel('UL')]);
+        const paragraph = createParagraph(true /*isImplicit*/);
+        const marker = createSelectionMarker();
+
+        paragraph.segments.push(createText('text'), marker);
+        listItem.blocks.push(paragraph);
+        model.blocks.push(listItem);
+
+        const result = deleteSelection(model, [deleteAllSegmentBefore]);
+        normalizeContentModel(model);
+
+        expect(result.deleteResult).toBe('range');
+        expect(model.blocks).toEqual([listItem]);
+        expect(paragraph.segments).toEqual([marker, createBr()]);
+    });
+});


### PR DESCRIPTION
## Summary

Keep an implicit list paragraph focusable after Command+Delete removes all content before the caret. The delete step now adds a formatted `Br` when only the selection marker remains, preventing Safari from producing an empty list item that cannot be focused or edited again.

Add a regression test covering the delete and normalization path.

## Minimal repro

```html
<ul>
	<li>Text</li>
</ul>
```

In Safari:

1. Load the HTML into the editor and place the caret after `Text`.
2. Press Command+Delete.
3. Click the now-empty list item and type `X`.

Before this fix, Safari cannot focus the empty list item and `X` is not inserted there. After this fix, the list item contains a focusable `<br>` and `X` is inserted into the same item.

## How to test

1. Run `yarn test:fast --testPathPattern='deleteAllSegmentBeforeTest|keyboardDeleteTest'`.
2. Repeat the minimal repro in Safari and verify the empty list item remains focusable and editable after Command+Delete.
