### PR TITLE
Support partial shortcut overrides in ShortcutPlugin

### DIFF
--- a/packages/roosterjs-content-model-plugins/lib/index.ts
+++ b/packages/roosterjs-content-model-plugins/lib/index.ts
@@ -26,7 +26,11 @@ export {
     ShortcutIndentList,
     ShortcutOutdentList,
 } from './shortcut/shortcuts';
-export { ShortcutPlugin } from './shortcut/ShortcutPlugin';
+export {
+    ShortcutPlugin,
+    ShortcutPluginOptions,
+    DefaultShortcutCommandName,
+} from './shortcut/ShortcutPlugin';
 export { ShortcutKeyDefinition, ShortcutCommand } from './shortcut/ShortcutCommand';
 export { ContextMenuPluginBase, ContextMenuOptions } from './contextMenuBase/ContextMenuPluginBase';
 export { WatermarkPlugin } from './watermark/WatermarkPlugin';

--- a/packages/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
+++ b/packages/roosterjs-content-model-plugins/lib/shortcut/ShortcutPlugin.ts
@@ -24,24 +24,84 @@ import type {
     PluginEvent,
 } from 'roosterjs-content-model-types';
 
-const defaultShortcuts: ShortcutCommand[] = [
-    ShortcutBold,
-    ShortcutItalic,
-    ShortcutUnderline,
-    ShortcutClearFormat,
-    ShortcutUndo,
-    ShortcutUndo2,
-    ShortcutRedo,
-    ShortcutRedoAlt,
-    ShortcutRedoMacOS,
-    ShortcutBullet,
-    ShortcutNumbering,
-    ShortcutIncreaseFont,
-    ShortcutDecreaseFont,
-    ShortcutIndentList,
-    ShortcutOutdentList,
-];
+/**
+ * Names of the built-in shortcut commands that can be overridden.
+ */
+export type DefaultShortcutCommandName =
+    | 'bold'
+    | 'italic'
+    | 'underline'
+    | 'clearFormat'
+    | 'undo'
+    | 'undo2'
+    | 'redo'
+    | 'redoAlt'
+    | 'redoMacOS'
+    | 'bullet'
+    | 'numbering'
+    | 'increaseFont'
+    | 'decreaseFont'
+    | 'indentList'
+    | 'outdentList';
+
+/**
+ * Built-in shortcut commands in matching order. Add new commands to
+ * DefaultShortcutCommandName and this map; the first matching command wins.
+ */
+const defaultShortcutCommands: Readonly<Record<DefaultShortcutCommandName, ShortcutCommand>> = {
+    bold: ShortcutBold,
+    italic: ShortcutItalic,
+    underline: ShortcutUnderline,
+    clearFormat: ShortcutClearFormat,
+    undo: ShortcutUndo,
+    undo2: ShortcutUndo2,
+    redo: ShortcutRedo,
+    redoAlt: ShortcutRedoAlt,
+    redoMacOS: ShortcutRedoMacOS,
+    bullet: ShortcutBullet,
+    numbering: ShortcutNumbering,
+    increaseFont: ShortcutIncreaseFont,
+    decreaseFont: ShortcutDecreaseFont,
+    indentList: ShortcutIndentList,
+    outdentList: ShortcutOutdentList,
+};
+const defaultShortcutCommandNames = Object.keys(
+    defaultShortcutCommands
+) as DefaultShortcutCommandName[];
+const defaultShortcutCommandList: readonly ShortcutCommand[] = defaultShortcutCommandNames.map(
+    name => defaultShortcutCommands[name]
+);
 const CommandCacheKey = '__ShortcutCommandCache';
+
+/**
+ * Options for ShortcutPlugin.
+ */
+export interface ShortcutPluginOptions {
+    /**
+     * Override keys for selected built-in commands while preserving all other defaults.
+     */
+    shortcutOverrides?: Partial<Record<DefaultShortcutCommandName, ShortcutKeyDefinition>>;
+}
+
+function createShortcutCommands(
+    shortcutOverrides?: ShortcutPluginOptions['shortcutOverrides']
+): readonly ShortcutCommand[] {
+    if (!shortcutOverrides) {
+        return defaultShortcutCommandList;
+    }
+
+    return defaultShortcutCommandNames.map(name => {
+        const command = defaultShortcutCommands[name];
+        const shortcutKey = shortcutOverrides[name];
+
+        return shortcutKey
+            ? {
+                  ...command,
+                  shortcutKey,
+              }
+            : command;
+    });
+}
 
 /**
  * Shortcut plugin hook on the specified shortcut keys and trigger related format API
@@ -49,12 +109,21 @@ const CommandCacheKey = '__ShortcutCommandCache';
 export class ShortcutPlugin implements EditorPlugin {
     private editor: IEditor | null = null;
     private isMac = false;
+    private readonly shortcuts: readonly ShortcutCommand[];
 
     /**
-     * Create a new instance of ShortcutPlugin
-     * @param [shortcuts=defaultShortcuts] Allowed commands
+     * Create a plugin with a complete custom command list.
      */
-    constructor(private shortcuts: ShortcutCommand[] = defaultShortcuts) {}
+    constructor(shortcuts: ShortcutCommand[]);
+    /**
+     * Create a plugin with built-in shortcuts and optional partial overrides.
+     */
+    constructor(options?: ShortcutPluginOptions);
+    constructor(shortcutsOrOptions: ShortcutCommand[] | ShortcutPluginOptions = {}) {
+        this.shortcuts = Array.isArray(shortcutsOrOptions)
+            ? shortcutsOrOptions
+            : createShortcutCommands(shortcutsOrOptions.shortcutOverrides);
+    }
 
     /**
      * Get name of this plugin
@@ -126,11 +195,11 @@ export class ShortcutPlugin implements EditorPlugin {
             }
             return (
                 editor &&
-                this.shortcuts.filter(
+                this.shortcuts.find(
                     command =>
                         this.matchOS(command.environment) &&
                         this.matchShortcut(command.shortcutKey, event.rawEvent)
-                )[0]
+                )
             );
         });
     }

--- a/packages/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
+++ b/packages/roosterjs-content-model-plugins/test/shortcut/ShortcutPluginTest.ts
@@ -9,6 +9,7 @@ import * as toggleNumbering from 'roosterjs-content-model-api/lib/publicApi/list
 import * as toggleUnderline from 'roosterjs-content-model-api/lib/publicApi/segment/toggleUnderline';
 import * as undo from 'roosterjs-content-model-core/lib/command/undo/undo';
 import { EditorEnvironment, IEditor, PluginEvent } from 'roosterjs-content-model-types';
+import type { ShortcutCommand } from '../../lib/shortcut/ShortcutCommand';
 import { ShortcutPlugin } from '../../lib/shortcut/ShortcutPlugin';
 
 const enum Keys {
@@ -17,6 +18,7 @@ const enum Keys {
     A = 65,
     B = 66,
     I = 73,
+    N = 78,
     U = 85,
     Y = 89,
     Z = 90,
@@ -58,6 +60,84 @@ describe('ShortcutPlugin', () => {
     }
 
     describe('Windows', () => {
+        it('uses a custom command list instead of the built-in shortcuts', () => {
+            const boldSpy = spyOn(toggleBold, 'toggleBold');
+            const customCommandSpy = jasmine.createSpy('customCommand');
+            const customCommands: ShortcutCommand[] = [
+                {
+                    shortcutKey: {
+                        modifierKey: 'ctrl',
+                        shiftKey: false,
+                        which: Keys.A,
+                    },
+                    onClick: customCommandSpy,
+                },
+            ];
+            const plugin = new ShortcutPlugin(customCommands);
+            const customEvent: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent(Keys.A, true, false, false, false),
+            };
+            const boldEvent: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent(Keys.B, true, false, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            expect(plugin.willHandleEventExclusively(customEvent)).toBe(true);
+            plugin.onPluginEvent(customEvent);
+            expect(customCommandSpy).toHaveBeenCalledWith(mockedEditor);
+
+            expect(plugin.willHandleEventExclusively(boldEvent)).toBe(false);
+            plugin.onPluginEvent(boldEvent);
+            expect(boldSpy).not.toHaveBeenCalled();
+        });
+
+        it('partially overrides a built-in shortcut and preserves other defaults', () => {
+            const boldSpy = spyOn(toggleBold, 'toggleBold');
+            const italicSpy = spyOn(toggleItalic, 'toggleItalic');
+            const plugin = new ShortcutPlugin({
+                shortcutOverrides: {
+                    bold: {
+                        modifierKey: 'ctrl',
+                        shiftKey: false,
+                        which: Keys.N,
+                    },
+                },
+            });
+            const oldBoldEvent: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent(Keys.B, true, false, false, false),
+            };
+            const newBoldEvent: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent(Keys.N, true, false, false, false),
+            };
+            const italicEvent: PluginEvent = {
+                eventType: 'keyDown',
+                rawEvent: createMockedEvent(Keys.I, true, false, false, false),
+            };
+
+            plugin.initialize(mockedEditor);
+
+            expect(plugin.willHandleEventExclusively(oldBoldEvent)).toBe(false);
+            plugin.onPluginEvent(oldBoldEvent);
+            expect(boldSpy).not.toHaveBeenCalled();
+
+            expect(plugin.willHandleEventExclusively(newBoldEvent)).toBe(true);
+            plugin.onPluginEvent(newBoldEvent);
+            expect(boldSpy).toHaveBeenCalledWith(mockedEditor, {
+                announceFormatChange: true,
+            });
+
+            expect(plugin.willHandleEventExclusively(italicEvent)).toBe(true);
+            plugin.onPluginEvent(italicEvent);
+            expect(italicSpy).toHaveBeenCalledWith(mockedEditor, {
+                announceFormatChange: true,
+            });
+        });
+
         it('not a shortcut', () => {
             const apiSpy = spyOn(toggleBold, 'toggleBold');
             const plugin = new ShortcutPlugin();


### PR DESCRIPTION
Adds partial override support to `ShortcutPlugin`, allowing consumers to customize selected built-in shortcut keys without replacing the complete command list.

```ts
new ShortcutPlugin({
    shortcutOverrides: {
        bold: {
            modifierKey: 'ctrl',
            shiftKey: false,
            which: 78,
        },
    },
});
```
An override changes only the selected command's shortcut key. Its callback, environment, command identity, matching order, and all unaffected default shortcuts remain unchanged.

Backward compatibility

•  new ShortcutPlugin()  continues to use all built-in shortcuts.
•  new ShortcutPlugin(undefined)  continues to use all built-in shortcuts.
• Passing a  ShortcutCommand[]  continues to replace the complete built-in command list.
• Existing shortcut matching behavior and precedence are preserved.

API changes

Exports:

•  ShortcutPluginOptions 
•  DefaultShortcutCommandName 