### PR TITLE
Avoid losing common ancestors on git history

### DIFF
--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -202,10 +202,32 @@ Create a draft PR targeting the `release` branch using the `gh` CLI:
 -   #124 Fix bug Y (https://github.com/microsoft/roosterjs/pull/124)
 ```
 
+3. Merge instructions that preserve branch ancestry:
+
+```markdown
+## Merge instructions
+
+-   [ ] Confirm the target branch is `release`
+-   [ ] Use **Create a merge commit**
+-   [ ] Do not squash or rebase this PR
+```
+
 Command:
 
 ```bash
 gh pr create --draft --base release --title "<title>" --body "<description>"
+```
+
+After creating the PR, verify that its base branch is `release`:
+
+```bash
+gh pr view --json baseRefName,url
+```
+
+If `baseRefName` is not `release`, update it before continuing:
+
+```bash
+gh pr edit --base release
 ```
 
 ### Step 16: Show the PR link

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://packagefeedproxy.microsoft.io/npm/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ context/          – DomToModelContext, ModelToDomContext, ElementProcessor, Fo
     -   **Tests**: `yarn test:fast`
     -   **Build**: `yarn b`
 -   PRs go against the `master` branch.
+-   Version bump PRs are the exception: they target `release` and must use **Create a merge commit**, never squash or rebase, so `master` remains an ancestor of `release`.
 
 ## Repo Metadata
 


### PR DESCRIPTION
When bumping rooster we might use a git squash approach, which ends losing the common ancestor, and during the commit history we might see an odd timelapse. As a result, improving this. On this PR, we add instructions to the agent used to bump by developers, and also adding new steps for the skill to verify, the branch is targeting release and not using squash approach.

In addition, this is the first step of the approach, since on another PR we will add a github action to check during the build, in case the agent wasn't used.

For example: below image you can see is showing commits from around 3 months ago, while the latest bump happened around 15 days ago. So, looking forward to display only the changes made since last bump. 

<img width="858" height="494" alt="image" src="https://github.com/user-attachments/assets/2be2c06a-50b0-4ffc-84b1-ba3a283d049a" />
