### PR TITLE
Preserve merged table spans when adding rows and columns

### DIFF
--- a/packages/roosterjs-content-model-dom/lib/modelApi/editing/mergeModel.ts
+++ b/packages/roosterjs-content-model-dom/lib/modelApi/editing/mergeModel.ts
@@ -242,7 +242,7 @@ function mergeTables(
                     const leftCell = table.rows[k]?.cells[newColIndex - 1];
                     table.rows[k].cells[newColIndex] = createTableCell(
                         false /*spanLeft*/,
-                        false /*spanAbove*/,
+                        leftCell?.spanAbove,
                         leftCell?.isHeader,
                         leftCell?.format
                     );
@@ -266,7 +266,7 @@ function mergeTables(
                 for (let k = 0; k < colCount; k++) {
                     const aboveCell = table.rows[newRowIndex - 1]?.cells[k];
                     table.rows[newRowIndex].cells[k] = createTableCell(
-                        false /*spanLeft*/,
+                        aboveCell?.spanLeft,
                         false /*spanAbove*/,
                         false /*isHeader*/,
                         aboveCell?.format

--- a/packages/roosterjs-content-model-dom/test/modelApi/editing/mergeModelTest.ts
+++ b/packages/roosterjs-content-model-dom/test/modelApi/editing/mergeModelTest.ts
@@ -6816,5 +6816,113 @@ describe('mergeModel', () => {
         expect(normalizeTable.normalizeTable).toHaveBeenCalledTimes(1);
     });
 
+    it('table to table, new row should preserve spanLeft cells from the row above', () => {
+        const majorModel = createContentModelDocument();
+        const sourceModel = createContentModelDocument();
+        const table = createTable(3);
+        const selectedParagraph = createParagraph();
+        const selectedText = createText('selected');
+
+        selectedText.isSelected = true;
+        selectedParagraph.segments.push(selectedText);
+        table.rows = [
+            {
+                format: {},
+                height: 0,
+                cells: [
+                    createTableCell(),
+                    createTableCell(),
+                    createTableCell(),
+                    createTableCell(),
+                    createTableCell(),
+                ],
+            },
+            {
+                format: {},
+                height: 0,
+                cells: [
+                    createTableCell(),
+                    createTableCell(true),
+                    createTableCell(),
+                    createTableCell(),
+                    createTableCell(),
+                ],
+            },
+            {
+                format: {},
+                height: 0,
+                cells: [
+                    createTableCell(),
+                    createTableCell(true),
+                    createTableCell(),
+                    createTableCell(),
+                    createTableCell(),
+                ],
+            },
+        ];
+        table.rows[2].cells[4].blocks.push(selectedParagraph);
+        majorModel.blocks.push(table);
+
+        const sourceTable = createTable(2);
+        sourceTable.rows[0].cells = [createTableCell()];
+        sourceTable.rows[1].cells = [createTableCell()];
+        sourceModel.blocks.push(sourceTable);
+
+        spyOn(applyTableFormat, 'applyTableFormat');
+        spyOn(normalizeTable, 'normalizeTable');
+
+        mergeModel(
+            majorModel,
+            sourceModel,
+            { newEntities: [], deletedEntities: [], newImages: [] },
+            { mergeTable: true }
+        );
+
+        expect(table.rows.length).toBe(4);
+        expect(table.rows[3].cells[1].spanLeft).toBe(true);
+    });
+
+    it('table to table, new column should preserve spanAbove cells from the column to the left', () => {
+        const majorModel = createContentModelDocument();
+        const sourceModel = createContentModelDocument();
+        const table = createTable(2);
+        const selectedParagraph = createParagraph();
+        const selectedText = createText('selected');
+
+        selectedText.isSelected = true;
+        selectedParagraph.segments.push(selectedText);
+        table.rows = [
+            {
+                format: {},
+                height: 0,
+                cells: [createTableCell(), createTableCell()],
+            },
+            {
+                format: {},
+                height: 0,
+                cells: [createTableCell(), createTableCell(false, true)],
+            },
+        ];
+        table.rows[0].cells[1].blocks.push(selectedParagraph);
+        majorModel.blocks.push(table);
+
+        const sourceTable = createTable(1);
+        sourceTable.rows[0].cells = [createTableCell(), createTableCell()];
+        sourceModel.blocks.push(sourceTable);
+
+        spyOn(applyTableFormat, 'applyTableFormat');
+        spyOn(normalizeTable, 'normalizeTable');
+
+        mergeModel(
+            majorModel,
+            sourceModel,
+            { newEntities: [], deletedEntities: [], newImages: [] },
+            { mergeTable: true }
+        );
+
+        expect(table.rows[0].cells.length).toBe(3);
+        expect(table.rows[1].cells[2].spanAbove).toBe(true);
+    });
+
     // #endregion
 });


### PR DESCRIPTION
## Summary

Preserve `spanLeft` and `spanAbove` metadata when `mergeModel` expands a table with new rows or columns. Add regression tests covering both expansion directions so merged cells remain aligned after merging table content.

Before: 
<img width="567" height="471" alt="MergeTablesPasteBug" src="https://github.com/user-attachments/assets/3adadb37-9d8f-451c-aa4c-ba4ff2de3556" />

After: 
<img width="567" height="471" alt="MergeTablesPasteFix" src="https://github.com/user-attachments/assets/8e0a6e32-f868-4c4a-9af8-01756691e6c6" />



## How to test

1. Run `yarn test:fast --testPathPattern=mergeModelTest`.
2. Merge table content that adds a row beneath horizontally merged cells or a column beside vertically merged cells, and verify the new cells retain the neighboring span state.
