### PR TITLE
Fix publish workflow install failure by removing registry-url from setup-node

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ jobs:
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
                   node-version: '24'
-                  registry-url: 'https://registry.npmjs.org'
 
             - name: Install dependencies
               run: yarn


### PR DESCRIPTION
## Summary

The `Publish` workflow was failing at the `Install dependencies` step with `error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}`. The cause was `registry-url: 'https://registry.npmjs.org'` on the `setup-node` step, which makes `setup-node` generate a user-level `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. During `yarn` install there is no `NODE_AUTH_TOKEN` in the environment, so Yarn Classic fails trying to expand it.

This removes `registry-url` from the `setup-node` step in `.github/workflows/publish.yml`, matching the working `Build and Test` workflow. Authentication for publishing is unaffected: `tools/buildTools/publish.js` already writes its own temporary `.npmrc` (registry + `--token`) per package at publish time, so it never needed `setup-node`'s `registry-url`.

## How to test

1. Run `yarn test:fast` to confirm existing tests still pass.
2. On a push to the `release` branch, the `Publish` workflow's `Install dependencies` step (`yarn`) now completes instead of failing with `Failed to replace env in config: ${NODE_AUTH_TOKEN}`, then proceeds to `Build` and `Publish`.
   - Before this fix: `yarn` install aborts with exit code 1 during the Publish workflow.
   - After this fix: `yarn` install succeeds using the project `.npmrc`, exactly like the Build and Test workflow.
