### PR TITLE
Add default strikethrough style for del elements

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/config/defaultHTMLStyleMap.ts
+++ b/packages/roosterjs-content-model-dom/lib/config/defaultHTMLStyleMap.ts
@@ -34,6 +34,9 @@ export const defaultHTMLStyleMap: DefaultStyleMap = {
         marginBottom: '1em',
     },
     dt: blockElement,
+    del: {
+        textDecoration: 'line-through',
+    },
     em: {
         fontStyle: 'italic',
     },

--- a/packages/roosterjs-content-model-dom/test/domToModel/utils/parseFormatTest.ts
+++ b/packages/roosterjs-content-model-dom/test/domToModel/utils/parseFormatTest.ts
@@ -52,6 +52,10 @@ describe('Default styles', () => {
         runTest('b', { fontWeight: 'bold' });
     });
 
+    it('Default style for DEL', () => {
+        runTest('del', { textDecoration: 'line-through' });
+    });
+
     it('Default style for EM', () => {
         runTest('em', { fontStyle: 'italic' });
     });


### PR DESCRIPTION
## Summary

Add the default `line-through` text decoration for `<del>` elements in `defaultHTMLStyleMap`, so DOM-to-Content Model conversion preserves the element's semantic strikethrough formatting. Add coverage to `parseFormatTest.ts` for the new default style.

## How to test

1. Run `yarn test:fast --testPathPattern=parseFormatTest`.
2. Parse content containing a `<del>` element and confirm its segment format includes `textDecoration: 'line-through'`.
